### PR TITLE
Make sure we have a platformVersion

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -7,7 +7,7 @@ Object.assign(extensions, iosCommands.context);
 
 // override, as appium-ios-driver's version uses UI Automation to close
 extensions.closeAlertBeforeTest = async function () {
-  return;
+  return true;
 };
 
 // the appium-ios-driver version of this function fails in CI,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -119,11 +119,29 @@ class XCUITestDriver extends BaseDriver {
       let sessionId;
       [sessionId] = await super.createSession(caps);
 
+      if (!this.xcodeVersion) {
+        this.xcodeVersion = await getAndCheckXcodeVersion();
+        log.debug(`Xcode version set to '${this.xcodeVersion.versionString}'`);
+      }
+
+      this.iosSdkVersion = await getAndCheckIosSdkVersion();
+      log.debug(`iOS SDK Version set to '${this.iosSdkVersion}'`);
+
       let { device, udid, realDevice } = await this.determineDevice();
       log.info(`Determining device to run tests on: udid: '${udid}', real device: ${realDevice}`);
       this.opts.device = device;
       this.opts.udid = udid;
       this.opts.realDevice = realDevice;
+
+      // at this point if there is no platformVersion, get it from the device
+      if (!this.opts.platformVersion) {
+        if (this.opts.device && _.isFunction(this.opts.device.getPlatformVersion)) {
+          this.opts.platformVersion = await this.opts.device.getPlatformVersion();
+          log.info(`No platformVersion specified. Using device version: '${this.opts.platformVersion}'`);
+        } else {
+          // TODO: this is when it is a real device. when we have a real object wire it in
+        }
+      }
 
       if (this.opts.browserName) {
         log.info('Safari test requested');
@@ -148,14 +166,6 @@ class XCUITestDriver extends BaseDriver {
       if (!this.opts.bundleId) {
         this.opts.bundleId = await extractBundleId(this.opts.app);
       }
-
-      if (!this.xcodeVersion) {
-        this.xcodeVersion = await getAndCheckXcodeVersion();
-        log.debug(`Xcode version set to '${this.xcodeVersion.versionString}'`);
-      }
-
-      this.iosSdkVersion = await getAndCheckIosSdkVersion();
-      log.debug(`iOS SDK Version set to '${this.iosSdkVersion}'`);
 
       // handle logging
       this.logs = {};
@@ -338,6 +348,10 @@ class XCUITestDriver extends BaseDriver {
 
     // no device of this type exists, so create one
     log.info('Simluator udid not provided, using desired caps to create a new simulator');
+    if (!this.opts.platformVersion) {
+      log.info(`No platformVersion specified. Using latest version '${this.iosSdkVersion}'`);
+      this.opts.platformVersion = this.iosSdkVersion;
+    }
     device = await this.createSim();
     return {device, realDevice: false, udid: device.udid};
   }


### PR DESCRIPTION
Make sure that we have a `platformVersion` set, even if one is not passed in.

For now, we have no way of getting the version of a real device. But once we have better support in (which is in the works) we should be able to.

Resolves https://github.com/appium/appium/issues/6765 and https://github.com/appium/appium-xcuitest-driver/issues/101