### PR TITLE
Make sure the result of getText call is always a string value

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -17,18 +17,23 @@ commands.getAttribute = async function (attribute, el) {
   let atomsElement = this.getAtomsElement(el);
   if (_.isNull(atomsElement)) {
     throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}`);
-  } else {
-    return await this.executeAtom('get_attribute_value', [atomsElement, attribute]);
   }
+  return await this.executeAtom('get_attribute_value', [atomsElement, attribute]);
 };
 
 commands.getText = async function (el) {
   el = util.unwrapElement(el);
-  if (!this.isWebContext()) {
-    return await this.proxyCommand(`/element/${el}/text`, 'GET');
+  let result;
+  if (this.isWebContext()) {
+    let atomsElement = this.useAtomsElement(el);
+    result = await this.executeAtom('get_text', [atomsElement]);
+  } else {
+    result = await this.proxyCommand(`/element/${el}/text`, 'GET');
   }
-  let atomsElement = this.useAtomsElement(el);
-  return await this.executeAtom('get_text', [atomsElement]);
+  if (_.isNull(result)) {
+    return result;
+  }
+  return _.isString(result) ? result : JSON.stringify(result);
 };
 
 commands.getRect = async function (el) {

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -1,0 +1,40 @@
+import sinon from 'sinon';
+import chai from 'chai';
+import XCUITestDriver from '../../..';
+
+
+describe('element commands', () => {
+  let driver = new XCUITestDriver();
+  let proxySpy = sinon.stub(driver, 'proxyCommand');
+
+  afterEach(() => {
+    proxySpy.reset();
+  });
+
+  describe('getText', () => {
+    it('should send translated POST request to WDA', async () => {
+      await driver.getText(1);
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql(`/element/1/text`);
+      proxySpy.firstCall.args[1].should.eql('GET');
+    });
+
+    it('should transform boolean response to a string', async () => {
+      proxySpy.returns(true);
+      const result = await driver.getText(1);
+      result.should.be.equal('true');
+    });
+
+    it('should not transform a valid string response', async () => {
+      proxySpy.returns('bla');
+      const result = await driver.getText(1);
+      result.should.be.equal('bla');
+    });
+
+    it('should not transform null response', async () => {
+      proxySpy.returns(null);
+      const result = await driver.getText(1);
+      chai.should().equal(result, null);
+    });
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/appium/java-client/issues/644
The corresponding Selenium client code, which causes the problem:

```java
    public String getText() {
        Response response = this.execute("getElementText", ImmutableMap.of("id", this.id));
        return (String)response.getValue();
    }
```