### PR TITLE
Clean up structure and functioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Differences noted here
 |`wdaConnectionTimeout`|Timeout, in ms, for waiting for a response from WebDriverAgent. Defaults to 240000ms.|e.g., `1000`|
 |`resetOnSessionStartOnly`|Whether to perform reset on test session finish (`false`) or not (`true`). Keeping this variable set to `true` and Simulator running (the default behaviour since version 1.6.4) may significantly shorten the duratiuon of test session initialization.|Either `true` or `false`. Defaults to `true`|
 |`commandTimeouts`|Custom timeout(s) in milliseconds for WDA backend commands execution. This might be useful if WDA backend freezes unexpectedly or requires too much time to fail and blocks automated test execution. The value is expected to be of type string and can either contain max milliseconds to wait for each WDA command to be executed before terminating the session forcefully or a valid JSON string, where keys are internal Appium command names (you can find these in logs, look for "Executing command 'command_name'" records) and values are timeouts in milliseconds. You can also set the 'default' key to assign the timeout for all other commands not explicitly enumerated as JSON keys.|`'120000'`, `'{"findElement": 40000, "findElements": 40000, "setValue": 20000, "default": 120000}'`|
+|`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
+|`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 
 
 ## Development<a id="development"></a>

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -8,6 +8,7 @@ let extensions = {};
 Object.assign(extensions, iosCommands.logging);
 
 extensions.startLogCapture = async function () {
+  this.logs = this.log || {};
   if (!_.isEmpty(this.logs)) {
     log.warn('Trying to start iOS log capture but it has already started!');
     return;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -69,6 +69,12 @@ let desiredCapConstraints = _.defaults({
   commandTimeouts: {
     isString: true
   },
+  wdaStartupRetries: {
+    isNumber: true
+  },
+  wdaStartupRetryInterval: {
+    isNumber: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,18 +1,21 @@
 import { BaseDriver } from 'appium-base-driver';
-import { fs, util } from 'appium-support';
+import { util } from 'appium-support';
 import _ from 'lodash';
-import { launch, installApp, removeApp, getAppContainer } from 'node-simctl';
+import { launch } from 'node-simctl';
 import WebDriverAgent from './webdriveragent';
 import log from './logger';
-import { simBooted, createSim, getExistingSim, runSimulatorReset } from './simulator-management';
-import { killAllSimulators, simExists, getSimulator, installSSLCert, uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
+import { simBooted, createSim, getExistingSim, runSimulatorReset,
+         installToSimulator } from './simulator-management';
+import { killAllSimulators, simExists, getSimulator, installSSLCert,
+         uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps, appUtils } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
 import commands from './commands/index';
-import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, adjustWDAAttachmentsPermissions } from './utils';
-import { getConnectedDevices, runRealDeviceReset } from './real-device-management';
-import IOSDeploy from './ios-deploy';
+import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
+         adjustWDAAttachmentsPermissions, checkAppPresent } from './utils';
+import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
+         getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
@@ -20,6 +23,7 @@ import { version } from '../../package.json'; // eslint-disable-line import/no-u
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const WDA_STARTUP_RETRIES = 2;
 const DEFAULT_TIMEOUT_KEY = 'default';
+const WDA_STARTUP_RETRY_INTERVAL = 10000;
 
 const NO_PROXY_NATIVE_LIST = [
   ['GET', /^\/session\/[^\/]+$/],
@@ -198,7 +202,7 @@ class XCUITestDriver extends BaseDriver {
       throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
     }
 
-    let { device, udid, realDevice } = await this.determineDevice();
+    let {device, udid, realDevice} = await this.determineDevice();
     log.info(`Determining device to run tests on: udid: '${udid}', real device: ${realDevice}`);
     this.opts.device = device;
     this.opts.udid = udid;
@@ -243,7 +247,7 @@ class XCUITestDriver extends BaseDriver {
 
     // fail very early if the app doesn't actually exist
     if (this.opts.app) {
-      await this.checkAppPresent();
+      await checkAppPresent(this.opts.app);
     }
 
     if (!this.opts.bundleId) {
@@ -258,7 +262,6 @@ class XCUITestDriver extends BaseDriver {
     await this.runReset();
 
     // handle logging
-    this.logs = {};
     await this.startLogCapture();
 
     log.info(`Setting up ${this.isRealDevice() ? 'real device' : 'simulator'}`);
@@ -273,16 +276,9 @@ class XCUITestDriver extends BaseDriver {
       let installAppPromise = null;
       if (this.opts.app) {
         if (await simBooted(this.opts.device)) {
-          installAppPromise = new B.Promise(async (resolve, reject) => {
-            try {
-              await this.installApp();
-              resolve();
-            } catch (err) {
-              reject(err);
-            }
-          });
+          installAppPromise = this.installApp();
         } else {
-          installAppPromise = new B.Promise(async (resolve, reject) => {
+          installAppPromise = new B(async (resolve, reject) => {
             this.opts.device.on(BOOT_COMPLETED_EVENT, async () => {
               try {
                 await this.installApp();
@@ -295,9 +291,7 @@ class XCUITestDriver extends BaseDriver {
         }
       }
       await this.startSim();
-      if (installAppPromise) {
-        await installAppPromise;
-      }
+      await installAppPromise;
     }
 
     await this.startWda(this.opts.sessionId, realDevice);
@@ -310,57 +304,57 @@ class XCUITestDriver extends BaseDriver {
     }
   }
 
-  async startWda (sessionId, realDevice, tries = 0) {
-    tries++;
-    this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
+  async startWda (sessionId, realDevice) {
+    let startupRetries = this.opts.wdaStartupRetries || WDA_STARTUP_RETRIES;
+    let startupRetryInterval = this.opts.wdaStartupRetryInterval || WDA_STARTUP_RETRY_INTERVAL;
+    await retryInterval(startupRetries, startupRetryInterval, async () => {
+      this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
-    if (this.opts.useNewWDA) {
-      log.debug(`Capability 'useNewWDA' set, so uninstalling WDA before proceeding`);
-      await this.wda.uninstall();
-    }
+      if (this.opts.useNewWDA) {
+        log.debug(`Capability 'useNewWDA' set, so uninstalling WDA before proceeding`);
+        await this.wda.uninstall();
+      }
 
-    // local helper for the two places we need to uninstall wda and re-start it
-    let uninstallAndRestart = async () => {
-      log.debug('Quitting and uninstalling WebDriverAgent, then retrying');
-      await this.wda.quit();
-      await this.wda.uninstall();
-      await this.startWda(sessionId, realDevice, tries);
-    };
+      // local helper for the two places we need to uninstall wda and re-start it
+      let quitAndUninstall = async (msg) => {
+        log.debug(msg);
+        log.debug('Quitting and uninstalling WebDriverAgent, then retrying');
+        await this.wda.quit();
+        await this.wda.uninstall();
+        throw new Error(msg);
+      };
 
-    try {
-      await this.wda.launch(sessionId, realDevice);
-    } catch (err) {
-      if (tries > WDA_STARTUP_RETRIES) throw err;
-      log.debug(`Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`);
-      await uninstallAndRestart();
-    }
+      try {
+        await this.wda.launch(sessionId, realDevice);
+      } catch (err) {
+        await quitAndUninstall(`Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`);
+      }
 
-    this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
-    this.jwpProxyActive = true;
+      this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
+      this.jwpProxyActive = true;
 
-    try {
-      await retryInterval(15, 1000, async () => {
-        log.debug('Sending createSession command to WDA');
-        try {
-          await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
-        } catch (err) {
-          log.debug('Failed to create WDA session. Retrying...');
-          throw err;
-        }
-      });
-    } catch (err) {
-      log.debug(`Unable to start WebDriverAgent session: ${err.message}`);
-      if (tries > WDA_STARTUP_RETRIES) throw err;
-      await uninstallAndRestart();
-    }
+      try {
+        await retryInterval(15, 1000, async () => {
+          log.debug('Sending createSession command to WDA');
+          try {
+            await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
+          } catch (err) {
+            log.debug('Failed to create WDA session. Retrying...');
+            throw err;
+          }
+        });
+      } catch (err) {
+        return await quitAndUninstall(`Unable to start WebDriverAgent session: ${err.message}`);
+      }
 
-    if (!_.isUndefined(this.opts.preventWDAAttachments)) {
-      await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
-    }
+      if (!_.isUndefined(this.opts.preventWDAAttachments)) {
+        await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
+      }
 
-    // we expect certain socket errors until this point, but now
-    // mark things as fully working
-    this.wda.fullyStarted = true;
+      // we expect certain socket errors until this point, but now
+      // mark things as fully working
+      this.wda.fullyStarted = true;
+    });
   }
 
   // create an alias so we can actually unit test createSession by stubbing
@@ -442,14 +436,6 @@ class XCUITestDriver extends BaseDriver {
     return await super.executeCommand(cmd, ...args);
   }
 
-  async checkAppPresent () {
-    log.debug(`Checking whether app '${this.opts.app}' is actually present on file system`);
-    if (!(await fs.exists(this.opts.app))) {
-      log.errorAndThrow(`Could not find app at ${this.opts.app}`);
-    }
-    log.debug('App is present');
-  }
-
   async configureApp () {
     function appIsPackageOrBundle (app) {
       return (/^([a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+)+$/).test(app);
@@ -526,7 +512,7 @@ class XCUITestDriver extends BaseDriver {
         }
       }
 
-      let device = await this.getIDeviceObj();
+      let device = await getRealDeviceObj(this.opts.udid);
       return {device, realDevice: true, udid: this.opts.udid};
     }
 
@@ -555,15 +541,13 @@ class XCUITestDriver extends BaseDriver {
     // if no udid, well lets see if we can start one up based on desired caps
     // if we support multiple sims we need to change this
 
-    if (!await simBooted(this.opts.device)) {
-      log.info(`Simulator with udid '${this.opts.udid}' not booted. Booting up now`);
-      await killAllSimulators();
-      await this.opts.device.run();
-      this.lifecycleData.bootSim = true;
-    } else {
+    if (await simBooted(this.opts.device)) {
       log.info(`Simulator with udid '${this.opts.udid}' already booted`);
-      this.lifecycleData.bootSim = false;
+      return;
     }
+    log.info(`Simulator with udid '${this.opts.udid}' not booted. Booting up now`);
+    await killAllSimulators();
+    await this.opts.device.run();
   }
 
   async createSim () {
@@ -715,77 +699,15 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this.isRealDevice()) {
-      await this.installToRealDevice();
+      await installToRealDevice (this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     } else {
-      await this.installToSimulator();
+      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     }
 
     if (util.hasValue(this.opts.iosInstallPause)) {
       // https://github.com/appium/appium/issues/6889
       let pause = parseInt(this.opts.iosInstallPause, 10);
       await B.delay(pause);
-    }
-  }
-
-  async installToSimulator () {
-    if (!this.opts.app) {
-      log.debug('No app path is given. Nothing to install.');
-      return;
-    }
-
-    if (this.opts.bundleId) {
-      let isAppAlreadyInstalled = false;
-      try {
-        const containerRoot = await getAppContainer(this.opts.device.udid, this.opts.bundleId);
-        isAppAlreadyInstalled = containerRoot.endsWith('.app');
-      } catch (err) {
-        // the app is not installed
-      }
-      if (isAppAlreadyInstalled) {
-        if (this.opts.noReset) {
-          log.debug(`App ${this.opts.bundleId} is already installed. No need to reinstall.`);
-          return;
-        }
-        log.debug(`Reset requested. Removing app with id "${this.opts.bundleId}" from the device`);
-        await removeApp(this.opts.device.udid, this.opts.bundleId);
-      }
-    }
-    log.debug(`Installing ${this.opts.app} on Simulator with UUID ${this.opts.device.udid}...`);
-    await installApp(this.opts.device.udid, this.opts.app);
-    log.debug('The app has been installed successfully.');
-  }
-
-  async installToRealDevice () {
-    if (!this.opts.udid || !this.opts.app) {
-      log.debug('No device id or app, not installing to real device.');
-      return;
-    }
-
-    if (await this.opts.device.isInstalled(this.opts.bundleId)) {
-      if (this.opts.noReset) {
-        log.debug(`App ${this.opts.bundleId} is already installed. No need to reinstall.`);
-        return;
-      }
-      log.debug(`Reset requested. Removing app with id "${this.opts.bundleId}" from the device`);
-      await this.opts.device.remove(this.opts.bundleId);
-    }
-    log.debug(`Installing ${this.opts.app} on iDevice with UUID ${this.opts.udid}...`);
-    await this.opts.device.install(this.opts.app);
-    log.debug('The app has been installed successfully.');
-  }
-
-  async getIDeviceObj () {
-    log.debug(`Creating iDevice object with udid '${this.opts.udid}'`);
-    try {
-      //This iDevice object could be ideviceinstaller (node-idevice) for future once we have ideviceinstaller working for ios 10
-      let iDevice = new IOSDeploy(this.opts.udid);
-      await iDevice.checkStatus();
-      return iDevice;
-    } catch (e) {
-      let msg = "Could not initialize ios-deploy make sure it is " +
-                "installed (npm install -g ios-deploy) and works on your system.";
-      log.error(msg);
-      throw new Error(msg);
     }
   }
 

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -1,4 +1,5 @@
 import { exec } from 'teen_process';
+import IOSDeploy from './ios-deploy';
 import log from './logger';
 
 
@@ -47,4 +48,38 @@ async function runRealDeviceReset (device, opts) {
   }
 }
 
-export { getConnectedDevices, runRealDeviceReset };
+async function installToRealDevice (device, app, bundleId, noReset = true) {
+  if (!device.udid || !app) {
+    log.debug('No device id or app, not installing to real device.');
+    return;
+  }
+
+  if (await device.isInstalled(bundleId)) {
+    if (noReset) {
+      log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
+      return;
+    }
+    log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
+    await device.remove(bundleId);
+  }
+  log.debug(`Installing '${app}' on device with UUID '${device.udid}'...`);
+  await device.install(app);
+  log.debug('The app has been installed successfully.');
+}
+
+async function getRealDeviceObj (udid) {
+  log.debug(`Creating iDevice object with udid '${udid}'`);
+  try {
+    //This iDevice object could be ideviceinstaller (node-idevice) for future once we have ideviceinstaller working for ios 10
+    let device = new IOSDeploy(udid);
+    await device.checkStatus();
+    return device;
+  } catch (e) {
+    let msg = 'Could not initialize ios-deploy make sure it is installed ' +
+              '(npm install -g ios-deploy) and works on your system.';
+    log.errorAndThrow(msg);
+  }
+}
+
+export { getConnectedDevices, runRealDeviceReset, installToRealDevice,
+         getRealDeviceObj };

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -87,6 +87,27 @@ async function isolateSimulatorDevice (device, isolateSimDevice = true) {
   }
 }
 
+async function installToSimulator (device, app, bundleId, noReset = true) {
+  if (!app) {
+    log.debug('No app path is given. Nothing to install.');
+    return;
+  }
+
+  if (bundleId) {
+    if (await device.isAppInstalled(bundleId)) {
+      if (noReset) {
+        log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
+        return;
+      }
+      log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
+      await device.removeApp(bundleId);
+    }
+  }
+  log.debug(`Installing ${app} on Simulator with UUID '${device.udid}'...`);
+  await device.installApp(app);
+  log.debug('The app has been installed successfully.');
+}
+
 
 export { simBooted, createSim, getExistingSim, runSimulatorReset,
-         isolateSimulatorDevice };
+         isolateSimulatorDevice, installToSimulator };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,6 +109,14 @@ CODE_SIGN_IDENTITY = ${signingId}
   return xcconfigPath;
 }
 
+async function checkAppPresent (app) {
+  log.debug(`Checking whether app '${app}' is actually present on file system`);
+  if (!(await fs.exists(app))) {
+    log.errorAndThrow(`Could not find app at '${app}'`);
+  }
+  log.debug('App is present');
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          killAppUsingAppName, adjustWDAAttachmentsPermissions,
-         generateXcodeConfigFile };
+         generateXcodeConfigFile, checkAppPresent };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "appium-base-driver": "^2.1.4",
     "appium-ios-driver": "^1.15.1",
-    "appium-ios-simulator": "^1.14.0",
+    "appium-ios-simulator": "^1.17.1",
     "appium-logger": "^2.0.0",
     "appium-support": "^2.3.2",
     "appium-xcode": "^3.1.0",

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -17,7 +17,10 @@ async function initDriver () {
 
 async function initSession (caps) {
   await initDriver();
-  await driver.init(caps);
+  let serverRes = await driver.init(caps);
+  if (!caps.udid && !caps.fullReset && serverRes[1].udid) {
+    caps.udid = serverRes[1].udid;
+  }
 
   await driver.setImplicitWaitTimeout(5000);
 

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -4,6 +4,7 @@ import XCUITestDriver from '../..';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from '../../lib/logger';
+import * as utils from '../../lib/utils';
 
 
 const caps = {platformName: "iOS", deviceName: "iPhone 6", app: "/foo.app"};
@@ -46,7 +47,6 @@ describe('driver commands', () => {
         };
       });
       sandbox.stub(d, "configureApp", anoop);
-      sandbox.stub(d, "checkAppPresent", anoop);
       sandbox.stub(d, "startLogCapture", anoop);
       sandbox.stub(d, "startSim", anoop);
       sandbox.stub(d, "startWdaSession", anoop);
@@ -58,6 +58,7 @@ describe('driver commands', () => {
       sandbox.stub(xcode, "getMaxIOSSDK", async () => {
         return '10.0';
       });
+      sandbox.stub(utils, "checkAppPresent", anoop);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Moves some functions out from the driver object to make things clearer. Also uses simulator functions instead of going directly to simctl.

To help with startup, add configuration through `wdaStartupRetries` and `wdaStartupRetryInterval` caps, and move from a recursive strategy to using `retryInterval` for startup retries (see https://github.com/appium/appium/issues/7828).

Fix problem with logging getting started over and over again in certain situations (see https://github.com/appium/appium/issues/7838).

Add xcodebuild log file into the stream when `showXcodeLog` is on and a failure happens (see https://github.com/appium/appium/issues/7844).

