### PR TITLE
Fixed touch_id end point when proxying to wda.

### DIFF
--- a/docs/endpoints-wda.md
+++ b/docs/endpoints-wda.md
@@ -53,7 +53,7 @@
 | GET    | /orientation                           | | |
 | POST   | /orientation                           | orientation | |
 | GET    | /screenshot                            | | |
-| POST   | /wda/simulator/touch_id                | match | |
+| POST   | /wda/touch_id                | match | |
 
 
 \* implemented but intentionally not supported

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -33,7 +33,7 @@ commands.touchId = async function (match = true) {
   let params = {
     match
   };
-  return await this.proxyCommand('/wda/simulator/touch_id', 'POST', params);
+  return await this.proxyCommand('/wda/touch_id', 'POST', params);
 };
 
 commands.getWindowSize = async function (windowHandle = 'current') {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -23,21 +23,21 @@ describe('general commands', () => {
     it('should send translated POST request to WDA', async () => {
       await driver.touchId();
       proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/wda/simulator/touch_id');
+      proxySpy.firstCall.args[0].should.eql('/wda/touch_id');
       proxySpy.firstCall.args[1].should.eql('POST');
       proxySpy.firstCall.args[2].should.eql({match: true});
     });
     it('should send translated POST request to WDA with true', async () => {
       await driver.touchId(true);
       proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/wda/simulator/touch_id');
+      proxySpy.firstCall.args[0].should.eql('/wda/touch_id');
       proxySpy.firstCall.args[1].should.eql('POST');
       proxySpy.firstCall.args[2].should.eql({match: true});
     });
     it('should send translated POST request to WDA with false', async () => {
       await driver.touchId(false);
       proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/wda/simulator/touch_id');
+      proxySpy.firstCall.args[0].should.eql('/wda/touch_id');
       proxySpy.firstCall.args[1].should.eql('POST');
       proxySpy.firstCall.args[2].should.eql({match: false});
     });


### PR DESCRIPTION
According to WDA it seems like there are two end points for touch id:

https://github.com/facebook/WebDriverAgent/blob/eeaa1a3bbc9559d41ff3779c73c6678c7715a3d0/WebDriverAgentLib/Commands/FBTouchIDCommands.m

/wda/touch_id
/simulator/touch_id

The second will be deprecated so /wda/touch_id is the correct one to use.