### PR TITLE
Fix error when checking is bundle id exists on simualtor

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -274,10 +274,6 @@ class XCUITestDriver extends BaseDriver {
     // or if bundle id doesn't point to an installed app
     if (this.opts.app) {
       await checkAppPresent(this.opts.app);
-    } else if (this.opts.bundleId && !this.safari) {
-      if (!await this.opts.device.isAppInstalled(this.opts.bundleId)) {
-        log.errorAndThrow(`App with bundle identifier '${this.opts.bundleId}' unknown`);
-      }
     }
 
     if (!this.opts.bundleId) {
@@ -311,6 +307,7 @@ class XCUITestDriver extends BaseDriver {
     } else {
       this.localeConfig = await iosSettings.setLocale(this.opts.device, this.opts, {}, this.isSafari());
       await iosSettings.setPreferences(this.opts.device, this.opts, this.isSafari());
+
       let installAppPromise = null;
       if (this.opts.app) {
         if (await simBooted(this.opts.device)) {
@@ -332,6 +329,13 @@ class XCUITestDriver extends BaseDriver {
       this.logEvent('simStarted');
       await installAppPromise;
       this.logEvent('appInstalled');
+    }
+
+    // if we only have bundle identifier and no app, fail if it is not already installed
+    if (!this.opts.app && this.opts.bundleId && !this.safari) {
+      if (!await this.opts.device.isAppInstalled(this.opts.bundleId)) {
+        log.errorAndThrow(`App with bundle identifier '${this.opts.bundleId}' unknown`);
+      }
     }
 
     await this.startWda(this.opts.sessionId, realDevice);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -42,24 +42,41 @@ describe('XCUITestDriver', function () {
       await driver.init(UICATALOG_SIM_CAPS);
       let els = await driver.elementsByClassName("XCUIElementTypeWindow");
       els.length.should.be.at.least(1);
-      await driver.quit();
     });
 
     it('should start and stop a session doing pre-build', async function () {
       await driver.init(_.defaults({prebuildWDA: true}, UICATALOG_SIM_CAPS));
       let els = await driver.elementsByClassName("XCUIElementTypeWindow");
       els.length.should.be.at.least(1);
-      await driver.quit();
     });
 
     it('should start and stop a session doing simple build-test', async function () {
       await driver.init(_.defaults({useSimpleBuildTest: true}, UICATALOG_SIM_CAPS));
       let els = await driver.elementsByClassName("XCUIElementTypeWindow");
       els.length.should.be.at.least(1);
-      await driver.quit();
     });
 
-    it('should fail to start and stop a session', async function () {
+    it('should start and stop a session with only bundle id', async function () {
+      let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'com.example.apple-samplecode.UICatalog'});
+      caps.app = null;
+      await driver.init(caps).should.not.eventually.be.rejected;
+    });
+
+    it('should start and stop a session with only bundle id when no sim is running', async function () {
+      await killAllSimulators();
+      let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'com.example.apple-samplecode.UICatalog'});
+      caps.app = null;
+      await driver.init(caps).should.not.eventually.be.rejected;
+    });
+
+    it('should fail to start and stop a session if unknown bundle id used', async function () {
+      let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'io.blahblahblah.blah'});
+      caps.app = null;
+      await driver.init(caps).should.eventually.be.rejected;
+    });
+
+    it('should fail to start and stop a session if unknown bundle id used when no sim is running', async function () {
+      await killAllSimulators();
       let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'io.blahblahblah.blah'});
       caps.app = null;
       await driver.init(caps).should.eventually.be.rejected;


### PR DESCRIPTION
The placement of the test for bundle id meant that if the simulator was not running the check would fail and nothing could progress.

Move the check, and add some tests.

Resolves https://github.com/appium/appium/issues/8605