### PR TITLE
Make sure scroll failure does not ruin click

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -2,6 +2,7 @@ import { errors } from 'appium-base-driver';
 import { util } from 'appium-support';
 import { iosCommands } from 'appium-ios-driver';
 import { retryInterval } from 'asyncbox';
+import log from '../logger';
 
 
 let helpers = {}, extensions = {}, commands = {};
@@ -192,7 +193,11 @@ commands.nativeClick = async function (el) {
       throw new Error(`could not scroll into view`);
     }
   };
-  await retryInterval(5, 1, scrollIntoView);
+  try {
+    await retryInterval(5, 1, scrollIntoView);
+  } catch (err) {
+    log.warn('Scrolling failed after five retries. Proceeding with click.');
+  }
   let endpoint = `/element/${el}/click`;
   return await this.proxyCommand(endpoint, 'POST', {});
 };


### PR DESCRIPTION
Rather than throw an error, try to do the click (which may, itself throw an error if it can't find the element, but at least we try).

See https://github.com/appium/appium/issues/6941