### PR TITLE
Allow users to provide their own WebDriverAgent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ Differences noted here
 |`keychainPassword`|Password for unlocking keychain specified in `keychainPath`.|e.g., `super awesome password`|
 |`scaleFactor`|Simulator scale factor. This is useful to have if the default resolution of simulated device is greater than the actual display resolution. So you can scale the simulator to see the whole device screen without scrolling. |Acceptable values are: `'1.0', '0.75', '0.5', '0.33' and '0.25'`. The value should be a string.|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|
-|'preventWDAAttachments`|Sets read only permissons to Attachments subfolder of WebDriverAgent root inside Xcode's DerivedData. This is necessary to prevent XCTest framework from creating tons of unnecessary screenshots and logs, which are impossible to shutdown using programming interfaces provided by Apple.|Setting the capability to `true` will set Posix permissions of the folder to `555` and `false` will reset them back to `755`|
+|`preventWDAAttachments`|Sets read only permissons to Attachments subfolder of WebDriverAgent root inside Xcode's DerivedData. This is necessary to prevent XCTest framework from creating tons of unnecessary screenshots and logs, which are impossible to shutdown using programming interfaces provided by Apple.|Setting the capability to `true` will set Posix permissions of the folder to `555` and `false` will reset them back to `755`|
+|`webDriverAgentUrl`|If provided, Appium will connect to an existing WebDriverAgent instance at this URL instead of starting a new one.|e.g., `http://localhost:8100`|
+
 
 
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -45,6 +45,9 @@ let desiredCapConstraints = _.defaults({
   preventWDAAttachments: {
     isBoolean: true
   },
+  webDriverAgentUrl: {
+    isString: true
+  }
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -45,6 +45,7 @@ class WebDriverAgent {
     this.keychainPassword = args.keychainPassword;
 
     this.usePrebuiltWDA = args.usePrebuiltWDA;
+    this.webDriverAgentUrl = args.webDriverAgentUrl;
   }
 
   setWDAPaths (bootstrapPath, agentPath) {
@@ -64,6 +65,13 @@ class WebDriverAgent {
   }
 
   async launch (sessionId) {
+    if (this.webDriverAgentUrl) {
+      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
+      this.url = url.parse(this.webDriverAgentUrl);
+      this.setupProxy(sessionId);
+      return this.webDriverAgentUrl;
+    }
+
     log.info('Launching WebDriverAgent on the device');
 
     if (!await fs.exists(this.agentPath)) {

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -20,3 +20,14 @@ describe('Constructor', () => {
     (await fs.exists(agent.agentPath)).should.be.true;
   });
 });
+
+describe('launch', () => {
+  it('should use webDriverAgentUrl override', async () => {
+    let override = "http://mockUrl:8100";
+    let args = Object.assign({}, fakeConstructorArgs);
+    args.webDriverAgentUrl = override;
+    let agent = new WebDriverAgent({}, args);
+
+    (await agent.launch("sessionId")).should.be.equal(override);
+  });
+});


### PR DESCRIPTION
I have added some functionality to my own WebDriverAgent fork. Right now I start my WebDriverAgent, then start Appium, which starts its own WebDriverAgent (killing mine in the process), and after the test is done I start mine again for some cleanup.

This pull request allows me to provide a DesiredCapability of `webDriverAgentUrl` which, if present, Appium will use instead of creating its own.