### PR TITLE
Fixes issues when initializing options and generating the xml hierarchy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -94,7 +94,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   resetIos () {
-    this.opts = {};
+    this.opts = this.opts || {};
     this.wda = null;
     this.opts.device = null;
     this.jwpProxyActive = false;


### PR DESCRIPTION
When driver.closeApp() and driver.launchApp() was called, options were reset in the driver which led then to other subsequent errors. This is fixed by just initializing the options map once.

The xml hierarchy did not contain values for element coordinates and element sizes. This is fixed by reading the coordinates and sizes correctly.