### PR TITLE
Try to get the screenshot from WDA first

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -6,21 +6,26 @@ import log from '../logger';
 let commands = {};
 
 commands.getScreenshot = async function () {
-  try {
-    if (!this.isRealDevice() && this.xcodeVersion.versionFloat >= 8.1) {
-      return await getScreenshot(this.opts.udid);
-    }
-  } catch (err) {
-    log.warn(`Cannot make a screenshot using simctl because of "${err.message}". Falling back to WDA API`);
-  }
-  let data;
-  await retryInterval(10, 1000, async () => {
-    data = await this.proxyCommand('/screenshot', 'GET');
+  const getScreenshotFromWDA = async () => {
+    const data = await this.proxyCommand('/screenshot', 'GET');
     if (!_.isString(data)) {
       throw new Error(`Unable to take screenshot. WDA returned '${JSON.stringify(data)}'`);
     }
-  });
-  return data;
+    return data;
+  };
+  try {
+    return await getScreenshotFromWDA();
+  } catch (err) {
+    if (!this.isRealDevice() && this.xcodeVersion.versionFloat >= 8.1) {
+      log.info(`Falling back to 'simctl io screenshot' API`);
+      return await getScreenshot(this.opts.udid);
+    }
+    let result;
+    await retryInterval(9, 1000, async () => {
+      result = await getScreenshotFromWDA();
+    });
+    return result;
+  }
 };
 
 export default commands;

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -20,6 +20,7 @@ commands.getScreenshot = async function () {
       log.info(`Falling back to 'simctl io screenshot' API`);
       return await getScreenshot(this.opts.udid);
     }
+    // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected
     let result;
     await retryInterval(9, 1000, async () => {
       result = await getScreenshotFromWDA();

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -1,0 +1,45 @@
+import sinon from 'sinon';
+import XCUITestDriver from '../../..';
+
+const simctlModule = require('node-simctl');
+
+describe('screenshots commands', () => {
+  let driver = new XCUITestDriver();
+  let proxySpy = sinon.stub(driver, 'proxyCommand');
+  let simctlSpy = sinon.stub(simctlModule, 'getScreenshot');
+
+  const base64Response = 'aGVsbG8=';
+
+  afterEach(() => {
+    proxySpy.reset();
+    simctlSpy.reset();
+  });
+
+  describe('getScreenshot', () => {
+    it('should get a screenshot from WDA if no errors are detected', async () => {
+      proxySpy.returns(base64Response);
+      await driver.getScreenshot();
+
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/screenshot');
+      proxySpy.firstCall.args[1].should.eql('GET');
+
+      simctlSpy.notCalled.should.be.true;
+    });
+
+    it('should get a screenshot from simctl for simulator if WDA call fails and Xcode version >= 8.1', async () => {
+      proxySpy.returns(null);
+      simctlSpy.returns(base64Response);
+
+      driver.opts.realDevice = false;
+      driver.xcodeVersion = {
+        versionFloat: 8.3
+      };
+      const result = await driver.getScreenshot();
+      result.should.equal(base64Response);
+
+      proxySpy.calledOnce.should.be.true;
+      simctlSpy.calledOnce.should.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Change screenshoting logic to get the screenshot from WDA first before falling back to simctl. This is done because Simulator window does not respect orientation change since iOS 10.3 and the screenshot returned by simctl gives us incorrectly rotated images, like this one:
<img width="413" alt="tablet" src="https://cloud.githubusercontent.com/assets/7767781/25311375/7f198900-27ff-11e7-88ce-316ac09d9d9a.png">

Also, added unit tests as a bonus ;)