### PR TITLE
Move to pinging WDA status for readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,6 @@ brew install carthage
 npm install -g ios-deploy
 ```
 
-On some systems the default logger, `idevicesyslog`, does not work. You can install `deviceconsole` and specify its path with the `realDeviceLogger` capability
-(**note:** This path should be the path to the _executable_ installed by the below command. It will be the directory created by the below command, followed by
-`/deviceconsole`).
-
-```
-npm install -g deviceconsole
-```
-
 For real devices we can use [xcpretty](https://github.com/supermarin/xcpretty) to make Xcode output more reasonable. This can be installed by
 
 ```
@@ -135,16 +127,7 @@ targets. This should also auto select `Signing Ceritificate`. The outcome should
 
 ### Known problems
 
-#### Logger not working
-
-If the system stops with log output like
-
-```
-[XCUITest] Waiting for WebDriverAgent to start on device
-[debug] [XCUITest] Log file for xcodebuild test: /Users/user/Library/Developer/Xcode/DerivedData/WebDriverAgent-dmeyhiwwsjtvnpfsgvqwxasavdxs/Logs/Test/23E16C13-3EFF-4980-95BD-8F69A04D91E3/Session-WebDriverAgentRunner-2016-10-07_095258-KgtUwt.log
-```
-
-The culprit is usually the real device logger. By default the system uses `idevicesyslog`, which is installed with `libimobiledevice`, but on some machines this does not work. You can test by running `idevicesyslog` in a terminal window. If it fails, you can use `deviceconsole`, specifying the full path to the program with the `realDeviceLogger` capability.
+After many failures on real devices, there can be a state where the device will no longer accept connections. To possibly remedy this, set the `useNewWDA` capability to `true`.
 
 #### Weird state
 
@@ -188,7 +171,6 @@ Differences noted here
 |`processArguments`|Process arguments and environment which will be sent to the WebDriverAgent server.|`{ args: ["a", "b", "c"] , env: { "a": "b", "c": "d" } }` or `'{"args": ["a", "b", "c"], "env": { "a": "b", "c": "d" }}'`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
-|`realDeviceLogger`|Device logger for real devices. It could be path to `deviceconsole` (installed with `npm install deviceconsole`, a compiled binary named `deviceconsole` will be added to `./node_modules/deviceconsole/`) or `idevicesyslog` (comes with libimobiledevice). Defaults to `idevicesyslog`|`idevicesyslog`, `/abs/path/to/deviceconsole`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`xcodeOrgId`|Apple developer team identifier string. Must be used in conjunction with `xcodeSigningId` to take effect.|e.g., `JWL241K123`|
 |`xcodeSigningId`|String representing a signing certificate. Must be used in conjunction with `xcodeOrgId`. This is usually just `iPhone Developer`, so the default (if not included) is `iPhone Developer`|e.g., `iPhone Developer`|
@@ -199,7 +181,8 @@ Differences noted here
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|
 |`preventWDAAttachments`|Sets read only permissons to Attachments subfolder of WebDriverAgent root inside Xcode's DerivedData. This is necessary to prevent XCTest framework from creating tons of unnecessary screenshots and logs, which are impossible to shutdown using programming interfaces provided by Apple.|Setting the capability to `true` will set Posix permissions of the folder to `555` and `false` will reset them back to `755`|
 |`webDriverAgentUrl`|If provided, Appium will connect to an existing WebDriverAgent instance at this URL instead of starting a new one.|e.g., `http://localhost:8100`|
-
+|`useNewWDA`|If `true`, forces uninstall of any existing WebDriverAgent app on device. This can provide stability in some situations. Defaults to `false`.|e.g., `true`|
+|`wdaLaunchTimeout`|Time, in ms, to wait for WebDriverAgewnt to be pingable. Defaults to 60000ms.|e.g., `30000`|
 
 
 
@@ -226,6 +209,18 @@ npm run watch
 ```
 npm test
 ```
