### PR TITLE
Add a separate proxy for WDA commands without session ID

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -66,7 +66,7 @@ commands.background = async function (duration) {
                       'The \'timeout\' attribute can be \'null\' or any negative number to put the app under test ' +
                       'into background and never come back or a positive number of milliseconds to wait until the app is restored.');
   }
-  return await this.proxyCommand(endpoint, 'POST', params);
+  return await this.proxyCommand(endpoint, 'POST', params, endpoint !== homescreenEndpoint);
 };
 
 /*

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -7,7 +7,7 @@ const GET_STATUS_COMMAND = 'getStatus';
 
 let helpers = {}, extensions = {};
 
-helpers.proxyCommand = async function (endpoint, method, body) {
+helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand=true) {
   if (this.shutdownUnexpectedly) return;
 
   if (!endpoint) {
@@ -16,8 +16,12 @@ helpers.proxyCommand = async function (endpoint, method, body) {
     log.errorAndThrow(`Proxying only works for the following requests: ${SUPPORTED_METHODS.join(', ')}`);
   }
 
-  if (!this.wda || !this.wda.jwproxy) {
-    throw new Error("Can't call proxyCommand without proxy active");
+  if (!this.wda) {
+    throw new Error("Can't call proxyCommand without WDA driver active");
+  }
+  const proxy = isSessionCommand ? this.wda.jwproxy : this.wda.noSessionProxy;
+  if (!proxy) {
+    throw new Error("Can't call proxyCommand without WDA proxy active");
   }
 
   const cmdName = routeToCommandName(endpoint, method);
@@ -26,19 +30,19 @@ helpers.proxyCommand = async function (endpoint, method, body) {
   if (timeout) {
     log.debug(`Setting custom timeout to ${timeout} ms for "${cmdName}" command`);
     let isCommandExpired = false;
-    res = await B.Promise.resolve(this.wda.jwproxy.command(endpoint, method, body))
+    res = await B.Promise.resolve(proxy.command(endpoint, method, body))
                   .timeout(timeout)
                   .catch(B.Promise.TimeoutError, () => {
                     isCommandExpired = true;
                   });
     if (isCommandExpired) {
-      this.wda.jwproxy.cancelActiveRequests();
+      proxy.cancelActiveRequests();
       const errMsg = `Appium did not get any response from "${cmdName}" command in ${timeout} ms`;
       await this.startUnexpectedShutdown(new errors.TimeoutError(errMsg));
       log.errorAndThrow(errMsg);
     }
   } else {
-    res = await this.wda.jwproxy.command(endpoint, method, body);
+    res = await proxy.command(endpoint, method, body);
   }
 
   // temporarily handle errors that can be returned

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -7,7 +7,7 @@ const GET_STATUS_COMMAND = 'getStatus';
 
 let helpers = {}, extensions = {};
 
-helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand=true) {
+helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand = true) {
   if (this.shutdownUnexpectedly) return;
 
   if (!endpoint) {

--- a/lib/no-session-proxy.js
+++ b/lib/no-session-proxy.js
@@ -1,0 +1,34 @@
+import { util } from 'appium-support';
+import { JWProxy } from 'appium-base-driver';
+
+class NoSessionProxy extends JWProxy {
+  constructor (opts = {}) {
+    super(opts);
+  }
+
+  getUrlForProxy (url) {
+    if (url === '') {
+      url = '/';
+    }
+    const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
+    let remainingUrl = '';
+    if ((new RegExp('^/')).test(url)) {
+      remainingUrl = url;
+    } else {
+      throw new Error(`Did not know what to do with url '${url}'`);
+    }
+    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+    return proxyBase + remainingUrl;
+  }
+
+  async proxyReqRes (req, res) {
+    let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
+    res.headers = response.headers;
+    res.set('Content-type', response.headers['content-type']);
+    body = util.safeJsonParse(body);
+    res.status(response.statusCode).send(JSON.stringify(body));
+  }
+}
+
+export { NoSessionProxy };
+export default NoSessionProxy;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -5,10 +5,9 @@ import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import { JWProxy } from 'appium-base-driver';
-import { fs, logger } from 'appium-support';
+import { fs, logger, util } from 'appium-support';
 import log from './logger';
 import { killAppUsingAppName, generateXcodeConfigFile } from './utils.js';
-import request from 'request-promise';
 import { updateProjectFile, resetProjectFile, checkForDependencies,
          setRealDeviceSecurity, fixXCUICoordinateFile } from './webdriveragent-utils';
 
@@ -24,6 +23,37 @@ const IPROXY_TIMEOUT = 5000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
 const BUILD_TEST_DELAY = 1000;
+
+
+class NoSessionProxy extends JWProxy {
+  constructor (opts = {}) {
+    super(opts);
+  }
+
+  getUrlForProxy (url) {
+    if (url === '') {
+      url = '/';
+    }
+    const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
+    let remainingUrl = '';
+    if ((new RegExp('^/')).test(url)) {
+      remainingUrl = url;
+    } else {
+      throw new Error(`Did not know what to do with url '${url}'`);
+    }
+    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+    return proxyBase + remainingUrl;
+  }
+
+  async proxyReqRes (req, res) {
+    let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
+    res.headers = response.headers;
+    res.set('Content-type', response.headers['content-type']);
+    body = util.safeJsonParse(body);
+    res.status(response.statusCode).send(JSON.stringify(body));
+  }
+}
+
 
 class WebDriverAgent {
 
@@ -80,11 +110,14 @@ class WebDriverAgent {
     if (this.webDriverAgentUrl) {
       log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
       this.url = this.webDriverAgentUrl;
+      this.setupNoSessionProxy();
       this.setupProxy(sessionId);
       return this.webDriverAgentUrl;
     }
 
     log.info('Launching WebDriverAgent on the device');
+
+    this.setupNoSessionProxy();
 
     if (!await fs.exists(this.agentPath)) {
       throw new Error(`Trying to use WebDriverAgent project at '${this.agentPath}' but the ` +
@@ -144,6 +177,16 @@ class WebDriverAgent {
     });
     this.jwproxy.sessionId = sessionId;
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
+  }
+
+  setupNoSessionProxy () {
+    this.noSessionProxy = new NoSessionProxy({
+      server: this.url.hostname,
+      port: this.url.port,
+      base: '',
+      timeout: this.wdaConnectionTimeout,
+    });
+    this.noSessionProxyReqRes = this.noSessionProxy.proxyReqRes.bind(this.noSessionProxy);
   }
 
   getXcodeBuildCommand (buildOnly = false) {
@@ -302,18 +345,13 @@ class WebDriverAgent {
           return;
         }
         try {
-          let opts = {
-            method: 'GET',
-            uri: `${this.url.href}status`,
-            headers: 'Content-Type: application/json;charset=UTF-8, accept: application/json',
-            forever: true,
-            json: true,
-          };
-          let res = await request(opts);
-          if (res.status !== 0) {
-            throw new Error(`Received non-zero status code from WDA server: '${res.status}'`);
+          const proxyTimeout = this.noSessionProxy.timeout;
+          try {
+            this.noSessionProxy.timeout = 5000;
+            currentStatus = await this.noSessionProxy.command('/status', 'GET');
+          } finally {
+            this.noSessionProxy.timeout = proxyTimeout;
           }
-          currentStatus = res;
           if (currentStatus.value && currentStatus.value.ios && currentStatus.value.ios.ip) {
             this.agentUrl = currentStatus.value.ios.ip;
             log.debug(`WebDriverAgent running on ip '${this.agentUrl}'`);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -110,14 +110,13 @@ class WebDriverAgent {
     if (this.webDriverAgentUrl) {
       log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
       this.url = this.webDriverAgentUrl;
-      this.setupNoSessionProxy();
-      this.setupProxy(sessionId);
+      this.setupProxies(sessionId);
       return this.webDriverAgentUrl;
     }
 
     log.info('Launching WebDriverAgent on the device');
 
-    this.setupNoSessionProxy();
+    this.setupProxies(sessionId);
 
     if (!await fs.exists(this.agentPath)) {
       throw new Error(`Trying to use WebDriverAgent project at '${this.agentPath}' but the ` +
@@ -162,30 +161,23 @@ class WebDriverAgent {
       await this.startiproxy();
     }
 
-    this.setupProxy(sessionId);
-
     // start the xcodebuild process
     return await this.startXcodebuild();
   }
 
-  setupProxy (sessionId) {
-    this.jwproxy = new JWProxy({
+  setupProxies (sessionId) {
+    const proxyOpts = {
       server: this.url.hostname,
       port: this.url.port,
       base: '',
       timeout: this.wdaConnectionTimeout,
-    });
+    };
+
+    this.jwproxy = new JWProxy(proxyOpts);
     this.jwproxy.sessionId = sessionId;
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
-  }
 
-  setupNoSessionProxy () {
-    this.noSessionProxy = new NoSessionProxy({
-      server: this.url.hostname,
-      port: this.url.port,
-      base: '',
-      timeout: this.wdaConnectionTimeout,
-    });
+    this.noSessionProxy = new NoSessionProxy(proxyOpts);
     this.noSessionProxyReqRes = this.noSessionProxy.proxyReqRes.bind(this.noSessionProxy);
   }
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -347,7 +347,7 @@ class WebDriverAgent {
         try {
           const proxyTimeout = this.noSessionProxy.timeout;
           try {
-            this.noSessionProxy.timeout = 5000;
+            this.noSessionProxy.timeout = this.wdaLaunchTimeout < 5000 ? this.wdaLaunchTimeout / 2 : 5000;
             currentStatus = await this.noSessionProxy.command('/status', 'GET');
           } finally {
             this.noSessionProxy.timeout = proxyTimeout;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -5,8 +5,9 @@ import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
 import { SubProcess } from 'teen_process';
 import { JWProxy } from 'appium-base-driver';
-import { fs, logger, util } from 'appium-support';
+import { fs, logger } from 'appium-support';
 import log from './logger';
+import { NoSessionProxy } from "./no-session-proxy";
 import { killAppUsingAppName, generateXcodeConfigFile } from './utils.js';
 import { updateProjectFile, resetProjectFile, checkForDependencies,
          setRealDeviceSecurity, fixXCUICoordinateFile } from './webdriveragent-utils';
@@ -23,37 +24,6 @@ const IPROXY_TIMEOUT = 5000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
 const BUILD_TEST_DELAY = 1000;
-
-
-class NoSessionProxy extends JWProxy {
-  constructor (opts = {}) {
-    super(opts);
-  }
-
-  getUrlForProxy (url) {
-    if (url === '') {
-      url = '/';
-    }
-    const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
-    let remainingUrl = '';
-    if ((new RegExp('^/')).test(url)) {
-      remainingUrl = url;
-    } else {
-      throw new Error(`Did not know what to do with url '${url}'`);
-    }
-    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
-    return proxyBase + remainingUrl;
-  }
-
-  async proxyReqRes (req, res) {
-    let [response, body] = await this.proxy(req.originalUrl, req.method, req.body);
-    res.headers = response.headers;
-    res.set('Content-type', response.headers['content-type']);
-    body = util.safeJsonParse(body);
-    res.status(response.statusCode).send(JSON.stringify(body));
-  }
-}
-
 
 class WebDriverAgent {
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -347,7 +347,7 @@ class WebDriverAgent {
         try {
           const proxyTimeout = this.noSessionProxy.timeout;
           try {
-            this.noSessionProxy.timeout = this.wdaLaunchTimeout < 5000 ? this.wdaLaunchTimeout / 2 : 5000;
+            this.noSessionProxy.timeout = 1000;
             currentStatus = await this.noSessionProxy.command('/status', 'GET');
           } finally {
             this.noSessionProxy.timeout = proxyTimeout;


### PR DESCRIPTION
Some WDA commands don't require session ID to be set. Such commands can be executed even if the application under test is not active. This PR adds support for such endpoints to WDA driver