### PR TITLE
Add the necessary stuff to support pasteboard on iOS simulator

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -37,7 +37,9 @@ extensions.executeMobile = async function (mobileCommand, opts={}) {
     tap: async (x) => await this.mobileTap(x),
     dragFromToForDuration: async (x) => await this.mobileDragFromToForDuration(x),
     selectPickerWheelValue: async (x) => await this.mobileSelectPickerWheelValue(x),
-    alert: async (x) => await this.mobileHandleAlert(x)
+    alert: async (x) => await this.mobileHandleAlert(x),
+    setPasteboard: async (x) => await this.mobileSetPasteboard(x),
+    getPasteboard: async (x) => await this.mobileGetPasteboard(x),
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -13,7 +13,7 @@ import navigationExtensions from './navigation';
 import elementExtensions from './element';
 import fileMovementExtensions from './file-movement';
 import screenshotExtensions from './screenshots';
-import pasteboardExctensions from './pasteboard';
+import pasteboardExtensions from './pasteboard';
 
 
 let commands = {};
@@ -22,6 +22,6 @@ Object.assign(commands, contextCommands, executeExtensions,
   gestureExtensions, findExtensions, proxyHelperExtensions, sourceExtensions,
   generalExtensions, logExtensions, webExtensions, timeoutExtensions,
   navigationExtensions, elementExtensions, fileMovementExtensions,
-  alertExtensions, screenshotExtensions, pasteboardExctensions);
+  alertExtensions, screenshotExtensions, pasteboardExtensions);
 
 export default commands;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -13,6 +13,7 @@ import navigationExtensions from './navigation';
 import elementExtensions from './element';
 import fileMovementExtensions from './file-movement';
 import screenshotExtensions from './screenshots';
+import pasteboardExctensions from './pasteboard';
 
 
 let commands = {};
@@ -21,6 +22,6 @@ Object.assign(commands, contextCommands, executeExtensions,
   gestureExtensions, findExtensions, proxyHelperExtensions, sourceExtensions,
   generalExtensions, logExtensions, webExtensions, timeoutExtensions,
   navigationExtensions, elementExtensions, fileMovementExtensions,
-  alertExtensions, screenshotExtensions);
+  alertExtensions, screenshotExtensions, pasteboardExctensions);
 
 export default commands;

--- a/lib/commands/pasteboard.js
+++ b/lib/commands/pasteboard.js
@@ -1,0 +1,31 @@
+import { setPasteboard, getPasteboard } from 'node-simctl';
+
+let commands = {};
+
+commands.mobileSetPasteboard = async function (opts = {}) {
+  if (!this.isSimulator()) {
+    throw new Error('Setting pasteboard content is not supported on real devices');
+  }
+  const {content, encoding} = opts;
+  if (!content) {
+    throw new Error('Pasteboard content is mandatory to set');
+  }
+  if (encoding) {
+    return await setPasteboard(content, encoding);
+  }
+  return await setPasteboard(content);
+};
+
+commands.mobileGetPasteboard = async function (opts = {}) {
+  if (!this.isSimulator()) {
+    throw new Error('Getting pasteboard content is not supported on real devices');
+  }
+  const {encoding} = opts;
+  if (encoding) {
+    return await getPasteboard(encoding);
+  }
+  return await getPasteboard();
+};
+
+export { commands };
+export default commands;

--- a/lib/commands/pasteboard.js
+++ b/lib/commands/pasteboard.js
@@ -17,8 +17,7 @@ commands.mobileGetPasteboard = async function (opts = {}) {
   if (!this.isSimulator()) {
     throw new Error('Getting pasteboard content is not supported on real devices');
   }
-  const {encoding} = opts;
-  return await getPasteboard(encoding);
+  return await getPasteboard(opts.encoding);
 };
 
 export { commands };

--- a/lib/commands/pasteboard.js
+++ b/lib/commands/pasteboard.js
@@ -10,10 +10,7 @@ commands.mobileSetPasteboard = async function (opts = {}) {
   if (!content) {
     throw new Error('Pasteboard content is mandatory to set');
   }
-  if (encoding) {
-    return await setPasteboard(content, encoding);
-  }
-  return await setPasteboard(content);
+  return await setPasteboard(content, encoding);
 };
 
 commands.mobileGetPasteboard = async function (opts = {}) {
@@ -21,10 +18,7 @@ commands.mobileGetPasteboard = async function (opts = {}) {
     throw new Error('Getting pasteboard content is not supported on real devices');
   }
   const {encoding} = opts;
-  if (encoding) {
-    return await getPasteboard(encoding);
-  }
-  return await getPasteboard();
+  return await getPasteboard(encoding);
 };
 
 export { commands };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.1.1",
     "lodash": "^4.0.0",
