### PR TITLE
Always use proxyCommand helper

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -37,7 +37,7 @@ helpers.findElOrEls = async function (cmd, endpoint, value, mult) {
   try {
     await this.implicitWaitForCondition(async () => {
       try {
-        els = await this.wda.jwproxy.command(endpoint, method, body);
+        els = await this.proxyCommand(endpoint, method, body);
         if (mult) {
           // we succeed if we get some elements
           return els && els.length;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -246,7 +246,7 @@ class XCUITestDriver extends BaseDriver {
     await launch(this.sim.udid, this.opts.bundleId);
 
     let checkStatus = async () => {
-      let response = await this.wda.jwproxy.command('/status', 'GET');
+      let response = await this.proxyCommand('/status', 'GET');
       let currentApp = response.currentApp.bundleID;
       if (currentApp !== this.opts.bundleId) {
         throw new Error(`${this.opts.bundleId} not in foreground. ${currentApp} is in foreground`);
@@ -263,7 +263,7 @@ class XCUITestDriver extends BaseDriver {
     let desired = {
       desiredCapabilities: {app, bundleId}
     };
-    await this.wda.jwproxy.command('/session', 'POST', desired);
+    await this.proxyCommand('/session', 'POST', desired);
   }
 
   shouldProxyToSafari (command) {


### PR DESCRIPTION
We should never be calling on the wda proxy directly, but instead use the `proxyCommand` helper.