### PR TITLE
Skip files cleanup and permissions setting if session reset is in progress

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -110,6 +110,8 @@ class XCUITestDriver extends BaseDriver {
     ];
     this.resetIos();
     this.settings = new DeviceSettings(DEFAULT_SETTINGS, this.onSettingsUpdate.bind(this));
+    // This property is set to true only if resetSession command is being executed
+    this._isSessionResetInProgress = false;
   }
 
   async onSettingsUpdate (key, value) {
@@ -458,15 +460,17 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await this.stop();
 
-    // reset the permissions on the derived data folder, if necessary
-    if (this.opts.preventWDAAttachments) {
-      await adjustWDAAttachmentsPermissions(this.wda, '755');
-    }
+    if (!this._isSessionResetInProgress) {
+      // reset the permissions on the derived data folder, if necessary
+      if (this.opts.preventWDAAttachments) {
+        await adjustWDAAttachmentsPermissions(this.wda, '755');
+      }
 
-    if (this.opts.clearSystemFiles) {
-      await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
-    } else {
-      log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+      if (this.opts.clearSystemFiles) {
+        await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
+      } else {
+        log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+      }
     }
 
     if (this.isWebContext()) {
@@ -881,20 +885,25 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async reset () {
-    if (this.opts.noReset) {
-      // This is to make sure reset happens even if noReset is set to true
-      let opts = _.cloneDeep(this.opts);
-      opts.noReset = false;
-      opts.fullReset = false;
-      const shutdownHandler = this.resetOnUnexpectedShutdown;
-      this.resetOnUnexpectedShutdown = () => {};
-      try {
-        await this.runReset(opts);
-      } finally {
-        this.resetOnUnexpectedShutdown = shutdownHandler;
+    try {
+      this._isSessionResetInProgress = true;
+      if (this.opts.noReset) {
+        // This is to make sure reset happens even if noReset is set to true
+        let opts = _.cloneDeep(this.opts);
+        opts.noReset = false;
+        opts.fullReset = false;
+        const shutdownHandler = this.resetOnUnexpectedShutdown;
+        this.resetOnUnexpectedShutdown = () => {};
+        try {
+          await this.runReset(opts);
+        } finally {
+          this.resetOnUnexpectedShutdown = shutdownHandler;
+        }
       }
+      await super.reset();
+    } finally {
+      this._isSessionResetInProgress = false;
     }
-    await super.reset();
   }
 
 }


### PR DESCRIPTION
The idea behind this PR is similar to https://github.com/appium/appium-xcuitest-driver/pull/496
We try to avoid unexpected files cleanup not to corrupt other parallel sessions, which might share the same derived data directory.