### PR TITLE
Avoid resetting the simulator after the test and speed up test execution by avoiding unnecessary restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Differences noted here
 |`useNewWDA`|If `true`, forces uninstall of any existing WebDriverAgent app on device. This can provide stability in some situations. Defaults to `false`.|e.g., `true`|
 |`wdaLaunchTimeout`|Time, in ms, to wait for WebDriverAgewnt to be pingable. Defaults to 60000ms.|e.g., `30000`|
 |`wdaConnectionTimeout`|Timeout, in ms, for waiting for a response from WebDriverAgent. Defaults to 240000ms.|e.g., `1000`|
-
+|`resetOnSessionStartOnly`|Whether to perform reset on test session finish (`false`) or not (`true`). This was the default behavior prior to Appium 1.6.4. Keeping this variable set to `true` (the default behaviour since 1.6.4) may significantly shorten time perion betweeen test sessions.|Either `true` or `false`. Defaults to `true`|
 
 
 ## Development<a id="development"></a>

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Differences noted here
 |`useNewWDA`|If `true`, forces uninstall of any existing WebDriverAgent app on device. This can provide stability in some situations. Defaults to `false`.|e.g., `true`|
 |`wdaLaunchTimeout`|Time, in ms, to wait for WebDriverAgewnt to be pingable. Defaults to 60000ms.|e.g., `30000`|
 |`wdaConnectionTimeout`|Timeout, in ms, for waiting for a response from WebDriverAgent. Defaults to 240000ms.|e.g., `1000`|
