### PR TITLE
Use WDA /url call to WDA for real devices only

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -179,7 +179,7 @@ commands.keys = async function (keys) {
 };
 
 commands.setUrl = async function (url) {
-  if (!this.isWebContext()) {
+  if (this.isRealDevice()) {
     return await this.proxyCommand('/url', 'POST', {url});
   }
   return await iosCommands.general.setUrl.call(this, url);


### PR DESCRIPTION
The openurl approach used by WDA has been reported as unstable, so we only keep it for real devices, as there is no other alternative, and use the old one (`simctl openurl`)  for Simulators.