### PR TITLE
Properly handle shared derived data folder in parallel sessions

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -14,7 +14,7 @@ import commands from './commands/index';
 import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
-         DEFAULT_TIMEOUT_KEY, resetXCTestProcesses } from './utils';
+         DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, markSystemFilesForCleanup } from './utils';
 import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
          getRealDeviceObj } from './real-device-management';
 import { NoSessionProxy } from "./wda/no-session-proxy";
@@ -431,6 +431,10 @@ class XCUITestDriver extends BaseDriver {
       this.opts.preventWDAAttachments = !util.hasValue(this.opts.preventWDAAttachments) || this.opts.preventWDAAttachments;
       await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');
       this.logEvent('wdaPermsAdjusted');
+
+      if (this.opts.clearSystemFiles) {
+        await markSystemFilesForCleanup(this.wda);
+      }
 
       // we expect certain socket errors until this point, but now
       // mark things as fully working

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,12 +111,8 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
   }
 
   const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
-  if (!await fs.exists(attachmentsFolder)) {
-    log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
-    return;
-  }
-
-  return await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
+  let shouldChangePerms = false;
+  await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
     const permsStack = derivedDataPermissionsStacks.get(attachmentsFolder) || [];
     if (permsStack.length) {
       if (_.last(permsStack) === perms) {
@@ -129,13 +125,20 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
         log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
         return;
       }
-      _.remove(permsStack);
     }
-    derivedDataPermissionsStacks.set(attachmentsFolder, permsStack);
+    derivedDataPermissionsStacks.set(attachmentsFolder, [perms]);
+    shouldChangePerms = true;
+  });
+  if (!shouldChangePerms) {
+    return;
+  }
+
+  if (await fs.exists(attachmentsFolder)) {
     log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
     await fs.chmod(attachmentsFolder, perms);
-    permsStack.push(perms);
-  });
+    return;
+  }
+  log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
 }
 
 // This map contains derived data logs folders as keys
@@ -149,6 +152,7 @@ async function markSystemFilesForCleanup (wda) {
     log.warn('No WebDriverAgent derived data available, so unable to mark system files for cleanup');
     return;
   }
