### PR TITLE
Update WDA and fix most of iOS 11 problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,14 @@
     "source-map-support": "^0.4.0",
     "teen_process": "^1.7.1",
     "xmldom": "^0.1.27",
-    "yargs": "^3.32.0"
+    "yargs": "^8.0.2"
   },
   "scripts": {
     "build": "gulp transpile",
     "mocha": "mocha",
     "prepublish": "gulp prepublish",
     "test": "gulp once",
+    "e2e-test": "gulp e2e-test",
     "watch": "gulp",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "lint": "gulp eslint"
@@ -61,7 +62,7 @@
   "devDependencies": {
     "appium-event-parser": "^1.0.0",
     "appium-gulp-plugins": "^1.2.12",
-    "appium-test-support": "0.0.5",
+    "appium-test-support": "^0.3.2",
     "babel-eslint": "^7.1.1",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",

--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
-import { UICATALOG_CAPS, isIOS11 } from '../desired';
+import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 
 
@@ -78,9 +78,7 @@ describe('XCUITestDriver - alerts', function () {
     await textField.type('hello world');
 
     let text = await textField.text();
-    // TODO: when alert text works in xcode 9, this will fail and we can fix
-    let expectedText = isIOS11() ? '' : 'hello world';
-    text.should.equal(expectedText);
+    text.should.equal('hello world');
 
     // on some devices the keyboard obscurs the buttons so no dismiss is possible
     await textField.type('\n');

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
-import { UICATALOG_CAPS, skipIOS11 } from '../desired';
+import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { GUINEA_PIG_PAGE } from '../web/helpers';
 
@@ -79,9 +79,6 @@ describe('XCUITestDriver - basics', function () {
   });
 
   describe('deactivate app', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
     it('should background the app for the specified time', async () => {
       let before = Date.now();
       await driver.backgroundApp(4);

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -3,13 +3,12 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
-import { UICATALOG_CAPS, skipIOS11, isIOS11 } from '../desired';
+import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 
 
 chai.should();
 chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('XCUITestDriver - element(s)', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -23,10 +22,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('text', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
-
     it('should get the text of an element', async () => {
       let el = await driver.elementByAccessibilityId('Buttons');
       let text = await el.text();
@@ -52,10 +47,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('displayed', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
-
     it('should get the displayed status for a displayed element', async () => {
       let el = await driver.elementByAccessibilityId('Buttons');
       let displayed = await el.isDisplayed();
@@ -69,10 +60,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('location', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
-
     it('should get the location of an element', async () => {
       let el = await driver.elementByAccessibilityId('Buttons');
       let loc = await el.getLocation();
@@ -92,10 +79,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('location_in_view', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
-
     it('should get the location of an element', async () => {
       let el = await driver.elementByAccessibilityId('Buttons');
       let loc = await el.getLocation();
@@ -115,10 +98,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('size', () => {
-    before(function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-    });
-
     it('should get the size of the element', async () => {
       let el = await driver.elementByAccessibilityId('Buttons');
       let size = await el.getSize();
@@ -138,13 +117,6 @@ describe('XCUITestDriver - element(s)', function () {
   });
 
   describe('interactions', function () {
-    function shouldEqual (str1, str2) {
-      if (isIOS11()) {
-        str2 = '';
-      }
-      str1.should.eql(str2);
-    }
-
     describe('text fields', () => {
       let text1 = 'bunchoftext';
       let text2 = 'differenttext';
@@ -167,14 +139,14 @@ describe('XCUITestDriver - element(s)', function () {
           await el.type(text1);
 
           let text = await el.text();
-          shouldEqual(text, text1);
+          text.should.eql(text1);
         });
         it('should type in the text field even before the keyboard is up', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
           await el.type(text1);
 
           let text = await el.text();
-          shouldEqual(text, text1);
+          text.should.eql(text1);
         });
         it('should type a url in the text field', async () => {
           // in Travis this sometimes gets the wrong text
@@ -185,7 +157,7 @@ describe('XCUITestDriver - element(s)', function () {
             await el.type(text3);
 
             let text = await el.text();
-            shouldEqual(text, text3);
+            text.should.eql(text3);
           });
         });
         it('should be able to type into two text fields', async () => {
@@ -197,23 +169,19 @@ describe('XCUITestDriver - element(s)', function () {
           await els[1].type(text2);
 
           let text = await els[0].text();
-          shouldEqual(text, text1);
+          text.should.eql(text1);
 
           text = await els[1].text();
-          shouldEqual(text, text2);
+          text.should.eql(text2);
         });
         it('should type in a secure text field', async () => {
           let els = await driver.elementsByClassName('XCUIElementTypeSecureTextField');
           await els[0].type(text1);
 
           let text = await els[0].text();
-          if (isIOS11()) {
-            expect(text).to.be.null;
-          } else {
-            text.should.not.eql(text1);
-            text.length.should.eql(text1.length);
-            shouldEqual(text, secureText);
-          }
+          text.should.not.eql(text1);
+          text.length.should.eql(text1.length);
+          text.should.eql(secureText);
         });
         it('should type a backspace', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
@@ -221,7 +189,7 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.type(el, ['0123456789\uE003']);
 
           let text = await el.text();
-          shouldEqual(text, '012345678');
+          text.should.eql('012345678');
         });
         it('should type a delete', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
@@ -229,7 +197,7 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.type(el, ['0123456789\ue017']);
 
           let text = await el.text();
-          shouldEqual(text, '012345678');
+          text.should.eql('012345678');
         });
         it('should type a newline', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
@@ -237,67 +205,60 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.type(el, ['0123456789\uE006']);
 
           let text = await el.text();
-          shouldEqual(text, '0123456789');
+          text.should.eql('0123456789');
         });
       });
 
       describe('clear', () => {
         it('should clear a text field', async () => {
+          let text1 = '0123456789abcdefghijklmnopqrstuvwxyz';
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
           await el.type(text1);
 
           let text = await el.text();
-          shouldEqual(text, text1);
+          text.should.eql(text1);
 
           await el.clear();
 
           text = await el.text();
-          shouldEqual(text, phText);
+          text.should.eql(phText);
         });
         it('should be able to clear two text fields', async () => {
           let els = await driver.elementsByClassName('XCUIElementTypeTextField');
           await els[0].type(text1);
 
           let text = await els[0].text();
-          shouldEqual(text, text1);
+          text.should.eql(text1);
 
           await driver.hideKeyboard();
 
           await els[1].type(text2);
 
           text = await els[1].text();
-          shouldEqual(text, text2);
+          text.should.eql(text2);
 
           await els[0].clear();
 
           text = await els[0].text();
-          shouldEqual(text, phText);
+          text.should.eql(phText);
 
           await driver.hideKeyboard();
 
           await els[1].clear();
 
           text = await els[1].text();
-          shouldEqual(text, phText);
+          text.should.eql(phText);
         });
         it('should clear a secure text field', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeSecureTextField');
           await el.type(text1);
 
           let text = await el.text();
-          if (isIOS11()) {
-            expect(text).to.be.null;
-          } else {
-            shouldEqual(text, secureText);
-          }
+          text.should.eql(secureText);
 
           await el.clear();
           text = await el.text();
-          if (isIOS11()) {
-            expect(text).to.be.null;
-          } else {
-            shouldEqual(text, phText);
-          }
+          text.should.eql(phText);
         });
       });
       describe('keys', () => {
@@ -316,7 +277,7 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.keys('0123456789\uE003');
 
           let text = await el.text();
-          shouldEqual(text, '012345678');
+          text.should.eql('012345678');
         });
         it('should type a delete', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
@@ -326,7 +287,7 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.keys('0123456789\ue017');
 
           let text = await el.text();
-          shouldEqual(text, '012345678');
+          text.should.eql('012345678');
         });
         it('should type a newline', async () => {
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
@@ -336,15 +297,13 @@ describe('XCUITestDriver - element(s)', function () {
           await driver.keys('0123456789\uE006');
 
           let text = await el.text();
-          shouldEqual(text, '0123456789');
+          text.should.eql('0123456789');
         });
       });
       describe('hide keyboard', () => {
-        before(function () {
-          if (skipIOS11(this)) return; // eslint-disable-line curly
-        });
-
         it('should be able to hide the keyboard', async () => {
+          // pause for a second, or else some systems will falsely fail on this test
+          await B.delay(1000);
           let el = await driver.elementByClassName('XCUIElementTypeTextField');
           await el.click();
 
@@ -374,20 +333,12 @@ describe('XCUITestDriver - element(s)', function () {
           let wheel = wheels[i];
 
           let value = await wheel.getAttribute('value');
-          if (isIOS11()) {
-            expect(value).to.be.null;
-          } else {
-            parseInt(value, 10).should.eql(values[i]);
-          }
+          parseInt(value, 10).should.eql(values[i]);
 
           await wheel.type(150);
 
           value = await wheel.getAttribute('value');
-          if (isIOS11()) {
-            expect(value).to.be.null;
-          } else {
-            parseInt(value, 10).should.eql(150);
-          }
+          parseInt(value, 10).should.eql(150);
         }
       });
     });

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -124,8 +124,6 @@ describe('XCUITestDriver - find', function () {
   describe('by xpath', () => {
     describe('individual calls', function () {
       before(async function () {
-        if (skipIOS11(this)) return; // eslint-disable-line curly
-
         // before anything, try to go back
         // otherwise the tests will fail erroneously
         await driver.back();
@@ -176,6 +174,8 @@ describe('XCUITestDriver - find', function () {
         await driver.elementByXPath('/XCUIElementTypeButton').should.be.rejectedWith(/NoSuchElement/);
       });
       it('should search an extended path by child', async () => {
+        if (skipIOS11(this)) return; // eslint-disable-line curly
+
         // pause a moment or the next command gets stuck getting the xpath :(
         await B.delay(500);
         let el = await driver.elementByXPath('//XCUIElementTypeNavigationBar/XCUIElementTypeStaticText');
@@ -317,8 +317,6 @@ describe('XCUITestDriver - find', function () {
 
   describe('by predicate string', () => {
     before(async function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-
       // if we don't pause, WDA freaks out sometimes, especially on fast systems
       await B.delay(500);
     });
@@ -355,8 +353,6 @@ describe('XCUITestDriver - find', function () {
 
   describe('by class chain', () => {
     before(async function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-
       // if we don't pause, WDA freaks out sometimes, especially on fast systems
       await B.delay(500);
     });

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -99,7 +99,7 @@ describe('XCUITestDriver - gestures', function () {
 
         await exitModal('Cancel');
       });
-      it('should long press on arbitrary coordinate', async function () {
+      it('should long press on arbitrary coordinates', async function () {
         if (skipIOS11(this)) return; // eslint-disable-line curly
 
         let el1 = await driver.elementByAccessibilityId('Okay / Cancel');
@@ -136,8 +136,6 @@ describe('XCUITestDriver - gestures', function () {
       await driver.elementByAccessibilityId('2').should.not.be.rejected;
     });
     it(`should swipe the table and the bottom cell's Y position should change accordingly`, async function () {
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-
       let winEl = await driver.elementByClassName('XCUIElementTypeWindow');
       let pickerEl = await driver.elementByAccessibilityId('Picker View');
       let yInit = (await pickerEl.getLocation()).y;

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -8,7 +8,7 @@ import { getDevices, createDevice, deleteDevice } from 'node-simctl';
 import _ from 'lodash';
 import B from 'bluebird';
 import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
-import { UICATALOG_CAPS, UICATALOG_SIM_CAPS, skipIOS11, isIOS11 } from '../desired';
+import { UICATALOG_CAPS, UICATALOG_SIM_CAPS, isIOS11 } from '../desired';
 
 
 const should = chai.should();
@@ -58,9 +58,6 @@ describe('XCUITestDriver', function () {
     });
 
     it('should start and stop a session with only bundle id', async function () {
-      // TODO: why?
-      if (skipIOS11(this)) return; // eslint-disable-line curly
-
       let caps = Object.assign({}, UICATALOG_SIM_CAPS, {bundleId: 'com.example.apple-samplecode.UICatalog'});
       caps.app = null;
       await driver.init(caps).should.not.eventually.be.rejected;

--- a/test/functional/long/typing-stress-e2e-specs.js
+++ b/test/functional/long/typing-stress-e2e-specs.js
@@ -7,11 +7,14 @@ import { initSession, deleteSession } from '../helpers/session';
 chai.should();
 chai.use(chaiAsPromised);
 
+// leave the long test to Travis
+const TYPING_TRIES = process.env.TRAVIS ? 200 : 10;
+
 describe('XCUITestDriver - long tests', function () {
   this.timeout(0);
 
   let driver;
-  before(async () => {
+  before(async function () {
     let caps = Object.assign({}, UICATALOG_CAPS, {maxTypingFrequency: 20});
     driver = await initSession(caps);
   });
@@ -20,25 +23,24 @@ describe('XCUITestDriver - long tests', function () {
   });
 
   describe('typing', function () {
-    beforeEach(async function () {
+    let text = 'bunchoftext';
+
+    before(async function () {
       let el = await driver.elementByAccessibilityId('Text Fields');
       await driver.execute('mobile: scroll', {element: el, toVisible: true});
       await el.click();
     });
-    afterEach(async () => {
-      await driver.back();
-    });
 
-    it('should not fail in typing', async () => {
-      let text = 'bunchoftext';
-      let el = await driver.elementByClassName('XCUIElementTypeTextField');
-      for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < TYPING_TRIES; i++) {
+      it(`should not fail in typing (try #${i+1})`, async () => {
+        let el = await driver.elementByClassName('XCUIElementTypeTextField');
+
         await el.type(text);
 
         (await el.text()).should.include(text);
 
         await el.clear();
-      }
-    });
+      });
+    }
   });
 });

--- a/test/functional/long/typing-stress-e2e-specs.js
+++ b/test/functional/long/typing-stress-e2e-specs.js
@@ -24,16 +24,18 @@ describe('XCUITestDriver - long tests', function () {
 
   describe('typing', function () {
     let text = 'bunchoftext';
-
+    let el;
     before(async function () {
-      let el = await driver.elementByAccessibilityId('Text Fields');
-      await driver.execute('mobile: scroll', {element: el, toVisible: true});
-      await el.click();
+      let tfEl = await driver.elementByAccessibilityId('Text Fields');
+      await driver.execute('mobile: scroll', {element: tfEl, toVisible: true});
+      await tfEl.click();
+
+      // get the text field for the subsequent tests
+      el = await driver.elementByClassName('XCUIElementTypeTextField');
     });
 
     for (let i = 0; i < TYPING_TRIES; i++) {
       it(`should not fail in typing (try #${i+1})`, async () => {
-        let el = await driver.elementByClassName('XCUIElementTypeTextField');
 
         await el.type(text);
 


### PR DESCRIPTION
Update WDA, which allows us to un-quarantine most of the tests for iOS 11. The exceptions are:
* Gestures on arbitrary coordinates seem to click the wrong thing
* A couple of tests that rely on parsing the device logs, which still don't exist for iOS 11