### PR TITLE
Add test to confirm absence of alerts throws correct error

### DIFF
--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -53,4 +53,9 @@ describe('XCUITestDriver - alerts', function () {
     (await driver.alertText()).should.include('A Short Title Is Best');
     await driver.dismissAlert();
   });
+
+  it('should throw a NoAlertOpenError when no alert is open', async () => {
+    await driver.acceptAlert()
+      .should.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
+  });
 });


### PR DESCRIPTION
WDA returns the wrong error when an alert is not found. For now, catch it and translate.

Upstream fix: https://github.com/facebook/WebDriverAgent/pull/271

Resolves, temporarily, #119