### PR TITLE
Change wording for logging message to make it more helpful for clients

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -377,7 +377,9 @@ class XCUITestDriver extends BaseDriver {
         if (!status) {
           throw new Error(`WDA response to /status command should be defined.`);
         }
-        log.debug(`Detected WDA listening at '${this.wda.url.href}'. Setting WDA endpoint to '${this.wda.url.href}'`);
+        log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'.` +
+                 `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} if this is an undesired behavior ` +
+                 `(for example, if the other device/Simulator is used on the same port).`);
         this.wda.webDriverAgentUrl = this.wda.url.href;
       } catch (err) {
         log.debug(`WDA is not listening at '${this.wda.url.href}'. Rebuilding...`);


### PR DESCRIPTION
For now it is not very clear for users why the session is not started if they replace the device.