### PR TITLE
Fixed typo in longPress action call

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -27,7 +27,7 @@ commands.performTouch = async function (gestures) {
     return await this.handleTap(gestures[0]);
   } else if (gestures.length === 1 && gestures[0].action === 'doubleTap') {
     return await this.handleDoubleTap(gestures[0]);
-  } else if (gestures.length === 1 && gestures[0].action === 'longpress') {
+  } else if (gestures.length === 1 && gestures[0].action === 'longPress') {
     return await this.handleLongPress(gestures[0]);
   } else if (this.isDrag(gestures)) {
     return await this.handleDrag(gestures);


### PR DESCRIPTION
I have fixed typo in longPress action call since the ruby_lib 8.0.2 call is 
```ruby
def long_press(opts)
      args = opts.select { |k, _v| [:element, :x, :y, :duration].include? k }
      args = args_with_ele_ref(args)
      chain_method(:longPress, args) # longPress is what the appium server expects
    end
```
