### PR TITLE
Fix an issue with simulators being re-created when noReset is specified

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -605,7 +605,7 @@ class XCUITestDriver extends BaseDriver {
         } catch (err) {
           // Trying to find matching UDID for Simulator
           log.warn(`Cannot detect any connected real devices. Falling back to Simulator. Original error: ${err.message}`);
-          const device = await getExistingSim(this.opts.deviceName, this.opts.platformVersion);
+          const device = await getExistingSim(this.opts);
           if (!device) {
             // No matching Simulator is found. Throw an error
             log.errorAndThrow(`Cannot detect udid for ${this.opts.deviceName} Simulator running iOS ${this.opts.platformVersion}`);
@@ -628,7 +628,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // figure out the correct simulator to use, given the desired capabilities
-    let device = await getExistingSim(this.opts.deviceName, this.opts.platformVersion);
+    let device = await getExistingSim(this.opts);
 
     // check for an existing simulator
     if (device) {
@@ -642,6 +642,15 @@ class XCUITestDriver extends BaseDriver {
                `This may cause problems if a simulator does not exist for this platform version.`);
       this.opts.platformVersion = this.iosSdkVersion;
     }
+
+    if (this.opts.noReset) {
+      // Check for existing simulator just with correct capabilities
+      let device = await getExistingSim(this.opts);
+      if (device) {
+        return {device, realDevice: false, udid: device.udid};
+      }
+    }
+
     device = await this.createSim();
     return {device, realDevice: false, udid: device.udid};
   }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -12,10 +12,10 @@ async function createSim (caps, sessionId) {
   return await getSimulator(udid);
 }
 
-async function getExistingSim (deviceName, platformVersion) {
-  let devices = await getDevices(platformVersion);
+async function getExistingSim (opts) {
+  let devices = await getDevices(opts.platformVersion);
   for (let device of _.values(devices)) {
-    if (device.name === deviceName) {
+    if (device.name === opts.deviceName) {
       return await getSimulator(device.udid);
     }
   }


### PR DESCRIPTION
If a platformVersion is not specified, but noReset is specified, the driver creates a simulator for the specific session but does not clean it up. This adds a check for noReset and gets a simulator based on a the detected platform version in that case.

This fixes https://github.com/appium/appium/issues/9134