### PR TITLE
Make sure we have the WDA resource structure

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -92,7 +92,16 @@ class WebDriverAgent {
 
   async checkForDependencies () {
     if (!await fs.hasAccess(`${this.bootstrapPath}/Carthage`)) {
+      log.debug('Running WebDriverAgent bootstrap script to install dependencies');
       await exec('/bin/bash', ['Scripts/bootstrap.sh', '-d'], {cwd: this.bootstrapPath});
+    }
+    if (!await fs.hasAccess(`${this.bootstrapPath}/Resources`)) {
+      log.debug('Creating WebDriverAgent resources directory');
+      await fs.mkdir(`${this.bootstrapPath}/Resources`);
+    }
+    if (!await fs.hasAccess(`${this.bootstrapPath}/Resources/WebDriverAgent.bundle`)) {
+      log.debug('Creating WebDriverAgent resource bundle directory');
+      await fs.mkdir(`${this.bootstrapPath}/Resources/WebDriverAgent.bundle`);
     }
   }
 


### PR DESCRIPTION
One more dependency from WDA needs to be accounted for. With this in the package appears to be runnable from Appium without needing Inspector and its node modules.

Added a little logging, too, to make things a little less opaque.