### PR TITLE
Fix screenshoting for real device

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -6,19 +6,20 @@ import log from '../logger';
 let commands = {};
 
 commands.getScreenshot = async function () {
-  let data;
-  if (this.xcodeVersion.versionFloat >= 8.1) {
-    data = await getScreenshot(this.opts.udid);
-  } else {
-    log.info(`Using legacy WDA screenshot for xcode version < 8.2`);
-    await retryInterval(10, 1000, async () => {
-      data = await this.proxyCommand('/screenshot', 'GET');
-      if (!_.isString(data)) {
-        throw new Error(`Unable to take screenshot. WDA returned '${JSON.stringify(data)}'`);
-      }
-    });
+  try {
+    if (!this.realDevice && this.xcodeVersion.versionFloat >= 8.1) {
+      return await getScreenshot(this.opts.udid);
+    }
+  } catch (err) {
+    log.warn(`Cannot make a screenshot using simctl because of "${err.message}". Falling back to WDA API`);
   }
-
+  let data;
+  await retryInterval(10, 1000, async () => {
+    data = await this.proxyCommand('/screenshot', 'GET');
+    if (!_.isString(data)) {
+      throw new Error(`Unable to take screenshot. WDA returned '${JSON.stringify(data)}'`);
+    }
+  });
   return data;
 };
 


### PR DESCRIPTION
Some of recent commits does not respect the fact, that "simctl io" command works only for simulator. Real devices should still use WDA API. This is fixed now.

Check https://github.com/appium/appium/issues/8146 for the reference