### PR TITLE
Remove check for null url, since we use iproxy

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -317,13 +317,6 @@ class WebDriverAgent {
           if (!agentUrl) {
             log.errorAndThrow(new Error('No url detected from WebDriverAgent'));
           }
-          // check for (null) url (e.g., 'http://(null):8100'), which happens on real devices
-          if (/(\(null\))/.test(agentUrl)) {
-            let msg = `Unable to detect url from WebDriverAgent: ${agentUrl}. ` +
-                      'Is the device on the same network as the server?';
-            log.errorAndThrow(new Error(msg));
-          }
-
           return true;
         }
       }


### PR DESCRIPTION
Since we proxy the commands over usb, there is no need for the restriction on devices being on the same network.