### PR TITLE
Remove unnecessary uninstall argument from ios-deploy command line

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -21,7 +21,7 @@ class IOSDeploy {
     try {
       await exec(this.cmd, remove);
     } catch (err) {
-      logger.debug(`Error : ${err.message}`);
+      logger.debug(`Stdout: '${err.stdout}'. Stderr: '${err.stderr}'.`);
       throw new Error(`Could not remove app: '${err.message}'`);
     }
   }
@@ -31,10 +31,11 @@ class IOSDeploy {
   }
 
   async install (app) {
-    let install = [`--id`, this.udid, `--uninstall`, `--bundle`, app];
+    const install = [`--id`, this.udid, `--bundle`, app];
     try {
       await exec(this.cmd, install);
     } catch (err) {
+      logger.debug(`Stdout: '${err.stdout}'. Stderr: '${err.stderr}'.`);
       throw new Error(`Could not install app: '${err.message}'`);
     }
   }


### PR DESCRIPTION
Exclude application uninstall from the default ios-deploy command line since the fact of application install is already verified in _installToRealDevice_ method of **real-device-management** module. Also, this argument forces ios-deploy utility itself to detect application bundle id (see https://github.com/phonegap/ios-deploy/blob/master/src/ios-deploy/ios-deploy.m -> `void uninstall_app(AMDeviceRef device)`), which affects performance and causes issues.