### PR TITLE
Add hide keyboard method

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,5 +1,7 @@
+import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import { iosCommands } from 'appium-ios-driver';
+import log from '../logger';
 
 
 let commands = {};
@@ -43,6 +45,20 @@ commands.getWindowSize = async function (windowHandle = 'current') {
     return await this.proxyCommand(`/window/${windowHandle}/size`, 'GET');
   } else {
     return await this.executeAtom('get_window_size', []);
+  }
+};
+
+commands.hideKeyboard = async function (strategy, ...possibleKeys) {
+  possibleKeys.pop(); // last parameter is the session id
+  possibleKeys = possibleKeys.filter((element) => !!element); // get rid of undefined elements
+  possibleKeys = possibleKeys && possibleKeys.length ? possibleKeys : ['Done'];
+  for (let key of possibleKeys) {
+    let el = _.last(await this.findNativeElementOrElements('accessibility id', key, true));
+    if (el) {
+      log.debug(`Attempting to hide keyboard by pressing '${key}' key.`);
+      await this.nativeClick(el);
+      return;
+    }
   }
 };
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -172,6 +172,7 @@ helpers.mobileScroll = async function (opts={}) {
 
 // This should be done in WDA. There is PR in progress for this. Once that is done this will be removed.
 commands.nativeClick = async function (el) {
+  el = util.unwrapElement(el);
   let application;
   let scrollIntoView = async () => {
     let params = { toVisible: true, element : el };

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -247,6 +247,20 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.keys('this is a test');
         });
       });
+      describe('hide keyboard', () => {
+        it('should be able to hide the keyboard', async () => {
+          let el = await driver.elementByClassName('XCUIElementTypeTextField');
+          await el.click();
+
+          let db = await driver.elementByAccessibilityId('Done');
+          (await db.isDisplayed()).should.be.true;
+
+          await driver.hideKeyboard();
+
+          db = await driver.elementByAccessibilityId('Done');
+          (await db.isDisplayed()).should.be.false;
+        });
+      });
     });
     describe('picker wheel', () => {
       it('should be able to set the value', async () => {


### PR DESCRIPTION
For now, just press the `Done` button on the keyboard. We will likely need to update as time goes on. Alas.