### PR TITLE
Minor tweaks after much test running on different platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Differences noted here
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`connectHardwareKeyboard`|Set this option to `true` in order to enable hardware keyboard in Simulator. It is set to `false` by default, because this helps to workaround some XCTest bugs.|`true` or `false`|
 |`maxTypingFrequency`|Maximum frequency of keystrokes for typing and clear. If your tests are failing because of typing errors, you may want to adjust this. Defaults to 60 keystrokes per minute.|e.g., `30`|
-|`simpleIsVisibleCheck`|Use native methods for determining visibility of elements. In some cases this takes a long time. Setting this capability to `false` will cause the system to use the position and size of elements to make sure they are visible on the screen. This can, however, lead to false results in some situations. Defaults to `true`.|e.g., `true`, `false`|
+|`simpleIsVisibleCheck`|Use native methods for determining visibility of elements. In some cases this takes a long time. Setting this capability to `false` will cause the system to use the position and size of elements to make sure they are visible on the screen. This can, however, lead to false results in some situations. Defaults to `false`, except iOS 9.3, where it defaults to `true`.|e.g., `true`, `false`|
 |`useCarthageSsl`|Use SSL to download dependencies for WebDriverAgent. Defaults to `false`|e.g., `true`|
 |`shouldUseSingletonTestManager`|Use default proxy for test management within WebDriverAgent. Setting this to `false` sometimes helps with socket hangup problems. Defaults to `true`.|e.g., `false`|
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -655,15 +655,26 @@ class XCUITestDriver extends BaseDriver {
     let args = processArguments ? processArguments.args : [];
     let env = processArguments ? processArguments.env : {};
 
+    let shouldWaitForQuiescence = util.hasValue(this.opts.waitForQuiescence) ? this.opts.waitForQuiescence : true;
+    let maxTypingFrequency = util.hasValue(this.opts.maxTypingFrequency) ? this.opts.maxTypingFrequency : 60;
+    let shouldUseSingletonTestManager = util.hasValue(this.opts.shouldUseSingletonTestManager) ? this.opts.shouldUseSingletonTestManager : true;
+    let shouldUseTestManagerForVisibilityDetection = false;
+    if (util.hasValue(this.opts.simpleIsVisibleCheck)) {
+      shouldUseTestManagerForVisibilityDetection = this.opts.simpleIsVisibleCheck;
+    }
+    if ((this.opts.platformVersion || '').indexOf('9') === 0) {
+      shouldUseTestManagerForVisibilityDetection = true;
+    }
+
     let desired = {
       desiredCapabilities: {
         bundleId,
         arguments: args,
         environment: env,
-        shouldWaitForQuiescence: util.hasValue(this.opts.waitForQuiescence) ? this.opts.waitForQuiescence : true,
-        shouldUseTestManagerForVisibilityDetection: util.hasValue(this.opts.simpleIsVisibleCheck) ? this.opts.simpleIsVisibleCheck : true,
-        maxTypingFrequency: util.hasValue(this.opts.maxTypingFrequency) ? this.opts.maxTypingFrequency : 60,
-        shouldUseSingletonTestManager: util.hasValue(this.opts.shouldUseSingletonTestManager) ? this.opts.shouldUseSingletonTestManager : true,
+        shouldWaitForQuiescence,
+        shouldUseTestManagerForVisibilityDetection,
+        maxTypingFrequency,
+        shouldUseSingletonTestManager,
       }
     };
 

--- a/lib/webdriveragent-utils.js
+++ b/lib/webdriveragent-utils.js
@@ -22,7 +22,7 @@ async function updateProjectFile (agentPath, newBundleId) {
   try {
     // backup the file, and then update the bundle id for the runner
     await fs.copyFile(projectFilePath, `${projectFilePath}.old`);
-    await replaceInFile(projectFilePath, WDA_RUNNER_BUNDLE_ID, newBundleId);
+    await replaceInFile(projectFilePath, new RegExp(WDA_RUNNER_BUNDLE_ID.replace('.', '\.'), 'g'), newBundleId); // jshint ignore:line
     log.debug(`Successfully updated '${projectFilePath}' with bundle id '${newBundleId}'`);
   } catch (err) {
     log.debug(`Error updating project file: ${err.message}`);
@@ -34,7 +34,7 @@ async function updateProjectFile (agentPath, newBundleId) {
 async function resetProjectFile (agentPath, newBundleId) {
   let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
   try {
-    await replaceInFile(projectFilePath, newBundleId, WDA_RUNNER_BUNDLE_ID);
+    await replaceInFile(projectFilePath, new RegExp(newBundleId.replace('.', '\.'), 'g'), WDA_RUNNER_BUNDLE_ID); // jshint ignore:line
     await fs.unlink(`${projectFilePath}.old`);
     log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
   } catch (err) {
@@ -91,7 +91,7 @@ async function setRealDeviceSecurity (keychainPath, keychainPassword) {
   await exec('security', ['set-keychain-settings', '-t', '3600', '-l', keychainPath]);
 }
 
-async function fixXCUICoordinateFile (bootstrapPath) {
+async function fixXCUICoordinateFile (bootstrapPath, initial = true) {
   // the way the updated XCTest headers are in the WDA project, building in
   // Xcode 8.0 causes a duplicate declaration of method
   // so fix the offending line in the local headers
@@ -99,8 +99,15 @@ async function fixXCUICoordinateFile (bootstrapPath) {
 
   let oldDef = '- (void)pressForDuration:(double)arg1 thenDragToCoordinate:(id)arg2;';
   let newDef = '- (void)pressForDuration:(NSTimeInterval)duration thenDragToCoordinate:(XCUICoordinate *)otherCoordinate;';
+  if (!initial) {
+    [oldDef, newDef] = [newDef, oldDef];
+  }
   await replaceInFile(file, oldDef, newDef);
 }
 
+async function fixForXcode7 (bootstrapPath, initial = true) {
+  await fixXCUICoordinateFile(bootstrapPath, initial);
+}
+
 export { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity, fixXCUICoordinateFile };
+         setRealDeviceSecurity, fixForXcode7 };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -10,7 +10,7 @@ import log from './logger';
 import { NoSessionProxy } from "./no-session-proxy";
 import { killAppUsingAppName, generateXcodeConfigFile } from './utils.js';
 import { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity, fixXCUICoordinateFile } from './webdriveragent-utils';
+         setRealDeviceSecurity, fixForXcode7 } from './webdriveragent-utils';
 
 
 const xcodeLog = logger.getLogger('Xcode');
@@ -107,8 +107,8 @@ class WebDriverAgent {
     await this.killHangingProcesses();
 
     if (this.xcodeVersion.major === 7 || (this.xcodeVersion.major === 8 && this.xcodeVersion.minor === 0)) {
-      log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing header files`);
-      await fixXCUICoordinateFile(this.bootstrapPath);
+      log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
+      await fixForXcode7(this.bootstrapPath, true);
     }
 
     if (this.prebuildWDA) {

--- a/test/unit/processargs-specs.js
+++ b/test/unit/processargs-specs.js
@@ -21,7 +21,7 @@ describe('process args', () => {
       arguments: PROCESS_ARGS_OBJECT.args,
       environment: PROCESS_ARGS_OBJECT.env,
       shouldWaitForQuiescence: true,
-      shouldUseTestManagerForVisibilityDetection: true,
+      shouldUseTestManagerForVisibilityDetection: false,
       maxTypingFrequency: 60,
       shouldUseSingletonTestManager: true,
     }


### PR DESCRIPTION
After much testing, it turns out the new isVisible check from WDA works on everything except iOS 9.3. So make that the default. And make sure that rewriting the WDA bundle id is global not just the first instance.