### PR TITLE
Handle all timeouts locally

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -294,7 +294,7 @@ class XCUITestDriver extends BaseDriver {
       ['POST', /execute/],
       ['POST', /element$/],
       ['POST', /elements$/],
-      ['POST', /timeouts\/implicit_wait/],
+      ['POST', /timeouts/],
       ['GET', /alert_text/],
       ['POST', /accept_alert/],
       ['POST', /dismiss_alert/],


### PR DESCRIPTION
All timeout commands should be handled by Appium, not WDA.