### PR TITLE
Added homeScreen endpoint

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -23,5 +23,15 @@ commands.touchId = async function (match = true) {
   return await this.proxyCommand('/simulator/touch_id', 'POST', params);
 };
 
+/*
+ * Return to home screen (simulates tapping on home button).
+ *
+ */
+commands.homeScreen = async function () {
+  let method = 'POST';
+  let endpoint = `/homescreen`;
+  return await this.proxyCommand(endpoint, method);
+};
+
 export { commands };
 export default commands;

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -42,4 +42,14 @@ describe('general commands', () => {
       proxySpy.firstCall.args[2].should.eql({match: false});
     });
   });
+
+  describe('homescreen', () => {
+    it('should send translated POST request to WDA', () => {
+      driver.homeScreen();
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/homescreen');
+      proxySpy.firstCall.args[1].should.eql('POST');
+    });
+  });
+
 });


### PR DESCRIPTION
This is a new endpoint provided by https://github.com/facebook/WebDriverAgent

It can be used to simulate tapping on the home button on an iOS device

```
curl -X POST $JSON_HEADER -d "" $DEVICE_URL/homescreen
```

This pull request depends on a change in appium-base-driver to work correctly
https://github.com/appium/appium-base-driver/pull/68
