### PR TITLE
Add device name translation for new iPhones

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,23 +77,26 @@ async function getAndCheckIosSdkVersion () {
 
 async function translateDeviceName (pv, dn = '') {
   let deviceName = dn;
-  dn = dn.toLowerCase().trim();
-  if (dn === 'iphone simulator') {
-    deviceName = 'iPhone 6';
-  } else if (dn === 'ipad simulator') {
-    if (parseFloat(pv).toFixed(1) < "10.3") {
-      deviceName = 'iPad Retina';
-    } else {
-      /* iPad Retina is no longer available for ios 10.3
-      so we pick another iPad to use as default */
-      deviceName = 'iPad Air';
-    }
-  } else if (dn === 'iphone 8') {
-    deviceName = 'iPhone2017-A';
-  } else if (dn === 'iphone 8 plus') {
-    deviceName = 'iPhone2017-B';
-  } else if (dn === 'iphone x') {
-    deviceName = 'iPhone2017-C';
+  switch (dn.toLowerCase().trim()) {
+    case 'iphone simulator':
+      deviceName = 'iPhone 6';
+      break;
+    case 'ipad simulator':
+      // no need to worry about floating point comparison because of the
+      //   nature of the numbers being compared
+      // iPad Retina is no longer available for ios 10.3
+      //   so we pick another iPad to use as default
+      deviceName = (parseFloat(pv) < 10.3) ? 'iPad Retina' : 'iPad Air';
+      break;
+    case 'iphone 8':
+      deviceName = 'iPhone2017-A';
+      break;
+    case 'iphone 8 plus':
+      deviceName = 'iPhone2017-B';
+      break;
+    case 'iphone x':
+      deviceName = 'iPhone2017-C';
+      break;
   }
 
   if (deviceName !== dn) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,9 +77,10 @@ async function getAndCheckIosSdkVersion () {
 
 async function translateDeviceName (pv, dn = '') {
   let deviceName = dn;
-  if (dn.toLowerCase() === 'iphone simulator') {
+  dn = dn.toLowerCase().trim();
+  if (dn === 'iphone simulator') {
     deviceName = 'iPhone 6';
-  } else if (dn.toLowerCase() === 'ipad simulator') {
+  } else if (dn === 'ipad simulator') {
     if (parseFloat(pv).toFixed(1) < "10.3") {
       deviceName = 'iPad Retina';
     } else {
@@ -87,7 +88,14 @@ async function translateDeviceName (pv, dn = '') {
       so we pick another iPad to use as default */
       deviceName = 'iPad Air';
     }
+  } else if (dn === 'iphone 8') {
+    deviceName = 'iPhone2017-A';
+  } else if (dn === 'iphone 8 plus') {
+    deviceName = 'iPhone2017-B';
+  } else if (dn === 'iphone x') {
+    deviceName = 'iPhone2017-C';
   }
+
   if (deviceName !== dn) {
     log.debug(`Changing deviceName from '${dn}' to '${deviceName}'`);
   }

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -131,17 +131,32 @@ describe('utils', () => {
     });
   }));
   describe('determineDevice', () => {
-    it('should set the correct iPad simultor generic device', async () => {
-      let deviceName = await translateDeviceName("10.1.2", "iPad Simulator");
+    it('should set the correct iPad simulator generic device', async function () {
+      const ipadDeviceName = 'iPad Simulator';
+      let deviceName = await translateDeviceName("10.1.2", ipadDeviceName);
       deviceName.should.equal("iPad Retina");
-      deviceName = await translateDeviceName(10.103, "iPad Simulator");
+      deviceName = await translateDeviceName(10.103, ipadDeviceName);
       deviceName.should.equal("iPad Retina");
-      deviceName = await translateDeviceName("10.3", "iPad Simulator");
+      deviceName = await translateDeviceName("10.3", ipadDeviceName);
       deviceName.should.equal("iPad Air");
-      deviceName = await translateDeviceName(10.3, "iPad Simulator");
+      deviceName = await translateDeviceName(10.3, ipadDeviceName);
       deviceName.should.equal("iPad Air");
-      deviceName = await translateDeviceName(10.3, "iPhone Simulator");
+    });
+    it('should set the correct iPhone simulator generic device', async function () {
+      let deviceName = await translateDeviceName(10.3, "iPhone Simulator");
       deviceName.should.equal("iPhone 6");
+    });
+    it('should set the correct device name for iPhone 8', async function () {
+      let deviceName = await translateDeviceName("10.1.2", "iPhone 8");
+      deviceName.should.equal("iPhone2017-A");
+    });
+    it('should set the correct device name for iPhone 8 Plus', async function () {
+      let deviceName = await translateDeviceName("10.1.2", "iPhone 8 PLus");
+      deviceName.should.equal("iPhone2017-B");
+    });
+    it('should set the correct device name for iPhone X', async function () {
+      let deviceName = await translateDeviceName("10.1.2", "iPhone X");
+      deviceName.should.equal("iPhone2017-C");
     });
   });
 });


### PR DESCRIPTION
Allow users to use the logical `"iPhone 8"`, `"iPhone 8 Plus"` and `"iPhone X"` for `deviceName`, instead of the actual `"iPhone2017-A"`, `"iPhone2017-B"` and `"iPhone2017-C"`.