### PR TITLE
Re-enable xcode 8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - _FORCE_LOGS=1 PLATFORM_VERSION=9.3 TEST=functional/web
 language:
   - objective-c
-osx_image: xcode7.3
+osx_image: xcode8
 git: # Handle git submodules yourself
   submodules: false
 node_js:


### PR DESCRIPTION
I moved it back when trying to fix the build. Re-enable now as everything seems stable.