### PR TITLE
Add agentPath and bootstrapPath caps to validator

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -24,6 +24,12 @@ let desiredCapConstraints = _.defaults({
   keychainPassword: {
     isString: true
   },
+  bootstrapPath: {
+    isString: true
+  },
+  agentPath: {
+    isString: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };


### PR DESCRIPTION
These are used in cases where we need to test out something in WebDriverAgent. If we don't validate them people complain that there is an "error" in the logs. 

But not adding these to the list of caps, since it is an internal thing.