### PR TITLE
Appium commands: background app, hide_keyboard, tap

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,0 +1,16 @@
+let commands = {};
+
+/**
+ * Close app (simulate device home button). If duration, app will re-open
+ * after that duration
+ */
+commands.background = async function (duration) {
+    let durationObject = {};
+    if (duration) {
+      durationObject = {'duration' : duration};
+    }
+    this.wda.sendCommandWithSession('deactivateApp', durationObject, 'POST');
+};
+
+export { commands };
+export default commands;

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,0 +1,44 @@
+import logger from '../logger';
+import errors from 'mobile-json-wire-protocol';
+
+let commands = {};
+
+/**
+ * Perform touch command
+ */
+commands.performTouch = async function (gestures) {
+  //Convert and pass on the touch command
+  if (gestures.length === 1 && gestures[0].action === 'tap') {
+    return await this.handleTap(gestures[0]);
+  }
+  throw new NotImplementedError('Support for multiple gestures or any other action than Tap not supported yet. Please contact an Appium dev');
+};
+
+commands.handleTap = async function (gesture) {
+  let options = gesture.options;
+
+  let nativeDriver = await this.getNativeDriver();
+  let gestureObject = {};
+  if (options.x) {
+    gestureObject.x = options.x;
+  }
+  if (options.y) {
+    gestureObject.y = options.y;
+  }
+  let endpoint = 'tap';
+  //Either an element or if there is none given, the WebDriverAgent API wants a param here
+  if (options.element) {
+    endpoint += '/' + options.element;
+  } else {
+    endpoint += '/0';
+  }
+  nativeDriver.sendCommandWithSession(endpoint, gestureObject, 'POST');
+};
+
+commands.parseTouch = function (gestures, cb) {
+  throw new NotImplementedError('Support for multiple gestures or any other action than Tap not supported yet. Please contact an Appium dev');
+  cb();
+};
+
+export { commands };
+export default commands;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,8 +1,10 @@
 import contextCommands from './context';
+import generalExtensions from './general';
+import gesture from './gesture';
 
 let commands = {};
 
-for (let obj of [contextCommands]) {
+for (let obj of [contextCommands, generalExtensions, gesture]) {
   Object.assign(commands, obj);
 }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -257,7 +257,9 @@ class WebDriverAgentDriver extends BaseDriver {
   getProxyAvoidList () {
     return [
       ['GET', /context/],
-      ['POST', /context/]
+      ['POST', /context/],
+      ['POST', /appium/],
+      ['POST', /touch/]
     ];
   }
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
+import request from 'request-promise';
 import B from 'bluebird';
 import { SubProcess } from 'teen_process';
 import { JWProxy } from 'appium-jsonwp-proxy';
@@ -148,6 +149,33 @@ class WebDriverAgent {
     this.jwproxy.sessionId = null;
 
     await B.all(stops);
+  }
+
+  //Body must be object
+  async sendCommandWithSession(command, body, method) {
+    //TODO: Support post body
+    log.info(`Sending command ${command} to WebDriverAgent with body ${JSON.stringify(body)} via method ${method}`);
+    try {
+      let commandurl = url.format(this.url) + 'session/' + this.jwproxy.sessionId + '/' + command;
+      await request({
+            url: commandurl,
+            body: body ? body : {},
+            method: method,
+            json: true,
+            resolveWithFullResponse: true
+          })
+          .then(function (response) {
+            // Command succeeded...
+            log.info(`Successfully processed command with response: ${response}`);
+          })
+          .catch(function (err) {
+            // Command failed...
+            log.warn(`Error while processing command: ${err}`);
+          });
+    } catch (err) {
+      log.warn(`Error while processing command: ${err}`);
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
Uses new Facebook/WebDriverAgent code to support 'hide keyboard' and background app. Also supports tapping an element using WDA mechanism.

I made some updates and combined a few previous PRs into this one.

Previously @Jonahss had suggested some further updates to me but I actually wasn't positive how to accomplish them. I'll note them here for further discussion:
1. See if we can update WDA to better match our commands, so we don't need the custom proxy intercept I added. My Concern: Commands like "hideKeyboard" have path  .../appium/..., so I wouldn't think we'd want that in WDA. So that was why I had the proxy intercept. That being said, if we want to suggest it, of course I'll defer to you.
2. Try to not have to have custom proxy code here in the driver, but rather make it part of jsonwp-proxy, e.g. adding here: https://github.com/appium/jsonwp-proxy/blob/master/lib/proxy.js. I understand as a concept for sure, but am not specifically what the implementation would look like.

Thank you!