### PR TITLE
Detach xcodebuild and iproxy processes to keep them running even after Node server is terminated

### DIFF
--- a/lib/wda/iproxy.js
+++ b/lib/wda/iproxy.js
@@ -15,7 +15,7 @@ class iProxy {
     this.expectIProxyErrors = true;
     this.iproxy = new SubProcess('iproxy', [localport, deviceport, udid], {
       detached: true,
-      stdio: ['ignore', 'inherit', 'inherit'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
   }
 

--- a/lib/wda/iproxy.js
+++ b/lib/wda/iproxy.js
@@ -13,7 +13,10 @@ class iProxy {
   constructor (udid, localport, deviceport) {
     log.debug(`Starting iproxy to forward traffic from local port ${localport} to device port ${deviceport} over USB`);
     this.expectIProxyErrors = true;
-    this.iproxy = new SubProcess(`iproxy`, [localport, deviceport, udid]);
+    this.iproxy = new SubProcess('iproxy', [localport, deviceport, udid], {
+      detached: true,
+      stdio: ['ignore'],
+    });
   }
 
   async start () {
@@ -51,6 +54,7 @@ class iProxy {
       return (async () => {
         try {
           await this.iproxy.start(IPROXY_TIMEOUT);
+          this.iproxy.proc.unref();
           resolve();
         } catch (err) {
           log.error(`Error starting iproxy: '${err.message}'`);

--- a/lib/wda/iproxy.js
+++ b/lib/wda/iproxy.js
@@ -15,7 +15,7 @@ class iProxy {
     this.expectIProxyErrors = true;
     this.iproxy = new SubProcess('iproxy', [localport, deviceport, udid], {
       detached: true,
-      stdio: ['ignore'],
+      stdio: ['ignore', 'inherit', 'inherit'],
     });
   }
 

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -151,7 +151,7 @@ class XcodeBuild {
       cwd: this.bootstrapPath,
       env: {USE_PORT: this.wdaRemotePort},
       detached: true,
-      stdio: ['ignore'],
+      stdio: ['ignore', 'inherit', 'inherit'],
     });
 
     let logXcodeOutput = this.showXcodeLog;

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -147,7 +147,12 @@ class XcodeBuild {
     let {cmd, args} = this.getCommand(buildOnly);
     log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
-    let xcodebuild = new SubProcess(cmd, args, {cwd: this.bootstrapPath, env: {USE_PORT: this.wdaRemotePort}});
+    let xcodebuild = new SubProcess(cmd, args, {
+      cwd: this.bootstrapPath,
+      env: {USE_PORT: this.wdaRemotePort},
+      detached: true,
+      stdio: ['ignore'],
+    });
 
     let logXcodeOutput = this.showXcodeLog;
     log.debug(`Output from xcodebuild ${logXcodeOutput ? 'will' : 'will not'} be logged. To see xcode logging, use 'showXcodeLog' desired capability`);
@@ -219,6 +224,7 @@ class XcodeBuild {
         try {
           let startTime = process.hrtime();
           await this.xcodebuild.start();
+          this.xcodebuild.proc.unref();
           if (!buildOnly) {
             let status = await this.waitForStart(startTime);
             resolve(status);

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -151,7 +151,7 @@ class XcodeBuild {
       cwd: this.bootstrapPath,
       env: {USE_PORT: this.wdaRemotePort},
       detached: true,
-      stdio: ['ignore', 'inherit', 'inherit'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     let logXcodeOutput = this.showXcodeLog;


### PR DESCRIPTION
This promises more stability for real device tests, since in XCTest world they don't not like multiple WDA reinstallations. We are already trying to pick up the session after restart and with this PR merged session pick up should be also possible after Node server restart (see https://stackoverflow.com/questions/37427360/parent-process-kills-child-process-even-though-detached-is-set-to-true for the reference). 