### PR TITLE
Use native WDA call to hide the keyboard

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -49,32 +49,7 @@ commands.getWindowSize = async function (windowHandle = 'current') {
 };
 
 commands.hideKeyboard = async function (strategy, ...possibleKeys) {
-  let keyboard;
-  try {
-    keyboard = await this.findNativeElementOrElements('class name', 'XCUIElementTypeKeyboard', false);
-  } catch (err) {
-    // no keyboard found
-    log.debug('No keyboard found. Unable to hide.');
-    return;
-  }
-
-  possibleKeys.pop(); // last parameter is the session id
-  possibleKeys = possibleKeys.filter((element) => !!element); // get rid of undefined elements
-  if (possibleKeys.length) {
-    for (let key of possibleKeys) {
-      let el = _.last(await this.findNativeElementOrElements('accessibility id', key, true, keyboard));
-      if (el) {
-        log.debug(`Attempting to hide keyboard by pressing '${key}' key.`);
-        await this.nativeClick(el);
-        return;
-      }
-    }
-  } else {
-    // find the keyboard, and hit the last Button
-    log.debug('Finding keyboard and clicking final button to close');
-    let buttons = await this.findNativeElementOrElements('class name', 'XCUIElementTypeButton', true, keyboard);
-    await this.nativeClick(_.last(buttons));
-  }
+  await this.proxyCommand('/wda/keyboard/dismiss', 'POST');
 };
 
 commands.getDeviceTime = iosCommands.general.getDeviceTime;

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -49,7 +49,31 @@ commands.getWindowSize = async function (windowHandle = 'current') {
 };
 
 commands.hideKeyboard = async function (strategy, ...possibleKeys) {
-  await this.proxyCommand('/wda/keyboard/dismiss', 'POST');
+  try {
+    await this.proxyCommand('/wda/keyboard/dismiss', 'POST');
+    return;
+  } catch (err) {
+    log.debug('Cannot dismiss the keyboard using the native call. Trying to apply a workaround...');
+  }
+
+  const keyboard = await this.findNativeElementOrElements('class name', 'XCUIElementTypeKeyboard', false);
+  possibleKeys.pop(); // last parameter is the session id
+  possibleKeys = possibleKeys.filter((element) => !!element); // get rid of undefined elements
+  if (possibleKeys.length) {
+    for (let key of possibleKeys) {
+      let el = _.last(await this.findNativeElementOrElements('accessibility id', key, true, keyboard));
+      if (el) {
+        log.debug(`Attempting to hide keyboard by pressing '${key}' key.`);
+        await this.nativeClick(el);
+        return;
+      }
+    }
+  } else {
+    // find the keyboard, and hit the last Button
+    log.debug('Finding keyboard and clicking final button to close');
+    let buttons = await this.findNativeElementOrElements('class name', 'XCUIElementTypeButton', true, keyboard);
+    await this.nativeClick(_.last(buttons));
+  }
 };
 
 commands.getDeviceTime = iosCommands.general.getDeviceTime;


### PR DESCRIPTION
Native call is much faster and is based on the native XCTest's _dismissKeyboard_ API of XCUIApplication class. There is a known issue about this method is unable to hide keyboard for iPhone if there is no special key assigned for it. This case is handled separately to show correct error description. See https://github.com/facebook/WebDriverAgent/pull/473 for more details.