### PR TITLE
fix Invalid device: undefined

### DIFF
--- a/lib/commands/pasteboard.js
+++ b/lib/commands/pasteboard.js
@@ -10,14 +10,14 @@ commands.mobileSetPasteboard = async function (opts = {}) {
   if (!content) {
     throw new Error('Pasteboard content is mandatory to set');
   }
-  return await setPasteboard(content, encoding);
+  return await setPasteboard(this.opts.udid, content, encoding);
 };
 
 commands.mobileGetPasteboard = async function (opts = {}) {
   if (!this.isSimulator()) {
     throw new Error('Getting pasteboard content is not supported on real devices');
   }
-  return await getPasteboard(opts.encoding);
+  return await getPasteboard(this.opts.udid, opts.encoding);
 };
 
 export { commands };

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -46,8 +46,8 @@ describe('pasteboard commands', function () {
     };
     await driver.mobileSetPasteboard(opts);
     setPasteboardSpy.calledOnce.should.be.true;
-    setPasteboardSpy.firstCall.args[0].should.eql(opts.content);
-    setPasteboardSpy.firstCall.args[1].should.eql(opts.encoding);
+    setPasteboardSpy.firstCall.args[1].should.eql(opts.content);
+    setPasteboardSpy.firstCall.args[2].should.eql(opts.encoding);
   });
 
   it('getPasteboard should invoke correct simctl method', async function () {


### PR DESCRIPTION
When I tried to call `getPasteboard` and `setPasteboard`, I got the following error.
According to [node-simctl](https://github.com/appium/node-simctl/blob/master/lib/simctl.js#L311), the commands require `udid` as the 1st argument.

```
[debug] [MJSONWP] Calling AppiumDriver.execute() with args: ["mobile: getPasteboard",[{}],"2f74b0a0-5a51-44b1-b25a-f67c887d91c7"]
[debug] [XCUITest] Executing command 'execute'
[simctl] Error: Error running 'xcrun simctl pbpaste ': Invalid device: undefined
    at Object.wrappedLogger.errorAndThrow (../../lib/logging.js:63:13)
    at getPasteboard$ (../../lib/simctl.js:318:11)
    at tryCatch (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at process._tickCallback (internal/process/next_tick.js:109:7)
 Error: Error running 'xcrun simctl pbpaste ': Invalid device: undefined
    at Object.wrappedLogger.errorAndThrow (../../lib/logging.js:63:13)
    at getPasteboard$ (../../lib/simctl.js:318:11)
    at tryCatch (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at process._tickCallback (internal/process/next_tick.js:109:7)
[MJSONWP] Encountered internal error running command: Error: Error running 'xcrun simctl pbpaste ': Invalid device: undefined
    at Object.wrappedLogger.errorAndThrow (../../lib/logging.js:63:13)
    at getPasteboard$ (../../lib/simctl.js:318:11)
    at tryCatch (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazu/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at process._tickCallback (internal/process/next_tick.js:109:7)
[HTTP] <-- POST /wd/hub/session/2f74b0a0-5a51-44b1-b25a-f67c887d91c7/execute 500 306 ms - 235
[HTTP] --> DELETE /wd/hub/session/2f74b0a0-5a51-44b1-b25a-f67c887d91c7 {}
```

After adding `udid` here, the commands works well 👍 