### PR TITLE
Fix compilation on Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
     # smoke test on xcode  9
     - osx_image: xcode9
-      env: CI_METRICS=1 PLATFORM_VERSION=11 TEST=functional/basic
+      env: CI_METRICS=1 PLATFORM_VERSION=11.0 TEST=functional/basic
 git:
   submodules: false
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ matrix:
 
     - osx_image: xcode9
       env: CI_METRICS=1 TEST=functional/parallel
+
+    # smoke test on xcode  7.3
+    - osx_image: xcode7.3
+      env: CI_METRICS=1 TEST=functional/basic
+
+    # smoke test on xcode  9
+    - osx_image: xcode9
+      env: CI_METRICS=1 TEST=functional/basic
 git:
   submodules: false
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ matrix:
 
     # smoke test on xcode  7.3
     - osx_image: xcode7.3
-      env: CI_METRICS=1 TEST=functional/basic
+      env: CI_METRICS=1 PLATFORM_VERSION=9.3 TEST=functional/basic
 
     # smoke test on xcode  9
     - osx_image: xcode9
-      env: CI_METRICS=1 TEST=functional/basic
+      env: CI_METRICS=1 PLATFORM_VERSION=11 TEST=functional/basic
 git:
   submodules: false
 before_install:

--- a/test/functional/parallel/parallel-simulators-e2e-specs.js
+++ b/test/functional/parallel/parallel-simulators-e2e-specs.js
@@ -23,7 +23,8 @@ async function resetMapping (mapping) {
   mapping.clear();
 }
 
-describe('XCUITestDriver - parallel Simulators', function () {
+// skip tests in Travis, because they're unstable due to slowness
+describe('XCUITestDriver - parallel Simulators @skip-ci', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   const sessionsMapping = new Map();
@@ -32,12 +33,6 @@ describe('XCUITestDriver - parallel Simulators', function () {
   const DEVICES = ['iPhone 6', 'iPhone 6s'];
   const HOST = '127.0.0.1';
 
-  before(async function () {
-    if (process.env.TRAVIS) {
-      // Skip tests, because they're unstable due to CI slowness
-      return this.skip();
-    }
-  });
   after(async function () {
     await resetMapping(sessionsMapping);
   });


### PR DESCRIPTION
For now we still need to support Xcode 7.3.

Also add subset of tests to run on 7.3 and 9 in Travis (currently 9 is failing... will look into under another PR).