### PR TITLE
Remove duplicate dep so warning is gone

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "ios-uicatalog": "^1.0.4",
     "pem": "^1.8.3",
     "pre-commit": "^1.1.3",
-    "request-promise": "^4.1.1",
     "sinon": "^1.17.4",
     "through2": "^2.0.0",
     "unzip": "^0.1.11",


### PR DESCRIPTION
Only need `request-promise` it in the dependencies.