### PR TITLE
Adjust permissions only on the current derived data folder

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -431,7 +431,7 @@ class XCUITestDriver extends BaseDriver {
       }
 
       this.opts.preventWDAAttachments = !util.hasValue(this.opts.preventWDAAttachments) || this.opts.preventWDAAttachments;
-      await adjustWDAAttachmentsPermissions(this.opts.preventWDAAttachments ? '555' : '755');
+      await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');
       this.logEvent('wdaPermsAdjusted');
 
       // we expect certain socket errors until this point, but now
@@ -462,7 +462,7 @@ class XCUITestDriver extends BaseDriver {
 
     // reset the permissions on the derived data folder, if necessary
     if (this.opts.preventWDAAttachments) {
-      await adjustWDAAttachmentsPermissions('755');
+      await adjustWDAAttachmentsPermissions(this.wda, '755');
     }
 
     if (this.opts.clearSystemFiles) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,12 +101,13 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
     log.debug('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
     return;
   }
-  const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
+  const derivedDataRoot = await wda.retrieveDerivedDataPath();
+  const attachmentsFolder = path.join(derivedDataRoot, WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
   if (await fs.exists(attachmentsFolder)) {
     log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
     await fs.chmod(attachmentsFolder, perms);
   } else {
-    log.info('No WDA derived data attachments folders have been found.');
+    log.info(`There is no ${WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH} subfolder under ${derivedDataRoot}, so not changing permissions`);
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -97,7 +97,7 @@ async function translateDeviceName (pv, dn = '') {
 
 async function adjustWDAAttachmentsPermissions (wda, perms) {
   if (!wda || !await wda.retrieveDerivedDataPath()) {
-    log.debug('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
+    log.warn('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
     return;
   }
   const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
@@ -111,7 +111,7 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
 async function clearSystemFiles (wda) {
   // only want to clear the system files for the particular WDA xcode run
   if (!wda || !await wda.retrieveDerivedDataPath()) {
-    log.debug('No WebDriverAgent derived data available, so unable to clear system files');
+    log.warn('No WebDriverAgent derived data available, so unable to clear system files');
     return;
   }
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,6 @@ import log from './logger';
 import pkgObj from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
-const WDA_DERIVED_DATA_SEARCH_SUFFIX = 'Library/Developer/Xcode/DerivedData/WebDriverAgent-*';
 const WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH = 'Logs/Test/Attachments';
 const DRIVER_VER = pkgObj.version;
 const DEFAULT_TIMEOUT_KEY = 'default';
@@ -97,35 +96,28 @@ async function translateDeviceName (pv, dn = '') {
   return deviceName;
 }
 
-async function adjustWDAAttachmentsPermissions (perms) {
-  if (!process.env.HOME) {
-    throw new Error('Need HOME env var to be set in order to adjust WDA attachments permission');
+async function adjustWDAAttachmentsPermissions (wda, perms) {
+  if (!wda || !await wda.retrieveDerivedDataPath()) {
+    log.debug('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
+    return;
   }
-  let derivedDataSearchMask = path.join(process.env.HOME, WDA_DERIVED_DATA_SEARCH_SUFFIX);
-  let folders = await fs.glob(derivedDataSearchMask);
-  let changesMade = false;
-  for (let folder of folders) {
-    log.debug(`Found WDA derived data folder: '${folder}'`);
-    let attachmentsFolder = path.join(folder, WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
-    if (await fs.exists(attachmentsFolder)) {
-      log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
-      await fs.chmod(attachmentsFolder, perms);
-      changesMade = true;
-    }
-  }
-  if (!changesMade) {
-    log.info('No WDA derived data folders have been found.');
+  const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
+  if (await fs.exists(attachmentsFolder)) {
+    log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
+    await fs.chmod(attachmentsFolder, perms);
+  } else {
+    log.info('No WDA derived data attachments folders have been found.');
   }
 }
 
 async function clearSystemFiles (wda) {
   // only want to clear the system files for the particular WDA xcode run
-  if (!wda || !wda.derivedDataPath) {
+  if (!wda || !await wda.retrieveDerivedDataPath()) {
     log.debug('No WebDriverAgent derived data available, so unable to clear system files');
     return;
   }
 
-  let toDelete = [path.resolve(wda.derivedDataPath, 'Logs')];
+  let toDelete = [path.resolve(await wda.retrieveDerivedDataPath(), 'Logs')];
   await iosUtils.clearLogs(toDelete);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,6 @@ import log from './logger';
 import pkgObj from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
-const WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH = 'Logs/Test/Attachments';
 const DRIVER_VER = pkgObj.version;
 const DEFAULT_TIMEOUT_KEY = 'default';
 
@@ -101,14 +100,12 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
     log.debug('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
     return;
   }
-  const derivedDataRoot = await wda.retrieveDerivedDataPath();
-  const attachmentsFolder = path.join(derivedDataRoot, WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH);
+  const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
   if (await fs.exists(attachmentsFolder)) {
     log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
-    await fs.chmod(attachmentsFolder, perms);
-  } else {
-    log.info(`There is no ${WDA_ATTACHMENTS_FOLDER_RELATIVE_PATH} subfolder under ${derivedDataRoot}, so not changing permissions`);
+    return await fs.chmod(attachmentsFolder, perms);
   }
+  log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
 }
 
 async function clearSystemFiles (wda) {
@@ -117,9 +114,12 @@ async function clearSystemFiles (wda) {
     log.debug('No WebDriverAgent derived data available, so unable to clear system files');
     return;
   }
-
-  let toDelete = [path.resolve(await wda.retrieveDerivedDataPath(), 'Logs')];
-  await iosUtils.clearLogs(toDelete);
+  const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
+  if (await fs.exists(logsRoot)) {
+    log.info(`Cleaning test logs in '${logsRoot}' folder`);
+    return await iosUtils.clearLogs([logsRoot]);
+  }
+  log.info(`There is no ${logsRoot} folder, so not cleaning files`);
 }
 
 async function checkAppPresent (app) {

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -152,10 +152,16 @@ CODE_SIGN_IDENTITY = ${signingId}
 
 async function getPidUsingAppName (udid, appName) {
   try {
-    const {stdout} = await exec('pgrep', ['-nif', `${appName}.*${udid}`]);
+    const args = ['-nif', `${appName}.*${udid}`];
+    const {stdout} = await exec('pgrep', args);
     const pid = parseInt(stdout, 10);
-    return isNaN(pid) ? null : `${pid}`;
+    if (isNaN(pid)) {
+      log.debug(`Cannot parse process id from 'pgrep ${args}' output: ${stdout}`);
+      return null;
+    }
+    return `${pid}`;
   } catch (err) {
+    log.debug(`'pgrep ${args}"' didn't detect any matching processes. Return code: ${err.code}`);
     return null;
   }
 }

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -150,10 +150,19 @@ CODE_SIGN_IDENTITY = ${signingId}
   return xcconfigPath;
 }
 
-async function killAppUsingAppName (udid, appName) {
-  let psArgs = [`-c`, `ps -ax|grep -i "${appName}"|grep -i "${udid}"|grep -v grep|awk '{print "kill -9 " $1}'|sh`];
+async function getPidUsingAppName (udid, appName) {
   try {
-    await exec(`bash`, psArgs);
+    const {stdout} = await exec('pgrep', ['-nif', `${appName}.*${udid}`]);
+    const pid = parseInt(stdout, 10);
+    return isNaN(pid) ? null : `${pid}`;
+  } catch (err) {
+    return null;
+  }
+}
+
+async function killAppUsingAppName (udid, appName) {
+  try {
+    await exec('pkill', ['-9', '-nif', `${appName}.*${udid}`]);
   } catch (err) {
     log.debug(`Error : ${err.message}`);
   }
@@ -184,5 +193,5 @@ async function killProcess (name, proc) {
 }
 
 export { updateProjectFile, resetProjectFile, checkForDependencies,
-         setRealDeviceSecurity, fixForXcode7, fixForXcode9,
+         setRealDeviceSecurity, fixForXcode7, fixForXcode9, getPidUsingAppName,
          generateXcodeConfigFile, killAppUsingAppName, killProcess };

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -162,7 +162,7 @@ async function getPidUsingAppName (udid, appName) {
 
 async function killAppUsingAppName (udid, appName) {
   try {
-    await exec('pkill', ['-9', '-nif', `${appName}.*${udid}`]);
+    await exec('pkill', ['-9', '-if', `${appName}.*${udid}`]);
   } catch (err) {
     log.debug(`Error : ${err.message}`);
   }

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -151,8 +151,8 @@ CODE_SIGN_IDENTITY = ${signingId}
 }
 
 async function getPidUsingAppName (udid, appName) {
+  const args = ['-nif', `${appName}.*${udid}`];
   try {
-    const args = ['-nif', `${appName}.*${udid}`];
     const {stdout} = await exec('pgrep', args);
     const pid = parseInt(stdout, 10);
     if (isNaN(pid)) {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -179,8 +179,8 @@ class WebDriverAgent {
     }
   }
 
-  get derivedDataPath () {
-    return this.xcodebuild.derivedDataPath;
+  async retrieveDerivedDataPath () {
+    return await this.xcodebuild.retrieveDerivedDataPath();
   }
 }
 

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -71,11 +71,20 @@ class XcodeBuild {
       const folderRegexp = /(.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
       const pid = await getPidUsingAppName(this.device.udid, 'xcodebuild');
       if (!pid) {
+        log.debug(`Cannot find xcodebuild's process id, so unable to retrieve DerivedData folder path`);
         return;
       }
-      const {stdout} = await exec('bash', ['-c', `lsof -p ${pid} | awk '{print $9}'`]);
+      let stdout = '';
+      try {
+        const execInfo = await exec('lsof', ['-p', pid]);
+        stdout = execInfo.stdout;
+      } catch (err) {
+        log.debug(`Cannot get the list of files opened by xcodebuild process because of "${err.stderr}"`);
+        return;
+      }
       const match = folderRegexp.exec(stdout);
       if (!match) {
+        log.debug(`Cannot find a match for DerivedData folder path from lsof output: ${stdout}`);
         return;
       }
       this._derivedDataPath = match[1];

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -1,10 +1,10 @@
 import { retryInterval } from 'asyncbox';
-import { SubProcess } from 'teen_process';
+import { SubProcess, exec } from 'teen_process';
 import { fs, logger } from 'appium-support';
 import log from '../logger';
 import B from 'bluebird';
 import { fixForXcode7, fixForXcode9, setRealDeviceSecurity, generateXcodeConfigFile,
-         updateProjectFile, resetProjectFile, killProcess } from './utils';
+         updateProjectFile, resetProjectFile, killProcess, getPidUsingAppName } from './utils';
 import _ from 'lodash';
 import path from 'path';
 
@@ -63,6 +63,24 @@ class XcodeBuild {
     if (this.realDevice && this.updatedWDABundleId) {
       await updateProjectFile(this.agentPath, this.updatedWDABundleId);
     }
+  }
+
+  async retrieveDerivedDataPath () {
+    if (!this._derivedDataPath) {
+      // https://regex101.com/r/PqmX8I/1
+      const folderRegexp = /(.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
+      const pid = await getPidUsingAppName(this.device.udid, 'xcodebuild');
+      if (!pid) {
+        return;
+      }
+      const {stdout} = await exec('bash', ['-c', `lsof -p ${pid} | awk '{print $9}'`]);
+      const match = folderRegexp.exec(stdout);
+      if (!match) {
+        return;
+      }
+      this._derivedDataPath = match[1];
+    }
+    return this._derivedDataPath;
   }
 
   async reset () {
@@ -278,19 +296,6 @@ class XcodeBuild {
 
   async quit () {
     await killProcess('xcodebuild', this.xcodebuild);
-  }
-
-  get derivedDataPath () {
-    if (!this._derivedDataPath && this.xcodebuild) {
-      // https://regex101.com/r/PqmX8I/1
-      const folderRegexp = /(.+\/WebDriverAgent-[^\/]+)/;
-      let match = folderRegexp.exec(this.xcodebuild.logLocation);
-      if (!match) {
-        return;
-      }
-      this._derivedDataPath = match[1];
-    }
-    return this._derivedDataPath;
   }
 }
 

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -67,8 +67,7 @@ class XcodeBuild {
 
   async retrieveDerivedDataPath () {
     if (!this._derivedDataPath) {
-      // https://regex101.com/r/PqmX8I/1
-      const folderRegexp = /(.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
+      const folderRegexp = /(\/.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
       const pid = await getPidUsingAppName(this.device.udid, 'xcodebuild');
       if (!pid) {
         log.debug(`Cannot find xcodebuild's process id, so unable to retrieve DerivedData folder path`);

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,32 +1,58 @@
-import { clearSystemFiles, translateDeviceName } from '../../lib/utils';
+import { clearSystemFiles, translateDeviceName, adjustWDAAttachmentsPermissions } from '../../lib/utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { withMocks } from 'appium-test-support';
 import { utils as iosUtils } from 'appium-ios-driver';
+import { fs } from 'appium-support';
 
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('utils', () => {
+  const DERIVED_DATA_ROOT = '/path/to/DerivedData/WebDriverAgent-eoyoecqmiqfeodgstkwbxkfyagll';
   describe('clearSystemFiles', withMocks({iosUtils}, (mocks) => {
     it('should delete logs', async () => {
-      let wda = {
-        derivedDataPath: '/path/to/DerivedData/WebDriverAgent-eoyoecqmiqfeodgstkwbxkfyagll',
-      };
+      let wda = {};
+      wda.retrieveDerivedDataPath = () => DERIVED_DATA_ROOT;
       mocks.iosUtils.expects('clearLogs')
         .once()
-        .withExactArgs([`${wda.derivedDataPath}/Logs`])
+        .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
         .returns();
       await clearSystemFiles(wda);
       mocks.iosUtils.verify();
     });
     it('should do nothing if no derived data path is found', async () => {
       let wda = {};
+      wda.retrieveDerivedDataPath = () => null;
       mocks.iosUtils.expects('clearLogs')
         .never();
       await clearSystemFiles(wda);
       mocks.iosUtils.verify();
+    });
+  }));
+  describe('adjustWDAAttachmentsPermissions', withMocks({fs}, (mocks) => {
+    it('should change permissions to Attachments folder', async () => {
+      let wda = {};
+      wda.retrieveDerivedDataPath = () => DERIVED_DATA_ROOT;
+      mocks.fs.expects('exists')
+        .once()
+        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`)
+        .returns(true);
+      mocks.fs.expects('chmod')
+        .once()
+        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`, '555')
+        .returns();
+      await adjustWDAAttachmentsPermissions(wda, '555');
+      mocks.fs.verify();
+    });
+    it('should do nothing if no derived data path is found', async () => {
+      let wda = {};
+      wda.retrieveDerivedDataPath = () => null;
+      mocks.fs.expects('exists').never();
+      mocks.fs.expects('chmod').never();
+      await adjustWDAAttachmentsPermissions(wda, '777');
+      mocks.fs.verify();
     });
   }));
   describe('determineDevice', () => {

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -11,10 +11,17 @@ chai.use(chaiAsPromised);
 
 describe('utils', () => {
   const DERIVED_DATA_ROOT = '/path/to/DerivedData/WebDriverAgent-eoyoecqmiqfeodgstkwbxkfyagll';
-  describe('clearSystemFiles', withMocks({iosUtils}, (mocks) => {
+  describe('clearSystemFiles', withMocks({iosUtils, fs}, (mocks) => {
     it('should delete logs', async () => {
-      let wda = {};
-      wda.retrieveDerivedDataPath = () => DERIVED_DATA_ROOT;
+      let wda = {
+        retrieveDerivedDataPath () {
+          return DERIVED_DATA_ROOT;
+        }
+      };
+      mocks.fs.expects('exists')
+        .once()
+        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
+        .returns(true);
       mocks.iosUtils.expects('clearLogs')
         .once()
         .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
@@ -23,8 +30,11 @@ describe('utils', () => {
       mocks.iosUtils.verify();
     });
     it('should do nothing if no derived data path is found', async () => {
-      let wda = {};
-      wda.retrieveDerivedDataPath = () => null;
+      let wda = {
+        retrieveDerivedDataPath () {
+          return null;
+        }
+      };
       mocks.iosUtils.expects('clearLogs')
         .never();
       await clearSystemFiles(wda);
@@ -33,8 +43,11 @@ describe('utils', () => {
   }));
   describe('adjustWDAAttachmentsPermissions', withMocks({fs}, (mocks) => {
     it('should change permissions to Attachments folder', async () => {
-      let wda = {};
-      wda.retrieveDerivedDataPath = () => DERIVED_DATA_ROOT;
+      let wda = {
+        retrieveDerivedDataPath () {
+          return DERIVED_DATA_ROOT;
+        }
+      };
       mocks.fs.expects('exists')
         .once()
         .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`)
@@ -47,8 +60,11 @@ describe('utils', () => {
       mocks.fs.verify();
     });
     it('should do nothing if no derived data path is found', async () => {
-      let wda = {};
-      wda.retrieveDerivedDataPath = () => null;
+      let wda = {
+        retrieveDerivedDataPath () {
+          return null;
+        }
+      };
       mocks.fs.expects('exists').never();
       mocks.fs.expects('chmod').never();
       await adjustWDAAttachmentsPermissions(wda, '777');


### PR DESCRIPTION
The previous implementation was trying to change permissions for all WDA derived data folders matched by glob pattern, which is a bad approach for parallel tests. Now we only try to change permissions to the folder, that our xcodebuild process owns.