### PR TITLE
Allow nativeWebTap on real devices

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -15,7 +15,7 @@ commands.click = async function (el) {
     return await this.nativeClick(el);
   }
   el = util.unwrapElement(el);
-  if (this.opts.nativeWebTap && !this.isRealDevice()) {
+  if (this.opts.nativeWebTap) {
     // atoms-based clicks don't always work in safari 7
     await this.nativeWebTap(el);
   } else {

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -15,8 +15,9 @@ commands.click = async function (el) {
     return await this.nativeClick(el);
   }
   el = util.unwrapElement(el);
-  if (this.opts.nativeWebTap) {
+  if (this.settings.getSettings().nativeWebTap) {
     // atoms-based clicks don't always work in safari 7
+    log.debug('Using native web tap');
     await this.nativeWebTap(el);
   } else {
     let atomsElement = this.useAtomsElement(el);

--- a/test/functional/web/safari-execute-e2e-specs.js
+++ b/test/functional/web/safari-execute-e2e-specs.js
@@ -91,11 +91,6 @@ describe('safari - execute', function () {
         await driver.setAsyncScriptTimeout(1000);
         await driver.executeAsync(`return 1 + 2`).should.eventually.be.rejected;
       });
-
-      it('should work with an HTTPS site', async () => {
-        await driver.get('https://google.com');
-        (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
-      });
     });
   }
 

--- a/test/functional/web/safari-execute-e2e-specs.js
+++ b/test/functional/web/safari-execute-e2e-specs.js
@@ -78,8 +78,8 @@ describe('safari - execute', function () {
     });
 
     describe('asynchronous', function () {
-      it('should bubble up javascript errors', async () => {
-        await driver.execute(`'nan'--`).should.eventually.be.rejected;
+      before(function () {
+        if (process.env.REAL_DEVICE) return this.skip(); // eslint-disable-line curly
       });
 
       it('should execute async javascript', async () => {
@@ -92,10 +92,10 @@ describe('safari - execute', function () {
         await driver.executeAsync(`return 1 + 2`).should.eventually.be.rejected;
       });
 
-      // it('should work with an HTTPS site', async () => {
-      //   await driver.get('https://google.com');
-      //   (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
-      // });
+      it('should work with an HTTPS site', async () => {
+        await driver.get('https://google.com');
+        (await driver.executeAsync(`arguments[arguments.length - 1](123);`)).should.be.equal(123);
+      });
     });
   }
 

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -24,10 +24,10 @@ describe('Safari SSL', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let server, sslServer, driver;
-  before(async () => {
-    if (!process.env.REAL_DEVICE) {
-      await killAllSimulators();
-    }
+  before(async function () {
+    if (process.env.REAL_DEVICE) return this.skip(); // eslint-disable-line curly
+
+    await killAllSimulators();
 
     driver = wd.promiseChainRemote(HOST, PORT);
     server = await startServer(PORT, HOST);
@@ -55,7 +55,9 @@ describe('Safari SSL', function () {
 
   describe('ssl cert', () => {
     afterEach(async function () {
-      await driver.quit();
+      if (driver) {
+        await driver.quit();
+      }
     });
 
     it('should open pages with untrusted certs if the cert was provided in desired capabilities', async function () {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -115,21 +115,22 @@ describe('general commands', () => {
     });
 
     it('should start out with setting defaulting to false', async () => {
-      await driver.getSettings().should.eventually.eql({nativeWebTap: false});
+      (await driver.getSettings()).nativeWebTap.should.eql(false);
     });
 
     it('should default to value sent in caps after session starts', async () => {
+      (await driver.getSettings()).nativeWebTap.should.eql(false);
       await driver.createSession(Object.assign({nativeWebTap: true}, baseCaps));
-      await driver.getSettings().should.eventually.eql({nativeWebTap: true});
+      (await driver.getSettings()).nativeWebTap.should.eql(true);
     });
 
     it('should update opts value based on settings update', async () => {
-      await driver.getSettings().should.eventually.eql({nativeWebTap: false});
+      (await driver.getSettings()).nativeWebTap.should.eql(false);
       await driver.updateSettings({nativeWebTap: true});
-      await driver.getSettings().should.eventually.eql({nativeWebTap: true});
+      (await driver.getSettings()).nativeWebTap.should.eql(true);
       driver.opts.nativeWebTap.should.be.true;
       await driver.updateSettings({nativeWebTap: false});
-      await driver.getSettings().should.eventually.eql({nativeWebTap: false});
+      (await driver.getSettings()).nativeWebTap.should.eql(false);
       driver.opts.nativeWebTap.should.be.false;
     });
   });


### PR DESCRIPTION
Remove restriction for `nativeWebTap` on real devices, since it will work for XCUITest. Also switch to using the settings value rather than the cap.