### PR TITLE
Throw error if carthage does not exist

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -94,6 +94,12 @@ class WebDriverAgent {
   }
 
   async checkForDependencies () {
+    try {
+      let carthagePath = await fs.which('carthage');
+      log.debug(`Carthage found: ${carthagePath}`);
+    } catch (err) {
+      log.errorAndThrow('Carthage not found. Install using `brew install carthage`');
+    }
     if (!await fs.hasAccess(`${this.bootstrapPath}/Carthage`)) {
       log.debug('Running WebDriverAgent bootstrap script to install dependencies');
       await exec('/bin/bash', ['Scripts/bootstrap.sh', '-d'], {cwd: this.bootstrapPath});


### PR DESCRIPTION
Otherwise we get difficult-to-discern errors in running the WebDriverScript. See, for instance, https://github.com/appium/appium/issues/6853