### PR TITLE
Handle real device startup better

### DIFF
--- a/bin/run-xcodebuild.sh
+++ b/bin/run-xcodebuild.sh
@@ -9,6 +9,7 @@ while [[ "$#" > 1 ]]; do case $1 in
     --scheme) scheme="$2";;
     --destination) destination="$2";;
     --xcode-config-file) xcodeConfigFile="$2";;
+    --xcode-version) xcodeVersion="$2";;
     *) break;;
   esac; shift; shift
 done
@@ -20,7 +21,12 @@ if [[ -n "$keychainPath" && -n "$keychainPassword" ]] ; then
     security set-keychain-settings -t 3600 -l "$keychainPath"
 fi
 
-cmd=("xcodebuild" "build" "test" "-project" "$project" "-scheme" "$scheme" "-destination" "$destination" "-configuration" "Debug")
+if [[ $xcodeVersion -lt 8 ]] ; then
+    cmd=("xcodebuild" "build" "test")
+else
+    cmd=("xcodebuild" "build-for-testing" "test-without-building")
+fi
+cmd=("${cmd[@]}" "-project" "$project" "-scheme" "$scheme" "-destination" "$destination" "-configuration" "Debug")
 
 if [[ -n "$xcodeConfigFile" ]] ; then
     cmd=("${cmd[@]}" "-xcconfig" "$xcodeConfigFile")

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -19,7 +19,7 @@ const AGENT_LOG_PREFIX = 'XCTStubApps[';
 const AGENT_RUNNER_LOG_PREFIX = 'XCTRunner[';
 const SIM_BRIDGE_LOG_PREFIX = 'CoreSimulatorBridge[';
 const AGENT_STARTED_REGEX = /ServerURLHere->(.*)<-ServerURLHere/;
-const LOG_STARTTIME_REGEX = /Built at (\w{3} [\d\s]\d \d{4} \d{2}:\d{2}:\d{2})/;
+const REAL_DEVICE_BUILD_LOG_STARTTIME_REGEX = /Built at (\w{3} [\d\s]\d \d{4} \d{2}:\d{2}:\d{2})/;
 const REAL_DEVICE_LOGGER_PATH = 'idevicesyslog';
 const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 
@@ -131,35 +131,15 @@ class WebDriverAgent {
     }
   }
 
-  async createXcodeBuildSubProcess () {
-    let cmd = 'xcodebuild';
-    let args;
-    if (this.xcodeVersion.major < 8) {
-      args =[
-        'build',
-        'test',
-      ];
-    } else {
-      args = this.usePrebuiltWDA ? [
-        'test-without-building'
-      ] : [
-        'build-for-testing',
-        'test-without-building'
-      ];
-    }
-    args.push(
-      '-project', this.agentPath,
-      '-scheme', 'WebDriverAgentRunner',
-      '-destination', `id=${this.device.udid}`,
-      '-configuration', 'Debug'
-    );
-
+  getXcodeBuildCommand () {
+    let cmd, args;
     if (this.realDevice) {
       cmd = path.resolve(__dirname, '..', '..', 'bin', 'run-xcodebuild.sh');
       args = [
         '--project', this.agentPath,
         '--scheme', 'WebDriverAgentRunner',
         '--destination', `id=${this.device.udid}`,
+        '--xcode-version', this.xcodeVersion.major,
       ];
       if (this.xcodeConfigFile) {
         log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
@@ -169,8 +149,37 @@ class WebDriverAgent {
         args.push('--keychain-path', this.keychainPath);
         args.push('--keychain-password', this.keychainPassword);
       }
-    }
 
+      if (this.usePrebuiltWDA) {
+        log.warn(`'usePrebuiltWDA' set, but on real device, so skipping`);
+      }
+    } else {
+      cmd = 'xcodebuild';
+      if (this.xcodeVersion.major < 8) {
+        args =[
+          'build',
+          'test',
+        ];
+      } else {
+        args = this.usePrebuiltWDA ? [
+          'test-without-building'
+        ] : [
+          'build-for-testing',
+          'test-without-building'
+        ];
+      }
+      args.push(
+        '-project', this.agentPath,
+        '-scheme', 'WebDriverAgentRunner',
+        '-destination', `id=${this.device.udid}`,
+        '-configuration', 'Debug'
+      );
+    }
+    return {cmd, args};
+  }
+
+  async createXcodeBuildSubProcess () {
+    let {cmd, args} = this.getXcodeBuildCommand();
     log.debug(`Beginning test with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
     let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath});
@@ -354,7 +363,7 @@ class WebDriverAgent {
       //     Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: Built at Jul 20 2016 13:03:50
       //     Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: ServerURLHere->http://10.35.4.122:8100<-ServerURLHere
       if (!reachedEnd) {
-        let dateMatch = LOG_STARTTIME_REGEX.exec(stdout);
+        let dateMatch = REAL_DEVICE_BUILD_LOG_STARTTIME_REGEX.exec(stdout);
         if (dateMatch) {
           let buildTime = new Date(dateMatch[1]);
           if (buildTime.isAfter(startTime)) {


### PR DESCRIPTION
Using `test-without-building` alone does not work with real devices, but together with `build-for-testing` is faster than the `build test` solution we were using.