### PR TITLE
Do not reset permissions or clear logs if these are managed by the other parallel session

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -429,7 +429,7 @@ class XCUITestDriver extends BaseDriver {
         }
         await quitAndUninstall(errorMsg);
       }
-      this._driverData.derivedDataPath = await this.wda.retrieveDerivedDataPath();
+      this.driverData.derivedDataPath = await this.wda.retrieveDerivedDataPath();
 
       this.opts.preventWDAAttachments = !util.hasValue(this.opts.preventWDAAttachments) || this.opts.preventWDAAttachments;
       await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -110,6 +110,9 @@ class XCUITestDriver extends BaseDriver {
     ];
     this.resetIos();
     this.settings = new DeviceSettings(DEFAULT_SETTINGS, this.onSettingsUpdate.bind(this));
+    this._driverData = {
+      derivedDataPath: null,
+    };
   }
 
   async onSettingsUpdate (key, value) {
@@ -142,8 +145,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   get driverData () {
-    // TODO fill out resource info here
-    return {};
+    return this._driverData;
   }
 
   async getStatus () {
@@ -427,6 +429,7 @@ class XCUITestDriver extends BaseDriver {
         }
         await quitAndUninstall(errorMsg);
       }
+      this._driverData.derivedDataPath = await this.wda.retrieveDerivedDataPath();
 
       this.opts.preventWDAAttachments = !util.hasValue(this.opts.preventWDAAttachments) || this.opts.preventWDAAttachments;
       await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');
@@ -455,16 +458,28 @@ class XCUITestDriver extends BaseDriver {
     this.logEvent('resetComplete');
   }
 
-  async deleteSession () {
+  async deleteSession (sessionId, otherSessionsData) {
+    const isDerivedDataManagedByOtherSession = this.driverData.derivedDataPath && _.isArray(otherSessionsData) && otherSessionsData
+       .filter((x) => x.derivedDataPath === this.driverData.derivedDataPath)
+       .length;
+
     await this.stop();
 
     // reset the permissions on the derived data folder, if necessary
     if (this.opts.preventWDAAttachments) {
-      await adjustWDAAttachmentsPermissions(this.wda, '755');
+      if (isDerivedDataManagedByOtherSession) {
+        log.debug('Not resetting derived data permissions because they are managed by the other session');
+      } else {
+        await adjustWDAAttachmentsPermissions(this.wda, '755');
+      }
     }
 
     if (this.opts.clearSystemFiles) {
-      await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
+      if (isDerivedDataManagedByOtherSession) {
+        log.debug('Not clearing system files because they are managed by the other session');
+      } else {
+        await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
+      }
     } else {
       log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
     }


### PR DESCRIPTION
It might be that any parallel session which is finished faster than other may reset permissions on shared attachments folder or clear files there. This may broke the other running sessions, since these may still depend on these files. The PR tries to avoid such situation and only allows the very last session in the pipeline to perform derived data cleanup.