### PR TITLE
Fix updateProjectFile/resetProjectFile potential problems.

### DIFF
--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -49,7 +49,7 @@ async function resetProjectFile (agentPath) {
   let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
   try {
     // restore projectFilePath from .old file
-    if (!fs.exists(`${projectFilePath}.old`)) {
+    if (!await fs.exists(`${projectFilePath}.old`)) {
       return;  // no need to reset
     }
     await fs.mv(`${projectFilePath}.old`, projectFilePath);

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -1,3 +1,4 @@
+import { nativeFs } from 'fs';
 import { fs, tempDir, plist } from 'appium-support';
 import { exec } from 'teen_process';
 import path from 'path';
@@ -21,10 +22,16 @@ async function replaceInFile (file, find, replace) {
   }
 }
 
+/**
+ * Update WebDriverAgentRunner project bundle ID with newBundleId.
+ * This method assumes project file in the correct state.
+ * @param {string} agentPath - Path to the .xcodeproj directory.
+ * @param {string} newBundleId the new bundle ID used to update.
+ */
 async function updateProjectFile (agentPath, newBundleId) {
   let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
   try {
-    // backup the file, and then update the bundle id for the runner
+    // Assuming projectFilePath is in the correct state, create .old from projectFilePath
     await fs.copyFile(projectFilePath, `${projectFilePath}.old`);
     await replaceInFile(projectFilePath, new RegExp(WDA_RUNNER_BUNDLE_ID.replace('.', '\.'), 'g'), newBundleId);
     log.debug(`Successfully updated '${projectFilePath}' with bundle id '${newBundleId}'`);
@@ -35,12 +42,20 @@ async function updateProjectFile (agentPath, newBundleId) {
   }
 }
 
-async function resetProjectFile (agentPath, newBundleId) {
+/**
+ * Reset WebDriverAgentRunner project bundle ID to correct state.
+ * @param {string} agentPath - Path to the .xcodeproj directory.
+ */
+async function resetProjectFile (agentPath) {
   let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
   try {
-    await replaceInFile(projectFilePath, new RegExp(newBundleId.replace('.', '\.'), 'g'), WDA_RUNNER_BUNDLE_ID);
-    await fs.unlink(`${projectFilePath}.old`);
-    log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
+    // restore projectFilePath from .old file
+    // TODO currently avoid using fs.exists since its implementation seems not be able to async/await well
+    if (nativeFs.existsSync(`${projectFilePath}.old`)) {
+      await fs.copyFile(`${projectFilePath}.old`, projectFilePath);
+      await fs.unlink(`${projectFilePath}.old`);
+      log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
+    }
   } catch (err) {
     log.debug(`Error resetting project file: ${err.message}`);
     log.warn(`Unable to reset project file '${projectFilePath}' with ` +

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -1,4 +1,3 @@
-import { nativeFs } from 'fs';
 import { fs, tempDir, plist } from 'appium-support';
 import { exec } from 'teen_process';
 import path from 'path';
@@ -24,7 +23,7 @@ async function replaceInFile (file, find, replace) {
 
 /**
  * Update WebDriverAgentRunner project bundle ID with newBundleId.
- * This method assumes project file in the correct state.
+ * This method assumes project file is in the correct state.
  * @param {string} agentPath - Path to the .xcodeproj directory.
  * @param {string} newBundleId the new bundle ID used to update.
  */
@@ -50,12 +49,11 @@ async function resetProjectFile (agentPath) {
   let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
   try {
     // restore projectFilePath from .old file
-    // TODO currently avoid using fs.exists since its implementation seems not be able to async/await well
-    if (nativeFs.existsSync(`${projectFilePath}.old`)) {
-      await fs.copyFile(`${projectFilePath}.old`, projectFilePath);
-      await fs.unlink(`${projectFilePath}.old`);
-      log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
+    if (!fs.exists(`${projectFilePath}.old`)) {
+      return;  // no need to reset
     }
+    await fs.mv(`${projectFilePath}.old`, projectFilePath);
+    log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
   } catch (err) {
     log.debug(`Error resetting project file: ${err.message}`);
     log.warn(`Unable to reset project file '${projectFilePath}' with ` +

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -79,8 +79,16 @@ class XcodeBuild {
       }
 
       // if necessary, update the bundleId to user's specification
-      if (this.realDevice && this.updatedWDABundleId) {
-        await updateProjectFile(this.agentPath, this.updatedWDABundleId);
+      if (this.realDevice) {
+        // In case the project still has the user specific bundle ID, reset the project file first.
+        // - We do this reset even updatedWDABundleId is not specified,
+        //   since the previous updatedWDABundleId test has generated the user specific bundle ID project file.
+        // - We don't call resetProjectFile for simulator,
+        //   since simulator test run will work with any user specific bundle ID.
+        await resetProjectFile(this.agentPath);
+        if (this.updatedWDABundleId) {
+          await updateProjectFile(this.agentPath, this.updatedWDABundleId);
+        }
       }
     });
   }
@@ -142,7 +150,7 @@ class XcodeBuild {
     // if necessary, reset the bundleId to original value
     if (this.realDevice && this.updatedWDABundleId) {
       await resourceUpdateLock.acquire(XcodeBuild.name, async () => {
-        await resetProjectFile(this.agentPath, this.updatedWDABundleId);
+        await resetProjectFile(this.agentPath);
       });
     }
   }

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -81,7 +81,7 @@ class XcodeBuild {
       // if necessary, update the bundleId to user's specification
       if (this.realDevice) {
         // In case the project still has the user specific bundle ID, reset the project file first.
-        // - We do this reset even updatedWDABundleId is not specified,
+        // - We do this reset even if updatedWDABundleId is not specified,
         //   since the previous updatedWDABundleId test has generated the user specific bundle ID project file.
         // - We don't call resetProjectFile for simulator,
         //   since simulator test run will work with any user specific bundle ID.


### PR DESCRIPTION
While investigating my xcodebuild code 65 error and updatedWDABundleId capability behavior, I found the following problems when I used updatedWDABundleId:

- When I tried simple dummy updatedWDABundleId value like "A" or "B", WebDriverAgent/WebDriverAgent.xcodeproj/project.pbxproj become broken. This is because resetProjectFile method replaced many occurrences of "A" or "B" in project.pbxproj despite these strings are not part of PRODUCT_BUNDLE_IDENTIFIER value.
- When Appium server is killed forcibly and resetProjectFile is not called unfortunately, project.pbxproj file keeps having the user specific bundle ID. When this happened, udpateProjectFile method cannot replace bundle ID again, since now project.pbxproj does not have the "com.facebook.WebDriverAgentRunner" string occurrence..

This PR resolves these problems by using project.pbxproj.old to restore the original project.pbxproj file.

- This restoration is called even if updatedWDABundleId is not specified, since test with updatedWDABundleId capabilities may have broken project.pbxproj.
- I checked the old invalid project.pbxproj.old will be removed when `npm install` for new version appium-xcuitest-driver is called. So we don't need to care about the possibility of the existing invalid project.pbxproj and project.pbxproj.old files.
- I use node.js native `fs.existsSync` instead of `fs.exists` of appium-support, since [fs.exists](https://github.com/appium/appium-support/blob/master/lib/fs.js#L23) implementation calls `this.hasAccess(path)` without async and caused the timing problem on my PC. I think this appium-support implementation also should be fixed, but I hesitate to do so since fs.exists is used for many Appium logic and this fix can affect them.. 
