### PR TITLE
A workaround for XCTest attachments creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ env:
   - _FORCE_LOGS=1 PLATFORM_VERSION=9.3 TEST=functional/web
 language:
   - objective-c
-osx_image: xcode7.3
+os: osx
+osx_image: xcode8
 git: # Handle git submodules yourself
   submodules: false
 node_js:
-  - 4
+  - "7"
+  - "6"
+  - "4"
 before_install:
   # Use sed to replace the SSH URL with the public URL, then initialize submodules
   # code from http://stackoverflow.com/a/24600210/375688

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# appium-xcuitest-driver
+=# appium-xcuitest-driver
 
 [![NPM version](http://img.shields.io/npm/v/appium-xcuitest-driver.svg)](https://npmjs.org/package/appium-xcuitest-driver)
 [![Downloads](http://img.shields.io/npm/dm/appium-xcuitest-driver.svg)](https://npmjs.org/package/appium-xcuitest-driver)
@@ -17,7 +17,11 @@
 
 ## Known issues
 
-* Unable to interact with elements on iPads in Landscape mode (https://github.com/appium/appium/issues/6994)
+* Unable to interact with elements on devices in Landscape mode (https://github.com/appium/appium/issues/6994)
+* `shake` is not implemented due to lack of support from Apple
+* `lock` is not implemented due to lack of support from Apple
+* Setting geo-location not supported due to lack of support from Apple
+* Through multi action API, `zoom` works but `pinch` does not, due to Apple issue.
 
 
 ## External dependencies
@@ -176,6 +180,7 @@ Differences noted here
 |`keychainPassword`|Password for unlocking keychain specified in `keychainPath`.|e.g., `super awesome password`|
 |`scaleFactor`|Simulator scale factor. This is useful to have if the default resolution of simulated device is greater than the actual display resolution. So you can scale the simulator to see the whole device screen without scrolling. |Acceptable values are: `'1.0', '0.75', '0.5', '0.33' and '0.25'`. The value should be a string.|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|
+|'preventWDAAttachments`|Sets read only permissons to Attachments subfolder of WebDriverAgent root inside Xcode's DerivedData. This is necessary to prevent XCTest framework from creating tons of unnecessary screenshots and logs, which are impossible to shutdown using programming interfaces provided by Apple.|Setting the capability to `true` will set Posix permissions of the folder to `555` and `false` will reset them back to `755`|
 
 
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,6 +1,7 @@
 import { errors } from 'appium-base-driver';
 import { util } from 'appium-support';
 import { iosCommands } from 'appium-ios-driver';
+import _ from 'lodash';
 import log from '../logger';
 
 
@@ -23,6 +24,8 @@ commands.click = async function (el) {
 };
 
 commands.performTouch = async function (gestures) {
+  log.debug(`Received the following touch action: ${_.map(gestures, 'action').join('-')}`);
+
   if (isDoubleTap(gestures)) {
     return await this.handleDoubleTap(gestures);
   } else if (isTap(gestures)) {
@@ -34,11 +37,19 @@ commands.performTouch = async function (gestures) {
   } else if (isScroll(gestures)) {
     return await this.handleScroll(gestures);
   }
-  throw new errors.NotYetImplementedError('Support for gestures other than Tap is not yet implemented. Please contact an Appium dev');
+  throw new errors.NotYetImplementedError('Support for this gesture is not yet implemented. Please contact an Appium dev');
 };
 
-commands.performMultiAction = async function (/*actions, elementId*/) {
-  throw new errors.NotYetImplementedError('Support for multi-action API is not yet implemented. Please contact an Appium dev.');
+commands.performMultiAction = async function (actions) {
+  log.debug(`Received the following multi touch action:`);
+  for (let i in actions) {
+    log.debug(`    ${i+1}: ${_.map(actions[i], 'action').join('-')}`);
+  }
+
+  if (isPinchOrZoom(actions)) {
+    return await this.handlePinchOrZoom(actions);
+  }
+  throw new errors.NotYetImplementedError('Support for this multi-action is not yet implemented. Please contact an Appium dev.');
 };
 
 commands.nativeClick = async function (el) {
@@ -97,6 +108,16 @@ function isScroll (gestures) {
         gestures[1].action === 'moveTo' &&
         gestures[2].action === 'release') {
     return true;
+  }
+  return false;
+}
+
+function isPinchOrZoom (actions = []) {
+  // symmetric two-finger action consisting of press-moveto-release
+  if (actions.length === 2) {
+    if (actions[0].length === 3 && actions[1].length === 3) {
+      return _.every(actions, (gestures) => isScroll(gestures));
+    }
   }
   return false;
 }
@@ -215,6 +236,66 @@ helpers.handleLongPress = async function (gestures) {
     endpoint = '/touchAndHold';
   }
   return await this.proxyCommand(endpoint, 'POST', params);
+};
+
+function determinePinchScale (x, y, pinch) {
+  let scale = x > y ? x - y : y - x;
+  if (pinch) {
+    // TODO: revisit this when pinching actually works, since it is impossible to
+    // know what the scale factor does at this point (Xcode 8.1)
+    scale = 1 / scale;
+    if (scale < 0.02) {
+      // this is the minimum that Apple will allow
+      // but WDA will not throw an error if it is too low
+      scale = 0.02;
+    }
+  } else {
+    // for zoom, each 10px is one scale factor
+    scale = scale / 10;
+  }
+  return scale;
+}
+
+helpers.handlePinchOrZoom = async function (actions) {
+  // currently we can only do this action on an element
+  if (!actions[0][0].options.element ||
+      actions[0][0].options.element !== actions[1][0].options.element) {
+    log.errorAndThrow('Pinch/zoom actions must be done on a single element');
+  }
+  let el = actions[0][0].options.element;
+
+  // assume that action is in a single plane (x or y, not horizontal at all)
+  // terminology all assuming right handedness
+  let scale, velocity;
+  if (actions[0][0].options.y === actions[0][1].options.y) {
+    // horizontal, since y offset is the same in press and moveTo
+    let thumb = (actions[0][0].options.x <= actions[1][0].options.x) ? actions[0] : actions[1];
+
+    // now decipher pinch vs. zoom,
+    //   pinch: thumb moving from left to right
+    //   zoom: thumb moving from right to left
+    scale = determinePinchScale(thumb[0].options.x, thumb[1].options.x, thumb[0].options.x <= thumb[1].options.x);
+  } else {
+    // vertical
+    let forefinger = (actions[0][0].options.y <= actions[1][0].options.y) ? actions[0] : actions[1];
+
+    // now decipher pinch vs. zoom
+    //   pinch: forefinger moving from top to bottom
+    //   zoom: forefinger moving from bottom to top
+    scale = determinePinchScale(forefinger[0].options.y, forefinger[1].options.y, forefinger[0].options.y <= forefinger[1].options.y);
+  }
+  velocity = scale < 1 ? -1 : 1;
+
+  log.debug(`Decoded ${scale < 1 ? 'pinch' : 'zoom'} action with scale '${scale}' and velocity '${velocity}'`);
+  if (scale < 1) {
+    log.warn('Pinch actions may not work, due to Apple issue.');
+  }
+
+  let params = {
+    scale,
+    velocity
+  };
+  await this.proxyCommand(`/element/${el}/pinch`, 'POST', params);
 };
 
 helpers.mobileScroll = async function (opts={}) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -39,6 +39,12 @@ let desiredCapConstraints = _.defaults({
   usePrebuiltWDA: {
     isBoolean: true
   },
+  customSSLCert: {
+    isString: true
+  },
+  preventWDAAttachments: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,12 +6,12 @@ import { extractBundleId } from 'ios-app-utils';
 import WebDriverAgent from './webdriveragent';
 import log from './logger';
 import { simBooted, createSim, getExistingSim, runSimulatorReset } from './simulator-management';
-import { killAllSimulators, simExists, getSimulator } from 'appium-ios-simulator';
+import { killAllSimulators, simExists, getSimulator, installSSLCert, uninstallSSLCert } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
 import commands from './commands/index';
-import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion } from './utils';
+import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, adjustWDAAttachmentsPermissions } from './utils';
 import { getConnectedDevices, runRealDeviceReset } from './real-device-management';
 import IOSDeploy from './ios-deploy';
 import B from 'bluebird';
@@ -47,6 +47,9 @@ const NO_PROXY_NATIVE_LIST = [
   ['POST', /value/],
   ['POST', /keys/],
   ['POST', /back/],
+  ['POST', /session\/[^\/]+\/location/], // geo location, but not element location
+  ['POST', /appium\/device\/lock/],
+  ['POST', /shake/],
 ];
 const NO_PROXY_WEB_LIST = [
   ['GET', /title/],
@@ -167,6 +170,10 @@ class XCUITestDriver extends BaseDriver {
     this.opts.udid = udid;
     this.opts.realDevice = realDevice;
 
+    if (this.isSimulator() && this.opts.customSSLCert) {
+      await installSSLCert(this.opts.customSSLCert, this.opts.udid);
+    }
+
     // at this point if there is no platformVersion, get it from the device
     if (!this.opts.platformVersion) {
       if (this.opts.device && _.isFunction(this.opts.device.getPlatformVersion)) {
@@ -271,6 +278,10 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       await this.startWda(sessionId, realDevice, tries);
     }
+
+    if (typeof this.opts.preventWDAAttachments !== 'undefined') {
+      await this.adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
+    }
   }
 
   // create an alias so we can actually unit test createSession by stubbing
@@ -305,6 +316,10 @@ class XCUITestDriver extends BaseDriver {
       await runRealDeviceReset(this.opts.device, this.opts);
     } else {
       await runSimulatorReset(this.opts.device, this.opts);
+    }
+
+    if (this.isSimulator() && this.opts.udid && this.opts.customSSLCert) {
+      await uninstallSSLCert(this.opts.customSSLCert, this.opts.udid);
     }
 
     if (!this.opts.noReset && !!this.opts.device) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -280,7 +280,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (typeof this.opts.preventWDAAttachments !== 'undefined') {
-      await this.adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
+      await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,11 @@
 import { fs } from 'appium-support';
+import path from 'path';
 import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import log from './logger';
 
+const WDA_DERIVED_DATA_SEARCH_SUFFIX = 'Library/Developer/Xcode/DerivedData/WebDriverAgent-*';
+const WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH = 'Logs/Test/Attachments';
 
 async function detectUdid () {
   log.debug('Auto-detecting real device udid...');
@@ -66,4 +69,25 @@ async function killAppUsingAppName (udid, appName) {
   }
 }
 
-export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, killAppUsingAppName };
+async function adjustWDAAttachmentsPermissions(perms) {
+  if (!process.env.HOME) {
+    throw new Error('Need HOME env var to be set in order to adjust WDA attachments permission');
+  }
+  let derivedDataSearchMask = path.join(process.env['HOME'], WDA_DERIVED_DATA_SEARCH_SUFFIX);
+  let folders = await fs.glob(derivedDataSearchMask);
+  let processedFolders = [];
+  for (let folder of folders) {
+    log.debug(`Found WDA derived data folder: ${folder}`);
+    let attachmentsFolder = path.join(folder, WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
+    if (await fs.exists(attachmentsFolder)) {
+      log.info(`Setting '${perms}' permissions to ${attachmentsFolder} folder`);
+      await fs.chmod(attachmentsFolder, perms);
+      processedFolders.push(attachmentsFolder);
+    }
+  }
+  if (!processedFolders.length) {
+    log.info('No WDA derived data folders have been found.');
+  }
+}
+
+export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, killAppUsingAppName, adjustWDAAttachmentsPermissions };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ async function adjustWDAAttachmentsPermissions(perms) {
   if (!process.env.HOME) {
     throw new Error('Need HOME env var to be set in order to adjust WDA attachments permission');
   }
-  let derivedDataSearchMask = path.join(process.env['HOME'], WDA_DERIVED_DATA_SEARCH_SUFFIX);
+  let derivedDataSearchMask = path.join(process.env.HOME, WDA_DERIVED_DATA_SEARCH_SUFFIX);
   let folders = await fs.glob(derivedDataSearchMask);
   let processedFolders = [];
   for (let folder of folders) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xcuitest",
     "xctest"
   ],
-  "version": "2.0.37",
+  "version": "2.2.0",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {
@@ -30,7 +30,7 @@
     "appium-base-driver": "^2.0.19",
     "appium-ios-driver": "^1.12.21",
     "appium-ios-log": "^1.2.0",
-    "appium-ios-simulator": "^1.7.9",
+    "appium-ios-simulator": "^1.9.0",
     "appium-logger": "^2.0.0",
     "appium-remote-debugger": "^3.1.4",
     "appium-support": "^2.3.2",
@@ -73,6 +73,8 @@
     "glob": "^7.1.0",
     "gulp": "^3.8.11",
     "ios-uicatalog": "^1.0.4",
+    "ios-webview-app": "^1.0.4",
+    "pem": "^1.8.3",
     "pre-commit": "^1.1.3",
     "request-promise": "^2.0.0",
     "sinon": "^1.17.4",

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -134,6 +134,24 @@ describe('XCUITestDriver - basics', function () {
     });
   });
 
+  describe('geo location', () => {
+    it('should throw a not-yet-implemented error', async () => {
+      await driver.setGeoLocation('0', '0', '0').should.be.rejectedWith(/Method has not yet been implemented/);
+    });
+  });
+
+  describe('shake', () => {
+    it('should throw a not-yet-implemented error', async () => {
+      await driver.shake().should.be.rejectedWith(/Method has not yet been implemented/);
+    });
+  });
+
+  describe('lock', () => {
+    it('should throw a not-yet-implemented error', async () => {
+      await driver.lock().should.be.rejectedWith(/Method has not yet been implemented/);
+    });
+  });
+
   describe.skip('contexts', () => {
     before(async () => {
       let el = await driver.elementByAccessibilityId('Web View');

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -310,7 +310,7 @@ describe('XCUITestDriver - find', function () {
     before(async () => {
       // if we don't pause, WDA freaks out sometimes, especially on fast systems
       await B.delay(500);
-    });
+    }); 
     it('should find visible elements', async () => {
       let els = await driver.elements('-ios predicate string', 'isWDVisible=true');
       els.should.have.length.above(0);
@@ -340,5 +340,6 @@ describe('XCUITestDriver - find', function () {
       let els = await driver.elements('-ios predicate string', 'wdRect.x >= 0 AND wdRect.y >= 0');
       els.should.have.length.above(1);
     });
+
   });
 });

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -1,0 +1,64 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import wd from 'wd';
+import _ from 'lodash';
+import B from 'bluebird';
+import { killAllSimulators } from 'appium-ios-simulator';
+import { HOST, PORT } from '../helpers/session';
+import { SAFARI_CAPS } from '../desired';
+import { startServer } from '../../..';
+import https from 'https';
+
+const pem = B.promisifyAll(require('pem'));
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let caps = _.defaults({
+  safariInitialUrl: "https://localhost:9758/"
+}, SAFARI_CAPS);
+
+let pemCertificate;
+
+describe('Safari SSL', function () {
+  this.timeout(4 * 60 * 1000);
+
+  let server, sslServer, driver;
+  before(async () => {
+    await killAllSimulators();
+
+    driver = wd.promiseChainRemote(HOST, PORT);
+    server = await startServer(PORT, HOST);
+
+    // Create a random pem certificate
+    let privateKey = await pem.createPrivateKeyAsync();
+    let keys = await pem.createCertificateAsync({days:1, selfSigned: true, serviceKey: privateKey.key});
+    pemCertificate = keys.certificate;
+
+    // Host an SSL server that uses that certificate
+    sslServer = https.createServer({key: keys.serviceKey, cert: pemCertificate}, function (req, res){ 
+      res.end('Arbitrary text');
+    }).listen(9758);
+  });
+
+  after(async () => {
+    await server.close();
+    await sslServer.close();
+  });
+
+  describe('ssl cert', () => {
+    afterEach(async function () {
+      await driver.quit();
+    });
+
+    it('should open pages with untrusted certs if the cert was provided in desired capabilities', async function () {
+      caps.customSSLCert = pemCertificate;
+      await driver.init(caps);
+      await driver.setPageLoadTimeout(3000);
+      await driver.get('https://localhost:9758/');
+      let source = await driver.source();
+      source.should.include('Arbitrary text');
+      driver.quit();
+    });
+  });
+});


### PR DESCRIPTION
This implementation is based on https://github.com/appium/appium/issues/7242 and the discussion with @imurchie in Slack. We are trying to workaround unnecessary XCTest stuff creation by denying write permissions for Attachments subfolder. This change is supposed to generate many warnings in logs similar to this one, which is considered as "by design" %) :

```
016-11-22 11:22:54:416 - info: [Xcode] 2016-11-22 12:22:54.416 xcodebuild[815:973559] [MT] DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-11246/IDEFoundation/ProjectModel/ActionRecords/IDESchemeActionTestActivitySummary.m:263
Details:  Error writing attachment data to file /Users/elf/Library/Developer/Xcode/DerivedData/WebDriverAgent-brdadhpuduowllgivnnvuygpwhzy/Logs/Test/Attachments/ElementsOfInterest_D416D4AD-9C55-4434-9510-D0C66ED9FB2D: Error Domain=NSCocoaErrorDomain Code=513 "You don’t have permission to save the file “ElementsOfInterest_D416D4AD-9C55-4434-9510-D0C66ED9FB2D” in the folder “Attachments”." UserInfo={NSFilePath=/Users/elf/Library/Developer/Xcode/DerivedData/WebDriverAgent-brdadhpuduowllgivnnvuygpwhzy/Logs/Test/Attachments/ElementsOfInterest_D416D4AD-9C55-4434-9510-D0C66ED9FB2D, NSUserStringVariant=Folder, NSUnderlyingError=0x7ff54c540570 {Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"}}
Object:   <IDESchemeActionTestActivitySummary: 0x7ff54c2cee20>
Method:   -_archiveData:withName:
Thread:   <NSThread: 0x7ff549605f90>{number = 1, name = main}
Please file a bug at http://bugreport.apple.com with this warning message and any useful information you can provide.  
```