+
+There are also a number of environment variables that can be used when running
+the tests locally. These include:
+
+* `REAL_DEVICE` - set to anything truthy, makes the tests use real device capabilities
+* `_FORCE_LOGS` - set to `1` to get the log output, not just spec
+* `PLATFORM_VERSION` - change the version to run the tests against (defaults to `9.3`)
+* `XCCONFIG_FILE` - specify where the xcode config file is for a real device run (if
+  blank, and running a real device test, it will search for the first file in
+  the root directory of the repo with the extension "xcconfig")
+* `UICATALOG_REAL_DEVICE` - path to the real device build of UICatalog, in case
+  the npm installed one is not built for real device
 
 
 ### WebDriverAgent Updating

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -6,9 +6,6 @@ let desiredCapConstraints = _.defaults({
   showXcodeLog: {
     isBoolean: true
   },
-  realDeviceLogger: {
-    isString: true
-  },
   wdaLocalPort: {
     isNumber: true
   },
@@ -53,7 +50,13 @@ let desiredCapConstraints = _.defaults({
   },
   webDriverAgentUrl: {
     isString: true
-  }
+  },
+  useNewWDA: {
+    isBoolean: true
+  },
+  wdaLaunchTimeout: {
+    isNumber: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -18,6 +18,7 @@ import { version } from '../../package.json'; // eslint-disable-line import/no-u
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
+const WDA_STARTUP_RETRIES = 2;
 
 const NO_PROXY_NATIVE_LIST = [
   ['GET', /^\/session\/[^\/]+$/],
@@ -250,33 +251,44 @@ class XCUITestDriver extends BaseDriver {
     tries++;
     this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
+    if (this.opts.useNewWDA) {
+      log.debug(`Capability 'useNewWDA' set, so uninstalling WDA before proceeding`);
+      await this.wda.uninstall();
+    }
+
+    // local helper for the two places we need to uninstall wda and re-start it
+    let uninstallAndRestart = async () => {
+      log.debug('Quitting and uninstalling WebDriverAgent, then retrying');
+      await this.wda.quit();
+      await this.wda.uninstall();
+      await this.startWda(sessionId, realDevice, tries);
+    };
+
     try {
       await this.wda.launch(sessionId, realDevice);
     } catch (err) {
-      if ((err.message || '').indexOf('xcodebuild failed with code 65') === -1) {
-        throw err;
-      }
-      // Xcode error code 65 means that the WDA app is still being installed
-      // and xcodebuild can't do its business, so it is reasonable to retry
-      log.debug('xcodebuild failure warrants retry. Retrying...');
-      await this.wda.quit();
-      await this.wda.uninstall();
-      await this.wda.launch(sessionId, realDevice);
+      if (tries > WDA_STARTUP_RETRIES) throw err;
+      log.debug(`Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`);
+      await uninstallAndRestart();
     }
 
     this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
     this.jwpProxyActive = true;
 
     try {
-      await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
+      await retryInterval(15, 500, async () => {
+        log.debug('Sending createSession command to WDA');
+        try {
+          await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
+        } catch (err) {
+          log.debug('Failed to create session. Retrying...');
+          throw err;
+        }
+      });
     } catch (err) {
       log.debug(`Unable to start WebDriverAgent session: ${err.message}`);
-      if (tries > 2) throw err;
-
-      log.debug('Quitting and uninstalling WebDriverAgent, then retrying');
-      await this.wda.quit();
-      await this.wda.uninstall();
-      await this.startWda(sessionId, realDevice, tries);
+      if (tries > WDA_STARTUP_RETRIES) throw err;
+      await uninstallAndRestart();
     }
 
     if (typeof this.opts.preventWDAAttachments !== 'undefined') {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -8,7 +8,7 @@ class IOSDeploy {
 
   constructor (udid) {
     this.udid = udid;
-    this.cmd = IOSDEPLOY_PATH;// this.cmd is in accordance with iDevice
+    this.cmd = IOSDEPLOY_PATH; // this.cmd is in accordance with iDevice
   }
 
   async checkStatus () {

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -2,26 +2,25 @@ import _ from 'lodash';
 import path from 'path';
 import url from 'url';
 import B from 'bluebird';
+import { retryInterval } from 'asyncbox';
 import { SubProcess, exec } from 'teen_process';
 import { JWProxy } from 'appium-base-driver';
 import { fs } from 'appium-support';
 import log from './logger';
 import { getLogger } from 'appium-logger';
-import { systemLogExists } from './simulator-management.js';
 import { killAppUsingAppName, generateXcodeConfigFile } from './utils.js';
+import request from 'request-promise';
 
-const agentLog = getLogger('WebDriverAgent');
+
 const xcodeLog = getLogger('Xcode');
 const iproxyLog = getLogger('iProxy');
 
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', 'WebDriverAgent');
-const AGENT_LOG_PREFIX = 'XCTStubApps[';
-const AGENT_RUNNER_LOG_PREFIX = 'XCTRunner[';
-const SIM_BRIDGE_LOG_PREFIX = 'CoreSimulatorBridge[';
-const AGENT_STARTED_REGEX = /ServerURLHere->(.*)<-ServerURLHere/;
-const REAL_DEVICE_LOGGER_PATH = 'idevicesyslog';
 const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const DEFAULT_SIGNING_ID = "iPhone Developer";
+const WDA_LAUNCH_TIMEOUT = 60 * 1000;
+const IPROXY_TIMEOUT = 5000;
+const WDA_BASE_URL = 'http://localhost:8100';
 
 class WebDriverAgent {
 
@@ -36,9 +35,7 @@ class WebDriverAgent {
 
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
-    this.realDeviceLogger = args.realDeviceLogger || REAL_DEVICE_LOGGER_PATH;
     this.wdaLocalPort = args.wdaLocalPort;
-    this.iosLogAlreadyShown = args.showIOSLog;
     this.showXcodeLog = !!args.showXcodeLog;
     this.xcodeConfigFile = args.xcodeConfigFile;
     this.xcodeOrgId = args.xcodeOrgId;
@@ -48,6 +45,10 @@ class WebDriverAgent {
 
     this.usePrebuiltWDA = args.usePrebuiltWDA;
     this.webDriverAgentUrl = args.webDriverAgentUrl;
+
+    this.expectIProxyErrors = true;
+
+    this.wdaLaunchTimeout = args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT;
   }
 
   setWDAPaths (bootstrapPath, agentPath) {
@@ -87,21 +88,9 @@ class WebDriverAgent {
     //kill all hanging processes
     await this.killHangingProcesses();
 
-    // start the logging process
-    if (this.realDevice) {
-      this.deviceLogs = await this.createRealDeviceLogsSubProcess();
-    } else {
-      this.deviceLogs = await this.createSimLogsSubProcess();
-    }
-
     this.xcodebuild = await this.createXcodeBuildSubProcess();
 
-    // start the xcodebuild process
-    let agentUrl = await this.startXcodebuild();
-
-    this.url = url.parse(agentUrl);
-
-    this.url.hostname = 'localhost';
+    this.url = url.parse(WDA_BASE_URL);
     if (this.realDevice) {
       let localport = this.wdaLocalPort || this.url.port;
       this.iproxy = this.createiProxySubProcess(localport, this.url.port);
@@ -111,7 +100,10 @@ class WebDriverAgent {
 
     this.setupProxy(sessionId);
 
-    return agentUrl;
+    // start the xcodebuild process
+    await this.startXcodebuild();
+
+    return;
   }
 
   setupProxy (sessionId) {
@@ -125,7 +117,7 @@ class WebDriverAgent {
       let carthagePath = await fs.which('carthage');
       log.debug(`Carthage found: ${carthagePath}`);
     } catch (err) {
-      log.info('Carthage not found. Install using `brew install carthage`');
+      log.warn('Carthage not found. Install using `brew install carthage`');
     }
     if (!await fs.hasAccess(`${this.bootstrapPath}/Carthage`)) {
       log.debug('Running WebDriverAgent bootstrap script to install dependencies');
@@ -220,13 +212,13 @@ class WebDriverAgent {
       // but do not log permission errors from trying to write to attachments folder
       if (out.indexOf('Error Domain=') !== -1 && out.indexOf('Error writing attachment data to file') === -1) {
         logXcodeOutput = true;
+
+        // terrible hack to handle case where xcode return 0 but is failing
+        xcodebuild._wda_error_occurred = true;
       }
 
       if (logXcodeOutput) {
         xcodeLog.info(out);
-
-        // terrible hack to handle case where xcode return 0 but is failing
-        xcodebuild._wda_error_occurred = true;
       }
     });
 
@@ -250,201 +242,79 @@ class WebDriverAgent {
     return new SubProcess(`iproxy`, [localport, deviceport, this.device.udid]);
   }
 
-  async createRealDeviceLogsSubProcess () {
-    async function checkForLogger (logger) {
-      // the logger can be the name of a program on the PATH
-      // or a path to the program
-      try {
-        await fs.which(logger);
-      } catch (err) {
-        // not on the PATH, so see if it is an accessible path itself
-        return await fs.exists(logger);
-      }
-
-      // no error thrown, so all is well
-      return true;
-    }
-
-    if (this.realDeviceLogger.indexOf('deviceconsole') !== -1 && await fs.exists(this.realDeviceLogger)) {
-      // the user might have passed in the directory for `deviceconsole`, in which case we want to
-      // make sure we use the executable
-      let stat = await fs.stat(this.realDeviceLogger);
-      if (stat.isDirectory()) {
-        log.warn(`Real device logger '${this.realDeviceLogger}' is a directory. Appending 'deviceconsole' executable`);
-        this.realDeviceLogger = path.resolve(this.realDeviceLogger, 'deviceconsole');
-      }
-    }
-
-    if (!await checkForLogger(this.realDeviceLogger)) {
-      // we have no logger
-      throw new Error(`Unable to find real device logging program '${this.realDeviceLogger}'`);
-    }
-    log.debug(`Using real device logger '${this.realDeviceLogger}'`);
-
-    let logs = new SubProcess(this.realDeviceLogger, ['-u', this.device.udid]);
-    this.setupLogging(logs, 'Device');
-    return logs;
-  }
-
-  setupLogging (logs, prefix) {
-    let loggingStarted = !this.realDevice;
-    let startTime = new Date();
-    function shouldStartLogging (row) {
-      let logRowParts = row.split(/\s+/);
-      let logRowDate = new Date(`${startTime.getFullYear()} ${logRowParts[0]} ${logRowParts[1]} ${logRowParts[2]}`);
-      loggingStarted = logRowDate.isAfter(startTime);
-      return loggingStarted;
-    }
-
-    function isPertinentLogLine (line) {
-      return line.length &&
-            (line.indexOf(AGENT_LOG_PREFIX) !== -1 ||
-             line.indexOf(AGENT_RUNNER_LOG_PREFIX) !== -1 ||
-             line.indexOf(SIM_BRIDGE_LOG_PREFIX) !== -1);
-    }
-
-    if (this.realDevice && this.realDeviceLogger.indexOf('idevicesyslog') !== -1) {
-      // we are using idevicesyslog, which sometimes cannot connect to the device
-      // at which time the system will not be able to figure out that the process
-      // has started
-      logs.on('output', (stdout, stderr) => {
-        let errorString = 'Could not start logger for udid';
-        if (stdout.indexOf(errorString) !== -1 || stderr.indexOf(errorString) !== -1) {
-          // unfortunately we have no way to stopping the process, so just log overtly
-          let msg = `The real device logger '${this.realDeviceLogger}' was ` +
-                    `unable to start log capture. Please try installing ` +
-                    `'deviceconsole' ('npm install -g deviceconsole') and ` +
-                    `specify the path to it using the 'realDeviceLogger' capability.`;
-          log.error(msg);
-        }
-      });
-    }
-
-    if (!this.iosLogAlreadyShown) {
-      logs.on('output', (stdout, stderr) => {
-        let out = stdout || stderr;
-        // make sure we are not reading logs from before this test run
-        if (!loggingStarted && !shouldStartLogging(out)) {
-          return;
-        }
-        if (isPertinentLogLine(out)) {
-          for (let line of out.split("\n").filter(Boolean)) {
-            agentLog.debug(`${prefix}: ${line}`);
-          }
-        }
-      });
-    }
-  }
-
-  async getStartTime () {
-    let startTime = new Date();
-    if (this.realDevice) {
-      let {stdout} = await exec('idevicedate', ['-u', this.device.udid]);
-      startTime = new Date(stdout);
-      if (isNaN(startTime.getTime())) {
-        log.debug('Unable to get device time. Using local system time');
-        // there is never any stderr output, just stdout
-        log.debug(`Output from idevicedate: ${stdout}`);
-        startTime = new Date();
-      }
-    }
-    return startTime;
-  }
-
   async startXcodebuild () {
     // wrap the start procedure in a promise so that we can catch, and report,
     // any startup errors that are thrown as events
-    return await new B(async (resolve, reject) => {
+    return await new B((resolve, reject) => {
       this.xcodebuild.on('exit', (code, signal) => {
         log.info(`xcodebuild exited with code '${code}' and signal '${signal}'`);
+        this.xcodebuild.processExited = true;
         if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
           return reject(new Error(`xcodebuild failed with code ${code}`));
         }
       });
 
-      this.deviceLogs.on('exit', (code) => {
-        let msg = `${this.realDevice ? 'System' : 'Simulator'} log exited with code '${code}'`;
-        log.info(msg);
-        if (code) {
-          return reject(msg);
+      return (async () => {
+        try {
+          let startTime = process.hrtime();
+          await this.xcodebuild.start();
+          await this.waitForStart(startTime);
+          resolve();
+        } catch (err) {
+          let msg = `Unable to start WebDriverAgent: ${err}`;
+          log.error(msg);
+          reject(new Error(msg));
         }
-      });
-
-      try {
-        let startTime = await this.getStartTime();
-        await this.xcodebuild.start();
-        let agentUrl = await this.waitForStart(startTime);
-        resolve(agentUrl);
-      } catch (err) {
-        let msg = `Unable to start WebDriverAgent: ${err}`;
-        log.error(msg);
-        return reject(msg);
-      }
+      })();
     });
   }
 
   async waitForStart (startTime) {
-    // we have to wait for the sim to start before we can tail the log file
-    if (!this.realDevice) {
-      await systemLogExists(this.device);
+    // try to connect once every 0.5 seconds, until `wdaLaunchTimeout` is up
+    log.debug(`Waiting up to ${this.wdaLaunchTimeout}ms for WebDriverAgent to start`);
+    try {
+      let retries = parseInt(this.wdaLaunchTimeout / 500, 10);
+      await retryInterval(retries, 500, async () => {
+        if (this.xcodebuild.processExited) {
+          // there has been an error elsewhere and we need to short-circuit
+          return;
+        }
+        try {
+          let res = await request(`${this.url.href}status`);
+          res = JSON.parse(res);
+          if (res.status !== 0) {
+            throw new Error(`Received non-zero status code from WDA server: '${res.status}'`);
+          }
+        } catch (err) {
+          throw new Error(`Unable to connect to running WebDriverAgent: ${err.message}`);
+        }
+      });
+      let endTime = process.hrtime(startTime);
+      // must get [s, ns] array into ms
+      let startupTime = parseInt((endTime[0] * 1e9 + endTime[1]) / 1e6, 10);
+      log.debug(`WebDriverAgent successfully started after ${startupTime}ms`);
+    } catch (err) {
+      // at this point, if we have not had any errors from xcode itself (reported
+      // elsewhere), we can let this go through and try to create the session
+      log.debug(err.message);
+      log.warn(`Getting status of WebDriverAgent on device timed out. Continuing`);
     }
 
-    let agentUrl;
-    let lineCount = 0;
-    let showWaitingMessage = true; // turn off logging once we have hit the end
-
-    let startDetector = (stdout) => {
-      let match = AGENT_STARTED_REGEX.exec(stdout);
-      if (match) {
-        if (this.realDevice) {
-          // on a real device there may already be system logs that need to be
-          // passed before we get to the real startup logs, otherwise
-          // it will be "done" before booting
-          // Expect a line like:
-          //     Dec  7 10:55:32 iamPhone XCTRunner(WebDriverAgentLib)[386] <Notice>: ServerURLHere->http://localhost:8100<-ServerURLHere
-          // need to get the date and add the year from the start date
-          let dateString = `${stdout.substr(0, 6)} ${startTime.getFullYear()} ${stdout.substr(7, 8)}`;
-          let buildTime = new Date(dateString);
-          if (!buildTime.isAfter(startTime)) {
-            return false;
-          }
-        }
-
-        agentUrl = match[1];
-        if (!agentUrl) {
-          log.errorAndThrow(new Error('No url detected from WebDriverAgent'));
-        }
-        log.info(`Detected that WebDriverAgent is running at url '${agentUrl}'`);
-        showWaitingMessage = false;
-        return true;
-      }
-
-      // periodically log, so it does not look like everything died
-      lineCount++;
-      let threshold = this.realDevice ? 5000 : 200;
-      if (showWaitingMessage && lineCount % threshold === 0) {
-        log.debug('Waiting for WebDriverAgent server to finish loading...');
-      }
-
-      return false;
-    };
-
-    log.info('Waiting for WebDriverAgent to start on device');
-    await this.deviceLogs.start(startDetector);
-    log.info(`WebDriverAgent started at url '${agentUrl}'`);
-
-    return agentUrl;
+    this.expectIProxyErrors = false;
   }
 
   async startiproxy () {
-    return await new B(async (resolve, reject) => {
+    return await new B((resolve, reject) => {
       this.iproxy.on('exit', (code) => {
-        log.warn(`iproxy exited with code '${code}'`);
+        log.debug(`iproxy exited with code '${code}'`);
         if (code) {
           return reject(new Error(`iproxy exited with code '${code}'`));
         }
       });
       this.iproxy.on('output', (stdout, stderr) => {
+        // do nothing if we expect errors
+        if (this.expectIProxyErrors) return;
+
         let out = stdout || stderr;
         for (let line of out.split('\n')) {
           if (!line.length) continue;
@@ -452,21 +322,23 @@ class WebDriverAgent {
         }
       });
 
-      try {
-        await this.iproxy.start(5000);
-        resolve();
-      } catch (err) {
-        log.error(`Error starting iproxy: '${err.message}'`);
-        reject('Unable to start iproxy. Is it installed?');
-      }
+      return (async () => {
+        try {
+          await this.iproxy.start(IPROXY_TIMEOUT);
+          resolve();
+        } catch (err) {
+          log.error(`Error starting iproxy: '${err.message}'`);
+          reject(new Error('Unable to start iproxy. Is it installed?'));
+        }
+      })();
     });
   }
 
   async killHangingProcesses () {
     log.debug('Killing hanging processes');
     await killAppUsingAppName(this.device.udid, `xcodebuild`);
-    let procNames = this.realDevice ? [this.realDeviceLogger, 'iproxy']
-                                    : ['tail', 'XCTRunner'];
+    let procNames = this.realDevice ? ['iproxy']
+                                    : ['XCTRunner'];
     for (let proc of procNames) {
       await killAppUsingAppName(this.device.udid, proc);
     }
@@ -500,12 +372,13 @@ class WebDriverAgent {
     }
 
     await killProcess('xcodebuild', this.xcodebuild);
-    await killProcess('Logger', this.deviceLogs);
     await killProcess('iproxy', this.iproxy);
 
     if (this.jwproxy) {
       this.jwproxy.sessionId = null;
     }
+
+    this.expectIProxyErrors = true;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "bluebird": "^3.1.1",
     "lodash": "^4.0.0",
     "node-simctl": "^3.1.0",
+    "request": "^2.79.0",
+    "request-promise": "^4.1.1",
     "source-map-support": "^0.4.0",
     "teen_process": "^1.7.1",
     "xmldom": "^0.1.27",

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -42,6 +42,7 @@ describe('XCUITestDriver - basics', function () {
       // don't really know a priori what the udid should be, so just ensure
       // it's there, and validate the rest
       delete actual.udid;
+      delete expected.udid; // for real device tests
       actual.should.eql(expected);
     });
   });

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -31,7 +31,7 @@ const GENERIC_CAPS = {
 };
 
 let simApp = path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalogApp[1]);
-let realApp = path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalogApp[0]);
+let realApp = process.env.UICATALOG_REAL_DEVICE || path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalogApp[0]);
 
 // on Travis, when load is high, the app often fails to build,
 // and tests fail, so use static one in assets if necessary,

--- a/test/functional/driver/webdriveragent-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-e2e-specs.js
@@ -61,18 +61,6 @@ describe('WebDriverAgent', () => {
         await request(testUrl);
         await agent.quit();
       });
-    });
-
-    describe('with sim not booted', () => {
-      it('should boot sim if not booted', async function () {
-        this.timeout(180 * 1000);
-        let agent = new WebDriverAgent(xcodeVersion, getStartOpts(device));
-
-        await agent.launch('sessionId');
-        await request(testUrl);
-        await agent.quit();
-        await device.shutdown();
-      });
 
       it('should fail if xcodebuild fails', async function () {
         this.timeout(35 * 1000);

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -26,14 +26,18 @@ describe('Safari', function () {
 
   let server, driver;
   before(async () => {
-    await killAllSimulators();
+    if (!process.env.REAL_DEVICE) {
+      await killAllSimulators();
+    }
 
     driver = wd.promiseChainRemote(HOST, PORT);
     server = await startServer(PORT, HOST);
   });
 
   after(async () => {
-    await server.close();
+    if (server) {
+      await server.close();
+    }
   });
 
   describe('init', () => {

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -25,7 +25,9 @@ describe('Safari SSL', function () {
 
   let server, sslServer, driver;
   before(async () => {
-    await killAllSimulators();
+    if (!process.env.REAL_DEVICE) {
+      await killAllSimulators();
+    }
 
     driver = wd.promiseChainRemote(HOST, PORT);
     server = await startServer(PORT, HOST);
@@ -43,8 +45,12 @@ describe('Safari SSL', function () {
   });
 
   after(async () => {
-    await server.close();
-    await sslServer.close();
+    if (server) {
+      await server.close();
+    }
+    if (sslServer) {
+      await sslServer.close();
+    }
   });
 
   describe('ssl cert', () => {


### PR DESCRIPTION
We currently use the technique of looking at the ios logs (sim or device) and waiting for [the marker that WDA writes on startup](https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Routing/FBWebServer.m#L109). This means we need to open and manage the logs, make sure we are looking at the right entries, etc. It is all fraught, as the issue tracker can attest.

This PR strips out all log handling, and instead pings the WDA server until it gets a valid status back, or times out. This is possible since (A) on simulators the WDA server is always on localhost, and (B) on real devices we use `iproxy`, which maps the request over USB, so we also end up talking to localhost. In neither case do we need to _actual_ server url, which is the only information that is available in the logs but not the status.

Tests are faster, and locally work without issue.

Two new caps are introduced:
* `useNewWDA` - forces uninstall of WDA before launch. This clears up some problems with hanging processes and "too many instances running" errors.
* `wdaLaunchTimeout` - ms to wait trying to connect.

@mykola-mokhnach Can you try this out for your setup?