### PR TITLE
Allow numerical platformVersion capabilities

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -674,7 +674,7 @@ class XCUITestDriver extends BaseDriver {
     if (util.hasValue(this.opts.simpleIsVisibleCheck)) {
       shouldUseTestManagerForVisibilityDetection = this.opts.simpleIsVisibleCheck;
     }
-    if ((this.opts.platformVersion || '').indexOf('9') === 0) {
+    if (parseFloat(this.opts.platformVersion) === 9.3) {
       shouldUseTestManagerForVisibilityDetection = true;
     }
 


### PR DESCRIPTION
If platformVersion is passed as a String, it is parsed just fine. If it is passed as a Float, the check against it in startWdaSession will fail, as indexOf() is not a method for Floats. Flip the handling around to parse it as a float regardless of it being a String, Float, or Null so the logic is trivial and easy to follow.

For the record I tested all the possible values I could think of to make sure the original logic would still give the same results, just without errors now. 😄 

```javascript
> parseFloat(9.3) === 9.3
true
> parseFloat("9.3") === 9.3
true
> parseFloat(10.3) === 9.3
false
> parseFloat("10.3.1") === 9.3
false
> parseFloat(null) === 9.3
false
```
