### PR TITLE
Add fallback to idevicescreenshot for real devices

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -1,9 +1,41 @@
 import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
 import { getScreenshot } from 'node-simctl';
+import { exec } from 'teen_process';
 import log from '../logger';
+import { fs, tempDir } from 'appium-support';
 
 let commands = {};
+
+async function getScreenshotWithIdevicelib (udid) {
+  const pathToScreenshotTiff = await tempDir.path({prefix: `screenshot-${udid}`, suffix: '.tiff'});
+  await fs.rimraf(pathToScreenshotTiff);
+  const pathToResultPng = await tempDir.path({prefix: `screenshot-${udid}`, suffix: '.png'});
+  await fs.rimraf(pathToResultPng);
+  try {
+    try {
+      await exec('idevicescreenshot', ['-u', udid, pathToScreenshotTiff]);
+    } catch (e) {
+      log.warn(`Cannot take a screenshot from the device ${udid} using idevicescreenshot. Original error: ${e.message}`);
+      return;
+    }
+    try {
+      // The sips tool is only present on Mac OS
+      await exec('sips', ['-s', 'format', 'png', pathToScreenshotTiff, '--out', pathToResultPng]);
+    } catch (e) {
+      log.warn(`Cannot convert a screenshot from TIFF to PNG using sips tool. Original error: ${e.message}`);
+      return;
+    }
+    if (!await fs.exists(pathToResultPng)) {
+      log.warn(`Cannot convert a screenshot from TIFF to PNG. The conversion result does not exist at ${pathToResultPng}`);
+      return;
+    }
+    return (await fs.readFile(pathToResultPng)).toString('base64');
+  } finally {
+    await fs.rimraf(pathToScreenshotTiff);
+    await fs.rimraf(pathToResultPng);
+  }
+}
 
 commands.getScreenshot = async function () {
   const getScreenshotFromWDA = async () => {
@@ -20,9 +52,16 @@ commands.getScreenshot = async function () {
       log.info(`Falling back to 'simctl io screenshot' API`);
       return await getScreenshot(this.opts.udid);
     }
+    if (this.isRealDevice() && await fs.which('idevicescreenshot')) {
+      log.info(`Falling back to 'idevicescreenshot' API`);
+      const data = await getScreenshotWithIdevicelib(this.opts.udid);
+      if (data) {
+        return data;
+      }
+    }
     // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected
     let result;
-    await retryInterval(9, 1000, async () => {
+    await retryInterval(5, 1000, async () => {
       result = await getScreenshotFromWDA();
     });
     return result;

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -1,7 +1,9 @@
 import sinon from 'sinon';
 import XCUITestDriver from '../../..';
+import { fs, tempDir } from 'appium-support';
 
 const simctlModule = require('node-simctl');
+const teenProcessModule = require('teen_process');
 
 describe('screenshots commands', () => {
   let driver = new XCUITestDriver();
@@ -16,7 +18,7 @@ describe('screenshots commands', () => {
   });
 
   describe('getScreenshot', () => {
-    it('should get a screenshot from WDA if no errors are detected', async () => {
+    it('should get a screenshot from WDA if no errors are detected', async function () {
       proxySpy.returns(base64Response);
       await driver.getScreenshot();
 
@@ -27,7 +29,7 @@ describe('screenshots commands', () => {
       simctlSpy.notCalled.should.be.true;
     });
 
-    it('should get a screenshot from simctl for simulator if WDA call fails and Xcode version >= 8.1', async () => {
+    it('should get a screenshot from simctl for simulator if WDA call fails and Xcode version >= 8.1', async function () {
       proxySpy.returns(null);
       simctlSpy.returns(base64Response);
 
@@ -40,6 +42,49 @@ describe('screenshots commands', () => {
 
       proxySpy.calledOnce.should.be.true;
       simctlSpy.calledOnce.should.be.true;
+    });
+
+    it('should use idevicescreenshot fallback if WDA fails to take a screenshot on real device', async function () {
+      proxySpy.throws();
+
+      const toolName = 'idevicescreenshot';
+      const tiffPath = '/some/file.tiff';
+      const pngPath = '/some/file.png';
+      const udid = '1234';
+      const pngFileContent = 'blabla';
+      const fsExistsSpy = sinon.stub(fs, 'exists');
+      fsExistsSpy.returns(true);
+      const fsWhichSpy = sinon.stub(fs, 'which');
+      fsWhichSpy.returns(toolName);
+      const fsRimRafSpy = sinon.stub(fs, 'rimraf');
+      const fsReadFileSpy = sinon.stub(fs, 'readFile');
+      fsReadFileSpy.returns(pngFileContent);
+      const execSpy = sinon.stub(teenProcessModule, 'exec');
+      const pathSpy = sinon.stub(tempDir, 'path');
+      pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
+      pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
+
+      driver.opts.realDevice = true;
+      driver.opts.udid = udid;
+      (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+
+      proxySpy.calledOnce.should.be.true;
+
+      fsWhichSpy.calledOnce.should.be.true;
+      fsWhichSpy.firstCall.args[0].should.eql(toolName);
+
+      execSpy.calledTwice.should.be.true;
+      execSpy.firstCall.args[0].should.eql(toolName);
+      execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
+      execSpy.secondCall.args[0].should.eql('sips');
+      execSpy.secondCall.args[1].should.eql(['-s', 'format', 'png', tiffPath, '--out', pngPath]);
+
+      fsRimRafSpy.callCount.should.eql(4);
+
+      fsReadFileSpy.calledOnce.should.be.true;
+      fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
+
+      pathSpy.calledTwice.should.be.true;
     });
   });
 });

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -64,27 +64,36 @@ describe('screenshots commands', () => {
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
 
-      driver.opts.realDevice = true;
-      driver.opts.udid = udid;
-      (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+      try {
+        driver.opts.realDevice = true;
+        driver.opts.udid = udid;
+        (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
 
-      proxySpy.calledOnce.should.be.true;
+        proxySpy.calledOnce.should.be.true;
 
-      fsWhichSpy.calledOnce.should.be.true;
-      fsWhichSpy.firstCall.args[0].should.eql(toolName);
+        fsWhichSpy.calledOnce.should.be.true;
+        fsWhichSpy.firstCall.args[0].should.eql(toolName);
 
-      execSpy.calledTwice.should.be.true;
-      execSpy.firstCall.args[0].should.eql(toolName);
-      execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
-      execSpy.secondCall.args[0].should.eql('sips');
-      execSpy.secondCall.args[1].should.eql(['-s', 'format', 'png', tiffPath, '--out', pngPath]);
+        execSpy.calledTwice.should.be.true;
+        execSpy.firstCall.args[0].should.eql(toolName);
+        execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
+        execSpy.secondCall.args[0].should.eql('sips');
+        execSpy.secondCall.args[1].should.eql(['-s', 'format', 'png', tiffPath, '--out', pngPath]);
 
-      fsRimRafSpy.callCount.should.eql(4);
+        fsRimRafSpy.callCount.should.eql(4);
 
-      fsReadFileSpy.calledOnce.should.be.true;
-      fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
+        fsReadFileSpy.calledOnce.should.be.true;
+        fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
 
-      pathSpy.calledTwice.should.be.true;
+        pathSpy.calledTwice.should.be.true;
+      } finally {
+        fsExistsSpy.reset();
+        fsWhichSpy.reset();
+        fsReadFileSpy.reset();
+        fsRimRafSpy.reset();
+        execSpy.reset();
+        pathSpy.reset();
+      }
     });
   });
 });

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -87,12 +87,12 @@ describe('screenshots commands', () => {
 
         pathSpy.calledTwice.should.be.true;
       } finally {
-        fsExistsSpy.reset();
-        fsWhichSpy.reset();
-        fsReadFileSpy.reset();
-        fsRimRafSpy.reset();
-        execSpy.reset();
-        pathSpy.reset();
+        fsExistsSpy.restore();
+        fsWhichSpy.restore();
+        fsReadFileSpy.restore();
+        fsRimRafSpy.restore();
+        execSpy.restore();
+        pathSpy.restore();
       }
     });
   });


### PR DESCRIPTION
In some issue reports I still can see that screenshots made by XCTest are not stable. Probably, falling back to idevicescreenshot will help to improve the state of the issue.