### PR TITLE
Parse webDriverAgentUrl

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -31,7 +31,9 @@ class WebDriverAgent {
 
     this.prebuildWDA = args.prebuildWDA;
 
-    this.webDriverAgentUrl = args.webDriverAgentUrl;
+    if (args.webDriverAgentUrl) {
+      this.webDriverAgentUrl = url.parse(args.webDriverAgentUrl);
+    }
 
     this.started = false;
 
@@ -76,10 +78,10 @@ class WebDriverAgent {
 
   async launch (sessionId) {
     if (this.webDriverAgentUrl) {
-      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
+      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl.href}'`);
       this.url = this.webDriverAgentUrl;
       this.setupProxies(sessionId);
-      return this.webDriverAgentUrl;
+      return;
     }
 
     log.info('Launching WebDriverAgent on the device');

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -31,9 +31,7 @@ class WebDriverAgent {
 
     this.prebuildWDA = args.prebuildWDA;
 
-    if (args.webDriverAgentUrl) {
-      this.webDriverAgentUrl = url.parse(args.webDriverAgentUrl);
-    }
+    this.webDriverAgentUrl = args.webDriverAgentUrl;
 
     this.started = false;
 
@@ -78,7 +76,7 @@ class WebDriverAgent {
 
   async launch (sessionId) {
     if (this.webDriverAgentUrl) {
-      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl.href}'`);
+      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
       this.url = this.webDriverAgentUrl;
       this.setupProxies(sessionId);
       return;

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 
 chai.should();
 chai.use(chaiAsPromised);
+const expect = chai.expect;
 
 const fakeConstructorArgs = {
   device: 'some sim',
@@ -45,11 +46,13 @@ describe('Constructor', () => {
 
 describe('launch', () => {
   it('should use webDriverAgentUrl override', async () => {
-    let override = "http://mockUrl:8100";
+    let override = "http://mockurl:8100/";
     let args = Object.assign({}, fakeConstructorArgs);
     args.webDriverAgentUrl = override;
     let agent = new WebDriverAgent({}, args);
 
-    (await agent.launch("sessionId")).should.be.equal(override);
+    expect(await agent.launch("sessionId")).to.be.undefined;
+
+    agent.url.href.should.eql(override);
   });
 });


### PR DESCRIPTION
Make sure that `webDriverAgentUrl` is parsed as a [url](https://nodejs.org/api/url.html#url_class_url) object, as we expect elsewhere. Also remove return value, so that we actually get the status later on.