### PR TITLE
Move resources lock to the top hierarchy layer

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -19,6 +19,7 @@ import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
          getRealDeviceObj } from './real-device-management';
 import { NoSessionProxy } from "./wda/no-session-proxy";
 import B from 'bluebird';
+import AsyncLock from 'async-lock';
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
@@ -29,6 +30,10 @@ const WDA_STARTUP_RETRY_INTERVAL = 10000;
 const DEFAULT_SETTINGS = {
   nativeWebTap: false,
 };
+// This lock assures, that each driver session does not
+// affect shared resources of the other parallel sessions
+const RESOURCES_LOCK = new AsyncLock();
+
 
 const NO_PROXY_NATIVE_LIST = [
   ['GET', /^\/session\/[^\/]+$/],
@@ -314,11 +319,11 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    await this.startWda(this.opts.sessionId, realDevice);
+    await RESOURCES_LOCK.acquire(XCUITestDriver.name,
+      async () => await this.startWda(this.opts.sessionId, realDevice));
 
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
-
 
     if (this.isRealDevice() && this.opts.startIWDP) {
       try {
@@ -464,16 +469,18 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await this.stop();
 
-    // reset the permissions on the derived data folder, if necessary
-    if (this.opts.preventWDAAttachments) {
-      await adjustWDAAttachmentsPermissions(this.wda, '755');
-    }
+    await RESOURCES_LOCK.acquire(XCUITestDriver.name, async () => {
+      // reset the permissions on the derived data folder, if necessary
+      if (this.opts.preventWDAAttachments) {
+        await adjustWDAAttachmentsPermissions(this.wda, '755');
+      }
 
-    if (this.opts.clearSystemFiles) {
-      await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
-    } else {
-      log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
-    }
+      if (this.opts.clearSystemFiles) {
+        await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
+      } else {
+        log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+      }
+    });
 
     if (this.isWebContext()) {
       log.debug('In a web session. Removing remote debugger');

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -32,7 +32,7 @@ const DEFAULT_SETTINGS = {
 };
 // This lock assures, that each driver session does not
 // affect shared resources of the other parallel sessions
-const RESOURCES_LOCK = new AsyncLock();
+const SHARED_RESOURCES_GUARD = new AsyncLock();
 
 
 const NO_PROXY_NATIVE_LIST = [
@@ -319,7 +319,7 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    await RESOURCES_LOCK.acquire(XCUITestDriver.name,
+    await SHARED_RESOURCES_GUARD.acquire(XCUITestDriver.name,
       async () => await this.startWda(this.opts.sessionId, realDevice));
 
     await this.setInitialOrientation(this.opts.orientation);
@@ -467,7 +467,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async deleteSession () {
-    await RESOURCES_LOCK.acquire(XCUITestDriver.name, async () => {
+    await SHARED_RESOURCES_GUARD.acquire(XCUITestDriver.name, async () => {
       await this.stop();
 
       // reset the permissions on the derived data folder, if necessary

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -467,9 +467,9 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async deleteSession () {
-    await this.stop();
-
     await RESOURCES_LOCK.acquire(XCUITestDriver.name, async () => {
+      await this.stop();
+
       // reset the permissions on the derived data folder, if necessary
       if (this.opts.preventWDAAttachments) {
         await adjustWDAAttachmentsPermissions(this.wda, '755');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,6 @@ import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from './logger';
-import AsyncLock from 'async-lock';
 
 
 const DEFAULT_TIMEOUT_KEY = 'default';
@@ -100,7 +99,6 @@ async function translateDeviceName (pv, dn = '') {
 // It is used to synchronize permissions change
 // on shared folders
 const derivedDataPermissionsStacks = new Map();
-const permissionsSettingLock = new AsyncLock();
 
 async function adjustWDAAttachmentsPermissions (wda, perms) {
   if (!wda || !await wda.retrieveDerivedDataPath()) {
@@ -109,27 +107,20 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
   }
 
   const attachmentsFolder = path.join(await wda.retrieveDerivedDataPath(), 'Logs/Test/Attachments');
-  let shouldChangePerms = false;
-  await permissionsSettingLock.acquire(adjustWDAAttachmentsPermissions.name, async () => {
-    const permsStack = derivedDataPermissionsStacks.get(attachmentsFolder) || [];
-    if (permsStack.length) {
-      if (_.last(permsStack) === perms) {
-        permsStack.push(perms);
-        log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because they were already set by the other session`);
-        return;
-      }
-      if (permsStack.length > 1) {
-        permsStack.pop();
-        log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
-        return;
-      }
+  const permsStack = derivedDataPermissionsStacks.get(attachmentsFolder) || [];
+  if (permsStack.length) {
+    if (_.last(permsStack) === perms) {
+      permsStack.push(perms);
+      log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because they were already set by the other session`);
+      return;
     }
-    derivedDataPermissionsStacks.set(attachmentsFolder, [perms]);
-    shouldChangePerms = true;
-  });
-  if (!shouldChangePerms) {
-    return;
+    if (permsStack.length > 1) {
+      permsStack.pop();
+      log.info(`Not changing permissions of '${attachmentsFolder}' to '${perms}', because the other session does not expect them to be changed`);
+      return;
+    }
   }
+  derivedDataPermissionsStacks.set(attachmentsFolder, [perms]);
 
   if (await fs.exists(attachmentsFolder)) {
     log.info(`Setting '${perms}' permissions to '${attachmentsFolder}' folder`);
@@ -143,7 +134,6 @@ async function adjustWDAAttachmentsPermissions (wda, perms) {
 // and values are the count of times the particular
 // folder has been scheduled for removal
 const derivedDataCleanupMarkers = new Map();
-const cleanupLock = new AsyncLock();
 
 async function markSystemFilesForCleanup (wda) {
   if (!wda || !await wda.retrieveDerivedDataPath()) {
@@ -152,13 +142,11 @@ async function markSystemFilesForCleanup (wda) {
   }
 
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
-  await cleanupLock.acquire(clearSystemFiles.name, async () => {
-    let markersCount = 0;
-    if (derivedDataCleanupMarkers.has(logsRoot)) {
-      markersCount = derivedDataCleanupMarkers.get(logsRoot);
-    }
-    derivedDataCleanupMarkers.set(logsRoot, ++markersCount);
-  });
+  let markersCount = 0;
+  if (derivedDataCleanupMarkers.has(logsRoot)) {
+    markersCount = derivedDataCleanupMarkers.get(logsRoot);
+  }
+  derivedDataCleanupMarkers.set(logsRoot, ++markersCount);
 }
 
 async function clearSystemFiles (wda) {
@@ -169,22 +157,15 @@ async function clearSystemFiles (wda) {
   }
 
   const logsRoot = path.resolve(await wda.retrieveDerivedDataPath(), 'Logs');
-  let shouldPerformCleanup = false;
-  await cleanupLock.acquire(clearSystemFiles.name, async () => {
-    if (derivedDataCleanupMarkers.has(logsRoot)) {
-      let markersCount = derivedDataCleanupMarkers.get(logsRoot);
-      derivedDataCleanupMarkers.set(logsRoot, --markersCount);
-      if (markersCount > 0) {
-        log.info(`Not cleaning '${logsRoot}' folder, because the other session does not expect it to be cleaned`);
-        return;
-      }
+  if (derivedDataCleanupMarkers.has(logsRoot)) {
+    let markersCount = derivedDataCleanupMarkers.get(logsRoot);
+    derivedDataCleanupMarkers.set(logsRoot, --markersCount);
+    if (markersCount > 0) {
+      log.info(`Not cleaning '${logsRoot}' folder, because the other session does not expect it to be cleaned`);
+      return;
     }
-    derivedDataCleanupMarkers.set(logsRoot, 0);
-    shouldPerformCleanup = true;
-  });
-  if (!shouldPerformCleanup) {
-    return;
   }
+  derivedDataCleanupMarkers.set(logsRoot, 0);
 
   if (await fs.exists(logsRoot)) {
     log.info(`Cleaning test logs in '${logsRoot}' folder`);

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -1,7 +1,6 @@
 import { fs, tempDir, plist } from 'appium-support';
 import { exec } from 'teen_process';
 import path from 'path';
-import AsyncLock from 'async-lock';
 import log from '../logger';
 import _ from 'lodash';
 
@@ -49,8 +48,6 @@ async function resetProjectFile (agentPath, newBundleId) {
   }
 }
 
-const dependenciesUpdateLock = new AsyncLock();
-
 async function checkForDependencies (bootstrapPath, useSsl = false) {
   try {
     let carthagePath = await fs.which('carthage');
@@ -61,38 +58,36 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
       `The current PATH value: '${process.env.PATH ? process.env.PATH : "<not defined for the Appium process>"}'`);
   }
   const carthageRoot = `${bootstrapPath}/Carthage`;
-  await dependenciesUpdateLock.acquire(carthageRoot, async () => {
-    if (!await fs.hasAccess(carthageRoot)) {
-      log.debug('Running WebDriverAgent bootstrap script to install dependencies');
-      try {
-        let args = useSsl ? ['-d', '-D'] : ['-d'];
-        await exec('Scripts/bootstrap.sh', args, {cwd: bootstrapPath});
-      } catch (err) {
-        // print out the stdout and stderr reports
-        for (let std of ['stdout', 'stderr']) {
-          for (let line of (err[std] || '').split('\n')) {
-            if (!line.length) {
-              continue;
-            }
-            log.error(line);
+  if (!await fs.hasAccess(carthageRoot)) {
+    log.debug('Running WebDriverAgent bootstrap script to install dependencies');
+    try {
+      let args = useSsl ? ['-d', '-D'] : ['-d'];
+      await exec('Scripts/bootstrap.sh', args, {cwd: bootstrapPath});
+    } catch (err) {
+      // print out the stdout and stderr reports
+      for (let std of ['stdout', 'stderr']) {
+        for (let line of (err[std] || '').split('\n')) {
+          if (!line.length) {
+            continue;
           }
+          log.error(line);
         }
-        // remove the carthage directory, or else subsequent runs will see it and
-        // assume the dependencies are already downloaded
-        await fs.rimraf(carthageRoot);
-
-        throw err;
       }
+      // remove the carthage directory, or else subsequent runs will see it and
+      // assume the dependencies are already downloaded
+      await fs.rimraf(carthageRoot);
+
+      throw err;
     }
-    if (!await fs.hasAccess(`${bootstrapPath}/Resources`)) {
-      log.debug('Creating WebDriverAgent resources directory');
-      await fs.mkdir(`${bootstrapPath}/Resources`);
-    }
-    if (!await fs.hasAccess(`${bootstrapPath}/Resources/WebDriverAgent.bundle`)) {
-      log.debug('Creating WebDriverAgent resource bundle directory');
-      await fs.mkdir(`${bootstrapPath}/Resources/WebDriverAgent.bundle`);
-    }
-  });
+  }
+  if (!await fs.hasAccess(`${bootstrapPath}/Resources`)) {
+    log.debug('Creating WebDriverAgent resources directory');
+    await fs.mkdir(`${bootstrapPath}/Resources`);
+  }
+  if (!await fs.hasAccess(`${bootstrapPath}/Resources/WebDriverAgent.bundle`)) {
+    log.debug('Creating WebDriverAgent resource bundle directory');
+    await fs.mkdir(`${bootstrapPath}/Resources/WebDriverAgent.bundle`);
+  }
 }
 
 async function setRealDeviceSecurity (keychainPath, keychainPassword) {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -9,7 +9,6 @@ import { checkForDependencies } from './utils';
 import { resetXCTestProcesses } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
-import AsyncLock from 'async-lock';
 
 
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', '..', 'WebDriverAgent');
@@ -18,7 +17,6 @@ const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
 
-const buildLock = new AsyncLock();
 
 class WebDriverAgent {
   constructor (xcodeVersion, args = {}) {
@@ -115,12 +113,10 @@ class WebDriverAgent {
     await this.xcodebuild.init(this.noSessionProxy);
 
     // Start the xcodebuild process
-    return await buildLock.acquire(WebDriverAgent.name, async () => {
-      if (this.prebuildWDA) {
-        await this.xcodebuild.prebuild();
-      }
-      return await this.xcodebuild.start();
-    });
+    if (this.prebuildWDA) {
+      await this.xcodebuild.prebuild();
+    }
+    return await this.xcodebuild.start();
   }
 
   setupProxies (sessionId) {

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -1,5 +1,4 @@
 import { retryInterval } from 'asyncbox';
-import AsyncLock from 'async-lock';
 import { SubProcess, exec } from 'teen_process';
 import { fs, logger } from 'appium-support';
 import log from '../logger';
@@ -20,7 +19,6 @@ const DERIVED_DATA_GREP_EXPRESSION = '/WebDriverAgentRunner-';
 
 const xcodeLog = logger.getLogger('Xcode');
 
-const resourceUpdateLock = new AsyncLock();
 
 class XcodeBuild {
   constructor (xcodeVersion, device, args = {}) {
@@ -67,22 +65,20 @@ class XcodeBuild {
       return;
     }
 
-    await resourceUpdateLock.acquire(XcodeBuild.name, async () => {
-      if (this.xcodeVersion.major === 7 || (this.xcodeVersion.major === 8 && this.xcodeVersion.minor === 0)) {
-        log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
-        await fixForXcode7(this.bootstrapPath, true);
-      }
+    if (this.xcodeVersion.major === 7 || (this.xcodeVersion.major === 8 && this.xcodeVersion.minor === 0)) {
+      log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
+      await fixForXcode7(this.bootstrapPath, true);
+    }
 
-      if (this.xcodeVersion.major === 9) {
-        log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
-        await fixForXcode9(this.bootstrapPath, true);
-      }
+    if (this.xcodeVersion.major === 9) {
+      log.debug(`Using Xcode ${this.xcodeVersion.versionString}, so fixing WDA codebase`);
+      await fixForXcode9(this.bootstrapPath, true);
+    }
 
-      // if necessary, update the bundleId to user's specification
-      if (this.realDevice && this.updatedWDABundleId) {
-        await updateProjectFile(this.agentPath, this.updatedWDABundleId);
-      }
-    });
+    // if necessary, update the bundleId to user's specification
+    if (this.realDevice && this.updatedWDABundleId) {
+      await updateProjectFile(this.agentPath, this.updatedWDABundleId);
+    }
   }
 
   async retrieveDerivedDataPath () {
@@ -141,9 +137,7 @@ class XcodeBuild {
   async reset () {
     // if necessary, reset the bundleId to original value
     if (this.realDevice && this.updatedWDABundleId) {
-      await resourceUpdateLock.acquire(XcodeBuild.name, async () => {
-        await resetProjectFile(this.agentPath, this.updatedWDABundleId);
-      });
+      await resetProjectFile(this.agentPath, this.updatedWDABundleId);
     }
   }
 


### PR DESCRIPTION
This PR is related to https://github.com/appium/appium-xcuitest-driver/pull/537

The idea is to apply the lock on top level, so we don't have to think about synchronisation on the lower levels, which makes the code safer and simpler. Yes, we'll probably loose several seconds in parallel drivers initialisation because of this change, but the overall safety about parallel sessions won't corrupt shared resources of each other is more important.