### PR TITLE
Remove dependency on node-ios-device

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ The `git diff --submodule` flag is useful here. It can also be set as the defaul
 `git config status.submodulesummary 1` is also useful.
 
 
+## External dependencies
+
+In addition to the git submodules mentioned above, this package currently depends on `libimobiledevice` to do certain things. Install it with [Homebrew](http://brew.sh/),
+
+```
+brew install ideviceinstaller
+```
+
+
 ## Sim Resetting
 
 By default, this driver will create a new iOS simulator and run tests on it, deleting the simulator afterward.

--- a/lib/realDeviceManagement.js
+++ b/lib/realDeviceManagement.js
@@ -1,14 +1,9 @@
-import _iosDevice from 'node-ios-device';
-import _ from 'lodash';
-import B from 'bluebird';
+import { exec } from 'teen_process';
 
-
-const getDevices = B.promisify(_iosDevice.devices, _iosDevice);
 
 async function getConnectedDevices () {
-  let devices = await getDevices();
-
-  return _.map(devices, 'udid');
+  let {stdout} = await exec('idevice_id', ['-l']);
+  return stdout.trim().split('\n');
 }
 
 export { getConnectedDevices };

--- a/package.json
+++ b/package.json
@@ -79,8 +79,5 @@
     "sinon": "^1.17.4",
     "through2": "^2.0.0",
     "wd": "^0.4.0"
-  },
-  "optionalDependencies": {
-    "node-ios-device": "^0.10.1"
   }
 }


### PR DESCRIPTION
Use `libimobiledevice`'s `idevice_id` instead. Otherwise we run into issues with not being able to load on non-OSX machines.