### PR TITLE
Fix ipad simulator dn translation

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -370,7 +370,7 @@ class XCUITestDriver extends BaseDriver {
       if (dn.toLowerCase() === 'iphone simulator') {
         deviceName = 'iPhone 6';
       } else if (dn.toLowerCase() === 'ipad simulator') {
-        deviceName = 'iPad 2';
+        deviceName = 'iPad Retina';
       }
       if (deviceName !== dn) {
         log.debug(`Changing deviceName from '${dn}' to '${deviceName}'`);


### PR DESCRIPTION
`iPad 2` no longer exists. Use `iPad Retina`. 

Fixes https://github.com/appium/appium/issues/7122
