### PR TITLE
Extend alert timeout for travis

### DIFF
--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -11,6 +11,9 @@ chai.use(chaiAsPromised);
 
 describe('XCUITestDriver - alerts', function () {
   this.timeout(200 * 1000);
+  if (process.env.TRAVIS) {
+    this.timeout(400 * 1000);
+  }
 
   let driver;
   before(async () => {

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -169,7 +169,7 @@ describe('XCUITestDriver - find', function () {
         await driver.elementByXPath('/XCUIElementTypeButton').should.be.rejectedWith(/NoSuchElement/);
       });
       it('should search an extended path by child', async () => {
-        // pause a moment or the next command gtes stuck getting the xpath :(
+        // pause a moment or the next command gets stuck getting the xpath :(
         await B.delay(500);
         let el = await driver.elementByXPath('//XCUIElementTypeNavigationBar/XCUIElementTypeStaticText');
         (await el.getAttribute('name')).should.equal('Buttons');


### PR DESCRIPTION
On Travis we sometimes get failures because the first test times out. Extend this a little bit, to make the tests more reliable when the load is high.