### PR TITLE
Add class chain locator to XCUITest driver

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -20,6 +20,9 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
   if (strategy === '-ios predicate string') {
     // WebDriverAgent uses 'predicate string'
     strategy = 'predicate string';
+  } else if (strategy === '-ios class chain') {
+    // WebDriverAgent uses 'class chain'
+    strategy = 'class chain';
   }
 
   // Check if the word 'View' is appended to selector and if it is, strip it out

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -119,6 +119,7 @@ class XCUITestDriver extends BaseDriver {
       'name',
       'class name',
       '-ios predicate string',
+      '-ios class chain',
       'accessibility id'
     ];
     this.webLocatorStrategies = [

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -343,4 +343,31 @@ describe('XCUITestDriver - find', function () {
       els.should.have.length.above(1);
     });
   });
+
+  describe('by class chain', () => {
+    before(async () => {
+      // if we don't pause, WDA freaks out sometimes, especially on fast systems
+      await B.delay(500);
+    });
+    it('should find elements', async () => {
+      let els = await driver.elements('-ios class chain', 'XCUIElementTypeWindow');
+      els.should.have.length.above(0);
+    });
+
+    it('should find child elements', async () => {
+      let els = await driver.elements('-ios class chain', 'XCUIElementTypeWindow/*');
+      els.should.have.length.above(0);
+    });
+
+    it('should find elements with index', async () => {
+      let els1 = await driver.elements('-ios class chain', 'XCUIElementTypeWindow[1]/*');
+      let els2 = await driver.elements('-ios class chain', 'XCUIElementTypeWindow/*');
+      els1.should.have.length(els2.length);
+    });
+
+    it('should find elements with negative index', async () => {
+      let els = await driver.elements('-ios class chain', 'XCUIElementTypeWindow/*[-1]');
+      els.should.have.length(1);
+    });
+  });
 });


### PR DESCRIPTION
Add a new locator type for XCUITest-based driver. See https://github.com/facebook/WebDriverAgent/pull/442 for more details.