### PR TITLE
Retry clear

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import { iosCommands } from 'appium-ios-driver';
 import { util } from 'appium-support';
-import { retryInterval } from 'asyncbox';
+import { retryInterval, retry } from 'asyncbox';
 import log from '../logger';
 
 
@@ -226,7 +226,7 @@ commands.clear = async function (el) {
     await this.executeAtom('clear', [atomsElement]);
     return;
   }
-  await this.proxyCommand(`/element/${el}/clear`, 'POST');
+  await retry(5, this.proxyCommand.bind(this), `/element/${el}/clear`, 'POST');
 };
 
 


### PR DESCRIPTION
We've been seeing a number of errors (including in the build) where clear times out waiting for an action. Since it is just clearing, it is fine to retry the call to WDA. Seems to much stabler.