### PR TITLE
Add travis xcode 9 to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
   - npm run build
 script:
   - npm run lint && npm run mocha -- -t 480000 --recursive build/test/$TEST -g @skip-ci -i
-  - if [ -n "$CI_METRICS" ]; then ls -la ./ci-metrics; fi
+  - if [ -n "$CI_METRICS" ]; then mkdir -p ./ci-metrics && ls -la ./ci-metrics; fi
   - if [ -n "$CI_METRICS" ]; then nvm install 7; fi
   - if [ -n "$CI_METRICS" ]; then npm install -g appium-event-parser; fi
   - if [ -n "$CI_METRICS" ]; then appium-event-parser -s -i ./ci-metrics; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,39 @@
 sudo: required
+os: osx
+language: node_js
+node_js: "6"
 env:
   global:
     - PLATFORM_VERSION=10.3
     - _FORCE_LOGS=1
     - secure: ls4nb5gcu0USHauJOkB9R5p86PMPJd/wCIQWjj/bhAfLNpSNNthtss2Ss9M7BjJg8lth8c85MrGfkAZOGgXknNtlQ2HHwKK4fbEiLAKLDS9diac6/OpAsxxE1/OvletYhkKLQSqb8d5Ju3S/xY6SmNDIzHUpeTYV2/5Ve+7Fh9zc1RztxsPwV1vxPtL6w0IAzNS9PQOmDXQ6x9KuZModtR7ohVKD47A91MzBlu3kk1CSaeQ4I8l7eXi4R9J6F81jkr51Vzoam4B6+4HTepSdfo02irBQWzaJ3VtRCbazFRBc/wfe4YgOPQTD9k69FiP19sa28lP9eSn6h5OCSXA9M803kju33Ml6OItRWDG0gUG1dzTroVXELEIcfnw1iTsFqKWoJLaEzEiXV8n2RsXLaLC5SHPgKwGEigGMfWDxM9leIC8hgervjQvApmx7btzq9S50tMcrzba5qwXDDrjJi1wKSjd4pQajhSj9VgOH9D5ihZBdn++VLwEvfAd4yQhjdsr9+COV1HrgK7Ro1HAHWgGnPtwBKiQdVU20QdQzNrhRdF2MLrJ4BfWpNm92JwlPxP/ojuA2l8mr9nDqlfBgXlnG32j59988gi85vaMfXssrUXtdJqsKJckI01c/mgaRh9pvG3UPX8K39quKBI5ftS8aCCa8tbF6bLq/ZuI2TRU=
-  matrix:
-    - TEST=unit
-    - CI_METRICS=1 TEST=functional/basic
-    - CI_METRICS=1 TEST=functional/driver
-    - CI_METRICS=1 TEST=functional/web
-    - CI_METRICS=1 TEST=functional/long
-language:
-- objective-c
-os: osx
+  # matrix:
+  #   - TEST=unit
+  #   - CI_METRICS=1 TEST=functional/basic
+  #   - CI_METRICS=1 TEST=functional/driver
+  #   - CI_METRICS=1 TEST=functional/web
+  #   - CI_METRICS=1 TEST=functional/long
+matrix:
+  include:
+    - osx_image: xcode8.3
+      env: TEST=unit
+
+    - osx_image: xcode8.3
+      env: CI_METRICS=1 TEST=functional/basic
+
+    - osx_image: xcode8.3
+      env: CI_METRICS=1 TEST=functional/driver
+
+    - osx_image: xcode8.3
+      env: CI_METRICS=1 TEST=functional/web
+
+    - osx_image: xcode8.3
+      env: CI_METRICS=1 TEST=functional/long
+
+    - osx_image: xcode9
+      env: CI_METRICS=1 TEST=functional/parallel
+
+
 osx_image: xcode8.3
 git:
   submodules: false

--- a/test/functional/basic/touch-id-e2e-specs.js
+++ b/test/functional/basic/touch-id-e2e-specs.js
@@ -11,9 +11,12 @@ import { killAllSimulators } from 'appium-ios-simulator';
 chai.should();
 chai.use(chaiAsPromised);
 
+const MOCHA_RETRIES = process.env.TRAVIS ? 3 : 1;
+
 if (!process.env.REAL_DEVICE) {
   describe('touchID() ', function () {
     this.timeout(MOCHA_TIMEOUT);
+    this.retries(MOCHA_RETRIES);
     let caps, driver;
 
     beforeEach(async () => {


### PR DESCRIPTION
Add a single Xcode 9 task to Travis. Also add retries in Travis to touch id tests, which tend toward flakiness in that environment.

There is a blank test in the `test/functional/parallel` directory, so that the mocha task does not fail. This should be deleted once we actually have tests in there.

Cc: @mykola-mokhnach 