### PR TITLE
Strip 'View' from XCUI selectors

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -26,7 +26,7 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
   function stripViewFromSelector (selector){
     // Don't strip it out if it's one of these 4 element types
     // (see https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m for reference)
-    var keepView = [
+    let keepView = [
       'XCUIElementTypeScrollView',
       'XCUIElementTypeCollectionView',
       'XCUIElementTypeTextView',

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -22,15 +22,33 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
     strategy = 'predicate string';
   }
 
+  // Tests if the word 'View' is appended to selector and if strips it out 
+  function stripViewFromSelector (selector){
+    // Don't strip it out if it's one of these 4 element types
+    // (see https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m for reference)
+    var keepView = [
+      'XCUIElementTypeScrollView',
+      'XCUIElementTypeCollectionView',
+      'XCUIElementTypeTextView',
+      'XCUIElementTypeWebView',
+    ].indexOf(selector) >= 0;
+
+    if (!keepView && selector.indexOf('View') === selector.length - 4){
+      return selector.substr(0, selector.length - 4);
+    } else {
+      return selector;
+    }
+  }
+
   if (strategy === 'class name') {
-    // XCUITest classes have `XCUIElementType` appended
+    // XCUITest classes have `XCUIElementType` prepended
     // first check if there is the old `UIA` prefix
     if (selector.indexOf('UIA') === 0) {
       selector = selector.substring(3);
     }
     // now check if we need to add `XCUIElementType`
     if (selector.indexOf('XCUIElementType') !== 0) {
-      selector = `XCUIElementType${selector}`;
+      selector = stripViewFromSelector(`XCUIElementType${selector}`);
       rewroteSelector = true;
     }
   }
@@ -38,7 +56,7 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
   if (strategy === 'xpath') {
     selector = selector.replace(/(UIA)([^\[\/]+)/g, (str, g1, g2) => {
       rewroteSelector = true;
-      return `XCUIElementType${g2}`;
+      return stripViewFromSelector(`XCUIElementType${g2}`);
     });
   }
 

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -28,6 +28,11 @@ describe('general commands', () => {
 
     it('should convert class names from UIA to XCUI', async () => {
       await verifyFind('class name', 'UIAButton', 'XCUIElementTypeButton');
+      await verifyFind('class name', 'UIAMapView', 'XCUIElementTypeMap');
+      await verifyFind('class name', 'UIAScrollView', 'XCUIElementTypeScrollView');
+      await verifyFind('class name', 'UIACollectionView', 'XCUIElementTypeCollectionView');
+      await verifyFind('class name', 'UIATextView', 'XCUIElementTypeTextView');
+      await verifyFind('class name', 'UIAWebView', 'XCUIElementTypeWebView');
     });
 
     it('should convert xpaths from UIA to XCUI', async () => {
@@ -44,6 +49,9 @@ describe('general commands', () => {
       await verifyFind('xpath',
                        '//UIAButton/Weird',
                        '//XCUIElementTypeButton/Weird');
+      await verifyFind('xpath',
+                        '//UIAMapView/UIAScrollView',
+                        '//XCUIElementTypeMap/XCUIElementTypeScrollView');
     });
   });
 });


### PR DESCRIPTION
UIAutomation selectors sometimes have the word 'View' appended to it and the XCUI equivalents don't. Added a function that strips out the word 'View' unless it is one of the exceptions (ScrollView, CollectionView, TextView, WebView)

(@jlipps @imurchie)