### PR TITLE
Add handling of autoWebview cap

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -216,7 +216,7 @@ class XCUITestDriver extends BaseDriver {
 
     await this.setInitialOrientation(this.opts.orientation);
 
-    if (this.isSafari()) {
+    if (this.isSafari() || this.opts.autoWebview) {
       log.debug('Waiting for initial webview');
       await this.navToInitialWebview();
     }


### PR DESCRIPTION
Auto-initialize webview when `autoWebview` cap set.

Fixes https://github.com/appium/appium/issues/6926