### PR TITLE
Make it so tap-release works as a gesture

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -84,6 +84,10 @@ function isTap (gestures) {
   if (gestures.length === 1 && gestures[0].action === 'tap') {
     return true;
   } else if (gestures.length === 2 &&
+              gestures[0].action === 'tap' &&
+              gestures[1].action === 'release') {
+    return true;
+  } else if (gestures.length === 2 &&
               gestures[0].action === 'press' &&
               gestures[1].action === 'release') {
     return true;


### PR DESCRIPTION
Some people have complained that they are adding a `release` to their `tap` actions and then it doesn't work. It is trivial to allow it, and map the whole thing to `tap` anyway.