### PR TITLE
Use script to set security and run xcodebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ dbug WebDriverAgent Device: Jul 26 13:21:57 iamPhone XCTRunner[240] <Warning>: E
 dbug WebDriverAgent Device: Jul 26 13:22:57 iamPhone XCTRunner[240] <Warning>: Enqueue Failure: UI Testing Failure - App state of (null) is still unknown <unknown> 0 1
 ```
 
+### Real device security settings
+
+On some systems there are Accessibility restrictions that make the `WebDriverAgent` system unable to run. This is usually manifest
+by `xcodebuild` returning an error code `65`. A workaround for this is to use a private key that is not stored on the system
+keychain. See [this issue](https://github.com/appium/appium/issues/6955) and [this Stack Exchange post](http://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails).
+
+To export the key, use
+
+```
+security create-keychain -p [keychain_password] MyKeychain.keychain
+security import MyPrivateKey.p12 -t agg -k MyKeychain.keychain -P [p12_Password] -A
+```
+
+where `MyPrivateKey.p12` is the private development key exported from the system keychain.
+
+The full path to the keychain can then be sent to the Appium system using the `keychainPath` desired capability,
+and the password sent through the `keychainPassword` capability.
+
 ## Usage
 
 Desired Capabilities:
@@ -119,6 +137,10 @@ Differences noted here
 |`realDeviceLogger`|Device logger for real devices. It could be path to `deviceconsole` (installed with `npm install deviceconsole`, a compiled binary named `deviceconsole` will be added to `./node_modules/deviceconsole/`) or `idevicesyslog` (comes with libimobiledevice). Defaults to `idevicesyslog`|`idevicesyslog`, `/abs/path/to/deviceconsole`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`xcodeConfigFile`|Full path to an optional Xcode configuration file that specifies the code signing identity and team for running the WebDriverAgent on the real device.|e.g., `/path/to/myconfig.xcconfig`|
+|`keychainPath`|Full path to the private development key exported from the system keychain. Used in conjunction with `keychainPassword` when testing on real devices.|e.g., `/path/to/MyPrivateKey.p12`|
+|`keychainPassword`|Password for unlocking keychain specified in `keychainPath`.|e.g., `super awesome password`|
+
+
 ## Watch
 
 ```

--- a/bin/run-xcodebuild.sh
+++ b/bin/run-xcodebuild.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+#
+#https://github.com/appium/appium/issues/6955
+
+while [[ "$#" > 1 ]]; do case $1 in
+    --keychain-path) keychainPath="$2";;
+    --keychain-password) keychainPassword="$2";;
+    --project) project="$2";;
+    --scheme) scheme="$2";;
+    --destination) destination="$2";;
+    --xcode-config-file) xcodeConfigFile="$2";;
+    *) break;;
+  esac; shift; shift
+done
+
+if [[ -n "$keychainPath" && -n "$keychainPassword" ]] ; then
+    echo "Setting security for iOS device"
+    security -v list-keychains -s "$keychainPath"
+    security -v unlock-keychain -p $keychainPassword "$keychainPath"
+    security set-keychain-settings -t 3600 -l "$keychainPath"
+fi
+
+cmd=("xcodebuild" "build" "test" "-project" $project "-scheme" $scheme "-destination" $destination "-configuration" "Debug")
+
+if [[ -n "$xcodeConfigFile" ]] ; then
+    cmd=("${cmd[@]}" '-xcconfig' $xcodeConfigFile)
+fi
+
+echo "Running command '${cmd[@]}'"
+
+${cmd[@]} | xcpretty

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -18,6 +18,12 @@ let desiredCapConstraints = _.defaults({
   xcodeConfigFile: {
     isString: true
   },
+  keychainPath: {
+    isString: true
+  },
+  keychainPassword: {
+    isString: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -557,7 +557,10 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-
+    // there is no point in having `keychainPath` without `keychainPassword`
+    if ((caps.keychainPath && !caps.keychainPassword) || (!caps.keychainPath && caps.keychainPassword)) {
+      log.errorAndThrow(`If 'keychainPath' is set, 'keychainPassword' must also be set (and vice versa).`);
+    }
 
     // finally, return true since the superclass check passed, as did this
     return true;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -51,6 +51,8 @@ class WebDriverAgent {
     this.iosLogAlreadyShown = args.showIOSLog;
     this.showXcodeLog = !!args.showXcodeLog;
     this.xcodeConfigFile = args.xcodeConfigFile;
+    this.keychainPath = args.keychainPath;
+    this.keychainPassword = args.keychainPassword;
   }
 
   async launch (sessionId) {
@@ -134,22 +136,36 @@ class WebDriverAgent {
   }
 
   async createXcodeBuildSubProcess () {
+    let cmd = 'xcodebuild';
     let args = [
+      'build',
+      'test',
       '-project', this.agentPath,
       '-scheme', 'WebDriverAgentRunner',
       '-destination', `id=${this.device.udid}`,
-      'build',
-      'test',
+      '-configuration', 'Debug',
     ];
 
-    if (this.xcodeConfigFile && this.realDevice) {
-      log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
-      args.push('-xcconfig', this.xcodeConfigFile);
+    if (this.realDevice) {
+      cmd = path.resolve(__dirname, '..', '..', 'bin', 'run-xcodebuild.sh');
+      args = [
+        '--project', this.agentPath,
+        '--scheme', 'WebDriverAgentRunner',
+        '--destination', `id=${this.device.udid}`,
+      ];
+      if (this.xcodeConfigFile) {
+        log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
+        args.push('--xcode-config-file', this.xcodeConfigFile);
+      }
+      if (this.keychainPath && this.keychainPassword) {
+        args.push('--keychain-path', this.keychainPath);
+        args.push('--keychain-password', this.keychainPassword);
+      }
     }
 
-    log.debug(`Beginning test with command 'xcodebuild ${args.join(' ')}' ` +
+    log.debug(`Beginning test with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
-    let xcodebuild = new SubProcess('xcodebuild', args, {cwd: this.bootstrapPath});
+    let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath});
 
     let logXcodeOutput = this.showXcodeLog;
     xcodebuild.on('output', (stdout, stderr) => {
@@ -164,7 +180,7 @@ class WebDriverAgent {
       }
 
       // if we have an error we want to output the logs
-      // otherwise the failuer is inscrutible
+      // otherwise the failure is inscrutible
       if (out.indexOf('Error Domain=') !== -1) {
         logXcodeOutput = true;
       }


### PR DESCRIPTION
People have problems with running real device tests. There is a chance that this is caused by being unable to access the private key for the certificate. See https://github.com/appium/appium/issues/6955