### PR TITLE
Use forever request for polling server at startup

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -276,7 +276,7 @@ class XCUITestDriver extends BaseDriver {
     this.jwpProxyActive = true;
 
     try {
-      await retryInterval(15, 500, async () => {
+      await retryInterval(15, 1000, async () => {
         log.debug('Sending createSession command to WDA');
         try {
           await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
@@ -294,6 +294,10 @@ class XCUITestDriver extends BaseDriver {
     if (typeof this.opts.preventWDAAttachments !== 'undefined') {
       await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
     }
+
+    // we expect certain socket errors until this point, but now
+    // mark things as fully working
+    this.wda.fullyStarted = true;
   }
 
   // create an alias so we can actually unit test createSession by stubbing

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -273,8 +273,14 @@ class WebDriverAgent {
           return;
         }
         try {
-          let res = await request(`${this.url.href}status`);
-          res = JSON.parse(res);
+          let opts = {
+            method: 'GET',
+            uri: `${this.url.href}status`,
+            headers: 'Content-Type: application/json;charset=UTF-8, accept: application/json',
+            forever: true,
+            json: true,
+          };
+          let res = await request(opts);
           if (res.status !== 0) {
             throw new Error(`Received non-zero status code from WDA server: '${res.status}'`);
           }
@@ -296,8 +302,6 @@ class WebDriverAgent {
       log.debug(err.message);
       log.warn(`Getting status of WebDriverAgent on device timed out. Continuing`);
     }
-
-    this.expectIProxyErrors = false;
   }
 
   async startiproxy () {
@@ -398,6 +402,14 @@ class WebDriverAgent {
 
   set url (_url) {
     this._url = url.parse(_url);
+  }
+
+  get fullyStarted () {
+    return this.expectIProxyErrors;
+  }
+
+  set fullyStarted (started = false) {
+    this.expectIProxyErrors = started;
   }
 }
 


### PR DESCRIPTION
The polling code, on real devices, often times out with socket hangups, even if the device is ready and the status can be retrieved using `curl`. Adding the `forever` flag fixes this, making startup much faster.