### PR TITLE
Add better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ npm install -g ios-deploy
 ```
 
 On some systems the default logger, `idevicesyslog`, does not work. You can install `deviceconsole` and specify its path with the `realDeviceLogger` capability
+(**note:** This path should be the path to the _executable_ installed by the below command. It will be the directory created by the below command, followed by
+`/deviceconsole`).
 
 ```
 npm install -g deviceconsole

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -263,8 +263,10 @@ class XCUITestDriver extends BaseDriver {
     this.jwpProxyActive = false;
     this.proxyReqRes = null;
 
-    if (this.wda && this.wda.jwproxy) {
-      await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
+    if (this.wda) {
+      if (this.wda.jwproxy) {
+        await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
+      }
       await this.wda.quit();
     }
 

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -19,22 +19,20 @@ class IOSDeploy {
   async remove (bundleid) {
     let remove = [`--uninstall_only`, `--id`, this.udid, `--bundle_id`, bundleid];
     try {
-      let {stdout} = await exec(this.cmd, remove, { maxBuffer: 524288});
-      logger.debug(`app uninstall stdout : ${stdout}`);
+      await exec(this.cmd, remove, { maxBuffer: 524288});
     } catch (err) {
       logger.debug(`Error : ${err.message}`);
-      throw new Error(`coulld not remove app ${err.message}`);
+      throw new Error(`Could not remove app ${err.message}`);
     }
   }
 
   async install (app) {
     let install = [`--id`, this.udid, `--uninstall`, `--bundle`, app];
     try {
-      let {stdout} =  await exec(this.cmd, install, { maxBuffer: 524288});
-      logger.debug(`app install stdout : ${stdout}`);
+      await exec(this.cmd, install, { maxBuffer: 524288});
     } catch (err) {
       logger.debug(`Error : ${err.message}`);
-      throw new Error(`could not install app ${err.message}`);
+      throw new Error(`Could not install app ${err.message}`);
     }
   }
 
@@ -42,7 +40,6 @@ class IOSDeploy {
     let isInstalled = [`--exists`, `--id`, this.udid, `--bundle_id`, bundleid];
     try {
       let {stdout} = await exec(this.cmd, isInstalled, { maxBuffer: 524288});
-      logger.debug(`Stdout from app isInstalled check: ${stdout}`);
       return (stdout && (stdout.indexOf("true") > -1));
     } catch (err) {
       logger.debug(`Error checking install status: ${err.message}`);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -224,12 +224,24 @@ class WebDriverAgent {
       // no error thrown, so all is well
       return true;
     }
+
+    if (this.realDeviceLogger.indexOf('deviceconsole') !== -1 && await fs.exists(this.realDeviceLogger)) {
+      // the user might have passed in the directory for `deviceconsole`, in which case we want to
+      // make sure we use the executable
+      let stat = await fs.stat(this.realDeviceLogger);
+      if (stat.isDirectory()) {
+        log.warn(`Real device logger '${this.realDeviceLogger}' is a directory. Appending 'deviceconsole' executable`);
+        this.realDeviceLogger = path.resolve(this.realDeviceLogger, 'deviceconsole');
+      }
+    }
+
     if (!await checkForLogger(this.realDeviceLogger)) {
       // we have no logger
       throw new Error(`Unable to find real device logging program '${this.realDeviceLogger}'`);
     }
+    log.debug(`Using real device logger '${this.realDeviceLogger}'`);
 
-    let logs = new SubProcess(`${this.realDeviceLogger}`, ['-u', this.device.udid]);
+    let logs = new SubProcess(this.realDeviceLogger, ['-u', this.device.udid]);
     this.setupLogging(logs, 'Device');
     return logs;
   }
@@ -386,8 +398,13 @@ class WebDriverAgent {
         }
       });
 
-      await this.iproxy.start(2000);
-      resolve();
+      try {
+        await this.iproxy.start(2000);
+        resolve();
+      } catch (err) {
+        log.error(`Error starting iproxy: '${err.message}'`);
+        reject('Unable to start iproxy. Is it installed?');
+      }
     });
   }
 


### PR DESCRIPTION
* Make sure that the path to `deviceconsole` is the executable, not the directory, or we get cryptic spawn errors (Fixes https://github.com/appium/appium/issues/6895 and #227)
* Throw an error if `iproxy` spawn does not happen (or else we just hang).