### PR TITLE
Fix logging of url

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -394,7 +394,7 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      log.debug(`Capability 'useNewWDA' set to false, so trying to reuse currently running WDA instance at ${this.wda.url}...`);
+      log.debug(`Capability 'useNewWDA' set to false, so trying to reuse currently running WDA instance at '${this.wda.url.href}'`);
       const noSessionProxy = new NoSessionProxy({
         server: this.wda.url.hostname,
         port: this.wda.url.port,
@@ -406,10 +406,10 @@ class XCUITestDriver extends BaseDriver {
         if (!status) {
           throw new Error(`WDA response to /status command should be defined.`);
         }
-        log.debug(`Detected WDA listening at ${this.wda.url}. Setting WDA endpoint to ${this.wda.url}`);
+        log.debug(`Detected WDA listening at '${this.wda.url.href}'. Setting WDA endpoint to '${this.wda.url.href}'`);
         this.wda.webDriverAgentUrl = this.wda.url;
       } catch (err) {
-        log.debug(`WDA is not listening at ${this.wda.url}. Rebuilding...`);
+        log.debug(`WDA is not listening at '${this.wda.url.href}'. Rebuilding...`);
       }
     }
 


### PR DESCRIPTION
Currently we log `[object Object]` instead of the href.
```
dbug XCUITest Capability 'useNewWDA' set to false, so trying to reuse currently running WDA instance at [object Object]...
```

We want:
```
dbug XCUITest Capability 'useNewWDA' set to false, so trying to reuse currently running WDA instance at http://localhost:8100/...
```