### PR TITLE
Only log changed find selector if it is necessary

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -37,9 +37,9 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
 
   if (strategy === 'xpath') {
     selector = selector.replace(/(UIA)([^\[\/]+)/g, (str, g1, g2) => {
+      rewroteSelector = true;
       return `XCUIElementType${g2}`;
     });
-    rewroteSelector = true;
   }
 
   if (rewroteSelector) {


### PR DESCRIPTION
We were logging every xpath search, no matter if we changed anything.