### PR TITLE
Pass realDeviceLogger on to ios-log

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -17,12 +17,14 @@ extensions.startLogCapture = async function () {
   this.logs.syslog = new IOSLog({
     sim: this.opts.device,
     udid: this.isRealDevice() ? this.opts.udid : undefined,
-    showLogs: this.opts.showIOSLog
+    showLogs: this.opts.showIOSLog,
+    realDeviceLogger: this.opts.realDeviceLogger,
   });
   try {
     await this.logs.syslog.startCapture();
   } catch (err) {
-    log.warn('Could not capture logs from device. Continuing without capturing logs.');
+    log.warn(`Could not capture logs from device: ${err.message}`);
+    log.debug('Continuing without capturing logs.');
     return;
   }
   await this.logs.crashlog.startCapture();


### PR DESCRIPTION
Once `appium-ios-driver` is updated, this will allow the user to specify what real device logger they have, and where. Before it is updated, it will do nothing (including doing no harm).