### PR TITLE
Make all XCTest gestures available for "mobile:" interface

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { iosCommands } from 'appium-ios-driver';
 import { errors } from 'appium-base-driver';
 
@@ -26,14 +27,21 @@ extensions.executeAsync = async function (script, args, sessionId) {
 
 // Overrides the 'executeMobile' function defined in appium-ios-driver
 extensions.executeMobile = async function (mobileCommand, opts={}) {
-  // we only support mobile: scroll and mobile: swipe
-  if (mobileCommand === 'scroll') {
-    await this.mobileScroll(opts);
-  } else if (mobileCommand === 'swipe') {
-    await this.mobileScroll(opts, true);
-  } else {
-    throw new errors.UnknownCommandError('Unknown command, all the mobile commands except scroll and swipe have been removed.');
+  const mobileCommandsMapping = {
+    scroll: async (x) => {await this.mobileScroll(x);},
+    swipe: async (x) => {await this.mobileScroll(x, true);},
+    pinch: async (x) => {await this.mobilePinch(x);},
+    doubleTap: async (x) => {await this.mobileDoubleTap(x);},
+    twoFingerTap: async (x) => {await this.mobileTwoFingerTap(x);},
+    touchAndHold: async (x) => {await this.mobileTouchAndHold(x);},
+    tap: async (x) => {await this.mobileTap(x);},
+    dragFromToForDuration: async (x) => {await this.mobileDragFromToForDuration(x);}
+  };
+
+  if (!_.has(mobileCommandsMapping, mobileCommand)) {
+    throw new errors.UnknownCommandError(`Unknown mobile command "${mobileCommand}". Only ${_.keys(mobileCommandsMapping)} commands are supported.`);
   }
+  return await mobileCommandsMapping[mobileCommand](opts);
 };
 
 export default extensions;

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -303,6 +303,15 @@ helpers.handlePinchOrZoom = async function (actions) {
   await this.proxyCommand(`/wda/element/${el}/pinch`, 'POST', params);
 };
 
+/*
+ * See https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Commands/FBElementCommands.m
+ * to get the info about available WDA gestures API
+ *
+ * See https://developer.apple.com/reference/xctest/xcuielement and
+ * https://developer.apple.com/reference/xctest/xcuicoordinate to get the detailed description of
+ * all XCTest gestures
+*/
+
 helpers.mobileScroll = async function (opts={}, swipe=false) {
   if (!opts.element) {
     opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
@@ -327,9 +336,95 @@ helpers.mobileScroll = async function (opts={}, swipe=false) {
     log.errorAndThrow(msg);
   }
 
-  let element = opts.element.ELEMENT ? opts.element.ELEMENT : opts.element;
+  let element = opts.element.ELEMENT || opts.element;
   let endpoint = `/wda/element/${element}/${swipe ? 'swipe' : 'scroll'}`;
   return await this.proxyCommand(endpoint, 'POST', params);
+};
+
+function parseFloatParameter (paramName, paramValue, methodName) {
+  if (_.isUndefined(paramValue)) {
+    log.errorAndThrow(`"${paramName}" parameter is mandatory for "${methodName}" call`);
+  }
+  const result = parseFloat(paramValue);
+  if (isNaN(result)) {
+    log.errorAndThrow(`"${paramName}" parameter should be a valid number. "${paramValue}" is given instead`);
+  }
+  return result;
+}
+
+helpers.mobilePinch = async function (opts={}) {
+  if (!opts.element) {
+    opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
+  }
+  const params = {
+    scale: parseFloatParameter('scale', opts.scale, 'pinch'),
+    velocity: parseFloatParameter('velocity', opts.velocity, 'pinch')
+  };
+  const el = opts.element.ELEMENT || opts.element;
+  return await this.proxyCommand(`/wda/element/${el}/pinch`, 'POST', params);
+};
+
+helpers.mobileDoubleTap = async function (opts={}) {
+  if (opts.element) {
+    // Double tap element
+    const el = opts.element.ELEMENT || opts.element;
+    return await this.proxyCommand(`/wda/element/${el}/doubleTap`, 'POST');
+  }
+  // Double tap coordinates
+  const params = {
+    x: parseFloatParameter('x', opts.x, 'doubleTap'),
+    y: parseFloatParameter('y', opts.y, 'doubleTap')
+  };
+  return await this.proxyCommand('/wda/doubleTap', 'POST', params);
+};
+
+helpers.mobileTwoFingerTap = async function (opts={}) {
+  if (!opts.element) {
+    opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
+  }
+  const el = opts.element.ELEMENT || opts.element;
+  return await this.proxyCommand(`/wda/element/${el}/twoFingerTap`, 'POST');
+};
+
+helpers.mobileTouchAndHold = async function (opts={}) {
+  let params = {
+    duration: parseFloatParameter('duration', opts.duration, 'touchAndHold')
+  };
+  if (opts.element) {
+    // Long tap element
+    const el = opts.element.ELEMENT || opts.element;
+    return await this.proxyCommand(`/wda/element/${el}/touchAndHold`, 'POST', params);
+  }
+  // Long tap coordinates
+  params.x = parseFloatParameter('x', opts.x, 'touchAndHold');
+  params.y = parseFloatParameter('y', opts.y, 'touchAndHold');
+  return await this.proxyCommand('/wda/touchAndHold', 'POST', params);
+};
+
+helpers.mobileTap = async function (opts={}) {
+  const params = {
+    x: parseFloatParameter('x', opts.x, 'tap'),
+    y: parseFloatParameter('y', opts.y, 'tap')
+  };
+  const el = opts.element ? (opts.element.ELEMENT || opts.element) : '0';
+  return await this.proxyCommand(`/wda/tap/${el}`, 'POST', params);
+};
+
+helpers.mobileDragFromToForDuration = async function (opts={}) {
+  const params = {
+    duration: parseFloatParameter('duration', opts.duration, 'dragFromToForDuration'),
+    fromX: parseFloatParameter('fromX', opts.fromX, 'dragFromToForDuration'),
+    fromY: parseFloatParameter('fromY', opts.fromY, 'dragFromToForDuration'),
+    toX: parseFloatParameter('toX', opts.toX, 'dragFromToForDuration'),
+    toY: parseFloatParameter('toY', opts.toY, 'dragFromToForDuration')
+  };
+  if (opts.element) {
+    // Drag element
+    const el = opts.element.ELEMENT || opts.element;
+    return await this.proxyCommand(`/wda/element/${el}/dragfromtoforduration`, 'POST', params);
+  }
+  // Drag coordinates
+  return await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
 };
 
 helpers.getCoordinates = async function(gesture) {

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -88,20 +88,199 @@ describe('gesture commands', () => {
     });
 
     describe('swipe', () => {
+      const commandName = 'swipe';
+
       it('should throw an error if no direction is specified', async () => {
-        await driver.execute('mobile: swipe', {element: 4}).should.be.rejectedWith(/Error: Mobile swipe requires direction/);
+        await driver.execute(`mobile: ${commandName}`, {element: 4})
+          .should.be.rejectedWith(/Error: Mobile swipe requires direction/);
       });
 
       it('should throw an error if invalid direction', async () => {
-        await driver.execute('mobile: swipe', {element: 4, direction: 'foo'}).should.be.rejectedWith(/Error: Direction must be up, down, left or right/);
+        await driver.execute(`mobile: ${commandName}`, {element: 4, direction: 'foo'})
+          .should.be.rejectedWith(/Error: Direction must be up, down, left or right/);
       });
 
       it('should proxy a swipe up request through to WDA', async () => {
-        await driver.execute('mobile: swipe', {element: 4, direction: 'up'});
+        await driver.execute(`mobile: ${commandName}`, {element: 4, direction: 'up'});
         proxySpy.calledOnce.should.be.true;
         proxySpy.firstCall.args[0].should.eql('/wda/element/4/swipe');
         proxySpy.firstCall.args[1].should.eql('POST');
         return proxySpy.firstCall.args[2].should.eql({direction: 'up'});
+      });
+    });
+
+    describe('pinch', () => {
+      const commandName = 'pinch';
+
+      it('should throw an error if no mandatory parameter is specified', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 4.1})
+          .should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {element: 4, velocity: -0.5})
+          .should.be.rejectedWith(/parameter is mandatory/);
+      });
+
+      it('should throw an error if param is invalid', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, scale: '', velocity: 1})
+          .should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 0, velocity: null})
+          .should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a pinch request through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 1, velocity: '1'});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/pinch');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['scale', 'velocity']);
+      });
+    });
+
+    describe('doubleTap', () => {
+      const commandName = 'doubleTap';
+
+      it('should throw an error if no mandatory parameter is specified', async () => {
+        await driver.execute(`mobile: ${commandName}`, {x: 100}).should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {y: 200}).should.be.rejectedWith(/parameter is mandatory/);
+      });
+
+      it('should throw an error if param is invalid', async () => {
+        await driver.execute(`mobile: ${commandName}`, {x: '', y: 1}).should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {x: 1, y: null}).should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a doubleTap request for an element through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/doubleTap');
+        proxySpy.firstCall.args[1].should.eql('POST');
+      });
+
+      it('should proxy a doubleTap request for a coordinate point through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {x: 100, y: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/doubleTap');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['x', 'y']);
+      });
+    });
+
+    describe('twoFingerTap', () => {
+      const commandName = 'twoFingerTap';
+
+      it('should proxy a twoFingerTap request for an element through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/twoFingerTap');
+        proxySpy.firstCall.args[1].should.eql('POST');
+      });
+    });
+
+    describe('touchAndHold', () => {
+      const commandName = 'touchAndHold';
+
+      it('should throw an error if no mandatory parameter is specified', async () => {
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, x: 1}).should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, y: 200}).should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {x: 100, y: 200}).should.be.rejectedWith(/parameter is mandatory/);
+      });
+
+      it('should throw an error if param is invalid', async () => {
+        await driver.execute(`mobile: ${commandName}`, {duration: '', x: 1, y: 1}).should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 1, x: '', y: 1}).should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 1, x: 1, y: null}).should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a touchAndHold request for an element through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, duration: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/touchAndHold');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['duration']);
+      });
+
+      it('should proxy a touchAndHold request for a coordinate point through to WDA', async () => {
+        await driver.execute('mobile: touchAndHold', {duration: 100, x: 100, y: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/touchAndHold');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['duration', 'x', 'y']);
+      });
+    });
+
+    describe('tap', () => {
+      const commandName = 'tap';
+
+      it('should throw an error if no mandatory parameter is specified', async () => {
+        await driver.execute(`mobile: ${commandName}`, {}).should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {x: 100}).should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {y: 200}).should.be.rejectedWith(/parameter is mandatory/);
+      });
+
+      it('should throw an error if param is invalid', async () => {
+        await driver.execute(`mobile: ${commandName}`, {x: '', y: 1}).should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {x: 1, y: null}).should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a tap request for an element through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, x: 100, y: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/tap/4');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['x', 'y']);
+      });
+
+      it('should proxy a tap request for a coordinate point through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {x: 100, y: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/tap/0');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['x', 'y']);
+      });
+    });
+
+    describe('dragFromToForDuration', () => {
+      const commandName = 'dragFromToForDuration';
+
+      it('should throw an error if no mandatory parameter is specified', async () => {
+        await driver.execute(`mobile: ${commandName}`, {fromX: 1, fromY: 1, toX: 100, toY: 100})
+          .should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromY: 1, toX: 100, toY: 100})
+          .should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, toX: 100, toY: 100})
+          .should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toY: 100})
+          .should.be.rejectedWith(/parameter is mandatory/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100})
+          .should.be.rejectedWith(/parameter is mandatory/);
+      });
+
+      it('should throw an error if param is invalid', async () => {
+        await driver.execute(`mobile: ${commandName}`, {duration: '', fromX: 1, fromY: 1, toX: 100, toY: 100})
+          .should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: '', fromY: 1, toX: 100, toY: 100})
+          .should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: null, toX: 100, toY: 100})
+          .should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 'blabla', toY: 100})
+          .should.be.rejectedWith(/should be a valid number/);
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100, toY: NaN})
+          .should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a dragFromToForDuration request for an element through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {element: 4, duration: 100, fromX: 1, fromY: 1, toX: 100, toY: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/element/4/dragfromtoforduration');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['duration', 'fromX', 'fromY', 'toX', 'toY']);
+      });
+
+      it('should proxy a dragFromToForDuration request for a coordinate point through to WDA', async () => {
+        await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100, toY: 100});
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/dragfromtoforduration');
+        proxySpy.firstCall.args[1].should.eql('POST');
+        proxySpy.firstCall.args[2].should.have.keys(['duration', 'fromX', 'fromY', 'toX', 'toY']);
       });
     });
   });


### PR DESCRIPTION
This PR makes all XCTest gestures available for calling via mobile: interface, so one can use them even without specialised wrappers in top-level drivers. This is just a POC, so I didn't create any tests yet. Please kindly check the basic implementation first.