### PR TITLE
Allow build and test phase of xcodebuild to be separated

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -75,6 +75,9 @@ let desiredCapConstraints = _.defaults({
   wdaStartupRetryInterval: {
     isNumber: true
   },
+  prebuildWDA: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -716,6 +716,7 @@ class XCUITestDriver extends BaseDriver {
     if (util.hasValue(this.opts.iosInstallPause)) {
       // https://github.com/appium/appium/issues/6889
       let pause = parseInt(this.opts.iosInstallPause, 10);
+      log.debug(`iosInstallPause set. Pausing ${pause} ms before continuing`);
       await B.delay(pause);
     }
   }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -208,8 +208,11 @@ class WebDriverAgent {
       }
 
       if (logXcodeOutput) {
-        for (let line of out.split('\n')) {
-          xcodeLog.info(line);
+        // do not log permission errors from trying to write to attachments folder
+        if (out.indexOf('Error writing attachment data to file') === -1) {
+          for (let line of out.split('\n')) {
+            xcodeLog.info(line);
+          }
         }
       }
     });

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -46,6 +46,7 @@ class WebDriverAgent {
     this.keychainPath = args.keychainPath;
     this.keychainPassword = args.keychainPassword;
 
+    this.prebuildWDA = args.prebuildWDA;
     this.usePrebuiltWDA = args.usePrebuiltWDA;
     this.webDriverAgentUrl = args.webDriverAgentUrl;
 
@@ -104,6 +105,15 @@ class WebDriverAgent {
       await fixXCUICoordinateFile(this.bootstrapPath);
     }
 
+    if (this.prebuildWDA) {
+      // first do a build phase
+      log.debug('Pre-building WDA before launching test');
+      this.usePrebuiltWDA = true;
+      this.xcodebuild = await this.createXcodeBuildSubProcess(true);
+      await this.startXcodebuild(true);
+      this.xcodebuild = null;
+    }
+
     this.xcodebuild = await this.createXcodeBuildSubProcess();
 
     if (this.realDevice) {
@@ -128,7 +138,7 @@ class WebDriverAgent {
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
   }
 
-  getXcodeBuildCommand () {
+  getXcodeBuildCommand (buildOnly = false) {
     let cmd = 'xcodebuild';
     let args;
 
@@ -145,12 +155,13 @@ class WebDriverAgent {
         'test',
       ];
     } else {
-      args = this.usePrebuiltWDA ? [
-        'test-without-building'
-      ] : [
-        'build-for-testing',
-        'test-without-building'
-      ];
+      if (buildOnly) {
+        args = ['build-for-testing'];
+      } else if (this.usePrebuiltWDA) {
+        args = ['test-without-building'];
+      } else {
+        args = ['build-for-testing', 'test-without-building'];
+      }
     }
 
     // add the rest of the arguments for the xcodebuild command
@@ -170,7 +181,7 @@ class WebDriverAgent {
     return {cmd, args};
   }
 
-  async createXcodeBuildSubProcess () {
+  async createXcodeBuildSubProcess (buildOnly = false) {
     if (this.realDevice) {
       if (this.keychainPath && this.keychainPassword) {
         await setRealDeviceSecurity(this.keychainPath, this.keychainPassword);
@@ -179,8 +190,8 @@ class WebDriverAgent {
         this.xcodeConfigFile = await generateXcodeConfigFile(this.xcodeOrgId, this.xcodeSigningId);
       }
     }
-    let {cmd, args} = this.getXcodeBuildCommand();
-    log.debug(`Beginning test with command '${cmd} ${args.join(' ')}' ` +
+    let {cmd, args} = this.getXcodeBuildCommand(buildOnly);
+    log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
     let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath});
 
@@ -225,7 +236,7 @@ class WebDriverAgent {
     return new SubProcess(`iproxy`, [localport, deviceport, this.device.udid]);
   }
 
-  async startXcodebuild () {
+  async startXcodebuild (buildOnly = false) {
     // wrap the start procedure in a promise so that we can catch, and report,
     // any startup errors that are thrown as events
     return await new B((resolve, reject) => {
@@ -247,14 +258,20 @@ class WebDriverAgent {
         if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
           return reject(new Error(`xcodebuild failed with code ${code}`));
         }
+        // in the case of just building, the process will exit and that is our finish
+        if (buildOnly) {
+          return resolve();
+        }
       });
 
       return (async () => {
         try {
           let startTime = process.hrtime();
           await this.xcodebuild.start();
-          await this.waitForStart(startTime);
-          resolve();
+          if (!buildOnly) {
+            await this.waitForStart(startTime);
+            resolve();
+          }
         } catch (err) {
           let msg = `Unable to start WebDriverAgent: ${err}`;
           log.error(msg);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -45,6 +45,13 @@ describe('XCUITestDriver', function () {
       await driver.quit();
     });
 
+    it('should start and stop a session doing pre-build', async function () {
+      await driver.init(_.defaults({prebuildWDA: true}, UICATALOG_SIM_CAPS));
+      let els = await driver.elementsByClassName("XCUIElementTypeWindow");
+      els.length.should.be.at.least(1);
+      await driver.quit();
+    });
+
     /* jshint ignore:start */
     describe('initial orientation', async () => {
       async function runOrientationTest (initialOrientation) {


### PR DESCRIPTION
On some systems there seems to be an error when the two phases are done together. Try out having them separated, behind a flag.