### PR TITLE
Add log line if logging fails

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -251,6 +251,23 @@ class WebDriverAgent {
              line.indexOf(SIM_BRIDGE_LOG_PREFIX) !== -1);
     }
 
+    if (this.realDeviceLogger.indexOf('idevicesyslog') !== -1) {
+      // we are using idevicesyslog, which sometimes cannot connect to the device
+      // at which time the system will not be able to figure out that the process
+      // has started
+      logs.on('output', (stdout, stderr) => {
+        let errorString = 'Could not start logger for udid';
+        if (stdout.indexOf(errorString) !== -1 || stderr.indexOf(errorString) !== 0) {
+          // unfortunately we have no way to stopping the process, so just log overtly
+          let msg = `The real device logger '${this.realDeviceLogger}' was ` +
+                    `unable to start log capture. Please try installing ` +
+                    `'deviceconsole' ('npm install -g deviceconsole') and ` +
+                    `specify the path to it using the 'realDeviceLogger' capability.`;
+          log.error(msg);
+        }
+      });
+    }
+
     if (!this.iosLogAlreadyShown) {
       logs.on('output', (stdout, stderr) => {
         let out = stdout || stderr;


### PR DESCRIPTION
`idevicesyslog` on some systems does not connect to the device. If that is the case, we will never be able to tell if the system is running, even if it is. Log the error.