### PR TITLE
Add ability to use build and test as build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules
   - git submodule update --init --recursive
   - pushd WebDriverAgent && ./Scripts/bootstrap.sh -d && popd
+  - brew install ios-webkit-debug-proxy
 before_script:
   - node --version
   - npm install

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -82,10 +82,16 @@ let desiredCapConstraints = _.defaults({
     isBoolean: true
   },
   calendarAccessAuthorized: {
-    isBoolean: true,
+    isBoolean: true
   },
   startIWDP: {
     isBoolean: true,
+  },
+  useSimpleBuildTest: {
+    isBoolean: true
+  },
+  waitForQuiescence: {
+    isBoolean: true
   },
 }, iosDesiredCapConstraints);
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -19,6 +19,7 @@ import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
 import B from 'bluebird';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
+
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const WDA_STARTUP_RETRIES = 2;
 const DEFAULT_TIMEOUT_KEY = 'default';
@@ -649,7 +650,7 @@ class XCUITestDriver extends BaseDriver {
         bundleId,
         arguments: args,
         environment: env,
-        shouldWaitForQuiescence: true
+        shouldWaitForQuiescence: util.hasValue(this.opts.waitForQuiescence) ? this.opts.waitForQuiescence : true,
       }
     };
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -23,6 +23,7 @@ const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const IPROXY_TIMEOUT = 5000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
+const BUILD_TEST_DELAY = 1000;
 
 class WebDriverAgent {
 
@@ -47,6 +48,8 @@ class WebDriverAgent {
 
     this.prebuildWDA = args.prebuildWDA;
     this.usePrebuiltWDA = args.usePrebuiltWDA;
+    this.useSimpleBuildTest = args.useSimpleBuildTest;
+
     this.webDriverAgentUrl = args.webDriverAgentUrl;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
@@ -114,6 +117,8 @@ class WebDriverAgent {
         this.xcodebuild = await this.createXcodeBuildSubProcess(true);
         await this.startXcodebuild(true);
         this.xcodebuild = null;
+        // pause a moment
+        await B.delay(BUILD_TEST_DELAY);
       }
     }
 
@@ -158,12 +163,13 @@ class WebDriverAgent {
         'test',
       ];
     } else {
+      let [buildCmd, testCmd] = this.useSimpleBuildTest ? ['build', 'test'] : ['build-for-testing', 'test-without-building'];
       if (buildOnly) {
-        args = ['build-for-testing'];
+        args = [buildCmd];
       } else if (this.usePrebuiltWDA) {
-        args = ['test-without-building'];
+        args = [testCmd];
       } else {
-        args = ['build-for-testing', 'test-without-building'];
+        args = [buildCmd, testCmd];
       }
     }
 

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -52,6 +52,13 @@ describe('XCUITestDriver', function () {
       await driver.quit();
     });
 
+    it('should start and stop a session doing simple build-test', async function () {
+      await driver.init(_.defaults({useSimpleBuildTest: true}, UICATALOG_SIM_CAPS));
+      let els = await driver.elementsByClassName("XCUIElementTypeWindow");
+      els.length.should.be.at.least(1);
+      await driver.quit();
+    });
+
     /* jshint ignore:start */
     describe('initial orientation', async () => {
       async function runOrientationTest (initialOrientation) {


### PR DESCRIPTION
Make whether you want to use `build-for-testing` and `test-without-building` configurable.