### PR TITLE
Add translation commands for alerts

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,3 +19,4 @@ if (require.main === module) {
 }
 
 export { XCUITestDriver, startServer };
+export default XCUITestDriver;

--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -1,0 +1,30 @@
+let commands = {}, helpers = {}, extensions = {};
+
+commands.getAlertText = async function () {
+  let method = 'GET';
+  let endpoint = `/alert/text`;
+  return await this.proxyCommand(endpoint, method);
+};
+
+// TODO: WDA does not currently support this natively
+commands.setAlertText = async function (text) {
+  let method = 'POST';
+  let endpoint = `/alert/text`;
+  return await this.proxyCommand(endpoint, method, text);
+};
+
+commands.postAcceptAlert = async function () {
+  let method = 'POST';
+  let endpoint = `/alert/accept`;
+  return await this.proxyCommand(endpoint, method);
+};
+
+commands.postDismissAlert = async function () {
+  let method = 'POST';
+  let endpoint = `/alert/dismiss`;
+  return await this.proxyCommand(endpoint, method);
+};
+
+Object.assign(extensions, commands, helpers);
+export { commands, helpers };
+export default extensions;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -3,10 +3,11 @@ import executeExtensions from './execute';
 import gestureExtensions from './gesture';
 import findExtensions from './find';
 import proxyHelperExtensions from './proxy-helper';
+import alertExtensions from './alert';
 
 let commands = {};
 
-Object.assign(commands, contextCommands, executeExtensions,
+Object.assign(commands, contextCommands, executeExtensions, alertExtensions,
   gestureExtensions, findExtensions, proxyHelperExtensions);
 
 export default commands;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -295,6 +295,9 @@ class XCUITestDriver extends BaseDriver {
       ['POST', /element$/],
       ['POST', /elements$/],
       ['POST', /timeouts\/implicit_wait/],
+      ['GET', /alert_text/],
+      ['POST', /accept_alert/],
+      ['POST', /dismiss_alert/],
     ];
   }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "appium-gulp-plugins": "^1.2.12",
+    "appium-test-support": "0.0.5",
     "babel-eslint": "^6.1.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
@@ -62,8 +63,10 @@
     "eslint-plugin-mocha": "^3.0.0",
     "gulp": "^3.8.11",
     "ios-test-app": "^2.3.3",
+    "ios-uicatalog": "^1.0.3",
     "ios-webview-app": "^1.0.3",
     "request-promise": "^2.0.0",
+    "sinon": "^1.17.4",
     "through2": "^2.0.0",
     "wd": "^0.4.0"
   }

