### PR TITLE
Delete carthage marker if it is not a directory

### DIFF
--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -54,7 +54,11 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
   } catch (err) {
     log.warn('Carthage not found. Install using `brew install carthage`');
   }
-  if (!await fs.hasAccess(`${bootstrapPath}/Carthage`)) {
+  const carthageRoot = `${bootstrapPath}/Carthage`;
+  if (await fs.hasAccess(carthageRoot) && !(await fs.lstat(carthageRoot)).isDirectory()) {
+    await fs.rimraf(carthageRoot);
+  }
+  if (!await fs.hasAccess(carthageRoot)) {
     log.debug('Running WebDriverAgent bootstrap script to install dependencies');
     try {
       let args = useSsl ? ['-d', '-D'] : ['-d'];
@@ -71,7 +75,7 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
       }
       // remove the carthage directory, or else subsequent runs will see it and
       // assume the dependencies are already downloaded
-      await fs.rimraf(`${bootstrapPath}/Carthage`);
+      await fs.rimraf(carthageRoot);
 
       throw err;
     }

--- a/test/unit/webdriveragent-utils-specs.js
+++ b/test/unit/webdriveragent-utils-specs.js
@@ -15,10 +15,11 @@ describe('webdriveragent utils', () => {
   describe('checkForDependencies', withMocks({teen_process, fs}, (mocks) => {
     it('should run script with -d argument in correct directory', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').thrice()
-        .onFirstCall().returns(false)
-        .onSecondCall().returns(true)
-        .onThirdCall().returns(true);
+      mocks.fs.expects('hasAccess').exactly(4)
+        .onCall(0).returns(false)
+        .onCall(1).returns(false)
+        .onCall(2).returns(true)
+        .onCall(3).returns(true);
       mocks.teen_process.expects("exec")
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d'], {cwd: '/path/to/wda'})
         .returns('');
@@ -28,10 +29,11 @@ describe('webdriveragent utils', () => {
     });
     it('should run script with -D argument when SSL requested', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').thrice()
-        .onFirstCall().returns(false)
-        .onSecondCall().returns(true)
-        .onThirdCall().returns(true);
+      mocks.fs.expects('hasAccess').exactly(4)
+        .onCall(0).returns(false)
+        .onCall(1).returns(false)
+        .onCall(2).returns(true)
+        .onCall(3).returns(true);
       mocks.teen_process.expects("exec")
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d', '-D'], {cwd: '/path/to/wda'})
         .returns('');
@@ -41,10 +43,11 @@ describe('webdriveragent utils', () => {
     });
     it('should not run script if Carthage directory already present', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').thrice()
-        .onFirstCall().returns(true)
-        .onSecondCall().returns(true)
-        .onThirdCall().returns(true);
+      mocks.fs.expects('hasAccess').exactly(4)
+        .onCall(0).returns(false)
+        .onCall(1).returns(true)
+        .onCall(2).returns(true)
+        .onCall(3).returns(true);
       mocks.teen_process.expects("exec").never();
       await checkForDependencies(bootstrapPath);
       mocks.teen_process.verify();
@@ -52,8 +55,9 @@ describe('webdriveragent utils', () => {
     });
     it('should delete Carthage folder and throw error on script error', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').once()
-        .onFirstCall().returns(false);
+      mocks.fs.expects('hasAccess').exactly(2)
+        .onCall(0).returns(false)
+        .onCall(1).returns(false);
       mocks.teen_process.expects("exec")
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d'], {cwd: '/path/to/wda'})
         .throws({stdout: '', stderr: '', message: 'Bootstrap script failure'});
@@ -63,10 +67,11 @@ describe('webdriveragent utils', () => {
     });
     it('should create Resources folder if not already there', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').thrice()
-        .onFirstCall().returns(true)
-        .onSecondCall().returns(false)
-        .onThirdCall().returns(true);
+      mocks.fs.expects('hasAccess').exactly(4)
+        .onCall(0).returns(false)
+        .onCall(1).returns(true)
+        .onCall(2).returns(false)
+        .onCall(3).returns(true);
       mocks.fs.expects('mkdir')
         .withExactArgs(`${bootstrapPath}/Resources`);
       mocks.teen_process.expects("exec").never();
@@ -76,10 +81,11 @@ describe('webdriveragent utils', () => {
     });
     it('should create WDA bundle if not already there', async () => {
       mocks.fs.expects('which').once().returns(true);
-      mocks.fs.expects('hasAccess').thrice()
-        .onFirstCall().returns(true)
-        .onSecondCall().returns(true)
-        .onThirdCall().returns(false);
+      mocks.fs.expects('hasAccess').exactly(4)
+        .onCall(0).returns(false)
+        .onCall(1).returns(true)
+        .onCall(2).returns(true)
+        .onCall(3).returns(false);
       mocks.fs.expects('mkdir')
         .withExactArgs(`${bootstrapPath}/Resources/WebDriverAgent.bundle`);
       mocks.teen_process.expects("exec").never();


### PR DESCRIPTION
It's just a safety measure. I had this problem while running my local tests - the Carthage item was a file instead of a folder due to unknown reason and this was causing boostrap.sh script to fail unless I manually removed the corrupted item.