### PR TITLE
Use separate cleaner for Safari

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -1,6 +1,8 @@
 import path from 'path';
 import { getSimulator } from 'appium-ios-simulator';
 import { createDevice, getDevices, terminate } from 'node-simctl';
+import { waitForCondition } from 'asyncbox';
+import { exec } from 'teen_process';
 import _ from 'lodash';
 import log from './logger';
 
@@ -26,6 +28,31 @@ async function getExistingSim (deviceName, platformVersion) {
     }
   }
   return null;
+}
+
+async function prepareSafariForCleanup (timeout = 5000) {
+  try {
+    await waitForCondition(async () => {
+      try {
+        await exec('pgrep', ['-x', 'MobileSafari']);
+      } catch (e) {
+        if (e.code === 1) return true;
+        try {
+          await exec('pkill', ['-9', '-x', 'MobileSafari']);
+        } catch (e1) {
+          if (e1.code === 1) return true;
+          log.warn(e1.message);
+        }
+      }
+      return false;
+    }, {
+      waitMs: timeout,
+      intervalMs: 200
+    });
+    log.debug('Mobile Safari process is not running. Continuing with cleanup');
+  } catch (err) {
+    log.warn(`Mobile Safari is still running after ${timeout} ms`);
+  }
 }
 
 async function runSimulatorReset (device, opts) {
@@ -66,6 +93,7 @@ async function runSimulatorReset (device, opts) {
     const isSafari = (opts.browserName || '').toLowerCase() === 'safari';
     try {
       if (isSafari) {
+        await prepareSafariForCleanup();
         await device.cleanSafari();
       } else {
         await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -63,11 +63,16 @@ async function runSimulatorReset (device, opts) {
       log.info('Not scrubbing third party app in anticipation of uninstall');
       return;
     }
+    const isSafari = (opts.browserName || '').toLowerCase() === 'safari';
     try {
-      await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
+      if (isSafari) {
+        await device.cleanSafari();
+      } else {
+        await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
+      }
     } catch (err) {
-      log.warn(err);
-      log.warn(`Reset: could not scrub application with id "${opts.bundleId}". Leaving as is.`);
+      log.warn(err.message);
+      log.warn(`Reset: could not scrub ${isSafari ? 'Safari browser' : 'application with id "' + opts.bundleId + '"'}. Leaving as is.`);
     }
   }
 }


### PR DESCRIPTION
This should fix Safari data cleanup on "soft-reset". Also, some more folders should be added to appium-ios-simulator module. It will be done in another PR.