### PR TITLE
Use native methods first for alerts, even in webview context

### DIFF
--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -4,15 +4,17 @@ import { errors, isErrorType } from 'appium-base-driver';
 let commands = {}, helpers = {}, extensions = {};
 
 commands.getAlertText = async function () {
-  if (this.isWebContext()) {
+  try {
+    let method = 'GET';
+    let endpoint = `/alert/text`;
+    return await this.proxyCommand(endpoint, method);
+  } catch (err) {
+    if (!this.isWebContext()) throw err;
+
     let alert = await this.getAlert();
     let text = await alert.getText();
     return text;
   }
-
-  let method = 'GET';
-  let endpoint = `/alert/text`;
-  return await this.proxyCommand(endpoint, method);
 };
 
 // TODO: WDA does not currently support this natively
@@ -20,19 +22,27 @@ commands.setAlertText = async function (text) {
   if (!Array.isArray(text)) {
     text = text.split('');
   }
-  if (this.isWebContext()) {
+  try {
+    let method = 'POST';
+    let endpoint = `/alert/text`;
+    return await this.proxyCommand(endpoint, method, text);
+  } catch (err) {
+    if (!this.isWebContext()) throw err;
+
     let alert = await this.getAlert();
     await alert.setText(text);
     return;
   }
-
-  let method = 'POST';
-  let endpoint = `/alert/text`;
-  return await this.proxyCommand(endpoint, method, text);
 };
 
 commands.postAcceptAlert = async function () {
-  if (this.isWebContext()) {
+  try {
+    let method = 'POST';
+    let endpoint = `/alert/accept`;
+    return await this.proxyCommand(endpoint, method);
+  } catch (err) {
+    if (!this.isWebContext()) throw err;
+
     let alert = await this.getAlert();
     if (alert.close) {
       await alert.close();
@@ -41,14 +51,16 @@ commands.postAcceptAlert = async function () {
     }
     return;
   }
-
-  let method = 'POST';
-  let endpoint = `/alert/accept`;
-  return await this.proxyCommand(endpoint, method);
 };
 
 commands.postDismissAlert = async function () {
-  if (this.isWebContext()) {
+  try {
+    let method = 'POST';
+    let endpoint = `/alert/dismiss`;
+    return await this.proxyCommand(endpoint, method);
+  } catch (err) {
+    if (!this.isWebContext()) throw err;
+
     let alert = await this.getAlert();
     if (alert.close) {
       await alert.close();
@@ -57,10 +69,6 @@ commands.postDismissAlert = async function () {
     }
     return;
   }
-
-  let method = 'POST';
-  let endpoint = `/alert/dismiss`;
-  return await this.proxyCommand(endpoint, method);
 };
 
 helpers.getAlert = async function () {


### PR DESCRIPTION
If a system alert opens there is no way to just click it. If there isn't, it will immediately fail and drop us back to using our logic to find the alert.