### PR TITLE
Allow getStatus to bypass command queue

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -494,6 +494,10 @@ class XCUITestDriver extends BaseDriver {
     if (cmd === 'receiveAsyncResponse') {
       return await this.receiveAsyncResponse(...args);
     }
+    // TODO: once this fix gets into base driver remove from here
+    if (cmd === 'getStatus') {
+      return await this.getStatus();
+    }
     return await super.executeCommand(cmd, ...args);
   }
 

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -30,14 +30,15 @@ describe('XCUITestDriver - basics', function () {
 
     it('should return status immediately if another operation is in progress', async () => {
       await driver.setImplicitWaitTimeout(10000);
-      let findElementPromise = B.Promise.resolve(driver.elementById('WrongLocator'));
+      let findElementPromise = B.resolve(driver.elementById('WrongLocator'));
       let status = await driver.status();
       status.wda.should.exist;
-      let isFindElementPromiseFulfilled = findElementPromise.isFulfilled();
-      isFindElementPromiseFulfilled.should.be.false;
+      findElementPromise.isPending().should.be.true;
       try {
         await findElementPromise;
-      } catch (err) {}
+      } catch (err) {
+        err.status.should.eql(7);
+      }
     });
   });
 


### PR DESCRIPTION
We have all sorts of logic around `getStatus` so it can function synchronously, but none of it works since the command still gets put into the queue and gets executed after the current command is done. While this is tested, the test just quietly throws an error and moves on:

```
      ✓ should get the server status
info HTTP --> POST /wd/hub/session/34ec4e62-b7a0-4e8d-a911-d7d471e97a45/timeouts/implicit_wait {"ms":10000}
dbug MJSONWP Calling XCUITestDriver.implicitWait() with args: [10000,"34ec4e62-b7a0-4e8d-a911-d7d471e97a45"]
dbug XCUITest Executing command 'implicitWait'
dbug BaseDriver Set implicit wait to 10000ms
dbug MJSONWP Responding to client with driver.implicitWait() result: null
info HTTP <-- POST /wd/hub/session/34ec4e62-b7a0-4e8d-a911-d7d471e97a45/timeouts/implicit_wait 200 95 ms - 76 
info HTTP --> POST /wd/hub/session/34ec4e62-b7a0-4e8d-a911-d7d471e97a45/element {"using":"id","value":"WrongLocator"}
dbug MJSONWP Calling XCUITestDriver.findElement() with args: ["id","WrongLocator","34ec4e62-b7a0-4e8d-a911-d7d471e97a45"]
dbug XCUITest Executing command 'findElement'
dbug BaseDriver Valid locator strategies for this request: xpath, id, name, class name, -ios predicate string, -ios class chain, accessibility id
dbug BaseDriver Waiting up to 10000 ms for condition
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
info HTTP --> GET /wd/hub/status {}
dbug MJSONWP Calling XCUITestDriver.getStatus() with args: []
dbug XCUITest Executing command 'getStatus'
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 402 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 1561 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 2521 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 3593 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 4642 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 5764 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 6788 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 7845 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 8964 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
dbug BaseDriver Waited for 9997 ms so far
dbug JSONWP Proxy Proxying [POST /element] to [POST http://localhost:8100/session/31F3918F-3CCB-4C96-A197-964D96085F67/element] with body: {"using":"id","value":"WrongLocator"}
dbug JSONWP Proxy Got response with status 200: {"value":{"using":"id","value":"WrongLocator","description":"unable to find an element"},"sessionId":"31F3918F-3CCB-4C96-A197-964D96085F67","status":7}
info HTTP <-- POST /wd/hub/session/34ec4e62-b7a0-4e8d-a911-d7d471e97a45/element 500 10953 ms - 164 
Unhandled rejection Error: [elementById("WrongLocator")] Error response status: 7, , NoSuchElement - An element could not be located on the page using the given search parameters. Selenium error: An element could not be located on the page using the given search parameters.
    at exports.newError (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/lib/utils.js:145:13)
    at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/lib/callbacks.js:75:19
    at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/lib/webdriver.js:179:5
    at Request._callback (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/lib/http-utils.js:88:7)
    at Request.self.callback (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/node_modules/request/request.js:186:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/node_modules/request/request.js:1081:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/wd/node_modules/request/request.js:1001:12)
    at IncomingMessage.g (events.js:291:16)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
dbug MJSONWP Responding to client with driver.getStatus() result: {"build":{"version":"2.20.0"},"wda":{"state":"success","os":{"name":"iPhone OS","version":"9.3"},"ios":{"simulatorVersion":"9.3","ip":"10.182.138.228"},"build":{"time":"Mar 16 2017 05:38:40"}}}
info HTTP <-- GET /wd/hub/status 200 10952 ms - 231 
```

The bypass should probably go into `appium-base-driver` but at this point the other drivers might not be ready for it.