### PR TITLE
POC for command execution timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Differences noted here
 |`wdaLaunchTimeout`|Time, in ms, to wait for WebDriverAgewnt to be pingable. Defaults to 60000ms.|e.g., `30000`|
 |`wdaConnectionTimeout`|Timeout, in ms, for waiting for a response from WebDriverAgent. Defaults to 240000ms.|e.g., `1000`|
 |`resetOnSessionStartOnly`|Whether to perform reset on test session finish (`false`) or not (`true`). Keeping this variable set to `true` and Simulator running (the default behaviour since version 1.6.4) may significantly shorten the duratiuon of test session initialization.|Either `true` or `false`. Defaults to `true`|
+|`commandTimeouts`|Custom timeout(s) in milliseconds for WDA backend commands execution. This might be useful if WDA backend freezes unexpectedly or requires too much time to fail and blocks automated test execution. The value is expected to be of type string and can either contain max milliseconds to wait for each WDA command to be executed before terminating the session forcefully or a valid JSON string, where keys are internal Appium command names (you can find these in logs, look for "Executing command 'command_name'" records) and values are timeouts in milliseconds. You can also set the 'default' key to assign the timeout for all other commands not explicitly enumerated as JSON keys.|`'120000'`, `'{"findElement": 40000, "findElements": 40000, "setValue": 20000, "default": 120000}'`|
 
 
 ## Development<a id="development"></a>

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -1,10 +1,13 @@
-import { errorFromCode } from 'appium-base-driver';
+import { errorFromCode, errors, routeToCommandName } from 'appium-base-driver';
 import log from '../logger';
