### PR TITLE
Make sure we get past proxying DELETE to WDA

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -358,9 +358,14 @@ class XCUITestDriver extends BaseDriver {
     this.jwpProxyActive = false;
     this.proxyReqRes = null;
 
-    if (this.wda) {
+    if (this.wda && this.wda.fullyStarted) {
       if (this.wda.jwproxy) {
-        await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
+        try {
+          await this.proxyCommand(`/session/${this.sessionId}`, 'DELETE');
+        } catch (err) {
+          // an error here should not short-circuit the rest of clean up
+          log.debug(`Unable to DELETE session on WDA: '${err.message}'. Continuing shutdown.`);
+        }
       }
       await this.wda.quit();
     }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -405,11 +405,13 @@ class WebDriverAgent {
   }
 
   get fullyStarted () {
-    return this.expectIProxyErrors;
+    return !this.expectIProxyErrors;
   }
 
   set fullyStarted (started = false) {
-    this.expectIProxyErrors = started;
+    // before WDA is started we expect errors from iproxy, since it is not
+    // communicating with anything yet
+    this.expectIProxyErrors = !started;
   }
 }
 


### PR DESCRIPTION
In the case that WDA has died or stopped responding in some way, sending a `DELETE` session request will fail, and the rest of the shutdown behaviour for the driver will be skipped. So catch and log, allowing the rest of the work to be done.

Hopefully this helps with cleaning up processes.