### PR TITLE
WdaLocalPort change implementation 

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -111,6 +111,9 @@ let desiredCapConstraints = _.defaults({
   shouldUseSingletonTestManager: {
     isBoolean: true
   },
+  wdaRemotePort: {
+    isNumber: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -58,6 +58,7 @@ class WebDriverAgent {
 
     this.wdaLaunchTimeout = args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT;
     this.wdaConnectionTimeout = args.wdaConnectionTimeout;
+    this.wdaRemotePort = args.wdaRemotePort;
 
     this.useCarthageSsl = _.isBoolean(args.useCarthageSsl) && args.useCarthageSsl;
   }
@@ -192,8 +193,8 @@ class WebDriverAgent {
     const versionMatch = new RegExp(/^(\d+)\.(\d+)/).exec(this.platformVersion);
     if (versionMatch) {
       args.push(`IPHONEOS_DEPLOYMENT_TARGET=${versionMatch[1]}.${versionMatch[2]}`);
-      if (this.wdaLocalPort) {
-        args.push(" WDAPORT="+this.wdaLocalPort);  
+      if (this.wdaRemotePort) {
+        args.push(`WDAPORT=${this.wdaRemotePort}`);
       }
     } else {
       log.warn(`Cannot parse major and minor version numbers from platformVersion "${this.platformVersion}". ` +
@@ -448,7 +449,7 @@ class WebDriverAgent {
 
   get url () {
     if (!this._url) {
-      if (this.wdaLocalPort) {
+      if (this.realDevice && this.wdaLocalPort) {
         this._url = url.parse(`${WDA_BASE_URL}:${this.wdaLocalPort}`);
       } else {
         this._url = url.parse(`${WDA_BASE_URL}:${WDA_AGENT_PORT}`);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -192,6 +192,9 @@ class WebDriverAgent {
     const versionMatch = new RegExp(/^(\d+)\.(\d+)/).exec(this.platformVersion);
     if (versionMatch) {
       args.push(`IPHONEOS_DEPLOYMENT_TARGET=${versionMatch[1]}.${versionMatch[2]}`);
+      if (this.wdaLocalPort) {
+        args.push(" WDAPORT="+this.wdaLocalPort);  
+      }
     } else {
       log.warn(`Cannot parse major and minor version numbers from platformVersion "${this.platformVersion}". ` +
                'Will build for the default platform instead');
@@ -445,7 +448,7 @@ class WebDriverAgent {
 
   get url () {
     if (!this._url) {
-      if (this.realDevice && this.wdaLocalPort) {
+      if (this.wdaLocalPort) {
         this._url = url.parse(`${WDA_BASE_URL}:${this.wdaLocalPort}`);
       } else {
         this._url = url.parse(`${WDA_BASE_URL}:${WDA_AGENT_PORT}`);


### PR DESCRIPTION
I noticed i couldn't change WDA port over command line in spite of that I wrote parameter to the capabilities. After that change, WDA port can be change and it is going to be possible run parallel test on a macOs.

I change a few thing over webdriver.js to give parameter to WebDriverAgent port via command line arg. But it requires WebDriverAgent changes. If I should open one more pull-request to WebDriverAgent repo please inform me. Or it can be add to https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md .

WebDriver Agent side changes: 
![image](https://cloud.githubusercontent.com/assets/1422426/25781394/658477ea-3342-11e7-9999-d31529c01005.png)