+import B from 'bluebird';
 
 
 let helpers = {}, extensions = {};
 
 helpers.proxyCommand = async function (endpoint, method, body) {
+  if (this.shutdownUnexpectedly) return;
+
   if (!endpoint) {
     log.errorAndThrow('Proxying requires an endpoint');
   } else if (method !== 'POST' && method !== 'GET' && method !== 'DELETE') {
@@ -15,7 +18,25 @@ helpers.proxyCommand = async function (endpoint, method, body) {
     throw new Error("Can't call proxyCommand without proxy active");
   }
 
-  let res = await this.wda.jwproxy.command(endpoint, method, body);
+  const cmdName = routeToCommandName(endpoint, method);
+  const timeout = this._getCommandTimeout(cmdName);
+  let res = null;
+  if (timeout) {
+    log.debug(`Setting custom timeout to ${timeout} ms for "${cmdName}" command`);
+    let isCommandExpired = false;
+    res = await B.Promise.resolve(this.wda.jwproxy.command(endpoint, method, body))
+                  .timeout(timeout)
+                  .catch(B.Promise.TimeoutError, () => {
+                    isCommandExpired = true;
+                  });
+    if (isCommandExpired) {
+      const errMsg = `Appium did not get any response from "${cmdName}" command in ${timeout} ms`;
+      await this.startUnexpectedShutdown(new errors.TimeoutError(errMsg));
+      log.errorAndThrow(errMsg);
+    }
+  } else {
+    res = await this.wda.jwproxy.command(endpoint, method, body);
+  }
 
   // temporarily handle errors that can be returned
   if (res && res.status && parseInt(res.status, 10) !== 0) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -66,6 +66,9 @@ let desiredCapConstraints = _.defaults({
   resetOnSessionStartOnly: {
     isBoolean: true
   },
+  commandTimeouts: {
+    isString: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -19,6 +19,7 @@ import { version } from '../../package.json'; // eslint-disable-line import/no-u
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const WDA_STARTUP_RETRIES = 2;
+const DEFAULT_TIMEOUT_KEY = 'default';
 
 const NO_PROXY_NATIVE_LIST = [
   ['GET', /^\/session\/[^\/]+$/],
@@ -71,6 +72,35 @@ const NO_PROXY_WEB_LIST = [
   ['POST', /keys/],
 ].concat(NO_PROXY_NATIVE_LIST);
 
+function normalizeCommandTimeouts (value) {
+  // The value is normalized already
+  if (typeof value !== 'string') return value;
+
+  let result = {};
+  // Use as default timeout for all commands if a single integer value is provided
+  if (!isNaN(value)) {
+    result[DEFAULT_TIMEOUT_KEY] = _.toInteger(value);
+    return result;
+  }
+
+  // JSON object has been provided. Let's parse it
+  try {
+    result = JSON.parse(value);
+    if (!_.isPlainObject(result)) {
+      throw new Error();
+    }
+  } catch (err) {
+    log.errorAndThrow(`"commandTimeouts" capability should be a valid JSON object. "${value}" was given instead`);
+  }
+  for (let [cmd, timeout] of _.toPairs(result)) {
+    if (!_.isInteger(timeout) || timeout <= 0) {
+      log.errorAndThrow(`The timeout for "${cmd}" should be a valid natural number of milliseconds. "${timeout}" was given instead`);
+    }
+  }
+  return result;
+}
+
+
 class XCUITestDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
@@ -118,8 +148,6 @@ class XCUITestDriver extends BaseDriver {
     this.implicitWaitMs = 0;
     this.asynclibWaitMs = 0;
     this.pageLoadMs = 6000;
-
-    this.opts.resetOnSessionStartOnly = !util.hasValue(this.opts.resetOnSessionStartOnly) || this.opts.resetOnSessionStartOnly;
   }
 
   get driverData () {
@@ -245,7 +273,7 @@ class XCUITestDriver extends BaseDriver {
       let installAppPromise = null;
       if (this.opts.app) {
         if (await simBooted(this.opts.device)) {
-          installAppPromise = new Promise(async (resolve, reject) => {
+          installAppPromise = new B.Promise(async (resolve, reject) => {
             try {
               await this.installApp();
               resolve();
@@ -254,7 +282,7 @@ class XCUITestDriver extends BaseDriver {
             }
           });
         } else {
-          installAppPromise = new Promise(async (resolve, reject) => {
+          installAppPromise = new B.Promise(async (resolve, reject) => {
             this.opts.device.on(BOOT_COMPLETED_EVENT, async () => {
               try {
                 await this.installApp();
@@ -407,12 +435,12 @@ class XCUITestDriver extends BaseDriver {
 
   async executeCommand (cmd, ...args) {
     log.debug(`Executing command '${cmd}'`);
+
     if (cmd === 'receiveAsyncResponse') {
       return await this.receiveAsyncResponse(...args);
     }
     return await super.executeCommand(cmd, ...args);
   }
-
 
   async checkAppPresent () {
     log.debug(`Checking whether app '${this.opts.app}' is actually present on file system`);
@@ -439,7 +467,6 @@ class XCUITestDriver extends BaseDriver {
       return;
     }
 
-
     // check for supported build-in apps
     if (this.opts.app && this.opts.app.toLowerCase() === 'settings') {
       this.opts.bundleId = 'com.apple.Preferences';
@@ -461,7 +488,6 @@ class XCUITestDriver extends BaseDriver {
         'server install dir, or a URL to compressed file, or a special app name.');
     }
   }
-
 
   async determineDevice () {
     // in the one case where we create a sim, we will set this state
@@ -671,6 +697,9 @@ class XCUITestDriver extends BaseDriver {
                `alert handling accordingly.`);
     }
 
+    // `resetOnSessionStartOnly` should be set to true by default
+    this.opts.resetOnSessionStartOnly = !util.hasValue(this.opts.resetOnSessionStartOnly) || this.opts.resetOnSessionStartOnly;
+
     // finally, return true since the superclass check passed, as did this
     return true;
   }
@@ -777,6 +806,17 @@ class XCUITestDriver extends BaseDriver {
       log.warn(`Setting initial orientation failed with: ${err}`);
     }
   }
+
+  _getCommandTimeout (cmdName) {
+    this.opts.commandTimeouts = normalizeCommandTimeouts(this.opts.commandTimeouts);
+    if (this.opts.commandTimeouts) {
+      if (cmdName && _.has(this.opts.commandTimeouts, cmdName)) {
+        return this.opts.commandTimeouts[cmdName];
+      }
+      return this.opts.commandTimeouts[DEFAULT_TIMEOUT_KEY];
+    }
+  }
+
 }
 
 for (let [cmd, fn] of _.toPairs(commands)) {

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -344,7 +344,7 @@ class WebDriverAgent {
       if (proc && proc.proc) {
         log.info(`Shutting down ${name} process (pid ${proc.proc.pid})`);
         try {
-          await proc.stop('SIGTERM');
+          await proc.stop('SIGTERM', 1000);
         } catch (err) {
           if (err.message.indexOf(`Process didn't end after`) === -1) {
             throw err;


### PR DESCRIPTION
This PR adds the ability to set custom timeouts for Appium commands. It might be extremely useful in case with WDA backend, since it sometimes experiences unexpected freezes and stops responding to Appium. This causes Appium to wait for 4-5 minutes until socket timeout happens, which is not very good for automated tests.

This implementation allows to set either common timeout for each command or to set it on per-command basis, which offers our customers better control over the framework.

Depends on https://github.com/appium/appium-base-driver/pull/104