### PR TITLE
Add a possibility to get page source in different formats

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -26,7 +26,7 @@ extensions.executeAsync = async function (script, args, sessionId) {
 };
 
 // Overrides the 'executeMobile' function defined in appium-ios-driver
-extensions.executeMobile = async function (mobileCommand, opts={}) {
+extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     scroll: async (x) => await this.mobileScroll(x),
     swipe: async (x) => await this.mobileScroll(x, true),
@@ -40,6 +40,7 @@ extensions.executeMobile = async function (mobileCommand, opts={}) {
     alert: async (x) => await this.mobileHandleAlert(x),
     setPasteboard: async (x) => await this.mobileSetPasteboard(x),
     getPasteboard: async (x) => await this.mobileGetPasteboard(x),
+    source: async (x) => await this.mobileGetSource(x),
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import xmldom from 'xmldom';
 
 
@@ -29,6 +30,12 @@ helpers.getNativePageSource = async function () {
   return new xmldom.XMLSerializer().serializeToString(doc);
 };
 
+helpers.mobileGetSource = async function (opts = {}) {
+  if (!_.isString(opts.format)) {
+    return await this.getNativePageSource();
+  }
+  return await this.proxyCommand(`/source?format=${encodeURIComponent(opts.format)}`, 'GET');
+};
 
 Object.assign(extensions, commands, helpers);
 export { commands, helpers };


### PR DESCRIPTION
WDA provides a possibility to represent page source in different formats (for now _xml_ and _json_ formats are available). I would like to [extend](https://github.com/facebook/WebDriverAgent/pull/731) it in WDA, so the _description_ format is available, which works much faster, since it's a single native call and might be extremely useful for debugging purposes.