### PR TITLE
Exclude isFirstSession from capabilities

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -176,8 +176,6 @@ class XCUITestDriver extends BaseDriver {
    *                        This method mutates capability values if needed.
    */
   _adjustSessionCapabilities (caps) {
-    caps.isFirstSession = this.isFirstSession;
-
     if (!this.isFirstSession && caps.allowTouchIdEnroll) {
       log.info(`Resetting 'allowTouchIdEnroll' capability, because it only makes sense for the very first session`);
       caps.allowTouchIdEnroll = false;
@@ -382,7 +380,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async startWda (sessionId, realDevice) {
-    this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
+    this.wda = new WebDriverAgent(this.xcodeVersion, Object.assign(this.opts, {isFirstSession: this.isFirstSession}));
 
     if (this.opts.useNewWDA) {
       log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -380,7 +380,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async startWda (sessionId, realDevice) {
-    this.wda = new WebDriverAgent(this.xcodeVersion, Object.assign(this.opts, {isFirstSession: this.isFirstSession}));
+    this.wda = new WebDriverAgent(this.xcodeVersion, Object.assign({}, this.opts, {isFirstSession: this.isFirstSession}));
 
     if (this.opts.useNewWDA) {
       log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -47,7 +47,6 @@ describe('XCUITestDriver - basics', function () {
         CFBundleIdentifier: "com.example.apple-samplecode.UICatalog",
         browserName: "UICatalog",
         device: "iphone",
-        isFirstSession: true,
       };
       let expected = Object.assign({}, UICATALOG_CAPS, extraWdaCaps);
       let actual = await driver.sessionCapabilities();


### PR DESCRIPTION
This is to avoid

>  2017-07-27 04:19:19:938 - warn: [BaseDriver] The following capabilities were provided, but are not recognized by appium: isFirstSession.

message in logs