### PR TITLE
Handle the situation when Simulator test is executed on the same port after a real device test

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -216,11 +216,26 @@ async function killAppUsingPattern (pgrepPattern) {
   }
 }
 
-async function resetXCTestProcesses (udid, isSimulator) {
-  const processMapping = [['xcodebuild', `xcodebuild.*${udid}`],
-                          isSimulator ? ['XCTRunner', `${udid}.*XCTRunner`] : ['iproxy', `iproxy.*${udid}`]];
-  log.debug(`Killing '${processMapping.map((x) => x[0]).join(', ')}' processes if running...`);
-  for (const [, pgrepPattern] of processMapping) {
+/**
+ * Kills running XCTest processes for the particular device.
+ *
+ * @param {string} udid - The device UDID.
+ * @param {boolean} isSimulator - Equals to true if the current device is a Simulator
+ * @param {object} opts - Additional options mapping. Possible keys are:
+ *   - {string|number} wdaLocalPort: The number of local port WDA is listening on.
+ */
+async function resetXCTestProcesses (udid, isSimulator, opts = {}) {
+  const processPatterns = [`xcodebuild.*${udid}`];
+  if (opts.wdaLocalPort) {
+    processPatterns.push(`iproxy ${opts.wdaLocalPort} `);
+  } else if (!isSimulator) {
+    processPatterns.push(`iproxy.*${udid}`);
+  }
+  if (isSimulator) {
+    processPatterns.push(`${udid}.*XCTRunner`);
+  }
+  log.debug(`Killing running processes '${processPatterns.join(', ')}' for the device ${udid}...`);
+  for (const pgrepPattern of processPatterns) {
     await killAppUsingPattern(pgrepPattern);
   }
 }

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -98,8 +98,10 @@ class WebDriverAgent {
     // make sure that the WDA dependencies have been built
     await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
 
-    //kill all hanging processes
-    await resetXCTestProcesses(this.device.udid, !this.realDevice);
+    // We need to provide WDA local port for simulators, because it might be occupied with
+    // iproxy instance initiated by some preceeding run with a real device
+    // (iproxy instances are not killed on session termination by default)
+    await resetXCTestProcesses(this.device.udid, !this.realDevice, this.realDevice ? {} : {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
       this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -98,10 +98,10 @@ class WebDriverAgent {
     // make sure that the WDA dependencies have been built
     await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
 
-    // We need to provide WDA local port for simulators, because it might be occupied with
+    // We need to provide WDA local port, because it might be occupied with
     // iproxy instance initiated by some preceeding run with a real device
     // (iproxy instances are not killed on session termination by default)
-    await resetXCTestProcesses(this.device.udid, !this.realDevice, this.realDevice ? {} : {wdaLocalPort: this.url.port});
+    await resetXCTestProcesses(this.device.udid, !this.realDevice, {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
       this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);


### PR DESCRIPTION
This situation might happen because we don't kill iproxy on session termination by default. Next time we try to run the same test on Simulator iproxy will be running and intercepting all requests to the WDA, so the requestor won't be able to contact Simulator host (which is the localhost). That is why we try to kill iproxy by local port number pattern rather than by udid in such case to make sure the port is free.