### PR TITLE
Add log line when platformVersion has been inferred

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -425,7 +425,8 @@ class XCUITestDriver extends BaseDriver {
     // no device of this type exists, so create one
     log.info('Simluator udid not provided, using desired caps to create a new simulator');
     if (!this.opts.platformVersion) {
-      log.info(`No platformVersion specified. Using latest version '${this.iosSdkVersion}'`);
+      log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
+               `This may cause problems if a simulator does not exist for this platform version.`);
       this.opts.platformVersion = this.iosSdkVersion;
     }
     device = await this.createSim();


### PR DESCRIPTION
We already log that we've made the `platformVersion` to the maximum sdk version. Add a line saying this might be a problem, since the problem that does come up is opaque.

See https://github.com/appium/appium/issues/7126