### PR TITLE
Cache /status API call result to make it pseudo-asynchronous

### DIFF
--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -2,6 +2,7 @@ import { errorFromCode, errors, routeToCommandName } from 'appium-base-driver';
 import log from '../logger';
 import B from 'bluebird';
 
+const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE'];
 
 let helpers = {}, extensions = {};
 
@@ -10,8 +11,8 @@ helpers.proxyCommand = async function (endpoint, method, body) {
 
   if (!endpoint) {
     log.errorAndThrow('Proxying requires an endpoint');
-  } else if (method !== 'POST' && method !== 'GET' && method !== 'DELETE') {
-    log.errorAndThrow('Proxying only works for GET, POST or DELETE requests');
+  } else if (SUPPORTED_METHODS.indexOf(method) === -1) {
+    log.errorAndThrow(`Proxying only works for the following requests: ${SUPPORTED_METHODS.join(', ')}`);
   }
 
   if (!this.wda || !this.wda.jwproxy) {
@@ -24,18 +25,28 @@ helpers.proxyCommand = async function (endpoint, method, body) {
   if (timeout) {
     log.debug(`Setting custom timeout to ${timeout} ms for "${cmdName}" command`);
     let isCommandExpired = false;
-    res = await B.Promise.resolve(this.wda.jwproxy.command(endpoint, method, body))
-                  .timeout(timeout)
-                  .catch(B.Promise.TimeoutError, () => {
-                    isCommandExpired = true;
-                  });
+    try {
+      this.isWDARequestRunning = true;
+      res = await B.Promise.resolve(this.wda.jwproxy.command(endpoint, method, body))
+                    .timeout(timeout)
+                    .catch(B.Promise.TimeoutError, () => {
+                      isCommandExpired = true;
+                    });
+    } finally {
+      this.isWDARequestRunning = false;
+    }
     if (isCommandExpired) {
       const errMsg = `Appium did not get any response from "${cmdName}" command in ${timeout} ms`;
       await this.startUnexpectedShutdown(new errors.TimeoutError(errMsg));
       log.errorAndThrow(errMsg);
     }
   } else {
-    res = await this.wda.jwproxy.command(endpoint, method, body);
+    try {
+      this.isWDARequestRunning = true;
+      res = await this.wda.jwproxy.command(endpoint, method, body);
+    } finally {
+      this.isWDARequestRunning = false;
+    }
   }
 
   // temporarily handle errors that can be returned

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -140,6 +140,8 @@ class XCUITestDriver extends BaseDriver {
     this.proxyReqRes = null;
     this.jwpProxyAvoid = [];
     this.safari = false;
+    this.isWDARequestRunning = false;
+    this.cachedWdaStatus = {};
 
     // some things that commands imported from appium-ios-driver need
     this.curWebFrames = [];
@@ -160,8 +162,13 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async getStatus () {
-    let wdaStatus = await this.proxyCommand('/status', 'GET');
-    return {wda: wdaStatus};
+    // WDA server responses are synchronous, but Selenium API consumers, like Selenium Grid,
+    // expect /status response to be async
+    if (this.isWDARequestRunning && !_.isEmpty(this.cachedWdaStatus)) return this.cachedWdaStatus;
+
+    const wdaStatus = await this.proxyCommand('/status', 'GET');
+    this.cachedWdaStatus = {wda: wdaStatus};
+    return this.cachedWdaStatus;
   }
 
   async createSession (caps) {
@@ -337,6 +344,8 @@ class XCUITestDriver extends BaseDriver {
         await retryInterval(15, 1000, async () => {
           log.debug('Sending createSession command to WDA');
           try {
+            // This is needed to put the '/status' output into the cache
+            await this.getStatus();
             await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
           } catch (err) {
             log.debug('Failed to create WDA session. Retrying...');


### PR DESCRIPTION
This PR addresses https://github.com/appium/appium/issues/6548

## Problem
All calls to WDA server are synchronous. So, if we are running some long request, like **createSession**, all the following requests will be automatically put in the internal queue and executed after **createSession**. This behaviour causes timeout errors for some API consumers, like Selenium Grid.

## Solution
We put the result of **getStatus** call into the cache and return the cached value in case there is some asynchronous WDA request running in the background, so the external consumer may get response in time.

Related to https://github.com/appium/appium/issues/6548