-    "node-simctl": "^3.7.0",
+    "node-simctl": "^3.9.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "source-map-support": "^0.4.0",

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -6,17 +6,15 @@ const simctlModule = require('node-simctl');
 
 describe('pasteboard commands', function () {
   const driver = new XCUITestDriver();
-  let isSimulatorSpy, deviceStub, setPasteboardSpy, getPasteboardSpy;
+  let isSimulatorSpy, setPasteboardSpy, getPasteboardSpy;
 
   beforeEach(() => {
-    deviceStub = sinon.mock(driver.opts, 'device');
     isSimulatorSpy = sinon.stub(driver, 'isSimulator');
     setPasteboardSpy = sinon.stub(simctlModule, 'setPasteboard');
     getPasteboardSpy = sinon.stub(simctlModule, 'getPasteboard');
   });
 
   afterEach(() => {
-    deviceStub.restore();
     isSimulatorSpy.restore();
     setPasteboardSpy.restore();
     getPasteboardSpy.restore();

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -1,0 +1,63 @@
+import sinon from 'sinon';
+import XCUITestDriver from '../../..';
+
+const simctlModule = require('node-simctl');
+
+
+describe('pasteboard commands', function () {
+  const driver = new XCUITestDriver();
+  let optsStub, deviceStub, setPasteboardSpy, getPasteboardSpy;
+
+  beforeEach(() => {
+    optsStub = sinon.mock(driver.opts);
+    deviceStub = sinon.mock(driver.opts, 'device');
+    setPasteboardSpy = sinon.spy(simctlModule, 'setPasteboard');
+    getPasteboardSpy = sinon.spy(simctlModule, 'getPasteboard');
+  });
+
+  afterEach(() => {
+    deviceStub.restore();
+    optsStub.restore();
+    setPasteboardSpy.restore();
+    getPasteboardSpy.restore();
+  });
+
+  it('setPasteboard should not be called on a real device', async function () {
+    deviceStub.object.realDevice = true;
+    await driver.mobileSetPasteboard({content: 'bla'}).should.eventually.be.rejectedWith(/not supported/);
+    setPasteboardSpy.notCalled.should.be.true;
+  });
+
+  it('setPasteboard should fail if no content is provided', async function () {
+    deviceStub.object.realDevice = false;
+    await driver.mobileSetPasteboard().should.eventually.be.rejectedWith(/mandatory to set/);
+    setPasteboardSpy.notCalled.should.be.true;
+  });
+
+  it('getPasteboard should not be called on a real device', async function () {
+    deviceStub.object.realDevice = true;
+    await driver.mobileGetPasteboard().should.eventually.be.rejectedWith(/not supported/);
+    getPasteboardSpy.notCalled.should.be.true;
+  });
+
+  it('setPasteboard should invoke correct simctl method', async function () {
+    deviceStub.object.realDevice = false;
+    const opts = {
+      content: 'bla',
+      encoding: 'latin-1',
+    };
+    await driver.mobileSetPasteboard(opts);
+    setPasteboardSpy.calledOnce.should.be.true;
+    setPasteboardSpy.firstCall.args[0].should.eql(opts.content);
+    setPasteboardSpy.firstCall.args[1].should.eql(opts.encoding);
+  });
+
+  it('getPasteboard should invoke correct simctl method', async function () {
+    deviceStub.object.realDevice = false;
+    const content = 'bla';
+    getPasteboardSpy.returns(content);
+    const result = await driver.mobileGetPasteboard();
+    getPasteboardSpy.calledOnce.should.be.true;
+    result.should.eql(content);
+  });
+});

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -11,8 +11,8 @@ describe('pasteboard commands', function () {
   beforeEach(() => {
     optsStub = sinon.mock(driver.opts);
     deviceStub = sinon.mock(driver.opts, 'device');
-    setPasteboardSpy = sinon.spy(simctlModule, 'setPasteboard');
-    getPasteboardSpy = sinon.spy(simctlModule, 'getPasteboard');
+    setPasteboardSpy = sinon.stub(simctlModule, 'setPasteboard');
+    getPasteboardSpy = sinon.stub(simctlModule, 'getPasteboard');
   });
 
   afterEach(() => {


### PR DESCRIPTION
simctl supports pasteboard operations starting since Xcode SDK 8.1. This PR supports setting and getting the content of simulator pasteboard, setting the encoding of pasteboard text and device type verification (simulator or real device). Client interaction is done via "mobile:" endpoint (the documentation will be added laster after this PR is merged)