### PR TITLE
Only retry xcodebuild execution for non-first session

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -117,7 +117,7 @@ class WebDriverAgent {
     // while doing parallel testing on Simulator. Adding a random delay should
     // reduce the probability of unexpected conflicts between different xcodebuild
     // instances running at the same time.
-    return await retryInterval(this.realDevice ? 1 : 3, 3000 + randomInt(0, 2001), async () => {
+    return await retryInterval((this.realDevice || this.isFirstSession) ? 1 : 3, 3000 + randomInt(0, 2001), async () => {
       if (this.prebuildWDA) {
         await this.xcodebuild.prebuild();
       }


### PR DESCRIPTION
The retry is not necessary for the very first session if we only want to workaround parallel access issues.