### PR TITLE
Use wdaLocalPort for sim port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,11 @@ git:
   submodules: false
 before_install:
   # objC project, so manually handle node version
-  - nvm install 4
+  - nvm install 6
   # Use sed to replace the SSH URL with the public URL, then initialize submodules
   # code from http://stackoverflow.com/a/24600210/375688
   - sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules
   - git submodule update --init --recursive
-  # - pushd WebDriverAgent && ./Scripts/bootstrap.sh -d && popd
 before_script:
   - node --version
   - npm install -g gulp

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -54,6 +54,7 @@ class WebDriverAgent {
       usePrebuiltWDA: args.usePrebuiltWDA,
       updatedWDABundleId: args.updatedWDABundleId,
       launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
+      wdaRemotePort: this.realDevice ? WDA_AGENT_PORT : (this.wdaLocalPort || WDA_AGENT_PORT),
     });
   }
 
@@ -155,11 +156,8 @@ class WebDriverAgent {
 
   get url () {
     if (!this._url) {
-      if (this.realDevice && this.wdaLocalPort) {
-        this._url = url.parse(`${WDA_BASE_URL}:${this.wdaLocalPort}`);
-      } else {
-        this._url = url.parse(`${WDA_BASE_URL}:${WDA_AGENT_PORT}`);
-      }
+      let port = this.wdaLocalPort || WDA_AGENT_PORT;
+      this._url = url.parse(`${WDA_BASE_URL}:${port}`);
     }
     return this._url;
   }

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -40,6 +40,8 @@ class XcodeBuild {
     this.useSimpleBuildTest = args.useSimpleBuildTest;
 
     this.launchTimeout = args.launchTimeout;
+
+    this.wdaRemotePort = args.wdaRemotePort;
   }
 
   async init (noSessionProxy) {
@@ -139,7 +141,7 @@ class XcodeBuild {
     let {cmd, args} = this.getCommand(buildOnly);
     log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
-    let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath});
+    let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath, env: {USE_PORT: this.wdaRemotePort}});
 
     let logXcodeOutput = this.showXcodeLog;
     log.debug(`Output from xcodebuild ${logXcodeOutput ? 'will' : 'will not'} be logged`);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -82,6 +82,23 @@ describe('XCUITestDriver', function () {
       await driver.init(caps).should.eventually.be.rejected;
     });
 
+    describe('WebdriverAgent port', function () {
+      it('should run on default port if no other specified', async function () {
+        let caps = Object.assign({}, UICATALOG_SIM_CAPS, {fullReset: true, showIOSLog: true});
+        caps.wdaLocalPort = null;
+        await driver.init(caps);
+        let logs = await driver.log('syslog');
+        logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.true;
+      });
+      it('should run on port specified', async function () {
+        let caps = Object.assign({}, UICATALOG_SIM_CAPS, {fullReset: true, showIOSLog: true, wdaLocalPort: 6000});
+        await driver.init(caps);
+        let logs = await driver.log('syslog');
+        logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.false;
+        logs.some((line) => line.message.indexOf(':6000<-') !== -1).should.be.true;
+      });
+    });
+
     /* jshint ignore:start */
     describe('initial orientation', async () => {
       async function runOrientationTest (initialOrientation) {


### PR DESCRIPTION
Real device remains the same (WDA runs on port 8100 on the device, `wdaLocalPort` specifies the local end of the iproxy bridge). On simulators there is no difference between local and remote, but users sometimes have something running on port 8100, so being able to specify it makes things able to work.