### PR TITLE
Xcode version check against iOS platform version only when webDriverAgentUrl is not set

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -226,7 +226,7 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (typeof this.opts.webDriverAgentUrl === 'undefined' || this.opts.webDriverAgentUrl === null) {
+    if (!this.opts.webDriverAgentUrl) {
       // make sure that the xcode we are using can handle the platform
       if (parseFloat(this.opts.platformVersion) > parseFloat(this.iosSdkVersion)) {
         let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -226,11 +226,15 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    // make sure that the xcode we are using can handle the platform
-    if (parseFloat(this.opts.platformVersion) > parseFloat(this.iosSdkVersion)) {
-      let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +
-                `It does not support iOS version ${this.opts.platformVersion}`;
-      log.errorAndThrow(msg);
+    if (typeof this.opts.webDriverAgentUrl === 'undefined' || this.opts.webDriverAgentUrl === null) {
+      // make sure that the xcode we are using can handle the platform
+      if (parseFloat(this.opts.platformVersion) > parseFloat(this.iosSdkVersion)) {
+        let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +
+                  `It does not support iOS version ${this.opts.platformVersion}`;
+        log.errorAndThrow(msg);
+      }
+    } else {
+      log.debug(`Xcode version will not be validated against iOS SDK version because webDriverAgentUrl capability is set (${this.opts.webDriverAgentUrl}).`);
     }
 
     if ((this.opts.browserName || '').toLowerCase() === 'safari') {


### PR DESCRIPTION
If the capability `webDriverAgentUrl` is set to a non-null value, checking the value of the Xcode version against the iOS platform version does not make sense. This change checks if the check needs to be executed. If this is not the case, a log message with `debug` severity will be emitted.