### PR TITLE
Add warning about autoAcceptAlerts and autoDismissAlerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Missing functionality
 
 * Setting geo location (https://github.com/appium/appium/issues/6856)
-* Auto accepting alerts (https://github.com/appium/appium/issues/6863)
+* Auto accepting/dismissing alerts (https://github.com/appium/appium/issues/6863)
 * Touch Actions
 
 ## Known issues

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -608,6 +608,12 @@ class XCUITestDriver extends BaseDriver {
       log.errorAndThrow(`If 'keychainPath' is set, 'keychainPassword' must also be set (and vice versa).`);
     }
 
+    if (caps.autoAcceptAlerts || caps.autoDismissAlerts) {
+      log.warn(`The capabilities 'autoAcceptAlerts' and 'autoDismissAlerts' ` +
+               `do not work for XCUITest-based tests. Please adjust your ` +
+               `alert handling accordingly.`);
+    }
+
     // finally, return true since the superclass check passed, as did this
     return true;
   }

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -2,7 +2,12 @@ import sinon from 'sinon';
 import { settings as iosSettings } from 'appium-ios-driver';
 import XCUITestDriver from '../..';
 import xcode from 'appium-xcode';
+import _ from 'lodash';
+import log from '../../lib/logger';
 
+
+const caps = {platformName: "iOS", deviceName: "iPhone 6", app: "/foo.app"};
+const anoop = async () => {};
 
 describe('driver commands', () => {
   let driver = new XCUITestDriver();
@@ -22,38 +27,45 @@ describe('driver commands', () => {
   });
 
   describe('createSession', () => {
-    let d, stubs = [];
+    let d;
+    let sandbox;
 
     beforeEach(() => {
       d = new XCUITestDriver();
-      let anoop = async () => {};
-      stubs.push(sinon.stub(d, "determineDevice", async () => {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(d, "determineDevice", async () => {
         return {device: null, udid: null, realDevice: null};
-      }));
-      stubs.push(sinon.stub(d, "configureApp", anoop));
-      stubs.push(sinon.stub(d, "checkAppPresent", anoop));
-      stubs.push(sinon.stub(d, "startLogCapture", anoop));
-      stubs.push(sinon.stub(d, "startSim", anoop));
-      stubs.push(sinon.stub(d, "startWdaSession", anoop));
-      stubs.push(sinon.stub(d, "startWda", anoop));
-      stubs.push(sinon.stub(d, "extractBundleId", anoop));
-      stubs.push(sinon.stub(d, "installApp", anoop));
-      stubs.push(sinon.stub(iosSettings, "setLocale", anoop));
-      stubs.push(sinon.stub(iosSettings, "setPreferences", anoop));
-      stubs.push(sinon.stub(xcode, "getMaxIOSSDK", async () => {
+      });
+      sandbox.stub(d, "configureApp", anoop);
+      sandbox.stub(d, "checkAppPresent", anoop);
+      sandbox.stub(d, "startLogCapture", anoop);
+      sandbox.stub(d, "startSim", anoop);
+      sandbox.stub(d, "startWdaSession", anoop);
+      sandbox.stub(d, "startWda", anoop);
+      sandbox.stub(d, "extractBundleId", anoop);
+      sandbox.stub(d, "installApp", anoop);
+      sandbox.stub(iosSettings, "setLocale", anoop);
+      sandbox.stub(iosSettings, "setPreferences", anoop);
+      sandbox.stub(xcode, "getMaxIOSSDK", async () => {
         return '10.0';
-      }));
+      });
     });
 
     afterEach(() => {
-      for (let s of stubs) {
-        s.restore();
-      }
+      sandbox.restore();
     });
 
     it('should include server capabilities', async () => {
-      let resCaps = await d.createSession({platformName: "iOS", deviceName: "iPhone 6", app: "/foo.app"});
+      let resCaps = await d.createSession(caps);
       resCaps[1].javascriptEnabled.should.be.true;
+    });
+    it('should warn', async () => {
+      let warnStub = sinon.stub(log, "warn", async () => {});
+      await d.createSession(_.defaults({autoAcceptAlerts: true}, caps));
+      warnStub.calledTwice.should.be.true;
+      _.filter(warnStub.args, (arg) => arg[0].indexOf('autoAcceptAlerts') !== -1)
+        .should.have.length(1);
+      warnStub.restore();
     });
   });
 });


### PR DESCRIPTION
Warn users who use `autoAcceptAlerts` or `autoDismissAlerts` that the capabilities do not work.

Partial "solution" to https://github.com/appium/appium/issues/6864

Also updates test to use sinon.sandbox instead of manually handling stubs.