### PR TITLE
Retry xcodebuild execution for simulator only

### DIFF
--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -198,6 +198,15 @@ async function killProcess (name, proc) {
   }
 }
 
+/**
+ * Generate a random integer.
+ *
+ * @return {number} A random integer number in range [low, hight). `low`` is inclusive and `high` is exclusive.
+ */
+function randomInt (low, high) {
+  return Math.floor(Math.random() * (high - low) + low);
+}
+
 export { updateProjectFile, resetProjectFile, checkForDependencies,
          setRealDeviceSecurity, fixForXcode7, fixForXcode9, getPidUsingAppName,
-         generateXcodeConfigFile, killAppUsingAppName, killProcess };
+         generateXcodeConfigFile, killAppUsingAppName, killProcess, randomInt };

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -6,7 +6,7 @@ import { fs } from 'appium-support';
 import log from '../logger';
 import { retryInterval } from 'asyncbox';
 import { NoSessionProxy } from "./no-session-proxy";
-import { checkForDependencies, killAppUsingAppName } from './utils';
+import { checkForDependencies, killAppUsingAppName, randomInt } from './utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
 
@@ -16,10 +16,6 @@ const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
-
-function randomInt (low, high) {
-  return Math.floor(Math.random() * (high - low) + low);
-}
 
 class WebDriverAgent {
   constructor (xcodeVersion, args = {}) {
@@ -117,7 +113,7 @@ class WebDriverAgent {
     await this.xcodebuild.init(this.noSessionProxy);
 
     // start the xcodebuild process
-    return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(1, 2000), async () => {
+    return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(0, 2001), async () => {
       if (this.prebuildWDA) {
         await this.xcodebuild.prebuild();
       }

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -115,8 +115,8 @@ class WebDriverAgent {
     // Start the xcodebuild process.
     // All xcodebuild instances are usually executed at the same time
     // while doing parallel testing on Simulator. Adding a random delay should
-    // reduce the probability of unexpected conflicts between different xcodebuild insances
-    // running at the same time.
+    // reduce the probability of unexpected conflicts between different xcodebuild
+    // instances running at the same time.
     return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(0, 2001), async () => {
       if (this.prebuildWDA) {
         await this.xcodebuild.prebuild();

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -112,7 +112,11 @@ class WebDriverAgent {
 
     await this.xcodebuild.init(this.noSessionProxy);
 
-    // start the xcodebuild process
+    // Start the xcodebuild process.
+    // All xcodebuild instances are usually executed at the same time
+    // while doing parallel testing on Simulator. Adding a random delay should
+    // reduce the probability of unexpected conflicts between different xcodebuild insances
+    // running at the same time.
     return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(0, 2001), async () => {
       if (this.prebuildWDA) {
         await this.xcodebuild.prebuild();

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -4,6 +4,7 @@ import url from 'url';
 import { JWProxy } from 'appium-base-driver';
 import { fs } from 'appium-support';
 import log from '../logger';
+import { retryInterval } from 'asyncbox';
 import { NoSessionProxy } from "./no-session-proxy";
 import { checkForDependencies, killAppUsingAppName } from './utils';
 import XcodeBuild from './xcodebuild';
@@ -15,6 +16,10 @@ const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
+
+function randomInt (low, high) {
+  return Math.floor(Math.random() * (high - low) + low);
+}
 
 class WebDriverAgent {
   constructor (xcodeVersion, args = {}) {
@@ -111,12 +116,13 @@ class WebDriverAgent {
 
     await this.xcodebuild.init(this.noSessionProxy);
 
-    if (this.prebuildWDA) {
-      await this.xcodebuild.prebuild();
-    }
-
     // start the xcodebuild process
-    return await this.xcodebuild.start();
+    return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(1, 2000), async () => {
+      if (this.prebuildWDA) {
+        await this.xcodebuild.prebuild();
+      }
+      return await this.xcodebuild.start();
+    });
   }
 
   setupProxies (sessionId) {


### PR DESCRIPTION
It looks like xcodebuild sometimes cannot connect to the simulator server hub while doing parallel tests on Xcode9. That is why we retry process startup. The example log file where this error is present: 
[EFE6BCCE-B610-4FB2-A11A-861674BF6775__HomePageTest2.txt](https://github.com/appium/appium-xcuitest-driver/files/1182559/EFE6BCCE-B610-4FB2-A11A-861674BF6775__HomePageTest2.txt)
