### PR TITLE
Only rename 'UIA' if it's in an XPath's axis

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -54,7 +54,14 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
   }
 
   if (strategy === 'xpath') {
-    selector = selector.replace(/(UIA)([^\[\/]+)/g, (str, g1, g2) => {
+    // Replace UIA if it comes after a forward slash
+    selector = selector.replace(/\/(UIA)([^\[\/]+)/g, (str, g1, g2) => {
+      rewroteSelector = true;
+      return '/' + stripViewFromSelector(`XCUIElementType${g2}`);
+    });
+
+    // Replace UIA if it is at the beginning of the selector string
+    selector = selector.replace(/^(UIA)([^\[\/]+)/, (str, g1, g2) => {
       rewroteSelector = true;
       return stripViewFromSelector(`XCUIElementType${g2}`);
     });

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -54,16 +54,10 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
   }
 
   if (strategy === 'xpath') {
-    // Replace UIA if it comes after a forward slash
-    selector = selector.replace(/\/(UIA)([^\[\/]+)/g, (str, g1, g2) => {
+    // Replace UIA if it comes after a forward slash or is at the beginning of the string
+    selector = selector.replace(/(^|\/)(UIA)([^\[\/]+)/g, (str, g1, g2, g3) => {
       rewroteSelector = true;
-      return '/' + stripViewFromSelector(`XCUIElementType${g2}`);
-    });
-
-    // Replace UIA if it is at the beginning of the selector string
-    selector = selector.replace(/^(UIA)([^\[\/]+)/, (str, g1, g2) => {
-      rewroteSelector = true;
-      return stripViewFromSelector(`XCUIElementType${g2}`);
+      return g1 + stripViewFromSelector(`XCUIElementType${g3}`);
     });
   }
 

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -52,6 +52,12 @@ describe('general commands', () => {
       await verifyFind('xpath',
                         '//UIAMapView/UIAScrollView',
                         '//XCUIElementTypeMap/XCUIElementTypeScrollView');
+      await verifyFind('xpath',
+                        '//UIAMapView/UIAScrollView[@name="UIADummyData"]',
+                        '//XCUIElementTypeMap/XCUIElementTypeScrollView[@name="UIADummyData"]');
+      await verifyFind('xpath',
+                        '//XCUIElementTypeMap[@name="UIADummyData"]',
+                        '//XCUIElementTypeMap[@name="UIADummyData"]');
     });
   });
 });


### PR DESCRIPTION
(see issue https://github.com/appium/appium-xcuitest-driver/issues/270)

To test if 'UIA' is in the axis of an xpath check if it has a forward slash preceding it or if it is at the beginning of the selector string
