### PR TITLE
Fix handling of real device timestamp

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -19,7 +19,6 @@ const AGENT_LOG_PREFIX = 'XCTStubApps[';
 const AGENT_RUNNER_LOG_PREFIX = 'XCTRunner[';
 const SIM_BRIDGE_LOG_PREFIX = 'CoreSimulatorBridge[';
 const AGENT_STARTED_REGEX = /ServerURLHere->(.*)<-ServerURLHere/;
-const REAL_DEVICE_BUILD_LOG_STARTTIME_REGEX = /Built at (\w{3} [\d\s]\d \d{4} \d{2}:\d{2}:\d{2})/;
 const REAL_DEVICE_LOGGER_PATH = 'idevicesyslog';
 const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 
@@ -204,7 +203,8 @@ class WebDriverAgent {
 
       // if we have an error we want to output the logs
       // otherwise the failure is inscrutible
-      if (out.indexOf('Error Domain=') !== -1) {
+      // but do not log permission errors from trying to write to attachments folder
+      if (out.indexOf('Error Domain=') !== -1 && out.indexOf('Error writing attachment data to file') === -1) {
         logXcodeOutput = true;
       }
 
@@ -322,6 +322,21 @@ class WebDriverAgent {
     }
   }
 
+  async getStartTime () {
+    let startTime = new Date();
+    if (this.realDevice) {
+      let {stdout} = await exec('idevicedate', ['-u', this.device.udid]);
+      startTime = new Date(stdout);
+      if (isNaN(startTime.getTime())) {
+        log.debug('Unable to get device time. Using local system time');
+        // there is never any stderr output, just stdout
+        log.debug(`Output from idevicedate: ${stdout}`);
+        startTime = new Date();
+      }
+    }
+    return startTime;
+  }
+
   async startXcodebuild () {
     // wrap the start procedure in a promise so that we can catch, and report,
     // any startup errors that are thrown as events
@@ -342,7 +357,7 @@ class WebDriverAgent {
       });
 
       try {
-        let startTime = new Date();
+        let startTime = await this.getStartTime();
         await this.xcodebuild.start();
         let agentUrl = await this.waitForStart(startTime);
         resolve(agentUrl);
@@ -362,36 +377,32 @@ class WebDriverAgent {
 
     let agentUrl;
     let lineCount = 0;
-    let reachedEnd = !this.realDevice; // simulator does not need to wait, since we are tailing
     let showWaitingMessage = true; // turn off logging once we have hit the end
 
     let startDetector = (stdout) => {
-      // on a real device there may already be system logs that need to be
-      // passed before we get to the real startup logs, otherwise
-      // we expect two lines, one after another
-      //     Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: Built at Jul 20 2016 13:03:50
-      //     Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: ServerURLHere->http://10.35.4.122:8100<-ServerURLHere
-      if (!reachedEnd) {
-        let dateMatch = REAL_DEVICE_BUILD_LOG_STARTTIME_REGEX.exec(stdout);
-        if (dateMatch) {
-          let buildTime = new Date(dateMatch[1]);
-          if (buildTime.isAfter(startTime)) {
-            reachedEnd = true;
+      let match = AGENT_STARTED_REGEX.exec(stdout);
+      if (match) {
+        if (this.realDevice) {
+          // on a real device there may already be system logs that need to be
+          // passed before we get to the real startup logs, otherwise
+          // it will be "done" before booting
+          // Expect a line like:
+          //     Dec  7 10:55:32 iamPhone XCTRunner(WebDriverAgentLib)[386] <Notice>: ServerURLHere->http://localhost:8100<-ServerURLHere
+          // need to get the date and add the year from the start date
+          let dateString = `${stdout.substr(0, 6)} ${startTime.getFullYear()} ${stdout.substr(7, 8)}`;
+          let buildTime = new Date(dateString);
+          if (!buildTime.isAfter(startTime)) {
+            return false;
           }
         }
-      }
 
-      if (reachedEnd) {
-        let match = AGENT_STARTED_REGEX.exec(stdout);
-        if (match) {
-          agentUrl = match[1];
-          log.info(`Detected that WebDriverAgent is running at url '${agentUrl}'`);
-          if (!agentUrl) {
-            log.errorAndThrow(new Error('No url detected from WebDriverAgent'));
-          }
-          showWaitingMessage = false;
-          return true;
+        agentUrl = match[1];
+        if (!agentUrl) {
+          log.errorAndThrow(new Error('No url detected from WebDriverAgent'));
         }
+        log.info(`Detected that WebDriverAgent is running at url '${agentUrl}'`);
+        showWaitingMessage = false;
+        return true;
       }
 
       // periodically log, so it does not look like everything died

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -169,6 +169,8 @@ describe('XCUITestDriver - find', function () {
         await driver.elementByXPath('/XCUIElementTypeButton').should.be.rejectedWith(/NoSuchElement/);
       });
       it('should search an extended path by child', async () => {
+        // pause a moment or the next command gtes stuck getting the xpath :(
+        await B.delay(500);
         let el = await driver.elementByXPath('//XCUIElementTypeNavigationBar/XCUIElementTypeStaticText');
         (await el.getAttribute('name')).should.equal('Buttons');
       });


### PR DESCRIPTION
The way in which we see that WDA is running has changed. Previously it would
print in the device logs two lines, one after another

```
Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: Built at Jul 20 2016 13:03:50
Jul 20 13:03:57 iamPhone XCTRunner[296] <Warning>: ServerURLHere->http://10.35.4.122:8100<-ServerURLHere
```

We would look at the first line to get the date, so that for real devices we did
not get some old lines from the logs (on sims we tail the logs, so it is not an
issue).

This has changed. Now I'm seeing

```
Dec  7 10:55:32 iamPhone XCTRunner(WebDriverAgentLib)[386] <Notice>: Built at Dec  7 2016 09:52:17
Dec  7 10:55:32 iamPhone testmanagerd[382] <Notice>: <private>
Dec  7 10:55:32 iamPhone duetexpertd(QueryPrediction)[167] <Error>: Missing results from Connections.
Dec  7 10:55:32 iamPhone duetexpertd(DuetExpertCenter)[167] <Info>: Total prediction time: 9.763208ms for expert <private>
Dec  7 10:55:32 iamPhone duetexpertd(QueryPrediction)[167] <Error>: Missing results from Connections.
Dec  7 10:55:32 iamPhone duetexpertd(DuetExpertCenter)[167] <Info>: Total prediction time: 3.531333ms for expert <private>
Dec  7 10:55:32 iamPhone XCTRunner(WebDriverAgentLib)[386] <Notice>: ServerURLHere->http://localhost:8100<-ServerURLHere
Dec  7 10:55:32 iamPhone XCTRunner(WebDriverAgentLib)[386] <Notice>: Listening on USB
```

So rather than getting the date from the "Built at" line, get it from the 
beginning of the "ServerURLHere" line, and parse it.

This also moves from getting the local system time to check for start, and
instead gets the device time (using `idevicedate` (part of `libimobiledevice`)). This has been tested by
manually changing the timezone on the device and all works. There _is_ potential
confusion when you change the time to and _earlier_ time, since the entire
checking of timestamps is there to make sure that we get the latest log entries,
and we might have ones that are later than the adjusted time.

Fixes https://github.com/appium/appium/issues/7313

**Also:** Adds a check for the permissions error that comes when trying to write to 
the attachments folder and not having permissions, so that we don't start
showing the Xcode logs from that point on.