### PR TITLE
First pass at Xcode 9/ios 11 support

### DIFF
--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -17,11 +17,20 @@ helpers.nativeBack = async function () {
   try {
     let navBar = await this.findNativeElementOrElements('class name', 'XCUIElementTypeNavigationBar', false);
     let buttons = await this.findNativeElementOrElements('class name', 'XCUIElementTypeButton', true, navBar);
+    if (buttons.length === 0) {
+      throw new Error('No buttons found in navigation bar');
+    }
+
     let backButton = _.filter(buttons, (value) => value.label === 'Back')[0];
-    log.debug(`Found navigation bar 'back' button. Clicking.`);
+    if (backButton) {
+      log.debug(`Found navigation bar 'back' button. Clicking.`);
+    } else {
+      log.debug(`Unable to find 'Back' button. Trying first button in navigation bar`);
+      backButton = buttons[0];
+    }
     await this.nativeClick(backButton);
   } catch (err) {
-    log.error('Unable to find navigation bar and back button.');
+    log.error(`Unable to find navigation bar and back button: ${err.message}`);
   }
 };
 

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -7,6 +7,8 @@ import log from '../logger';
 const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
 const PROJECT_FILE = 'project.pbxproj';
 const XCUICOORDINATE_FILE = 'PrivateHeaders/XCTest/XCUICoordinate.h';
+const FBMACROS_FILE = 'WebDriverAgentLib/Utilities/FBMacros.h';
+const XCUIAPPLICATION_FILE = 'PrivateHeaders/XCTest/XCUIApplication.h';
 
 async function replaceInFile (file, find, replace) {
   let contents = await fs.readFile(file, 'utf-8');
@@ -109,6 +111,33 @@ async function fixForXcode7 (bootstrapPath, initial = true) {
   await fixXCUICoordinateFile(bootstrapPath, initial);
 }
 
+async function fixFBMacrosFile (bootstrapPath, initial = true) {
+  const file = path.resolve(bootstrapPath, FBMACROS_FILE);
+
+  let oldDef = '#define FBStringify(class, property) ({if(NO){[class.new property];} @#property;})';
+  let newDef = '#define FBStringify(class, property) ({@#property;})';
+  if (!initial) {
+    [oldDef, newDef] = [newDef, oldDef];
+  }
+  await replaceInFile(file, oldDef, newDef);
+}
+
+async function fixXCUIApplicationFile (bootstrapPath, initial = true) {
+  const file = path.resolve(bootstrapPath, XCUIAPPLICATION_FILE);
+
+  let oldDef = '@property(nonatomic, readonly) NSUInteger state; // @synthesize state=_state;';
+  let newDef = '@property XCUIApplicationState state;';
+  if (!initial) {
+    [oldDef, newDef] = [newDef, oldDef];
+  }
+  await replaceInFile(file, oldDef, newDef);
+}
+
+async function fixForXcode9 (bootstrapPath, initial = true) {
+  await fixFBMacrosFile(bootstrapPath, initial);
+  await fixXCUIApplicationFile(bootstrapPath, initial);
+}
+
 async function generateXcodeConfigFile (orgId, signingId) {
   log.debug(`Generating xcode config file for orgId '${orgId}' and signingId ` +
             `'${signingId}'`);
@@ -155,5 +184,5 @@ async function killProcess (name, proc) {
 }
 
 export { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity, fixForXcode7, generateXcodeConfigFile,
-         killAppUsingAppName, killProcess };
+         setRealDeviceSecurity, fixForXcode7, fixForXcode9,
+         generateXcodeConfigFile, killAppUsingAppName, killProcess };

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -3,7 +3,7 @@ import { SubProcess } from 'teen_process';
 import { fs, logger } from 'appium-support';
 import log from '../logger';
 import B from 'bluebird';
-import { fixForXcode7, setRealDeviceSecurity, generateXcodeConfigFile,
+import { fixForXcode7, fixForXcode9, setRealDeviceSecurity, generateXcodeConfigFile,
          updateProjectFile, resetProjectFile, killProcess } from './utils';
 import _ from 'lodash';
 import path from 'path';
@@ -52,6 +52,11 @@ class XcodeBuild {
     if (this.xcodeVersion.major === 7 || (this.xcodeVersion.major === 8 && this.xcodeVersion.minor === 0)) {
       log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
       await fixForXcode7(this.bootstrapPath, true);
+    }
+
+    if (this.xcodeVersion.major === 9) {
+      log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
+      await fixForXcode9(this.bootstrapPath, true);
     }
 
     // if necessary, update the bundleId to user's specification

--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
+import { retryInterval } from 'asyncbox';
 import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 
@@ -21,10 +22,17 @@ describe('XCUITestDriver - alerts', function () {
 
 
   beforeEach(async () => {
-    let el1 = await driver.elementByAccessibilityId('Alert Views');
-    await el1.click();
+    await retryInterval(5, 500, async () => {
+      let el = await driver.elementByAccessibilityId('Alert Views');
+      await el.click();
+
+      (await driver.elementsByAccessibilityId('Simple')).should.have.length(1);
+    });
   });
   afterEach(async () => {
+    try {
+      await driver.acceptAlert();
+    } catch (ign) {}
     await driver.back();
   });
 

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -1,7 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
-import _ from 'lodash';
 import { retryInterval } from 'asyncbox';
 import { UICATALOG_CAPS, PLATFORM_VERSION } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
@@ -212,15 +211,8 @@ describe('XCUITestDriver - basics', function () {
         contexts.length.should.be.at.least(2);
       });
 
-      let urlBar = await driver.elementByClassName('XCUIElementTypeTextField');
-      await urlBar.clear();
-
-      await urlBar.sendKeys(GUINEA_PIG_PAGE);
-
-      let buttons = await driver.elementsByClassName('XCUIElementTypeButton');
-      await _.last(buttons).click();
-
       await driver.context(contexts[1]);
+      await driver.get(GUINEA_PIG_PAGE);
 
       await retryInterval(100, 1000, async () => {
         let title = await driver.title();

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import _ from 'lodash';
+import { retryInterval } from 'asyncbox';
 import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 
@@ -134,8 +135,12 @@ describe('XCUITestDriver - find', function () {
       });
       beforeEach(async () => {
         // go into the right page
-        let el = await driver.elementByAccessibilityId('Buttons');
-        await el.click();
+        await retryInterval(10, 500, async () => {
+          let el = await driver.elementByAccessibilityId('Buttons');
+          await el.click();
+
+          (await driver.elementsByAccessibilityId('Button')).should.have.length.at.least(1);
+        });
       });
       afterEach(async () => {
         await driver.back();

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -35,9 +35,11 @@ describe('XCUITestDriver - gestures', function () {
 
     describe('tap, press, longpress', () => {
       beforeEach(async () => {
-        let el = await driver.elementByAccessibilityId('Action Sheets');
-        await driver.execute('mobile: scroll', {element: el, toVisible: true});
-        await el.click();
+        await retryInterval(10, 500, async () => {
+          let el = await driver.elementByAccessibilityId('Action Sheets');
+          await driver.execute('mobile: scroll', {element: el, toVisible: true});
+          await el.click();
+        });
       });
       describe('tap', () => {
         it('should tap on the element', async () => {


### PR DESCRIPTION
Make launching the driver with Xcode 9 and iOS 11 _possible_. There are still many issues with running tests, not least of which are (a) unable to get the text (either value or label) from text elements, and (b) 3-5 second pause before clicking on any element, after the device gets the request.

This PR is largely to get this in, so things don't get ahead of the work.