### PR TITLE
Improve the error message, which is shown when carthage binary cannot be located

### DIFF
--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -56,11 +56,9 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
     let carthagePath = await fs.which('carthage');
     log.debug(`Carthage found: '${carthagePath}'`);
   } catch (err) {
-    log.errorAndThrow('Carthage binary is not found. ' +
-      'Install using `brew install carthage` if it is not installed ' +
-      'and make sure the root folder, where carthage binary is installed, is present in PATH. ' +
-      'The current PATH value: ' + (process.env('PATH') ? `'${process.env('PATH')}'` :
-        'This variable is not defined for the Appium process.'));
+    log.errorAndThrow('Carthage binary is not found. Install using `brew install carthage` if it is not installed ' +
+      'and make sure the root folder, where carthage binary is installed, is present in PATH environment variable. ' +
+      'The current PATH value: ' + (process.env('PATH') ? `'${process.env('PATH')}'` : '<not defined for the Appium process>'));
   }
   const carthageRoot = `${bootstrapPath}/Carthage`;
   await dependenciesUpdateLock.acquire(carthageRoot, async () => {

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -56,7 +56,11 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
     let carthagePath = await fs.which('carthage');
     log.debug(`Carthage found: '${carthagePath}'`);
   } catch (err) {
-    log.errorAndThrow('Carthage not found. Install using `brew install carthage`');
+    log.errorAndThrow('Carthage binary is not found. ' +
+      'Install using `brew install carthage` if it is not installed ' +
+      'and make sure the root folder, where carthage binary is installed, is present in PATH. ' +
+      'The current PATH value: ' + (process.env('PATH') ? `'${process.env('PATH')}'` :
+        'This variable is not defined for the Appium process.'));
   }
   const carthageRoot = `${bootstrapPath}/Carthage`;
   await dependenciesUpdateLock.acquire(carthageRoot, async () => {

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -58,7 +58,7 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
   } catch (err) {
     log.errorAndThrow('Carthage binary is not found. Install using `brew install carthage` if it is not installed ' +
       'and make sure the root folder, where carthage binary is installed, is present in PATH environment variable. ' +
-      'The current PATH value: ' + (process.env('PATH') ? `'${process.env('PATH')}'` : '<not defined for the Appium process>'));
+      `The current PATH value: '${process.env.PATH ? process.env.PATH : "<not defined for the Appium process>"}'`);
   }
   const carthageRoot = `${bootstrapPath}/Carthage`;
   await dependenciesUpdateLock.acquire(carthageRoot, async () => {


### PR DESCRIPTION
I see many people complain about they don't get this error message, because it is shown even if carthage is installed, but not present in PATH. So I decided to improve it.