### PR TITLE
Make wda error check more defensive

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -15,6 +15,7 @@ import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion } from '.
 import { getConnectedDevices } from './real-device-management';
 import IOSDeploy from './ios-deploy';
 import B from 'bluebird';
+import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
@@ -68,6 +69,8 @@ const NO_PROXY_WEB_LIST = [
 class XCUITestDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
+
+    log.debug(`XCUITestDriver version: ${version}`);
 
     this.desiredCapConstraints = desiredCapConstraints;
 
@@ -225,7 +228,7 @@ class XCUITestDriver extends BaseDriver {
     try {
       await this.wda.launch(sessionId, realDevice);
     } catch (err) {
-      if (err.message.indexOf('xcodebuild failed with code 65') === -1) {
+      if ((err.message || '').indexOf('xcodebuild failed with code 65') === -1) {
         throw err;
       }
       // Xcode error code 65 means that the WDA app is still being installed


### PR DESCRIPTION
Make sure we have a message before trying to check it. Addresses #191.

Also add a line mentioning the driver version, so that we know.