### PR TITLE
Make sure status gets through on startup

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,7 +124,7 @@ async function getDriverInfo () {
   let stat = await fs.stat(path.resolve(__dirname, '..'));
   let built = stat.mtime.getTime();
   let info = {
-    built: built,
+    built,
     version: DRIVER_VER,
   };
   return info;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -123,7 +123,7 @@ class WebDriverAgent {
     this.setupProxy(sessionId);
 
     // start the xcodebuild process
-    await this.startXcodebuild();
+    return await this.startXcodebuild();
   }
 
   setupProxy (sessionId) {
@@ -268,8 +268,8 @@ class WebDriverAgent {
           let startTime = process.hrtime();
           await this.xcodebuild.start();
           if (!buildOnly) {
-            await this.waitForStart(startTime);
-            resolve();
+            let status = await this.waitForStart(startTime);
+            resolve(status);
           }
         } catch (err) {
           let msg = `Unable to start WebDriverAgent: ${err}`;
@@ -304,8 +304,8 @@ class WebDriverAgent {
             throw new Error(`Received non-zero status code from WDA server: '${res.status}'`);
           }
           currentStatus = res;
-          if (res.value && res.value.ios && res.value.ios.ip) {
-            this.agentUrl = res.value.ios.ip;
+          if (currentStatus.value && currentStatus.value.ios && currentStatus.value.ios.ip) {
+            this.agentUrl = currentStatus.value.ios.ip;
             log.debug(`WebDriverAgent running on ip '${this.agentUrl}'`);
           }
         } catch (err) {


### PR DESCRIPTION
The driver call to launch currently expects the WDA status to be returned (https://github.com/appium/appium-xcuitest-driver/blob/master/lib/driver.js#L342) but it is not. 