-|`resetOnSessionStartOnly`|Whether to perform reset on test session finish (`false`) or not (`true`). This was the default behavior prior to Appium 1.6.4. Keeping this variable set to `true` (the default behaviour since 1.6.4) may significantly shorten time perion betweeen test sessions.|Either `true` or `false`. Defaults to `true`|
+|`resetOnSessionStartOnly`|Whether to perform reset on test session finish (`false`) or not (`true`). Keeping this variable set to `true` and Simulator running (the default behaviour since version 1.6.4) may significantly shorten the duratiuon of test session initialization.|Either `true` or `false`. Defaults to `true`|
 
 
 ## Development<a id="development"></a>

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -63,6 +63,9 @@ let desiredCapConstraints = _.defaults({
   updatedWDABundleId: {
     isString: true
   },
+  resetOnSessionStartOnly: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -709,7 +709,7 @@ class XCUITestDriver extends BaseDriver {
       let isAppAlreadyInstalled = false;
       try {
         const containerRoot = await getAppContainer(this.opts.device.udid, this.opts.bundleId);
-        isAppAlreadyInstalled = containerRoot.indexOf('/data/') > 0;
+        isAppAlreadyInstalled = containerRoot.endsWith('.app');
       } catch (err) {
         // the app is not installed
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,10 +1,9 @@
 import { BaseDriver } from 'appium-base-driver';
 import { fs, util } from 'appium-support';
 import _ from 'lodash';
-import { launch, installApp, removeApp } from 'node-simctl';
+import { launch, installApp, removeApp, getAppContainer } from 'node-simctl';
 import WebDriverAgent from './webdriveragent';
 import log from './logger';
-import { getAppContainer } from 'node-simctl';
 import { simBooted, createSim, getExistingSim, runSimulatorReset } from './simulator-management';
 import { killAllSimulators, simExists, getSimulator, installSSLCert, uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { launch, installApp, removeApp } from 'node-simctl';
 import WebDriverAgent from './webdriveragent';
 import log from './logger';
+import { getAppContainer } from 'node-simctl';
 import { simBooted, createSim, getExistingSim, runSimulatorReset } from './simulator-management';
 import { killAllSimulators, simExists, getSimulator, installSSLCert, uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
@@ -14,7 +15,6 @@ import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, adjustWD
 import { getConnectedDevices, runRealDeviceReset } from './real-device-management';
 import IOSDeploy from './ios-deploy';
 import B from 'bluebird';
-import path from 'path';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
@@ -706,8 +706,14 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this.opts.bundleId) {
-      const appDirs = await this.opts.device.getAppDirs(path.basename(this.opts.app), this.opts.bundleId);
-      if (appDirs.length > 0) {
+      let isAppAlreadyInstalled = false;
+      try {
+        const containerRoot = await getAppContainer(this.opts.device.udid, this.opts.bundleId);
+        isAppAlreadyInstalled = containerRoot.indexOf('/data/') > 0;
+      } catch (err) {
+        // the app is not installed
+      }
+      if (isAppAlreadyInstalled) {
         if (this.opts.noReset) {
           log.debug(`App ${this.opts.bundleId} is already installed. No need to reinstall.`);
           return;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -14,6 +14,7 @@ import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, adjustWD
 import { getConnectedDevices, runRealDeviceReset } from './real-device-management';
 import IOSDeploy from './ios-deploy';
 import B from 'bluebird';
+import path from 'path';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
@@ -118,6 +119,8 @@ class XCUITestDriver extends BaseDriver {
     this.implicitWaitMs = 0;
     this.asynclibWaitMs = 0;
     this.pageLoadMs = 6000;
+
+    this.opts.resetOnSessionStartOnly = !util.hasValue(this.opts.resetOnSessionStartOnly) || this.opts.resetOnSessionStartOnly;
   }
 
   get driverData () {
@@ -225,11 +228,11 @@ class XCUITestDriver extends BaseDriver {
       device.setScaleFactor(this.opts.scaleFactor);
     }
 
+    await this.runReset();
+
     // handle logging
     this.logs = {};
     await this.startLogCapture();
-
-    await this.runReset();
 
     log.info(`Setting up ${this.isRealDevice() ? 'real device' : 'simulator'}`);
 
@@ -360,20 +363,18 @@ class XCUITestDriver extends BaseDriver {
       await this.stopRemote();
     }
 
-    await this.runReset();
+    if (this.opts.resetOnSessionStartOnly === false) {
+      await this.runReset();
+    }
 
     if (this.isSimulator() && this.opts.udid && this.opts.customSSLCert) {
       await uninstallSSLCert(this.opts.customSSLCert, this.opts.udid);
     }
 
     if (this.isSimulator() && !this.opts.noReset && !!this.opts.device) {
-      log.debug('Resetting simulator');
-      if (this.lifecycleData.bootSim) {
-        log.debug('Shutting down simulator');
-        await this.opts.device.shutdown();
-      }
       if (this.lifecycleData.createSim) {
         log.debug('Deleting simulator created for this run');
+        await this.opts.device.shutdown();
         await this.opts.device.delete();
       }
     }
@@ -699,37 +700,44 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async installToSimulator () {
-    log.debug(`Installing app '${this.opts.app}' on device`);
-    if (this.opts.fullReset && this.opts.bundleId) {
-      log.debug('Full reset requested. Removing app from device');
-      await removeApp(this.opts.device.udid, this.opts.bundleId);
+    if (!this.opts.app) {
+      log.debug('No app path is given. Nothing to install.');
+      return;
     }
+
+    if (this.opts.bundleId) {
+      const appDirs = await this.opts.device.getAppDirs(path.basename(this.opts.app), this.opts.bundleId);
+      if (appDirs.length > 0) {
+        if (this.opts.noReset) {
+          log.debug(`App ${this.opts.bundleId} is already installed. No need to reinstall.`);
+          return;
+        }
+        log.debug(`Reset requested. Removing app with id "${this.opts.bundleId}" from the device`);
+        await removeApp(this.opts.device.udid, this.opts.bundleId);
+      }
+    }
+    log.debug(`Installing ${this.opts.app} on Simulator with UUID ${this.opts.device.udid}...`);
     await installApp(this.opts.device.udid, this.opts.app);
+    log.debug('The app has been installed successfully.');
   }
 
   async installToRealDevice () {
-    if (!this.opts.udid) {
+    if (!this.opts.udid || !this.opts.app) {
       log.debug('No device id or app, not installing to real device.');
       return;
     }
 
     if (await this.opts.device.isInstalled(this.opts.bundleId)) {
-      if (!this.opts.fullReset) {
-        log.debug('App is already installed.');
+      if (this.opts.noReset) {
+        log.debug(`App ${this.opts.bundleId} is already installed. No need to reinstall.`);
         return;
       }
-      log.debug('Full reset requested. Uninstalling app');
+      log.debug(`Reset requested. Removing app with id "${this.opts.bundleId}" from the device`);
       await this.opts.device.remove(this.opts.bundleId);
     }
-    log.debug('App is not installed. Will try to install.');
-
-    if (this.opts.app) {
-      await this.opts.device.install(this.opts.app);
-      log.debug('App installed successfully.');
-    } else {
-      log.debug('Real device specified but no ipa or app path, assuming bundle ID is ' +
-                'on device');
-    }
+    log.debug(`Installing ${this.opts.app} on iDevice with UUID ${this.opts.udid}...`);
+    await this.opts.device.install(this.opts.app);
+    log.debug('The app has been installed successfully.');
   }
 
   async getIDeviceObj () {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { getSimulator } from 'appium-ios-simulator';
-import { createDevice, getDevices } from 'node-simctl';
+import { createDevice, getDevices, terminate } from 'node-simctl';
 import _ from 'lodash';
 import log from './logger';
 
@@ -40,17 +40,31 @@ async function runSimulatorReset (device, opts) {
     return;
   }
 
-  // The simulator process must be ended before we delete applications.
-  await endSimulator(device);
-
   if (opts.fullReset) {
-    // noReset === false && fullReset === true
     log.debug('Reset: fullReset is on. Cleaning simulator');
+    // The simulator process must be ended before we delete applications.
+    await endSimulator(device);
     await fullResetSimulator(device);
-  } else {
-    // noReset === false && fullReset === false
-    log.debug(`Reset: fullReset is not on. Performing 'fast reset' by removing app resources`);
-    await resetSimulator(device, opts);
+  } else if (opts.bundleId) {
+    // Terminate the app under test if it is still running on Simulator
+    // Termination is not needed if Simulator is not running
+    if (await simBooted(device)) {
+      try {
+        await terminate(device.udid, opts.bundleId);
+      } catch (err) {
+        log.warn(`Reset: failed to terminate Simulator application with id "${opts.bundleId}"`);
+      }
+    }
+    if (opts.app) {
+      log.info('Not scrubbing third party app in anticipation of uninstall');
+      return;
+    }
+    try {
+      await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
+    } catch (err) {
+      log.warn(err);
+      log.warn(`Reset: could not scrub application with id "${opts.bundleId}". Leaving as is.`);
+    }
   }
 }
 
@@ -58,17 +72,6 @@ async function fullResetSimulator (device) {
   if (!device) return;
 
   await device.clean();
-}
-
-async function resetSimulator (device, opts) {
-  if (!device || !opts.app || !opts.bundleId) return;
-
-  try {
-    await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
-  } catch (err) {
-    log.warn(err);
-    log.warn('Reset: could not scrub application. Leaving as is.');
-  }
 }
 
 async function endSimulator (device) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.1.1",
     "lodash": "^4.0.0",
-    "node-simctl": "^3.1.0",
+    "node-simctl": "^3.5.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "source-map-support": "^0.4.0",

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -83,30 +83,6 @@ describe('XCUITestDriver', function () {
         simsAfter.should.equal(simsBefore);
       });
 
-      it('with udid: uses sim and shuts it down afterwards', async () => {
-        // before
-        let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);
-        let sim = await getSimulator(udid);
-
-        // test
-        let caps = _.defaults({
-          udid
-        }, UICATALOG_SIM_CAPS);
-
-        let simsBefore = await getNumSims();
-        await driver.init(caps);
-        let simsDuring = await getNumSims();
-        await driver.quit();
-        let simsAfter = await getNumSims();
-        (await simBooted(sim)).should.be.false;
-
-        simsDuring.should.equal(simsBefore);
-        simsAfter.should.equal(simsBefore);
-
-        // cleanup
-        await deleteDevice(udid);
-      });
-
       it('with udid booted: uses sim and leaves it afterwards', async () => {
         // before
         let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -83,6 +83,35 @@ describe('XCUITestDriver', function () {
         simsAfter.should.equal(simsBefore);
       });
 
+      it('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async () => {
+        // before
+        let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);
+        let sim = await getSimulator(udid);
+        await sim.run();
+
+        // test
+        let caps = _.defaults({
+          udid,
+          fullReset: true,
+          resetOnSessionStartOnly: false
+        }, UICATALOG_SIM_CAPS);
+
+        (await simBooted(sim)).should.be.true;
+        let simsBefore = await getNumSims();
+        await driver.init(caps);
+        let simsDuring = await getNumSims();
+        await driver.quit();
+        let simsAfter = await getNumSims();
+        (await simBooted(sim)).should.be.false;
+
+        // make sure no new simulators were created during the test
+        simsDuring.should.equal(simsBefore);
+        simsAfter.should.equal(simsBefore);
+
+        // cleanup
+        await deleteDevice(udid);
+      });
+
       it('with udid booted: uses sim and leaves it afterwards', async () => {
         // before
         let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);


### PR DESCRIPTION
Simulator restart procedure is very expensive operation. This PR tries to avoid restarting the Simulator where it is possible and keep it running  between sessions, which will allow to save A LOT of time. And time is money 💯 

The PR depends on https://github.com/appium/node-simctl/pull/30