### PR TITLE
Fail fast if only bundleId is passed in and corresponding app does no…

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -264,8 +264,13 @@ class XCUITestDriver extends BaseDriver {
     this.logEvent('appConfigured');
 
     // fail very early if the app doesn't actually exist
+    // or if bundle id doesn't point to an installed app
     if (this.opts.app) {
       await checkAppPresent(this.opts.app);
+    } else if (this.opts.bundleId && !this.safari) {
+      if (!await this.opts.device.isAppInstalled(this.opts.bundleId)) {
+        log.errorAndThrow(`App with bundle identifier '${this.opts.bundleId}' unknown`);
+      }
     }
 
     if (!this.opts.bundleId) {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -39,7 +39,7 @@ class IOSDeploy {
     }
   }
 
-  async isInstalled (bundleid) {
+  async isAppInstalled (bundleid) {
     let isInstalled = [`--exists`, `--id`, this.udid, `--bundle_id`, bundleid];
     try {
       let {stdout} = await exec(this.cmd, isInstalled);

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -26,7 +26,7 @@ async function resetRealDevice (device, opts) {
 
   let bundleId = opts.bundleId;
   log.debug(`Reset: fullReset requested. Will try to uninstall the app '${bundleId}'.`);
-  if (!await device.isInstalled(bundleId)) {
+  if (!await device.isAppInstalled(bundleId)) {
     log.debug('Reset: app not installed. No need to uninstall');
     return;
   }
@@ -56,7 +56,7 @@ async function installToRealDevice (device, app, bundleId, noReset = true) {
     return;
   }
 
-  if (await device.isInstalled(bundleId)) {
+  if (await device.isAppInstalled(bundleId)) {
     if (noReset) {
       log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
       return;

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -59,6 +59,12 @@ describe('XCUITestDriver', function () {
       await driver.quit();
     });
 
+    it('should fail to start and stop a session', async function () {
+      let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'io.blahblahblah.blah'});
+      caps.app = null;
+      await driver.init(caps).should.eventually.be.rejected;
+    });
+
     /* jshint ignore:start */
     describe('initial orientation', async () => {
       async function runOrientationTest (initialOrientation) {


### PR DESCRIPTION
…t exist on device

If you try to start a WDA session with a bundle identifier for an app that is not on the device, it just hangs indefinitely.

This way, if there is no `app` desired capability, and therefore no way to install an app, if the bundle identifier doesn't specify an app already on the device, we can error out early.