### PR TITLE
Update xcodebuild targets for real devices

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -22,7 +22,7 @@ class IOSDeploy {
       await exec(this.cmd, remove, { maxBuffer: 524288});
     } catch (err) {
       logger.debug(`Error : ${err.message}`);
-      throw new Error(`Could not remove app ${err.message}`);
+      throw new Error(`Could not remove app: '${err.message}'`);
     }
   }
 
@@ -35,8 +35,8 @@ class IOSDeploy {
     try {
       await exec(this.cmd, install, { maxBuffer: 524288});
     } catch (err) {
-      logger.debug(`Error : ${err.message}`);
-      throw new Error(`Could not install app ${err.message}`);
+      logger.debug(`Error : ${err}`);
+      throw new Error(`Could not install app: '${err.message}'`);
     }
   }
 
@@ -46,7 +46,7 @@ class IOSDeploy {
       let {stdout} = await exec(this.cmd, isInstalled, { maxBuffer: 524288});
       return (stdout && (stdout.indexOf("true") > -1));
     } catch (err) {
-      logger.debug(`Error checking install status: ${err.message}`);
+      logger.debug(`Error checking install status: '${err.message}'`);
       return false;
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,9 @@ import { fs, tempDir } from 'appium-support';
 import path from 'path';
 import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
+import _ from 'lodash';
 import log from './logger';
+
 
 const WDA_DERIVED_DATA_SEARCH_SUFFIX = 'Library/Developer/Xcode/DerivedData/WebDriverAgent-*';
 const WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH = 'Logs/Test/Attachments';
@@ -21,7 +23,12 @@ async function detectUdid () {
   let udid;
   try {
     let {stdout} = await exec(cmd, args, {timeout: 3000});
-    udid = stdout.split('\n')[0];
+    let udids = _.filter(stdout.split('\n'), Boolean);
+    udid = _.last(udids);
+    if (udids.length > 1) {
+      log.warn(`Multiple devices found: ${udids.join(', ')}`);
+      log.warn(`Choosing '${udid}'. If this is wrong, manually set with 'udid' desired capability`);
+    }
   } catch (err) {
     log.errorAndThrow(`Error detecting udid: ${err.message}`);
   }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -137,40 +137,41 @@ class WebDriverAgent {
     let cmd = 'xcodebuild';
     let args;
 
-    const GENERIC_ARGS = [
+    // figure out the targets for xcodebuild
+    if (this.xcodeVersion.major < 8) {
+      if (this.usePrebuiltWDA) {
+        let msg = `'usePrebuiltWDA' set, but on Xcode ` +
+                  `'${this.xcodeVersion.versionString}', so skipping, as it ` +
+                  `needs a version >= 8`;
+        log.warn(msg);
+      }
+      args =[
+        'build',
+        'test',
+      ];
+    } else {
+      args = this.usePrebuiltWDA ? [
+        'test-without-building'
+      ] : [
+        'build-for-testing',
+        'test-without-building'
+      ];
+    }
+
+    // add the rest of the arguments for the xcodebuild command
+    let genericArgs = [
       '-project', this.agentPath,
       '-scheme', 'WebDriverAgentRunner',
       '-destination', `id=${this.device.udid}`,
       '-configuration', 'Debug'
     ];
+    args.push(...genericArgs);
 
-    if (this.realDevice) {
-      args = ['build', 'test'];
-      args.push(...GENERIC_ARGS);
-      if (this.xcodeConfigFile) {
-        log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
-        args.push('-xcconfig', this.xcodeConfigFile);
-      }
-
-      if (this.usePrebuiltWDA) {
-        log.warn(`'usePrebuiltWDA' set, but on real device, so skipping`);
-      }
-    } else {
-      if (this.xcodeVersion.major < 8) {
-        args =[
-          'build',
-          'test',
-        ];
-      } else {
-        args = this.usePrebuiltWDA ? [
-          'test-without-building'
-        ] : [
-          'build-for-testing',
-          'test-without-building'
-        ];
-      }
-      args.push(...GENERIC_ARGS);
+    if (this.realDevice && this.xcodeConfigFile) {
+      log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
+      args.push('-xcconfig', this.xcodeConfigFile);
     }
+
     return {cmd, args};
   }
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "glob": "^7.1.0",
     "gulp": "^3.8.11",
     "ios-uicatalog": "^1.0.4",
-    "ios-webview-app": "^1.0.4",
     "pem": "^1.8.3",
     "pre-commit": "^1.1.3",
     "request-promise": "^2.0.0",

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -177,6 +177,9 @@ describe('XCUITestDriver - basics', function () {
       let el = await driver.elementByAccessibilityId('Web View');
       await driver.execute('mobile: scroll', {element: el, toVisible: true});
       await el.click();
+
+      // pause a moment to allow the view to load before trying to do anything
+      await B.delay(1000);
     });
     after(async () => {
       await driver.back();


### PR DESCRIPTION
Previously there were some issues with using `test-without-building` on real devices. This has been fixed with recent changes to how we check for the server running.