### PR TITLE
TouchID request should be forwarded to proper WebDriverAgent endpoint

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,0 +1,16 @@
+let commands = {};
+
+/**
+ * Simulate Touch ID with either valid fingerprint (match == true) or invalid
+ * fingerprint (match == false).
+ */
+commands.touchId = async function (match) {
+    let matchObject = {};
+    if (match) {
+      matchObject = {'match' : match};
+    }
+    this.wda.sendCommandWithSession('simulator/touch_id', matchObject, 'POST');
+};
+
+export { commands };
+export default commands;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,8 +1,9 @@
 import contextCommands from './context';
+import generalExtensions from './general';
 
 let commands = {};
 
-for (let obj of [contextCommands]) {
+for (let obj of [contextCommands, generalExtensions]) {
   Object.assign(commands, obj);
 }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -257,7 +257,8 @@ class WebDriverAgentDriver extends BaseDriver {
   getProxyAvoidList () {
     return [
       ['GET', /context/],
-      ['POST', /context/]
+      ['POST', /context/],
+      ['POST', /appium/]
     ];
   }
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
+import request from 'request-promise';
 import B from 'bluebird';
 import { SubProcess } from 'teen_process';
 import { JWProxy } from 'appium-jsonwp-proxy';
@@ -148,6 +149,33 @@ class WebDriverAgent {
     this.jwproxy.sessionId = null;
 
     await B.all(stops);
+  }
+
+  //Body must be object
+  async sendCommandWithSession(command, body, method) {
+    //TODO: Support post body
+    log.info(`Sending command ${command} to WebDriverAgent with body ${JSON.stringify(body)} via method ${method}`);
+    try {
+      let commandurl = url.format(this.url) + 'session/' + this.jwproxy.sessionId + '/' + command;
+      await request({
+            url: commandurl,
+            body: body ? body : {},
+            method: method,
+            json: true,
+            resolveWithFullResponse: true
+          })
+          .then(function (response) {
+            // Command succeeded...
+            log.info(`Successfully processed command with response: ${response}`);
+          })
+          .catch(function (err) {
+            // Command failed...
+            log.warn(`Error while processing command: ${err}`);
+          });
+    } catch (err) {
+      log.warn(`Error while processing command: ${err}`);
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
The request was getting proxied to the wrong endpoint, so it would return an error saying it was an unhandled endpoint. This change causes requests to the `appium/simulator/touch_id` endpoint of the appium-xcuitest-driver to be forwarded to the `simulator/touch_id` endpoint of the WebDriverAgent.

It uses a function that @kaleposhobios added to a separate fork [here](https://github.com/truveris/appium-xcuitest-driver/commit/7e9a0676784ca0e1dabb93955b9c03522385f43d).