### PR TITLE
Add modification of short class name forms

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -19,6 +19,18 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
     strategy = 'predicate string';
   }
 
+  if (strategy === 'class name') {
+    // XCUITest classes have `XCUIElementType` appended
+    // first check if there is the old `UIA` prefix
+    if (selector.indexOf('UIA') === 0) {
+      selector = selector.substring(3);
+    }
+    // now check if we need to add `XCUIElementType`
+    if (selector.indexOf('XCUIElementType') !== 0) {
+      selector = `XCUIElementType{selector}`;
+    }
+  }
+
   context = util.unwrapElement(context);
 
   let endpoint;


### PR DESCRIPTION
Allow the use of the short forms of class names. 

Fixes https://github.com/appium/appium/issues/6871