### PR TITLE
Starts IWDP if real device and cap is set

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -41,7 +41,7 @@ commands.background = async function (duration) {
     log.warn('commands.background: Passing numbers to \'duration\' argument is deprecated. ' +
              'See https://github.com/appium/appium/issues/7741');
     if (duration >= 0) {
-      params = {duration: duration};
+      params = {duration};
       endpoint = deactivateAppEndpoint;
     } else {
       endpoint = homescreenEndpoint;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -84,6 +84,9 @@ let desiredCapConstraints = _.defaults({
   calendarAccessAuthorized: {
     isBoolean: true,
   },
+  startIWDP: {
+    isBoolean: true,
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -815,8 +815,10 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async startIWDP () {
+    this.logEvent('iwdpStarting');
     this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid);
     await this.iwdpServer.start();
+    this.logEvent('iwdpStarted');
   }
 
   async stopIWDP () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,7 +9,7 @@ import { simBooted, createSim, getExistingSim, runSimulatorReset,
 import { killAllSimulators, simExists, getSimulator, installSSLCert,
          uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
-import { settings as iosSettings, defaultServerCaps, appUtils } from 'appium-ios-driver';
+import { settings as iosSettings, defaultServerCaps, appUtils, IWDP } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
 import commands from './commands/index';
 import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
@@ -18,7 +18,6 @@ import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
          getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
-
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const WDA_STARTUP_RETRIES = 2;
@@ -320,6 +319,16 @@ class XCUITestDriver extends BaseDriver {
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
 
+
+    if (this.isRealDevice() && this.opts.startIWDP) {
+      try {
+        await this.startIWDP();
+        log.debug(`Started ios_webkit_debug proxy server at: ${this.iwdpServer.endpoint}`);
+      } catch (err) {
+        log.errorAndThrow(`Could not start ios_webkit_debug_proxy server: ${err.message}`);
+      }
+    }
+
     if (this.isSafari() || this.opts.autoWebview) {
       log.debug('Waiting for initial webview');
       await this.navToInitialWebview();
@@ -449,6 +458,10 @@ class XCUITestDriver extends BaseDriver {
     if (!_.isEmpty(this.logs)) {
       this.logs.syslog.stopCapture();
       this.logs = {};
+    }
+
+    if (this.iwdpServer) {
+      this.stopIWDP();
     }
 
     this.resetIos();
@@ -799,6 +812,18 @@ class XCUITestDriver extends BaseDriver {
     let wdaCaps = await this.proxyCommand('/', 'GET');
     log.info("Merging WDA caps over Appium caps for session detail response");
     return Object.assign({udid: this.opts.udid}, driverSession, wdaCaps.capabilities);
+  }
+
+  async startIWDP () {
+    this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid);
+    await this.iwdpServer.start();
+  }
+
+  async stopIWDP () {
+    if (this.iwdpServer) {
+      await this.iwdpServer.stop();
+      delete this.iwdpServer;
+    }
   }
 
 }

--- a/test/functional/basic/iwdp-e2e-specs.js
+++ b/test/functional/basic/iwdp-e2e-specs.js
@@ -1,0 +1,39 @@
+// transpile:mocha
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { SAFARI_CAPS } from '../desired';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import B from 'bluebird';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+if (process.env.REAL_DEVICE) {
+  describe('ios_webkit_debug_proxy: ', function () {
+    this.timeout(MOCHA_TIMEOUT);
+    let caps, driver;
+
+    beforeEach(async () => {
+      caps = Object.assign(SAFARI_CAPS);
+      caps.startIWDP = true;
+    });
+
+    afterEach(async () => {
+      await deleteSession();
+      await B.delay(2000);
+    });
+
+    it('Should start a Safari session if "caps.startIWDP === true"', async () => {
+      caps.startIWDP = true;
+      driver = await initSession(caps);
+      await driver.source().should.not.be.rejected;
+      await driver.quit();
+    });
+
+    it('Should not start a Safari session if "caps.startIWDP === false"', async () => {
+      caps.startIWDP = false;
+      await initSession(caps).should.be.rejected;
+    });
+  });
+}

--- a/test/functional/basic/iwdp-e2e-specs.js
+++ b/test/functional/basic/iwdp-e2e-specs.js
@@ -21,7 +21,7 @@ if (process.env.REAL_DEVICE) {
 
     afterEach(async () => {
       await deleteSession();
-      await B.delay(2000);
+      await B.delay(500);
     });
 
     it('Should start a Safari session if "caps.startIWDP === true"', async () => {
@@ -33,7 +33,7 @@ if (process.env.REAL_DEVICE) {
 
     it('Should not start a Safari session if "caps.startIWDP === false"', async () => {
       caps.startIWDP = false;
-      await initSession(caps).should.be.rejected;
+      await initSession(caps).should.be.rejectedWith(/environment you requested was unavailable/);
     });
   });
 }

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import chai from 'chai';
 import log from '../../lib/logger';
 import * as utils from '../../lib/utils';
-
+import request from 'request-promise';
 
 const caps = {platformName: "iOS", deviceName: "iPhone 6", app: "/foo.app"};
 const anoop = async () => {};
@@ -102,6 +102,18 @@ describe('driver commands', () => {
         .should.have.length(1);
       warnStub.restore();
     });
+  });
+
+  describe('startIWDP()', () => {
+
+    it('should start and stop IWDP server', async () => {
+      await driver.startIWDP();
+      let endpoint = driver.iwdpServer.endpoint;
+      await request(endpoint).should.eventually.have.string('<html');
+      await driver.stopIWDP();
+      await request(endpoint).should.eventually.be.rejected;
+    });
+
   });
 });
 


### PR DESCRIPTION
* If startIWDP === true, start ios_webkit_debug_proxy
* Add test to confirm that Safari page can be opened and interacted with when startIWDP == true
* Add test to confirm that interactions with Safari page are rejected when startIWDP == false
* Add unit test to check that it's starting and stopping the server
* Fixed object-shorthand lint error in general.js

(please review @jlipps @imurchie)