### PR TITLE
Print contents of xcodebuild log file on xcodebuild error

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -187,8 +187,8 @@ class WebDriverAgent {
       if (out.indexOf('Writing diagnostic log for test session to') !== -1) {
         // pull out the first line that begins with the path separator
         // which *should* be the line indicating the log file generated
-        let logLocation = _.first(_.remove(out.trim().split('\n'), (v) => v.indexOf(path.sep) === 0));
-        log.debug(`Log file for xcodebuild test: ${logLocation}`);
+        xcodebuild.logLocation = _.first(_.remove(out.trim().split('\n'), (v) => v.indexOf(path.sep) === 0));
+        log.debug(`Log file for xcodebuild test: ${xcodebuild.logLocation}`);
       }
 
       // if we have an error we want to output the logs
@@ -218,10 +218,23 @@ class WebDriverAgent {
     // wrap the start procedure in a promise so that we can catch, and report,
     // any startup errors that are thrown as events
     return await new B((resolve, reject) => {
-      this.xcodebuild.on('exit', (code, signal) => {
+      this.xcodebuild.on('exit', async (code, signal) => {
         log.info(`xcodebuild exited with code '${code}' and signal '${signal}'`);
         this.xcodebuild.processExited = true;
         if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
+          // print out the xcodebuild file if users have asked for it
+          if (this.showXcodeLog && this.xcodebuild.logLocation) {
+            xcodeLog.info(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
+            try {
+              let data = await fs.readFile(this.xcodebuild.logLocation, 'utf-8');
+              for (let line of data.split('\n')) {
+                xcodeLog.info(line);
+              }
+            } catch (err) {
+              log.debug(`Unable to access xcodebuild log file: '${err.message}'`);
+            }
+          }
+
           return reject(new Error(`xcodebuild failed with code ${code}`));
         }
       });


### PR DESCRIPTION
If the `showXcodeLog` capability is set, and there is an error, print out the contents of the xcodebuild log.

Addresses https://github.com/appium/appium/issues/7844