### PR TITLE
Add IPHONEOS_DEPLOYMENT_TARGET argument to avoid “unguarded availability” warning with Xcode 8.3+

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -187,6 +187,14 @@ class WebDriverAgent {
     ];
     args.push(...genericArgs);
 
+    const versionMatch = new RegExp(/^(\d+)\.(\d+)/).exec(this.platformVersion);
+    if (versionMatch) {
+      args.push(`IPHONEOS_DEPLOYMENT_TARGET=${versionMatch[1]}.${versionMatch[2]}`);
+    } else {
+      log.warn(`Cannot parse major and minor version number from platformVersion "${this.platformVersion}". ` +
+               'Will build for the default platform instead');
+    }
+
     if (this.realDevice && this.xcodeConfigFile) {
       log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
       args.push('-xcconfig', this.xcodeConfigFile);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -191,7 +191,7 @@ class WebDriverAgent {
     if (versionMatch) {
       args.push(`IPHONEOS_DEPLOYMENT_TARGET=${versionMatch[1]}.${versionMatch[2]}`);
     } else {
-      log.warn(`Cannot parse major and minor version number from platformVersion "${this.platformVersion}". ` +
+      log.warn(`Cannot parse major and minor version numbers from platformVersion "${this.platformVersion}". ` +
                'Will build for the default platform instead');
     }
 


### PR DESCRIPTION
This fixes webdriver build with Xcode 8.3+ and does not require any WDA sources modification. See https://github.com/facebook/WebDriverAgent/pull/525 for more details.