### PR TITLE
Remove build-without-testing/test-without-building for real devices

### DIFF
--- a/bin/run-xcodebuild.sh
+++ b/bin/run-xcodebuild.sh
@@ -2,6 +2,8 @@
 #
 #https://github.com/appium/appium/issues/6955
 
+set -e
+
 while [[ "$#" > 1 ]]; do case $1 in
     --keychain-path) keychainPath="$2";;
     --keychain-password) keychainPassword="$2";;
@@ -21,11 +23,7 @@ if [[ -n "$keychainPath" && -n "$keychainPassword" ]] ; then
     security set-keychain-settings -t 3600 -l "$keychainPath"
 fi
 
-if [[ $xcodeVersion -lt 8 ]] ; then
-    cmd=("xcodebuild" "build" "test")
-else
-    cmd=("xcodebuild" "build-for-testing" "test-without-building")
-fi
+cmd=("xcodebuild" "build" "test")
 cmd=("${cmd[@]}" "-project" "$project" "-scheme" "$scheme" "-destination" "$destination" "-configuration" "Debug")
 
 if [[ -n "$xcodeConfigFile" ]] ; then

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -204,6 +204,9 @@ class WebDriverAgent {
 
       if (logXcodeOutput) {
         xcodeLog.info(out);
+
+        // terrible hack to handle case where xcode return 0 but is failing
+        xcodebuild._wda_error_occurred = true;
       }
     });
 
@@ -319,7 +322,7 @@ class WebDriverAgent {
     return await new B(async (resolve, reject) => {
       this.xcodebuild.on('exit', (code, signal) => {
         log.info(`xcodebuild exited with code '${code}' and signal '${signal}'`);
-        if (!signal && code !== 0) {
+        if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
           return reject(new Error(`xcodebuild failed with code ${code}`));
         }
       });


### PR DESCRIPTION
Ugh.

So it turns out that on real devices the changes to build targets swallows any error handling. So reverse it. The marginal increase in performance is not worth the opacity.