### PR TITLE
Do not fail on cleanup if xcodebuild property is not set

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -469,7 +469,7 @@ class WebDriverAgent {
   }
 
   get derivedDataPath () {
-    if (!this._derivedDataPath) {
+    if (!this._derivedDataPath && this.xcodebuild) {
       // https://regex101.com/r/PqmX8I/1
       const folderRegexp = /(.+\/WebDriverAgent-[^\/]+)/;
       let match = folderRegexp.exec(this.xcodebuild.logLocation);


### PR DESCRIPTION
Fixes the issue when the driver throws an error on exit if xcodebuild properly was not initialised properly and files cleanup is enabled:

```
2017-05-02 09:47:39:042 - error: [MJSONWP] Encountered internal error running command: TypeError: Cannot read property 'logLocation' of undefined
    at WebDriverAgent.get (../../lib/webdriveragent.js:475:52)
    at clearSystemFiles$ (../../lib/utils.js:112:19)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at clearSystemFiles (../../lib/utils.js:117:15)
    at XCUITestDriver.deleteSession$ (../../lib/driver.js:446:13)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
```