--- a/test/functional/alert-e2e-specs.js
+++ b/test/functional/alert-e2e-specs.js
@@ -1,0 +1,70 @@
+import { startServer } from '../..';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import wd from 'wd';
+import B from 'bluebird';
+import { UICATALOG_CAPS } from './desired';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const HOST = "localhost",
+      PORT = 4994;
+
+async function clickBack (driver) {
+  let el = (await driver.elementsByAccessibilityId('Back'))[0];
+  if (el && (await el.isDisplayed())) {
+    await el.click();
+  }
+}
+
+describe('XCUITestDriver - alerts', function () {
+  this.timeout(200 * 1000);
+
+  let server, driver;
+  before(async () => {
+    driver = wd.promiseChainRemote(HOST, PORT);
+    server = await startServer(PORT, HOST);
+    await driver.init(UICATALOG_CAPS);
+  });
+  after(async () => {
+    await driver.quit();
+    await server.close();
+  });
+
+  beforeEach(async () => {
+    let el1 = await driver.elementByAccessibilityId('Alert Views');
+    await el1.click();
+  });
+  afterEach(async () => {
+    await clickBack(driver);
+  });
+
+  it('should detect Simple', async () => {
+    let el = await driver.elementByAccessibilityId('Simple');
+    await el.click();
+    await B.delay(2000);
+
+    (await driver.alertText()).should.include('A Short Title Is Best');
+    await driver.dismissAlert();
+  });
+
+  it('should detect Okay', async () => {
+    let el = await driver.elementByAccessibilityId('Okay / Cancel');
+    await el.click();
+    await B.delay(2000);
+
+    (await driver.alertText()).should.include('A Short Title Is Best');
+    await driver.acceptAlert();
+  });
+
+  it('should detect Other', async () => {
+    let el = await driver.elementByAccessibilityId('Other');
+    await el.click();
+    await B.delay(2000);
+
+    (await driver.alertText()).should.include('A Short Title Is Best');
+    await driver.dismissAlert();
+  });
+});

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -1,0 +1,23 @@
+import uiCatalog from 'ios-uicatalog';
+import { absolute } from 'ios-test-app';
+import _ from 'lodash';
+import path from 'path';
+
+
+const GENERIC_CAPS = {
+  platformName: 'iOS',
+  platformVersion: '9.3',
+  deviceName: 'iPhone 6',
+  automationName: 'XCUITest'
+};
+
+const UICATALOG_CAPS = _.defaults({
+  app: path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalog[1]),
+}, GENERIC_CAPS);
+
+const TESTAPP_CAPS = _.defaults({
+  app: absolute.iphonesimulator,
+  bundleId: 'io.appium.TestApp',
+}, GENERIC_CAPS);
+
+export { UICATALOG_CAPS, TESTAPP_CAPS };

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -2,32 +2,20 @@ import { startServer } from '../..';
 import { simBooted } from '../../lib/simulatorManagement.js';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { absolute } from 'ios-test-app';
 import wd from 'wd';
 import { killAllSimulators, getSimulator } from 'appium-ios-simulator';
 import { getDevices, createDevice, deleteDevice } from 'node-simctl';
