### PR TITLE
Change carthage error to info log

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -98,7 +98,7 @@ class WebDriverAgent {
       let carthagePath = await fs.which('carthage');
       log.debug(`Carthage found: ${carthagePath}`);
     } catch (err) {
-      log.errorAndThrow('Carthage not found. Install using `brew install carthage`');
+      log.info('Carthage not found. Install using `brew install carthage`');
     }
     if (!await fs.hasAccess(`${this.bootstrapPath}/Carthage`)) {
       log.debug('Running WebDriverAgent bootstrap script to install dependencies');


### PR DESCRIPTION
#157 Introduced a check for the presence of Carthage. It seems that some systems don't pass the check even if Carthage is available, so there were false negatives. 

Change this to a log line, which in conjunction with the scripts not working will point to the correct solution to users' problems.