### PR TITLE
Handle errors from manual proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ before_script:
 #  - gulp transpile we don't need to transpile here since `gulp test` runs transpilation
 script:
   - gulp eslint
-  - gulp test
+  - gulp once
+  - gulp e2e-test
   - gulp coveralls

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -1,12 +1,13 @@
 import { errors } from 'appium-base-driver';
 
+
 let helpers = {}, extensions = {};
 
 helpers.proxyCommand = async function (endpoint, method, body) {
   if (!endpoint) {
-    throw new errors.BadParametersError('s/commands/requires');
+    throw new errors.BadParametersError('Proxying requires an endpoint');
   } else if (method !== 'POST' && method !== 'GET') {
-    throw new errors.BadParametersError('"POST" or "GET" Methods');
+    throw new errors.BadParametersError('Proxying only works for GET or POST requests');
   }
   return await this.wda.jwproxy.command(endpoint, method, body);
 };

--- a/test/unit/commands/proxy-helper-specs.js
+++ b/test/unit/commands/proxy-helper-specs.js
@@ -1,0 +1,58 @@
+import { errors } from 'appium-base-driver';
+import sinon from 'sinon';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import XCUITestDriver from '../../..';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('proxy commands', () => {
+  let driver = new XCUITestDriver();
+  // give the driver a spy-able proxy object
+  driver.wda = {jwproxy: {command: () => {}}};
+  let proxyStub = sinon.stub(driver.wda.jwproxy, 'command');
+
+  afterEach(() => {
+    if (proxyStub) {
+      proxyStub.reset();
+    }
+  });
+
+  describe('proxyCommand', () => {
+    it('should send command through WDA', async () => {
+      proxyStub.returns({status: 0});
+
+      await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
+      proxyStub.calledOnce.should.be.true;
+      proxyStub.firstCall.args[0].should.eql('/some/endpoint');
+      proxyStub.firstCall.args[1].should.eql('POST');
+      proxyStub.firstCall.args[2].some.should.eql('stuff');
+    });
+    it('should throw an error if no endpoint is given', async () => {
+      await driver.proxyCommand(null, 'POST', {some: 'stuff'}).should.eventually.be.rejectedWith(/endpoint/);
+      proxyStub.callCount.should.eql(0);
+    });
+    it('should throw an error if no endpoint is given', async () => {
+      await driver.proxyCommand('/some/endpoint', null, {some: 'stuff'}).should.eventually.be.rejectedWith(/GET or POST/);
+      proxyStub.callCount.should.eql(0);
+    });
+    it('should throw an error if wda returns an error (even if http status is 200)', async () => {
+      proxyStub.returns({status: 13, value: 'WDA error occurred'});
+      try {
+        await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
+      } catch (err) {
+        err.jsonwpCode.should.eql(13);
+        err.message.should.include('WDA error occurred');
+        err.should.be.an.instanceof(errors.UnknownError);
+      }
+      proxyStub.calledOnce.should.be.true;
+    });
+    it('should not throw an error if no status is returned', async () => {
+      proxyStub.returns({value: 'WDA error occurred'});
+      await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
+      proxyStub.calledOnce.should.be.true;
+    });
+  });
+});


### PR DESCRIPTION
WDA does not necessarily return an http error code, so our proxy logic does not necessarily catch errors.  Handle this case while the WDA folks fix things.