-
+import _ from 'lodash';
+import { TESTAPP_CAPS } from './desired';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 const HOST = "localhost",
-      PORT = 4994,
-      APP = absolute.iphonesimulator,
-      BUNDLE_ID = 'io.appium.TestApp',
-      PLATFORM_VERSION = '9.3';
-
-const DEFAULT_CAPS = {
-  platformName: 'iOS',
-  platformVersion: PLATFORM_VERSION,
-  app: APP,
-  bundleId: BUNDLE_ID,
-  deviceName: "iPhone 6",
-  automationName: "XCUITest",
-};
+      PORT = 4994;
 
 let getNumSims = async () => {
-  return (await getDevices())[PLATFORM_VERSION].length;
+  return (await getDevices())[TESTAPP_CAPS.platformVersion].length;
 };
 
 describe('XCUITestDriver', () => {
@@ -49,7 +37,7 @@ describe('XCUITestDriver', () => {
 
   it('should start and stop a session', async function () {
     this.timeout(200 * 1000);
-    await driver.init(DEFAULT_CAPS);
+    await driver.init(TESTAPP_CAPS);
     let els = await driver.elementsByClassName("XCUIElementTypeButton");
     els.length.should.equal(7);
     await driver.quit();
@@ -58,14 +46,7 @@ describe('XCUITestDriver', () => {
   describe('reset', () => {
     it.skip('default: creates sim and deletes it afterwards', async function () {
       this.timeout(120 * 1000);
-      let caps = {
-        platformName: 'iOS',
-        platformVersion: PLATFORM_VERSION,
-        app: APP,
-        bundleId: BUNDLE_ID,
-        deviceName: "iPhone 6",
-        automationName: "XCUITest",
-      };
+      let caps = TESTAPP_CAPS;
 
       await killAllSimulators();
       let simsBefore = await getNumSims();
@@ -84,19 +65,13 @@ describe('XCUITestDriver', () => {
       this.timeout(120 * 1000);
 
       // before
-      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', PLATFORM_VERSION);
+      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', TESTAPP_CAPS.platformVersion);
       let sim = await getSimulator(udid);
 
       // test
-      let caps = {
-        platformName: 'iOS',
-        platformVersion: PLATFORM_VERSION,
-        app: APP,
-        bundleId: BUNDLE_ID,
-        deviceName: "iPhone 6",
-        automationName: "XCUITest",
+      let caps = _.defaults({
         udid
-      };
+      }, TESTAPP_CAPS);
 
       let simsBefore = await getNumSims();
       await driver.init(caps);
@@ -116,20 +91,14 @@ describe('XCUITestDriver', () => {
       this.timeout(120 * 1000);
 
       // before
-      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', PLATFORM_VERSION);
+      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', TESTAPP_CAPS.platformVersion);
       let sim = await getSimulator(udid);
       await sim.run();
 
       // test
-      let caps = {
-        platformName: 'iOS',
-        platformVersion: PLATFORM_VERSION,
-        app: APP,
-        bundleId: BUNDLE_ID,
-        deviceName: "iPhone 6",
-        automationName: "XCUITest",
+      let caps = _.defaults({
         udid
-      };
+      }, TESTAPP_CAPS);
 
       (await simBooted(sim)).should.be.true;
       let simsBefore = await getNumSims();
@@ -151,15 +120,9 @@ describe('XCUITestDriver', () => {
       this.timeout(120 * 1000);
 
       // test
-      let caps = {
-        platformName: 'iOS',
-        platformVersion: PLATFORM_VERSION,
-        app: APP,
-        bundleId: BUNDLE_ID,
-        deviceName: "iPhone 6",
-        automationName: "XCUITest",
+      let caps = _.defaults({
         udid: 'some-random-udid'
-      };
+      }, TESTAPP_CAPS);
 
       await driver.init(caps).should.be.rejectedWith('environment you requested was unavailable');
     });
@@ -168,20 +131,14 @@ describe('XCUITestDriver', () => {
       this.timeout(120 * 1000);
 
       // before
-      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', PLATFORM_VERSION);
+      let udid = await createDevice('webDriverAgentTest', 'iPhone 6', TESTAPP_CAPS.platformVersion);
       let sim = await getSimulator(udid);
 
       // test
-      let caps = {
-        platformName: 'iOS',
-        platformVersion: PLATFORM_VERSION,
-        app: APP,
-        bundleId: BUNDLE_ID,
-        deviceName: "iPhone 6",
-        automationName: "XCUITest",
+      let caps = _.defaults({
         udid,
         noReset: true
-      };
+      }, TESTAPP_CAPS);
 
       let simsBefore = await getNumSims();
       await driver.init(caps);

--- a/test/unit/commands/alert-specs.js
+++ b/test/unit/commands/alert-specs.js
@@ -1,0 +1,46 @@
+import sinon from 'sinon';
+import XCUITestDriver from '../../..';
+
+
+describe('alert commands', () => {
+  let driver = new XCUITestDriver();
+  let proxySpy = sinon.spy(driver, 'proxyCommand');
+
+  afterEach(() => {
+    proxySpy.reset();
+  });
+
+  describe('getAlertText', () => {
+    it('should send translated GET request to WDA', () => {
+      driver.getAlertText();
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/alert/text');
+      proxySpy.firstCall.args[1].should.eql('GET');
+    });
+  });
+  describe.skip('setAlertText', () => {
+    it('should send translated POST request to WDA', () => {
+      driver.setAlertText('some text');
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/alert/text');
+      proxySpy.firstCall.args[1].should.eql('POST');
+      proxySpy.firstCall.args[2].should.eql('some text');
+    });
+  });
+  describe('postAcceptAlert', () => {
+    it('should send translated POST request to WDA', () => {
+      driver.postAcceptAlert();
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/alert/accept');
+      proxySpy.firstCall.args[1].should.eql('POST');
+    });
+  });
+  describe('postDismissAlert', () => {
+    it('should send translated POST request to WDA', () => {
+      driver.postDismissAlert();
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/alert/dismiss');
+      proxySpy.firstCall.args[1].should.eql('POST');
+    });
+  });
+});


### PR DESCRIPTION
Appium uses old-style alert endpoints while WDA uses W3C spec versions. This means we cannot just proxy, but need to catch, manipulate the endpoint, and send along.