### PR TITLE
if there is no element passed then do action on application.

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -36,7 +36,7 @@ helpers.handleTap = async function (gesture) {
 
 helpers.mobileScroll = async function (opts={}) {
   if (!opts.element) {
-    throw new errors.BadParametersError('Mobile scroll needs an element');
+    opts.element = await this.findElement(`class name`, `XCUIElementTypeApplication`);
   }
   // WDA supports four scrolling strategies: predication based on name, direction,
   // predicateString, and toVisible, in that order.


### PR DESCRIPTION
This is for backward compatibility as we supported scroll without element.