### PR TITLE
Add driver capability to prevent XCTest attachments creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Differences noted here
 |`keychainPassword`|Password for unlocking keychain specified in `keychainPath`.|e.g., `super awesome password`|
 |`scaleFactor`|Simulator scale factor. This is useful to have if the default resolution of simulated device is greater than the actual display resolution. So you can scale the simulator to see the whole device screen without scrolling. |Acceptable values are: `'1.0', '0.75', '0.5', '0.33' and '0.25'`. The value should be a string.|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|
+|'preventWDAAttachments`|Sets read only permissons to Attachments subfolder of WebDriverAgent root inside Xcode's DerivedData. This is necessary to prevent XCTest framework from creating tons of unnecessary screenshots and logs, which are impossible to shutdown using programming interfaces provided by Apple.|Setting the capability to `true` will set Posix permissions of the folder to `555` and `false` will reset them back to `755`|
 
 
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -42,6 +42,9 @@ let desiredCapConstraints = _.defaults({
   customSSLCert: {
     isString: true
   },
+  preventWDAAttachments: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -11,7 +11,7 @@ import { retryInterval } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
 import commands from './commands/index';
-import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion } from './utils';
+import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, adjustWDAAttachmentsPermissions } from './utils';
 import { getConnectedDevices, runRealDeviceReset } from './real-device-management';
 import IOSDeploy from './ios-deploy';
 import B from 'bluebird';
@@ -277,6 +277,10 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.quit();
       await this.wda.uninstall();
       await this.startWda(sessionId, realDevice, tries);
+    }
+
+    if (typeof this.opts.preventWDAAttachments !== 'undefined') {
+      await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,11 @@
 import { fs } from 'appium-support';
+import path from 'path';
 import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import log from './logger';
 
+const WDA_DERIVED_DATA_SEARCH_SUFFIX = 'Library/Developer/Xcode/DerivedData/WebDriverAgent-*';
+const WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH = 'Logs/Test/Attachments';
 
 async function detectUdid () {
   log.debug('Auto-detecting real device udid...');
@@ -66,4 +69,25 @@ async function killAppUsingAppName (udid, appName) {
   }
 }
 
-export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, killAppUsingAppName };
+async function adjustWDAAttachmentsPermissions(perms) {
+  if (!process.env.HOME) {
+    throw new Error('Need HOME env var to be set in order to adjust WDA attachments permission');
+  }
+  let derivedDataSearchMask = path.join(process.env.HOME, WDA_DERIVED_DATA_SEARCH_SUFFIX);
+  let folders = await fs.glob(derivedDataSearchMask);
+  let processedFolders = [];
+  for (let folder of folders) {
+    log.debug(`Found WDA derived data folder: ${folder}`);
+    let attachmentsFolder = path.join(folder, WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
+    if (await fs.exists(attachmentsFolder)) {
+      log.info(`Setting '${perms}' permissions to ${attachmentsFolder} folder`);
+      await fs.chmod(attachmentsFolder, perms);
+      processedFolders.push(attachmentsFolder);
+    }
+  }
+  if (!processedFolders.length) {
+    log.info('No WDA derived data folders have been found.');
+  }
+}
+
+export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, killAppUsingAppName, adjustWDAAttachmentsPermissions };


### PR DESCRIPTION
These are the same changes as in https://github.com/appium/appium-xcuitest-driver/pull/308, which has been corrupted by my screwed hands.