### PR TITLE
Add webkitDebugProxyPort to desired capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Differences noted here
 |`startIWDP`|Set this to `true` if you want to start ios_webkit_debug proxy server automatically for accessing webviews on iOS. The capatibility only works for real device automation. Defaults to `false`.|e.g., `true`|
 |`calendarAccessAuthorized`|Set this to `true` if you want to enable calendar access on IOS Simulator with given bundleId. Set to `false`, if you want to disable calendar access on IOS Simulator with given bundleId. If not set, the calendar authorization status will not be set.|e.g., `true`|
 |`isHeadless`|Set this capability to `true` if automated tests are running on Simulator and the device display is not needed to be visible. This only has an effect since Xcode9 and only for simulators. All running instances of Simulator UI are going to be automatically terminated if headless test is started. `false` is the default value.|e.g., `true`|
+|`webkitDebugProxyPort`|Local port number used for communication with ios-webkit-debug-proxy. Only relevant for real devices. The default value equals to `27753`.|e.g. `20000`|
 
 
 ## Development<a id="development"></a>

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -111,6 +111,9 @@ let desiredCapConstraints = _.defaults({
   isHeadless: {
     isBoolean: true
   },
+  webkitDebugProxyPort: {
+    isNumber: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };


### PR DESCRIPTION
This is useful for parallel testing using real devices.