### PR TITLE
Fix: Typo was causing startCapture to be called more than once

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -8,7 +8,7 @@ let extensions = {};
 Object.assign(extensions, iosCommands.logging);
 
 extensions.startLogCapture = async function () {
-  this.logs = this.log || {};
+  this.logs = this.logs || {};
   if (!_.isEmpty(this.logs)) {
     log.warn('Trying to start iOS log capture but it has already started!');
     return;

--- a/test/unit/log-specs.js
+++ b/test/unit/log-specs.js
@@ -1,0 +1,48 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import sinon from 'sinon';
+import * as IOSDriver from 'appium-ios-driver';
+import { startLogCapture } from '../../lib/commands/log';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('XCUITestDriver - startLogCapture', function () {
+
+  let startCaptureSpy, crashLogStub, iosLogStub;
+
+  before(function () {
+    let spy = {
+      startCapture: _.noop,
+    };
+    startCaptureSpy = sinon.spy(spy, 'startCapture');
+    crashLogStub = sinon.stub(IOSDriver, 'IOSCrashLog', function () {
+      this.startCapture = _.noop;
+    });
+    iosLogStub = sinon.stub(IOSDriver, 'IOSLog', function () {
+      this.startCapture = spy.startCapture;
+    });
+  });
+
+  after(function () {
+    startCaptureSpy.restore();
+    crashLogStub.restore();
+    iosLogStub.restore();
+  });
+
+  // establish that the basic things work as we imagine
+  it('should not spawn more than one instance of idevicesyslog', async () => {
+    const fakeInstance = {
+      logs: undefined,
+      opts: {},
+      isRealDevice: _.noop,
+    };
+    startCaptureSpy.callCount.should.equal(0);
+    await startLogCapture.call(fakeInstance);
+    startCaptureSpy.callCount.should.equal(1);
+    await startLogCapture.call(fakeInstance);
+    startCaptureSpy.callCount.should.equal(1);
+  });
+});


### PR DESCRIPTION
* Replaced `this.logs = this.log || {}` with `this.logs = this.logs || {}`
* This was causing it to be overwritten every time
* Was able to reproduce with a unit test that showed startCapture being called more than once

(connected to: https://github.com/appium/appium/issues/7838)