### PR TITLE
Opening apps through deep links

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -36,6 +36,8 @@ const NO_PROXY_NATIVE_LIST = [
   ['GET', /^\/session\/[^\/]+$/],
   ['GET', /context/],
   ['POST', /context/],
+  ['GET', /url/],
+  ['POST', /url/],
   ['GET', /window/],
   ['POST', /window/],
   ['DELETE', /window/],
@@ -68,8 +70,6 @@ const NO_PROXY_NATIVE_LIST = [
 ];
 const NO_PROXY_WEB_LIST = [
   ['GET', /title/],
-  ['GET', /url/],
-  ['POST', /url/],
   ['POST', /element/],
   ['POST', /forward/],
   ['GET', /attribute/],


### PR DESCRIPTION
With this change i can open both url in safari and deep links in registered apps through driver.get(). I was not able to make it work without it.

I'll continue using my appium fork so I don't need this request merged. I just want to share result of several day-long investigation.