+
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
   await cleanupLock.acquire(clearSystemFiles.name, async () => {
     let markersCount = 0;
@@ -165,7 +169,9 @@ async function clearSystemFiles (wda) {
     log.warn('No WebDriverAgent derived data available, so unable to clear system files');
     return;
   }
+
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
+  let shouldPerformCleanup = false;
   await cleanupLock.acquire(clearSystemFiles.name, async () => {
     if (derivedDataCleanupMarkers.has(logsRoot)) {
       let markersCount = derivedDataCleanupMarkers.get(logsRoot);
@@ -176,13 +182,18 @@ async function clearSystemFiles (wda) {
       }
     }
     derivedDataCleanupMarkers.set(logsRoot, 0);
-    if (await fs.exists(logsRoot)) {
-      log.info(`Cleaning test logs in '${logsRoot}' folder`);
-      await iosUtils.clearLogs([logsRoot]);
-      return;
-    }
-    log.info(`There is no ${logsRoot} folder, so not cleaning files`);
+    shouldPerformCleanup = true;
   });
+  if (!shouldPerformCleanup) {
+    return;
+  }
+
+  if (await fs.exists(logsRoot)) {
+    log.info(`Cleaning test logs in '${logsRoot}' folder`);
+    await iosUtils.clearLogs([logsRoot]);
+    return;
+  }
+  log.info(`There is no ${logsRoot} folder, so not cleaning files`);
 }
 
 async function checkAppPresent (app) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from './logger';
+import AsyncLock from 'async-lock';
 import pkgObj from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
@@ -96,6 +97,13 @@ async function translateDeviceName (pv, dn = '') {
   return deviceName;
 }
 
+// This map contains derived data attachment folders as keys
+// and values are stacks of permssion masks
+// It is used to synchronize permissions change
+// on shared folders
+const derivedDataPermissionsStacks = new Map();
+const permissionsSettingLock = new AsyncLock();
+
 async function adjustWDAAttachmentsPermissions (wda, perms) {
   if (!wda || !await wda.retrieveDerivedDataPath()) {
     log.warn('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
@@ -103,10 +111,53 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
   }
   const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
   if (await fs.exists(attachmentsFolder)) {
-    log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
-    return await fs.chmod(attachmentsFolder, perms);
+    let permsStack = [];
+    return await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
+      if (derivedDataPermissionsStacks.has(attachmentsFolder)) {
+        permsStack = derivedDataPermissionsStacks.get(attachmentsFolder);
+        if (permsStack.length) {
+          if (permsStack[permsStack.length - 1] === perms) {
+            permsStack.push(perms);
+            log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because they were already set by the other session`);
+            return;
+          }
+          if (permsStack.length > 1) {
+            permsStack.pop();
+            log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
+            return;
+          }
+        }
+        _.remove(permsStack);
+      } else {
+        derivedDataPermissionsStacks.set(attachmentsFolder, permsStack);
+      }
+      log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
+      await fs.chmod(attachmentsFolder, perms);
+      permsStack.push(perms);
+    });
   }
   log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
+}
+
+// This map contains derived data logs folders as keys
+// and values are the count of times the particular
+// folder has been scheduled for removal
+const derivedDataCleanupMarkers = new Map();
+const cleanupLock = new AsyncLock();
+
+async function markSystemFilesForCleanup (wda) {
+  if (!wda || !await wda.retrieveDerivedDataPath()) {
+    log.warn('No WebDriverAgent derived data available, so unable to mark system files for cleanup');
+    return;
+  }
+  const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
+  await cleanupLock.acquire(clearSystemFiles.name, async () => {
+    let markersCount = 0;
+    if (derivedDataCleanupMarkers.has(logsRoot)) {
+      markersCount = derivedDataCleanupMarkers.get(logsRoot);
+    }
+    derivedDataCleanupMarkers.set(logsRoot, ++markersCount);
+  });
 }
 
 async function clearSystemFiles (wda) {
@@ -116,11 +167,23 @@ async function clearSystemFiles (wda) {
     return;
   }
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
-  if (await fs.exists(logsRoot)) {
-    log.info(`Cleaning test logs in '${logsRoot}' folder`);
-    return await iosUtils.clearLogs([logsRoot]);
-  }
-  log.info(`There is no ${logsRoot} folder, so not cleaning files`);
+  await cleanupLock.acquire(clearSystemFiles.name, async () => {
+    if (derivedDataCleanupMarkers.has(logsRoot)) {
+      let markersCount = derivedDataCleanupMarkers.get(logsRoot);
+      derivedDataCleanupMarkers.set(logsRoot, --markersCount);
+      if (markersCount > 0) {
+        log.info(`Not cleaning '${logsRoot}' folder, because the other session does not expect it to be cleaned`);
+        return;
+      }
+    }
+    derivedDataCleanupMarkers.set(logsRoot, 0);
+    if (await fs.exists(logsRoot)) {
+      log.info(`Cleaning test logs in '${logsRoot}' folder`);
+      await iosUtils.clearLogs([logsRoot]);
+      return;
+    }
+    log.info(`There is no ${logsRoot} folder, so not cleaning files`);
+  });
 }
 
 async function checkAppPresent (app) {
@@ -228,4 +291,5 @@ async function resetXCTestProcesses (udid, isSimulator) {
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
-         DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern };
+         DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
+         markSystemFilesForCleanup };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,34 +109,33 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
     log.warn('No WebDriverAgent derived data available, so unable to set permissions on WDA attachments folder');
     return;
   }
+
   const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
-  if (await fs.exists(attachmentsFolder)) {
-    let permsStack = [];
-    return await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
-      if (derivedDataPermissionsStacks.has(attachmentsFolder)) {
-        permsStack = derivedDataPermissionsStacks.get(attachmentsFolder);
-        if (permsStack.length) {
-          if (permsStack[permsStack.length - 1] === perms) {
-            permsStack.push(perms);
-            log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because they were already set by the other session`);
-            return;
-          }
-          if (permsStack.length > 1) {
-            permsStack.pop();
-            log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
-            return;
-          }
-        }
-        _.remove(permsStack);
-      } else {
-        derivedDataPermissionsStacks.set(attachmentsFolder, permsStack);
-      }
-      log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
-      await fs.chmod(attachmentsFolder, perms);
-      permsStack.push(perms);
-    });
+  if (!await fs.exists(attachmentsFolder)) {
+    log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
+    return;
   }
-  log.info(`There is no ${attachmentsFolder} folder, so not changing permissions`);
+
+  return await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
+    const permsStack = derivedDataPermissionsStacks.get(attachmentsFolder) || [];
+    if (permsStack.length) {
+      if (_.last(permsStack) === perms) {
+        permsStack.push(perms);
+        log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because they were already set by the other session`);
+        return;
+      }
+      if (permsStack.length > 1) {
+        permsStack.pop();
+        log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
+        return;
+      }
+      _.remove(permsStack);
+    }
+    derivedDataPermissionsStacks.set(attachmentsFolder, permsStack);
+    log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
+    await fs.chmod(attachmentsFolder, perms);
+    permsStack.push(perms);
+  });
 }
 
 // This map contains derived data logs folders as keys

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,4 +1,5 @@
-import { clearSystemFiles, translateDeviceName, adjustWDAAttachmentsPermissions } from '../../lib/utils';
+import { clearSystemFiles, translateDeviceName, adjustWDAAttachmentsPermissions,
+         markSystemFilesForCleanup } from '../../lib/utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { withMocks } from 'appium-test-support';
@@ -26,6 +27,25 @@ describe('utils', () => {
         .once()
         .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
         .returns();
+      await clearSystemFiles(wda);
+      mocks.iosUtils.verify();
+    });
+    it('should only delete logs once if the same folder was marked twice for deletion', async () => {
+      let wda = {
+        retrieveDerivedDataPath () {
+          return DERIVED_DATA_ROOT;
+        }
+      };
+      mocks.fs.expects('exists')
+        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
+        .returns(true);
+      mocks.iosUtils.expects('clearLogs')
+        .once()
+        .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
+        .returns();
+      await markSystemFilesForCleanup(wda);
+      await markSystemFilesForCleanup(wda);
+      await clearSystemFiles(wda);
       await clearSystemFiles(wda);
       mocks.iosUtils.verify();
     });
@@ -57,6 +77,25 @@ describe('utils', () => {
         .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`, '555')
         .returns();
       await adjustWDAAttachmentsPermissions(wda, '555');
+      mocks.fs.verify();
+    });
+    it('should not repeat permissions change with equal flags for the particular folder', async () => {
+      let wda = {
+        retrieveDerivedDataPath () {
+          return DERIVED_DATA_ROOT;
+        }
+      };
+      mocks.fs.expects('exists')
+        .atLeast(2)
+        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`)
+        .returns(true);
+      mocks.fs.expects('chmod')
+        .twice()
+        .returns();
+      await adjustWDAAttachmentsPermissions(wda, '333');
+      await adjustWDAAttachmentsPermissions(wda, '333');
+      await adjustWDAAttachmentsPermissions(wda, '444');
+      await adjustWDAAttachmentsPermissions(wda, '444');
       mocks.fs.verify();
     });
     it('should do nothing if no derived data path is found', async () => {


### PR DESCRIPTION
I decided to rely on internal synchronization primitives rather than AppiumDriver session management. This will make local functional tests more stable and predictable.