### PR TITLE
Add showXcodeLog cap and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ideviceinstaller doesn't work with ios 10 yet. So we need to install [ios-deploy
 
 ```
 npm install -g ios-deploy
-``` 
+```
 
 ## Sim Resetting
 
@@ -110,7 +110,8 @@ Differences noted here
 |`noReset`|Do not destroy or shut down sim after test. Start tests running on whichever sim is running, or device is plugged in. Default `false`|`true`, `false`|
 |`processArguments`|Process arguments and environment which will be sent to the WebDriverAgent server.|`{ args: ["a", "b", "c"] , env: { "a": "b", "c": "d" } }` or `'{"args": ["a", "b", "c"], "env": { "a": "b", "c": "d" }}'`|
 |`realDeviceLogger`|Device logger for real devices. It could be path to `deviceconsole` (Need to get this from https://github.com/rpetrich/deviceconsole) or `idevicesyslog` (This comes with libimobiledevice)|`idevicesyslog`, `/abs/path/to/deviceconsole`|
-|`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|`eg. 8100`|
+|`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
+|`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 
 ## Watch
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import { desiredCapConstraints as iosDesiredCapConstraints } from 'appium-ios-driver';
+
+
+let desiredCapConstraints = _.defaults({
+  showXcodeLog: {
+    isBoolean: true
+  },
+}, iosDesiredCapConstraints);
+
+export { desiredCapConstraints };
+export default desiredCapConstraints;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -8,8 +8,8 @@ import log from './logger';
 import { simBooted, createSim, getExistingSim } from './simulator-management';
 import { killAllSimulators, simExists, getSimulator } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
-import { settings as iosSettings, desiredCapConstraints,
-         defaultServerCaps } from 'appium-ios-driver';
+import { settings as iosSettings, defaultServerCaps } from 'appium-ios-driver';
+import desiredCapConstraints from './desired-caps';
 import commands from './commands/index';
 import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion } from './utils';
 import { getConnectedDevices } from './real-device-management';
@@ -542,6 +542,8 @@ class XCUITestDriver extends BaseDriver {
         log.errorAndThrow('processArguments must be an object, or a string JSON object with format {arguments : [], environment : {a:b, c:d}}. Both environment and argument can be null.');
       }
     }
+
+
 
     // finally, return true since the superclass check passed, as did this
     return true;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -11,6 +11,7 @@ import { systemLogExists } from './simulator-management.js';
 
 
 const agentLog = getLogger('WebDriverAgent');
+const xcodeLog = getLogger('Xcode');
 
 const AGENT_PATH = path.resolve(__dirname, '..', '..', 'WebDriverAgent', 'WebDriverAgent.xcodeproj');
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', 'WebDriverAgent');
@@ -47,6 +48,7 @@ class WebDriverAgent {
     this.realDeviceLogger = args.realDeviceLogger || DEVICE_CONSOLE_PATH;
     this.wdaLocalPort = args.wdaLocalPort;
     this.iosLogAlreadyShown = args.showIOSLog;
+    this.showXcodeLog = !!args.showXcodeLog;
   }
 
   async launch (sessionId) {
@@ -132,7 +134,7 @@ class WebDriverAgent {
               `in directory '${this.bootstrapPath}'`);
     let xcodebuild = new SubProcess('xcodebuild', args, {cwd: this.bootstrapPath});
 
-    let logXcodeOutput = false;
+    let logXcodeOutput = this.showXcodeLog;
     xcodebuild.on('output', (stdout, stderr) => {
       let out = stdout || stderr;
       // we want to pull out the log file that is created, and highlight it
@@ -151,7 +153,7 @@ class WebDriverAgent {
       }
 
       if (logXcodeOutput) {
-        log.info(out);
+        xcodeLog.info(out);
       }
     });
 


### PR DESCRIPTION
Many people are having problems involving Xcode not being able to run the test. This adds a desired capability, `showXcodeLog` which puts all of xcodebuild's logs into the appium server log. Hopefully this will make things a little less blind.