### PR TITLE
Fix double tap implementation

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -23,10 +23,10 @@ commands.click = async function (el) {
 };
 
 commands.performTouch = async function (gestures) {
-  if (isTap(gestures)) {
+  if (isDoubleTap(gestures)) {
+    return await this.handleDoubleTap(gestures);
+  } else if (isTap(gestures)) {
     return await this.handleTap(gestures[0]);
-  } else if (gestures.length === 1 && (gestures[0] || '').action.toLowerCase() === 'doubletap') {
-    return await this.handleDoubleTap(gestures[0]);
   } else if (isLongPress(gestures)) {
     return await this.handleLongPress(gestures);
   } else if (isDrag(gestures)) {
@@ -55,6 +55,17 @@ function isDrag (gestures) {
       gestures[2].action === 'moveTo' &&
       gestures[3].action === 'release'
   );
+}
+
+function isDoubleTap (gestures) {
+  if (gestures.length === 1 && gestures[0].action.toLowerCase() === 'doubletap') {
+    return true;
+  } else if (gestures.length === 1 &&
+             gestures[0].action === 'tap' &&
+             (gestures[0].options || {}).count === 2) {
+    return true;
+  }
+  return false;
 }
 
 function isTap (gestures) {
@@ -158,14 +169,15 @@ helpers.handleTap = async function (gesture) {
   return await this.proxyCommand(endpoint, 'POST', params);
 };
 
-helpers.handleDoubleTap = async function (gesture) {
+helpers.handleDoubleTap = async function (gestures) {
+  let gesture = gestures[0];
   let opts = gesture.options || {};
 
   if (!opts.element) {
     log.errorAndThrow('WDA double tap needs an element');
   }
 
-  let el = opts.element.ELEMENT ? opts.element.ELEMENT : opts.element;
+  let el = util.unwrapElement(opts.element);
   let endpoint = `/uiaElement/${el}/doubleTap`;
 
   return await this.proxyCommand(endpoint, 'POST');

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -102,6 +102,18 @@ describe('XCUITestDriver - gestures', function () {
       let el3 = await driver.elementByAccessibilityId('Text Fields');
       await el3.click().should.not.be.rejected;
     });
+    it('should double tap on an element', async () => {
+      let el = await driver.elementByAccessibilityId('Steppers');
+      await driver.execute('mobile: scroll', {element: el, toVisible: true});
+      await el.click();
+
+      let stepper = await driver.elementByAccessibilityId('Increment');
+      let action = new wd.TouchAction(driver);
+      action.tap({el: stepper, count: 2});
+      await action.perform();
+
+      await driver.elementByAccessibilityId('2').should.not.be.rejected;
+    });
   });
   describe('tap with tapWithShortPressDuration cap', () => {
     // needs a special cap, so has to be in its own session


### PR DESCRIPTION
We had a wonky double tap implementation that needed a new action to be added to the TouchAction API. Add to that the ability to set a "count" to the options on tap.