### PR TITLE
Prefer libimobiledevice over WDA for real device screenshot

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -16,18 +16,21 @@ async function getScreenshotWithIdevicelib (udid) {
     try {
       await exec('idevicescreenshot', ['-u', udid, pathToScreenshotTiff]);
     } catch (e) {
-      log.warn(`Cannot take a screenshot from the device ${udid} using idevicescreenshot. Original error: ${e.message}`);
+      log.warn(`Cannot take a screenshot from the device '${udid}' using ` +
+               `idevicescreenshot. Original error: ${e.message}`);
       return;
     }
     try {
       // The sips tool is only present on Mac OS
       await exec('sips', ['-s', 'format', 'png', pathToScreenshotTiff, '--out', pathToResultPng]);
     } catch (e) {
-      log.warn(`Cannot convert a screenshot from TIFF to PNG using sips tool. Original error: ${e.message}`);
+      log.warn(`Cannot convert a screenshot from TIFF to PNG using sips tool. ` +
+               `Original error: ${e.message}`);
       return;
     }
     if (!await fs.exists(pathToResultPng)) {
-      log.warn(`Cannot convert a screenshot from TIFF to PNG. The conversion result does not exist at ${pathToResultPng}`);
+      log.warn(`Cannot convert a screenshot from TIFF to PNG. The conversion ` +
+               `result does not exist at '${pathToResultPng}'`);
       return;
     }
     return (await fs.readFile(pathToResultPng)).toString('base64');
@@ -35,6 +38,10 @@ async function getScreenshotWithIdevicelib (udid) {
     await fs.rimraf(pathToScreenshotTiff);
     await fs.rimraf(pathToResultPng);
   }
+}
+
+async function isIdevicescreenshotAvailable () {
+  return !!(await fs.which('idevicescreenshot'));
 }
 
 commands.getScreenshot = async function () {
@@ -45,26 +52,42 @@ commands.getScreenshot = async function () {
     }
     return data;
   };
+
   try {
-    return await getScreenshotFromWDA();
+    if (this.isRealDevice() && await isIdevicescreenshotAvailable()) {
+      log.debug(`Taking screenshot with 'idevicescreenshot'`);
+      return await getScreenshotWithIdevicelib(this.opts.udid);
+    } else {
+      log.debug(`Taking screenshot with WDA`);
+      return await getScreenshotFromWDA();
+    }
   } catch (err) {
-    if (!this.isRealDevice() && this.xcodeVersion.versionFloat >= 8.1) {
+    log.debug(`Error getting screenshot: ${err.message}`);
+
+    if (!this.isRealDevice()) {
+      if (this.xcodeVersion.versionFloat < 8.1) {
+        log.errorAndThrow(`No command line screenshot ability with Xcode ` +
+                 `${this.xcodeVersion.versionFloat}. Please upgrade to ` +
+                 `at least Xcode 8.1`);
+      }
       log.info(`Falling back to 'simctl io screenshot' API`);
       return await getScreenshot(this.opts.udid);
-    }
-    if (this.isRealDevice() && await fs.which('idevicescreenshot')) {
-      log.info(`Falling back to 'idevicescreenshot' API`);
-      const data = await getScreenshotWithIdevicelib(this.opts.udid);
-      if (data) {
-        return data;
+    } else {
+      if (await isIdevicescreenshotAvailable()) {
+        log.info(`Falling back to 'idevicescreenshot' API`);
+        const data = await getScreenshotWithIdevicelib(this.opts.udid);
+        if (data) {
+          return data;
+        }
+      } else {
+        log.info(`No 'idevicescreenshot' program found. To use, install ` +
+                 `using 'brew install libimobiledevice'`);
       }
     }
+
     // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected
-    let result;
-    await retryInterval(5, 1000, async () => {
-      result = await getScreenshotFromWDA();
-    });
-    return result;
+    log.debug('Retrying screenshot through WDA');
+    return await retryInterval(5, 1000, getScreenshotFromWDA);
   }
 };
 

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -97,6 +97,10 @@ describe('XCUITestDriver - basics', function () {
       let screenshot = await driver.takeScreenshot();
       screenshot.should.exist;
       screenshot.should.be.a.string;
+
+      // make sure WDA didn't crash, by using it again
+      let els = await driver.elementsByAccessibilityId('Action Sheets');
+      els.length.should.eql(1);
     });
 
     it('should get an app screenshot in landscape mode', async () => {

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -44,9 +44,7 @@ describe('screenshots commands', () => {
       simctlSpy.calledOnce.should.be.true;
     });
 
-    it('should use idevicescreenshot fallback if WDA fails to take a screenshot on real device', async function () {
-      proxySpy.throws();
-
+    it('should use idevicescreenshot to take a screenshot on real device', async function () {
       const toolName = 'idevicescreenshot';
       const tiffPath = '/some/file.tiff';
       const pngPath = '/some/file.png';
@@ -69,7 +67,7 @@ describe('screenshots commands', () => {
         driver.opts.udid = udid;
         (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
 
-        proxySpy.calledOnce.should.be.true;
+        proxySpy.called.should.be.false;
 
         fsWhichSpy.calledOnce.should.be.true;
         fsWhichSpy.firstCall.args[0].should.eql(toolName);


### PR DESCRIPTION
On iPhone 7/8 Plus devices WDA screenshot crashes. Since we don't really have any reliable way to tell if something is one of those devices, prefer `idevicescreenshot` to do real device screenshoting.