### PR TITLE
Send correct opts to create sim

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -471,7 +471,7 @@ class XCUITestDriver extends BaseDriver {
     this.lifecycleData.createSim = true;
 
     // create sim for caps
-    let sim = await createSim(this.caps, this.sessionId);
+    let sim = await createSim(this.opts, this.sessionId);
     log.info(`Created simulator with udid '${sim.udid}'.`);
 
     return sim;


### PR DESCRIPTION
`this.opts` has the massaged capabilities, so use it. Otherwise all the prior config work is ignored.

Fixes #77