### PR TITLE
Added swipe capability to gestures

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -24,4 +24,16 @@ extensions.executeAsync = async function (script, args, sessionId) {
   return await iosExecuteAsync.call(this, script, args, sessionId);
 };
 
+// Overrides the 'executeMobile' function defined in appium-ios-driver
+extensions.executeMobile = async function (mobileCommand, opts={}) {
+  // we only support mobile: scroll and mobile: swipe
+  if (mobileCommand === 'scroll') {
+    await this.mobileScroll(opts);
+  } else if (mobileCommand === 'swipe') {
+    await this.mobileScroll(opts, true);
+  } else {
+    throw new errors.UnknownCommandError('Unknown command, all the mobile commands except scroll and swipe have been removed.');
+  }
+};
+
 export default extensions;

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -299,29 +299,32 @@ helpers.handlePinchOrZoom = async function (actions) {
   await this.proxyCommand(`/wda/element/${el}/pinch`, 'POST', params);
 };
 
-helpers.mobileScroll = async function (opts={}) {
+helpers.mobileScroll = async function (opts={}, swipe=false) {
   if (!opts.element) {
     opts.element = await this.findElement(`class name`, `XCUIElementTypeApplication`);
   }
   // WDA supports four scrolling strategies: predication based on name, direction,
-  // predicateString, and toVisible, in that order.
+  // predicateString, and toVisible, in that order. Swiping requires direction.
   let params = {};
-  if (opts.name) {
+  if (opts.name && !swipe) {
     params.name = opts.name;
   } else if (opts.direction) {
+    if (['up', 'down', 'left', 'right'].indexOf(opts.direction.toLowerCase()) < 0) {
+      let msg = 'Direction must be up, down, left or right';
+      log.errorAndThrow(msg);
+    }
     params.direction = opts.direction;
-  } else if (opts.predicateString) {
+  }  else if (opts.predicateString && !swipe) {
     params.predicateString = opts.predicateString;
-  } else if (opts.toVisible) {
+  } else if (opts.toVisible && !swipe) {
     params.toVisible = opts.toVisible;
   } else {
-    let msg = 'Mobile scroll supports the following strategies: name, ' +
-              'direction, predicateString, and toVisible. Specify one of these';
+    let msg = swipe ? 'Mobile swipe requires direction' :  'Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. Specify one of these';
     log.errorAndThrow(msg);
   }
 
   let element = opts.element.ELEMENT ? opts.element.ELEMENT : opts.element;
-  let endpoint = `/wda/element/${element}/scroll`;
+  let endpoint = `/wda/element/${element}/${swipe ? 'swipe' : 'scroll'}`;
   return await this.proxyCommand(endpoint, 'POST', params);
 };
 

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -11,6 +11,7 @@ import { APPIUM_IMAGE } from '../web/helpers';
 
 chai.should();
 chai.use(chaiAsPromised);
+let expect = chai.expect;
 
 describe('XCUITestDriver - gestures', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -112,6 +113,15 @@ describe('XCUITestDriver - gestures', function () {
       await action.perform();
 
       await driver.elementByAccessibilityId('2').should.not.be.rejected;
+    });
+    it('should swipe the table and the bottom cell\'s Y position should change accordingly', async () => {
+      let winEl = await driver.elementByClassName('XCUIElementTypeWindow');
+      let toolbarsEl = await driver.elementByAccessibilityId('Toolbars');
+      let yInit = (await toolbarsEl.getLocation()).y;
+      await driver.execute('mobile: swipe', {element: winEl, direction: 'up'}).should.not.be.rejected;
+      expect((await toolbarsEl.getLocation()).y).to.be.above(yInit);
+      await driver.execute('mobile: swipe', {element: winEl, direction: 'down'}).should.not.be.rejected;
+      expect((await toolbarsEl.getLocation()).y).to.equal(yInit);
     });
     describe('pinch and zoom', () => {
       beforeEach(async () => {

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -86,5 +86,23 @@ describe('gesture commands', () => {
         proxySpy.firstCall.args[2].should.eql({predicateString: 'something'});
       });
     });
+
+    describe('swipe', () => {
+      it('should throw an error if no direction is specified', async () => {
+        await driver.execute('mobile: swipe', {element: 4}).should.be.rejectedWith(/Error: Mobile swipe requires direction/);
+      });
+
+      it('should throw an error if invalid direction', async () => {
+        await driver.execute('mobile: swipe', {element: 4, direction: 'foo'}).should.be.rejectedWith(/Error: Direction must be up, down, left or right/);
+      });
+
+      it('should proxy a swipe up request through to WDA', async () => {
+        await driver.execute('mobile: swipe', {element: 4, direction: 'up'});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/swipe');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        return proxySpy.firstCall.args[2].should.eql({direction: 'up'});
+      });
+    });
   });
 });


### PR DESCRIPTION
Called via execution of 'mobile: swipe'. Must provide direction (up, down, left, or right). Similar to 'scroll'.