### PR TITLE
Update derived data parsing to handle xcode 9

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -106,7 +106,7 @@ class XcodeBuild {
         return;
       }
       // now parse the log file for the derived data folder
-      let logFile = match[1];
+      const logFile = match[1];
       stdout = await fs.readFile(logFile);
       match = DERIVED_DATA_FOLDER_REGEXP.exec(stdout);
       if (!match) {

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -12,6 +12,9 @@ import path from 'path';
 const DEFAULT_SIGNING_ID = "iPhone Developer";
 const BUILD_TEST_DELAY = 1000;
 
+const DERIVED_DATA_FOLDER_REGEXP = /(\/.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
+const DERIVED_DATA_LOG_REGEXP = /\s+(\/.+\/WebDriverAgentRunner-.+\/.+\.log)/;
+
 const xcodeLog = logger.getLogger('Xcode');
 
 class XcodeBuild {
@@ -73,28 +76,49 @@ class XcodeBuild {
   }
 
   async retrieveDerivedDataPath () {
-    if (!this._derivedDataPath) {
-      const folderRegexp = /(\/.+\/DerivedData\/WebDriverAgent-[^\/]+)/;
-      const pid = await getPidUsingAppName(this.device.udid, 'xcodebuild');
-      if (!pid) {
-        log.debug(`Cannot find xcodebuild's process id, so unable to retrieve DerivedData folder path`);
-        return;
-      }
-      let stdout = '';
-      try {
-        const execInfo = await exec('lsof', ['-p', pid]);
-        stdout = execInfo.stdout;
-      } catch (err) {
-        log.debug(`Cannot get the list of files opened by xcodebuild process because of "${err.stderr}"`);
-        return;
-      }
-      const match = folderRegexp.exec(stdout);
-      if (!match) {
-        log.debug(`Cannot find a match for DerivedData folder path from lsof output: ${stdout}`);
-        return;
-      }
-      this._derivedDataPath = match[1];
+    if (this._derivedDataPath) {
+      return this._derivedDataPath;
     }
+
+    // try a number of ways to find the derived data folder for this run
+    const pid = await getPidUsingAppName(this.device.udid, 'xcodebuild');
+    if (!pid) {
+      log.debug(`Cannot find xcodebuild's process id, so unable to retrieve DerivedData folder path`);
+      return;
+    }
+    let stdout = '';
+    try {
+      const execInfo = await exec('lsof', ['-p', pid]);
+      stdout = execInfo.stdout;
+    } catch (err) {
+      log.debug(`Cannot get the list of files opened by xcodebuild process (pid: ${pid}) because of '${err.stderr}'`);
+      return;
+    }
+    // try to find a derived data folder open by xcodebuild
+    let match = DERIVED_DATA_FOLDER_REGEXP.exec(stdout);
+    if (!match) {
+      // no match found, so try to find the log file and search inside for the derived data instead
+      log.debug(`Cannot find a match for DerivedData folder path from lsof. Trying to access logs`);
+      match = DERIVED_DATA_LOG_REGEXP.exec(stdout);
+      if (!match) {
+        // still no go. We are done
+        log.debug(`Cannot find a match for xcodebuild log file. No derived data folder will be found`);
+        return;
+      }
+      // now parse the log file for the derived data folder
+      let logFile = match[1];
+      stdout = await fs.readFile(logFile);
+      match = DERIVED_DATA_FOLDER_REGEXP.exec(stdout);
+      if (!match) {
+        // nothing found. We are done
+        log.debug(`Cannot find the derived data location from the xcodebuild log file '${logFile}'`);
+        return;
+      }
+    }
+
+    // at this point we have gotten a match by one of the two ways above, so save it
+    this._derivedDataPath = match[1];
+
     return this._derivedDataPath;
   }
 


### PR DESCRIPTION
In Xcode 9 the derived data folder does not comes up on the list of opened files `lsof` returns. So, find the xcodebuild log file and try to find the derived data folder from there.