### PR TITLE
Move reset logic out of stop into deleteSession

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -312,20 +312,6 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await this.stop();
 
-    await super.deleteSession();
-  }
-
-  async stop () {
-    this.jwpProxyActive = false;
-    this.proxyReqRes = null;
-
-    if (this.wda) {
-      if (this.wda.jwproxy) {
-        await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
-      }
-      await this.wda.quit();
-    }
-
     // reset the permissions on the derived data folder, if necessary
     if (!_.isUndefined(this.opts.preventWDAAttachments)) {
       await adjustWDAAttachmentsPermissions('755');
@@ -364,6 +350,20 @@ class XCUITestDriver extends BaseDriver {
     }
 
     this.resetIos();
+
+    await super.deleteSession();
+  }
+
+  async stop () {
+    this.jwpProxyActive = false;
+    this.proxyReqRes = null;
+
+    if (this.wda) {
+      if (this.wda.jwproxy) {
+        await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
+      }
+      await this.wda.quit();
+    }
   }
 
   async executeCommand (cmd, ...args) {


### PR DESCRIPTION
There is too much in the `stop` function, which is used by the `closeApp` function, too. So move some out, so it is much like the `stop` function in `appium-ios-driver`.