### PR TITLE
overriding waitForAtom for xcuitest driver so that we don't wait for alert

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -66,4 +66,15 @@ extensions.checkForAlert = async function () {
   return false;
 };
 
+extensions.waitForAtom = async function (promise) {
+  //TODO: Add check for alert and accept/dismiss it as per autoAcceptAlert capability
+  let res = null;
+  try {
+    res = await promise;
+  } catch (err) {
+    throw new Error(`Error while executing atom: ${err.message}`);
+  }
+  return this.parseExecuteResponse(res);
+};
+
 export default extensions;


### PR DESCRIPTION
There is bug with new architecture where we wait for alert for at least 500 ms even if there is no alert. So if you check code here  (https://github.com/appium/appium-ios-driver/blob/master/lib/commands/web.js#L334-L346) , `this.remote.executeAtom` get called and then we immediately call `for loop`, at this point `done` is still `false`  as executing atom takes at least 10 ms. So we end up waiting for alert for at least `500 ms`, this increases over all test time significantly. For `xcuitest` , we anyways don't do anything for alert. So i though its better to `override` and remove `checkForAlert`.
Later on we should solve this problem by actually putting `for loop` in different `promise` or some other trick of `promise`