### PR TITLE
Accept longPress duration in ms (not seconds)

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -248,9 +248,9 @@ helpers.handleLongPress = async function (gestures) {
   let pressOpts = gestures[0].options || {};
 
   let el = util.unwrapElement(pressOpts.element);
-  let duration;
+  let duration; // In seconds (not milliseconds)
   if (gestures.length === 1 && util.hasValue(pressOpts.duration)) {
-    duration = pressOpts.duration;
+    duration = pressOpts.duration / 1000;
   } else if (gestures.length === 3) {
     // duration is the `wait` action
     // upstream system expects seconds not milliseconds

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -79,6 +79,15 @@ describe('XCUITestDriver - gestures', function () {
         let el2 = await driver.elementByAccessibilityId('Cancel');
         await el2.click();
       });
+      it('should long press on an element with duration through pressOpts.duration', async () => {
+        let el1 = await driver.elementByAccessibilityId('Okay / Cancel');
+        let action = new wd.TouchAction(driver);
+        action.longPress({el: el1, duration: 1200});
+        await action.perform();
+
+        let el2 = await driver.elementByAccessibilityId('Cancel');
+        await el2.click();
+      });
       it('should long press on arbitrary coordinate', async () => {
         let el1 = await driver.elementByAccessibilityId('Okay / Cancel');
         let loc = await el1.getLocation();


### PR DESCRIPTION
* java-client and python client documents it in ms
* 'appium-android-driver' uses duration in ms for longPress (https://github.com/appium/appium-android-driver/blob/ab024485ee1e31b8287a7549f343b294a8ebd29b/lib/commands/touch.js see lines 23-24)
* Found in https://github.com/appium/appium/issues/7597

Reviewers @jlipps @imurchie 