### PR TITLE
Enable toggle touchId enrollment by default

### DIFF
--- a/docs/touch-id.md
+++ b/docs/touch-id.md
@@ -1,13 +1,13 @@
 ## Touch ID
 
-Appium has the capability to simulate Touch ID (https://support.apple.com/en-ca/HT201371) on iOS Simulators.
+Appium has the capability to simulate [Touch ID](https://support.apple.com/en-ca/HT201371) on iOS Simulators.
 
 ### Support
 * TouchID simulation is only supported in iOS Simulators. It is not possible to simulate touchId on real devices.
 * Not all iOS devices have touchId so your tests should handle the case where touchId is not supported
 
 ### Configuration
-* To use touchId, Terminal must be added to the accessibility preferences on your Mac (navigate to `System Preferences > Security & Privacy > Accessibility` and under `Allow the apps below to control your computer` add `Terminal`)
+* To use touchId, the application that Appium launches from (such as Terminal, AppiumDesktop, or iTerm) must be added to the accessibility preferences on your Mac. Navigate to `System Preferences > Security & Privacy > Accessibility` and under `Allow the apps below to control your computer` add the application. (The only way Appium can enable enrollment and toggling of Touch ID is to use system-level accessibility APIs to simulate mouse clicks on the Simulator menus via AppleScript. For this reason this feature requires that you give Appium's running context access to these accessibility APIs).
 
 ### Usage
 * Set the desired capability `allowTouchIdEnroll` to true.

--- a/docs/touch-id.md
+++ b/docs/touch-id.md
@@ -1,0 +1,15 @@
+## Touch ID
+
+Appium has the capability to simulate Touch ID (https://support.apple.com/en-ca/HT201371) on iOS Simulators.
+
+### Support
+* TouchID simulation is only supported in iOS Simulators. It is not possible to simulate touchId on real devices.
+* Not all iOS devices have touchId so your tests should handle the case where touchId is not supported
+
+### Configuration
+* To use touchId, Terminal must be added to the accessibility preferences on your Mac (navigate to `System Preferences > Security & Privacy > Accessibility` and under `Allow the apps below to control your computer` add `Terminal`)
+
+### Usage
+* Set the desired capability `allowTouchIdEnroll` to true.
+* When the Simulator starts, touch id enrollment will be enabled by default.
+* You can toggle touchId enrollment by calling the client method associated with the endpoint /session/:sessionId/appium/simulator/toggle_touch_id_enrollment

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -637,7 +637,7 @@ class XCUITestDriver extends BaseDriver {
 
     // Enable toggleEnrollTouchId initially
     if (this.opts.allowTouchIdEnroll) {
-      await commands.toggleEnrollTouchId.call(this);
+      await this.toggleEnrollTouchId();
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -634,6 +634,11 @@ class XCUITestDriver extends BaseDriver {
     log.info(`Simulator with udid '${this.opts.udid}' not booted. Booting up now`);
     await killAllSimulators();
     await this.opts.device.run(undefined, this.opts.allowTouchIdEnroll);
+
+    // Enable toggleEnrollTouchId initially
+    if (this.opts.allowTouchIdEnroll) {
+      await commands.toggleEnrollTouchId.call(this);
+    }
   }
 
   async createSim () {

--- a/test/functional/basic/touch-id-e2e-specs.js
+++ b/test/functional/basic/touch-id-e2e-specs.js
@@ -51,7 +51,6 @@ describe('touchID() ', function () {
     });
 
     it('should accept matching fingerprint if touchID is enrolled or it should not be supported if phone doesn\'t support touchID', async () => {
-      await driver.toggleTouchIdEnrollment();
       let authenticateButton = await driver.elementByName(' Authenticate with Touch ID');
       await authenticateButton.click();
       await driver.touchId(true);
@@ -60,11 +59,9 @@ describe('touchID() ', function () {
       } catch (ign) {
         await driver.elementByName('TouchID not supported').should.eventually.exist;
       }
-      await driver.toggleTouchIdEnrollment();
     });
 
     it('should reject not matching fingerprint if touchID is enrolled or it should not be supported if phone doesn\'t support touchID', async () => {
-      await driver.toggleTouchIdEnrollment();
       let authenticateButton = await driver.elementByName(' Authenticate with Touch ID');
       await authenticateButton.click();
       await driver.touchId(false);
@@ -73,11 +70,11 @@ describe('touchID() ', function () {
       } catch (ign) {
         await driver.elementByName('TouchID not supported').should.eventually.exist;
       }
-      await driver.toggleTouchIdEnrollment();
     });
 
     it('should enroll touchID and accept matching fingerprints then unenroll touchID and not be supported', async () => {
-      // Don't enroll
+      //Unenroll
+      await driver.toggleTouchIdEnrollment();
       let authenticateButton = await driver.elementByName(' Authenticate with Touch ID');
       await authenticateButton.click();
       await driver.elementByName('TouchID not supported').should.eventually.exist;
@@ -85,7 +82,7 @@ describe('touchID() ', function () {
       await okButton.click();
       await B.delay(1000);
 
-      // Enroll
+      // Re-enroll
       await driver.toggleTouchIdEnrollment();
       await authenticateButton.click();
       await driver.touchId(true);
@@ -98,7 +95,7 @@ describe('touchID() ', function () {
       await okButton.click();
       await B.delay(1000);
 
-      // Unenroll
+      // Unenroll again
       await driver.toggleTouchIdEnrollment();
       authenticateButton = await driver.elementByName(' Authenticate with Touch ID');
       await authenticateButton.click();


### PR DESCRIPTION
* Previously, when allowTouchIdEnroll is set to true, you had to call the client method to toggle touch ID enrollment
* With this PR, we now enable touchId enrollment by default if allowTouchIdEnroll is set to true when the simulator starts
* Also added documentation for Touch ID as there wasn't any before

(connected to https://github.com/appium/appium/issues/8676 and https://github.com/appium/appium/issues/8578#issuecomment-308696488)