### PR TITLE
Handle bug from WDA for click action

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,8 +1,34 @@
 import { errors } from 'appium-base-driver';
 import { util } from 'appium-support';
-
+import { retryInterval } from 'asyncbox';
 
 let helpers = {}, extensions = {}, commands = {};
+
+// This should be done in WDA. There is PR in progress for this. Once that is done this will be removed.
+commands.click = async function (el) {
+  let application;
+  let scrollIntoView = async () => {
+    let params = { toVisible: true, element : el };
+    let response = await this.mobileScroll(params);
+    if (response && response.status !== 0 && response.value && response.value.indexOf("Failed to perform scroll") > -1) {
+      if (!application) {
+        application = await this.findElement(`class name`, `XCUIElementTypeApplication`);
+      }
+      let locEndpoint = `/element/${el}/location`;
+      let locResponse =  await this.proxyCommand(locEndpoint, 'GET', {});
+      let directionVal = `down`;
+      if (locResponse.y < 0) {
+        directionVal = `up`;
+      }
+      params = { direction: directionVal, element : application };
+      await this.mobileScroll(params);
+      throw new Error(`could not scroll into view`);
+    }
+  };
+  await retryInterval(5, 1, scrollIntoView);
+  let endpoint = `/element/${el}/click`;
+  return await this.proxyCommand(endpoint, 'POST', {});
+};
 
 commands.performTouch = async function (gestures) {
   if (gestures.length === 1 && (gestures[0].action === 'tap' || gestures[0].action === 'doubleTap')) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -22,6 +22,7 @@ const NO_PROXY_NATIVE_LIST = [
   ['POST', /execute/],
   ['POST', /element$/],
   ['POST', /elements$/],
+  ['POST', /click/],    
   ['POST', /timeouts/],
   ['GET', /alert_text/],
   ['POST', /accept_alert/],


### PR DESCRIPTION
This is to accommodate a bug from WDA where it doesnt scroll into view before clicking an element

Scrollintoview can fail if its parent is not visible