### PR TITLE
Only install WDA dependencies we use

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ The `git diff --submodule` flag is useful here. It can also be set as the defaul
 
 ## External dependencies
 
-In addition to the git submodules mentioned above, this package currently depends on `libimobiledevice` to do certain things. Install it with [Homebrew](http://brew.sh/),
+In addition to the git submodules mentioned above, this package currently depends
+on `libimobiledevice` to do certain things. Install it with [Homebrew](http://brew.sh/),
 
 ```
 brew install ideviceinstaller
+```
+
+There is also a dependency, made necessary by Facebook's [WebDriverAgent](https://github.com/facebook/WebDriverAgent),
+for the [Carthage](https://github.com/Carthage/Carthage) dependency manager. If you
+do not have Carthage on your system, it can also be installed with
+[Homebrew]((http://brew.sh/)
+
+```
+brew install carthage
 ```
 
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -92,7 +92,7 @@ class WebDriverAgent {
 
   async checkForDependencies () {
     if (!await fs.hasAccess(`${this.bootstrapPath}/Carthage`)) {
-      await exec('/bin/bash', ['Scripts/bootstrap.sh'], {cwd: this.bootstrapPath});
+      await exec('/bin/bash', ['Scripts/bootstrap.sh', '-d'], {cwd: this.bootstrapPath});
     }
   }
 


### PR DESCRIPTION
Add documentation about Carthage, and only build the actual dependencies, not Inspector, which we don't need.