### PR TITLE
Add pinch/zoom multi-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * `shake` is not implemented due to lack of support from Apple
 * `lock` is not implemented due to lack of support from Apple
 * Setting geo-location not supported due to lack of support from Apple
+* Through multi action API, `zoom` works but `pinch` does not, due to Apple issue.
 
 
 ## External dependencies

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,6 +1,7 @@
 import { errors } from 'appium-base-driver';
 import { util } from 'appium-support';
 import { iosCommands } from 'appium-ios-driver';
+import _ from 'lodash';
 import log from '../logger';
 
 
@@ -23,6 +24,8 @@ commands.click = async function (el) {
 };
 
 commands.performTouch = async function (gestures) {
+  log.debug(`Received the following touch action: ${_.map(gestures, 'action').join('-')}`);
+
   if (isDoubleTap(gestures)) {
     return await this.handleDoubleTap(gestures);
   } else if (isTap(gestures)) {
@@ -34,11 +37,19 @@ commands.performTouch = async function (gestures) {
   } else if (isScroll(gestures)) {
     return await this.handleScroll(gestures);
   }
-  throw new errors.NotYetImplementedError('Support for gestures other than Tap is not yet implemented. Please contact an Appium dev');
+  throw new errors.NotYetImplementedError('Support for this gesture is not yet implemented. Please contact an Appium dev');
 };
 
-commands.performMultiAction = async function (/*actions, elementId*/) {
-  throw new errors.NotYetImplementedError('Support for multi-action API is not yet implemented. Please contact an Appium dev.');
+commands.performMultiAction = async function (actions) {
+  log.debug(`Received the following multi touch action:`);
+  for (let i in actions) {
+    log.debug(`    ${i+1}: ${_.map(actions[i], 'action').join('-')}`);
+  }
+
+  if (isPinchOrZoom(actions)) {
+    return await this.handlePinchOrZoom(actions);
+  }
+  throw new errors.NotYetImplementedError('Support for this multi-action is not yet implemented. Please contact an Appium dev.');
 };
 
 commands.nativeClick = async function (el) {
@@ -97,6 +108,16 @@ function isScroll (gestures) {
         gestures[1].action === 'moveTo' &&
         gestures[2].action === 'release') {
     return true;
+  }
+  return false;
+}
+
+function isPinchOrZoom (actions = []) {
+  // symmetric two-finger action consisting of press-moveto-release
+  if (actions.length === 2) {
+    if (actions[0].length === 3 && actions[1].length === 3) {
+      return _.every(actions, (gestures) => isScroll(gestures));
+    }
   }
   return false;
 }
@@ -215,6 +236,66 @@ helpers.handleLongPress = async function (gestures) {
     endpoint = '/touchAndHold';
   }
   return await this.proxyCommand(endpoint, 'POST', params);
+};
+
+function determinePinchScale (x, y, pinch) {
+  let scale = x > y ? x - y : y - x;
+  if (pinch) {
+    // TODO: revisit this when pinching actually works, since it is impossible to
+    // know what the scale factor does at this point (Xcode 8.1)
+    scale = 1 / scale;
+    if (scale < 0.02) {
+      // this is the minimum that Apple will allow
+      // but WDA will not throw an error if it is too low
+      scale = 0.02;
+    }
+  } else {
+    // for zoom, each 10px is one scale factor
+    scale = scale / 10;
+  }
+  return scale;
+}
+
+helpers.handlePinchOrZoom = async function (actions) {
+  // currently we can only do this action on an element
+  if (!actions[0][0].options.element ||
+      actions[0][0].options.element !== actions[1][0].options.element) {
+    log.errorAndThrow('Pinch/zoom actions must be done on a single element');
+  }
+  let el = actions[0][0].options.element;
+
+  // assume that action is in a single plane (x or y, not horizontal at all)
+  // terminology all assuming right handedness
+  let scale, velocity;
+  if (actions[0][0].options.y === actions[0][1].options.y) {
+    // horizontal, since y offset is the same in press and moveTo
+    let thumb = (actions[0][0].options.x <= actions[1][0].options.x) ? actions[0] : actions[1];
+
+    // now decipher pinch vs. zoom,
+    //   pinch: thumb moving from left to right
+    //   zoom: thumb moving from right to left
+    scale = determinePinchScale(thumb[0].options.x, thumb[1].options.x, thumb[0].options.x <= thumb[1].options.x);
+  } else {
+    // vertical
+    let forefinger = (actions[0][0].options.y <= actions[1][0].options.y) ? actions[0] : actions[1];
+
+    // now decipher pinch vs. zoom
+    //   pinch: forefinger moving from top to bottom
+    //   zoom: forefinger moving from bottom to top
+    scale = determinePinchScale(forefinger[0].options.y, forefinger[1].options.y, forefinger[0].options.y <= forefinger[1].options.y);
+  }
+  velocity = scale < 1 ? -1 : 1;
+
+  log.debug(`Decoded ${scale < 1 ? 'pinch' : 'zoom'} action with scale '${scale}' and velocity '${velocity}'`);
+  if (scale < 1) {
+    log.warn('Pinch actions may not work, due to Apple issue.');
+  }
+
+  let params = {
+    scale,
+    velocity
+  };
+  await this.proxyCommand(`/element/${el}/pinch`, 'POST', params);
 };
 
 helpers.mobileScroll = async function (opts={}) {


### PR DESCRIPTION
This is the first multi-action to be supported.

Zoom works. Pinch does not, for Apple reasons (a bug has been issued).

[Apple's API](https://developer.apple.com/reference/xctest/xcuielement/1618669-pinchwithscale?language=objc): 

```objective-c
- (void)pinchWithScale:(CGFloat)scale 
              velocity:(CGFloat)velocity;
```

The only things we can adjust are scale (0.02 to 1 for pinch, 1 to ? for zoom) and velocity. It is unclear what either mean in real terms.

We map two finger action with `touch`-`moveTo`-`release` signature. Expects `touch` and `moveTo` to be on the same element, and then takes the `x` and `y` offsets and uses them to decided upon a "scale", which for now is (for zoom) 1 scale factor for every 10 x or y offset difference. From experimentation this comes out to a reasonable amount of zooming.

For pinch it remains to be seen what scale does what.

For good measure this also adds some logging about the requests coming in for gestures in general.