### PR TITLE
Add simLaunchTimeout and set high for Travis

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -96,6 +96,9 @@ let desiredCapConstraints = _.defaults({
   nativeTyping: {
     isBoolean: true
   },
+  simLaunchTimeout: {
+    isNumber: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -608,7 +608,7 @@ class XCUITestDriver extends BaseDriver {
     }
     log.info(`Simulator with udid '${this.opts.udid}' not booted. Booting up now`);
     await killAllSimulators();
-    await this.opts.device.run();
+    await this.opts.device.run(this.opts.simLaunchTimeout);
   }
 
   async createSim () {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -33,6 +33,10 @@ const GENERIC_CAPS = {
   noReset: true,
 };
 
+if (process.env.TRAVIS) {
+  GENERIC_CAPS.simLaunchTimeout = 240000;
+}
+
 let simUICatalogApp = path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalogApp[1]);
 let realUICatalogApp = process.env.UICATALOG_REAL_DEVICE || path.resolve('.', 'node_modules', 'ios-uicatalog', uiCatalogApp[0]);
 

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -101,7 +101,7 @@ describe('XCUITestDriver', function () {
         // before
         let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);
         let sim = await getSimulator(udid);
-        await sim.run();
+        await sim.run(MOCHA_TIMEOUT);
 
         // test
         let caps = _.defaults({
@@ -130,7 +130,7 @@ describe('XCUITestDriver', function () {
         // before
         let udid = await createDevice('webDriverAgentTest', 'iPhone 6', UICATALOG_SIM_CAPS.platformVersion);
         let sim = await getSimulator(udid);
-        await sim.run();
+        await sim.run(MOCHA_TIMEOUT);
 
         // test
         let caps = _.defaults({

--- a/test/functional/driver/webdriveragent-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-e2e-specs.js
@@ -48,9 +48,9 @@ describe('WebDriverAgent', function () {
     });
 
     describe('with running sim', function () {
-      this.timeout(6 * 60 * 1000);
+      this.timeout(MOCHA_TIMEOUT);
       beforeEach(async () => {
-        await device.run();
+        await device.run(MOCHA_TIMEOUT);
       });
       afterEach(async () => {
         await device.shutdown();


### PR DESCRIPTION
When there is lots of load, the timeout waiting for sims to start on Travis is often not enough. Alas.