### PR TITLE
Log xcodebuild file even on success if showXcodeLog is on

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -180,6 +180,7 @@ class WebDriverAgent {
     let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath});
 
     let logXcodeOutput = this.showXcodeLog;
+    log.debug(`Output from xcodebuild ${logXcodeOutput ? 'will' : 'will not'} be logged`);
     xcodebuild.on('output', (stdout, stderr) => {
       let out = stdout || stderr;
       // we want to pull out the log file that is created, and highlight it
@@ -222,21 +223,20 @@ class WebDriverAgent {
     return await new B((resolve, reject) => {
       this.xcodebuild.on('exit', async (code, signal) => {
         log.info(`xcodebuild exited with code '${code}' and signal '${signal}'`);
+        // print out the xcodebuild file if users have asked for it
+        if (this.showXcodeLog && this.xcodebuild.logLocation) {
+          xcodeLog.info(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
+          try {
+            let data = await fs.readFile(this.xcodebuild.logLocation, 'utf-8');
+            for (let line of data.split('\n')) {
+              xcodeLog.info(line);
+            }
+          } catch (err) {
+            log.debug(`Unable to access xcodebuild log file: '${err.message}'`);
+          }
+        }
         this.xcodebuild.processExited = true;
         if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
-          // print out the xcodebuild file if users have asked for it
-          if (this.showXcodeLog && this.xcodebuild.logLocation) {
-            xcodeLog.info(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
-            try {
-              let data = await fs.readFile(this.xcodebuild.logLocation, 'utf-8');
-              for (let line of data.split('\n')) {
-                xcodeLog.info(line);
-              }
-            } catch (err) {
-              log.debug(`Unable to access xcodebuild log file: '${err.message}'`);
-            }
-          }
-
           return reject(new Error(`xcodebuild failed with code ${code}`));
         }
       });

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -282,8 +282,8 @@ describe('XCUITestDriver - find', function () {
   describe('duplicate text field', () => {
     beforeEach(async () => {
       try {
-        let element = await driver.elementByClassName('XCUIElementTypeTable');
-        await driver.execute('mobile: scroll', {element, direction: 'down', name: 'Text Fields'});
+        let element = await driver.elementByAccessibilityId('Text Fields');
+        await driver.execute('mobile: scroll', {element, toVisible: true});
       } catch (ign) {}
       await driver.setImplicitWaitTimeout(5000);
     });


### PR DESCRIPTION
Slight tweak so that if the `showXcodeLog` capability is set, and we have an xcodebuild file, we print it out even on success.