### PR TITLE
Allow async exec through https

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -229,6 +229,12 @@ class XCUITestDriver extends BaseDriver {
       this.logEvent('customCertInstalled');
     }
 
+    if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
+      await this.opts.device.shutdown();
+      await this.startHttpsAsyncServer();
+    }
+
+
     // at this point if there is no platformVersion, get it from the device
     if (!this.opts.platformVersion) {
       if (this.opts.device && _.isFunction(this.opts.device.getPlatformVersion)) {
@@ -481,6 +487,10 @@ class XCUITestDriver extends BaseDriver {
 
     if (this.iwdpServer) {
       this.stopIWDP();
+    }
+
+    if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
+      await this.stopHttpsAsyncServer();
     }
 
     this.resetIos();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -230,6 +230,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
+      // shutdown the simulator so that the ssl cert is recognized
       await this.opts.device.shutdown();
       await this.startHttpsAsyncServer();
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "appium-base-driver": "^2.4.1",
-    "appium-ios-driver": "^1.15.1",
+    "appium-ios-driver": "^1.24.0",
     "appium-ios-simulator": "^1.17.1",
     "appium-support": "^2.4.0",
     "appium-xcode": "^3.2.0",


### PR DESCRIPTION
Make use of the `appium-ios-driver` capability to execute async javascript from https (using `enableAsyncExecuteFromHttps`).

See https://github.com/appium/appium/issues/3471