### PR TITLE
Make header files work for xcode 8.0

### DIFF
--- a/lib/webdriveragent-utils.js
+++ b/lib/webdriveragent-utils.js
@@ -1,10 +1,12 @@
 import { fs } from 'appium-support';
 import { exec } from 'teen_process';
+import path from 'path';
 import log from './logger';
 
 
 const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
 const PROJECT_FILE = 'project.pbxproj';
+const XCUICOORDINATE_FILE = 'PrivateHeaders/XCTest/XCUICoordinate.h';
 
 async function replaceInFile (file, find, replace) {
   let contents = await fs.readFile(file, 'utf-8');
@@ -71,5 +73,16 @@ async function setRealDeviceSecurity (keychainPath, keychainPassword) {
   await exec('security', ['set-keychain-settings', '-t', '3600', '-l', keychainPath]);
 }
 
+async function fixXCUICoordinateFile (bootstrapPath) {
+  // the way the updated XCTest headers are in the WDA project, building in
+  // Xcode 8.0 causes a duplicate declaration of method
+  // so fix the offending line in the local headers
+  const file = path.resolve(bootstrapPath, XCUICOORDINATE_FILE);
+
+  let oldDef = '- (void)pressForDuration:(double)arg1 thenDragToCoordinate:(id)arg2;';
+  let newDef = '- (void)pressForDuration:(NSTimeInterval)duration thenDragToCoordinate:(XCUICoordinate *)otherCoordinate;';
+  await replaceInFile(file, oldDef, newDef);
+}
+
 export { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity };
+         setRealDeviceSecurity, fixXCUICoordinateFile };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -11,7 +11,7 @@ import { getLogger } from 'appium-logger';
 import { killAppUsingAppName, generateXcodeConfigFile } from './utils.js';
 import request from 'request-promise';
 import { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity } from './webdriveragent-utils';
+         setRealDeviceSecurity, fixXCUICoordinateFile } from './webdriveragent-utils';
 
 
 const xcodeLog = getLogger('Xcode');
@@ -98,6 +98,11 @@ class WebDriverAgent {
 
     //kill all hanging processes
     await this.killHangingProcesses();
+
+    if (this.xcodeVersion.major === 8 && this.xcodeVersion.minor === 0) {
+      log.debug('Using Xcode 8.0, so fixing header files');
+      await fixXCUICoordinateFile(this.bootstrapPath);
+    }
 
     this.xcodebuild = await this.createXcodeBuildSubProcess();
 


### PR DESCRIPTION
On xcode 8.0 there is a problem with the latest private headers, in that a method gets duplicated with different parameters. This causes building WDA to break.