### PR TITLE
Add ability to auto-detect xcconfig for running test suite

### DIFF
--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -2,13 +2,25 @@ import uiCatalogApp from 'ios-uicatalog';
 import iosWebViewApp from 'ios-webview-app';
 import _ from 'lodash';
 import path from 'path';
+import glob from 'glob';
 
 
 const PLATFORM_VERSION = process.env.PLATFORM_VERSION ? process.env.PLATFORM_VERSION : '9.3';
 const DEVICE_NAME = process.env.DEVICE_NAME ? process.env.DEVICE_NAME : 'iPhone 6';
 
 const REAL_DEVICE = !!process.env.REAL_DEVICE;
-const REAL_DEVICE_CAPS = REAL_DEVICE ? {udid: 'auto'} : {};
+let XCCONFIG_FILE = process.env.XCCONFIG_FILE;
+if (REAL_DEVICE && !XCCONFIG_FILE) {
+  // no xcconfig file specified, so try to find in the root directory of the package
+  // this happens once, at the start of a test run, so using sync method is ok
+  let cwd = path.resolve(__dirname, '..', '..', '..');
+  let files = glob.sync('*.xcconfig', {cwd});
+  XCCONFIG_FILE = path.resolve(cwd, _.first(files));
+}
+const REAL_DEVICE_CAPS = REAL_DEVICE ? {
+  udid: 'auto',
+  xcodeConfigFile: XCCONFIG_FILE,
+} : {};
 
 const GENERIC_CAPS = {
   platformName: 'iOS',


### PR DESCRIPTION
Make it so running the test suite on real devices without needing to change anything.