### PR TITLE
Update simulator logs capture logic

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -10,25 +10,28 @@ Object.assign(extensions, iosCommands.logging);
 
 extensions.startLogCapture = async function () {
   this.logs = this.logs || {};
-  if (!_.isEmpty(this.logs)) {
+  if (!_.isUndefined(this.logs.syslog) && this.logs.syslog.isCapturing) {
     log.warn('Trying to start iOS log capture but it has already started!');
-    return;
+    return true;
   }
-  this.logs.crashlog = new IOSCrashLog();
-  this.logs.syslog = new IOSLog({
-    sim: this.opts.device,
-    udid: this.isRealDevice() ? this.opts.udid : undefined,
-    showLogs: this.opts.showIOSLog,
-    realDeviceLogger: this.opts.realDeviceLogger,
-  });
+  if (_.isUndefined(this.logs.syslog)) {
+    this.logs.crashlog = new IOSCrashLog();
+    this.logs.syslog = new IOSLog({
+      sim: this.opts.device,
+      udid: this.isRealDevice() ? this.opts.udid : undefined,
+      showLogs: this.opts.showIOSLog,
+      realDeviceLogger: this.opts.realDeviceLogger,
+    });
+  }
   try {
     await this.logs.syslog.startCapture();
   } catch (err) {
-    log.warn(`Could not capture logs from device: ${err.message}`);
+    log.warn(`Could not capture logs from the device: ${err.message}`);
     log.debug('Continuing without capturing logs.');
-    return;
+    return false;
   }
   await this.logs.crashlog.startCapture();
+  return true;
 };
 
 export default extensions;

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,7 +1,38 @@
 import { IOSLog as IOSDriverIOSLog } from 'appium-ios-driver';
-
+import path from 'path';
+import _ from 'lodash';
+import logger from '../logger';
+import { fs } from 'appium-support';
+import { SubProcess, exec } from 'teen_process';
 
 class IOSLog extends IOSDriverIOSLog {
+  async startCaptureSimulator () {
+    if (_.isUndefined(this.sim.udid)) {
+      throw new Error(`Log capture requires a sim udid`);
+    }
+
+    logger.debug(`Starting log capture for iOS Simulator with udid ${this.sim.udid}`);
+    const systemLogPath = path.resolve(this.sim.getLogDir(), 'system.log');
+    if (!await fs.exists(systemLogPath)) {
+      throw new Error(`No logs could be found at ${systemLogPath}`);
+    }
+    logger.debug(`System log path: ${systemLogPath}`);
+    const tailArgs = ['-f', '-n', '1', systemLogPath];
+    try {
+      // cleanup existing listeners if the previous session has not been terminated properly
+      await exec('pkill', ['-xf', ['tail', ...tailArgs].join(' ')]);
+    } catch (e) {}
+    try {
+      this.proc = new SubProcess('tail', tailArgs);
+      await this.finishStartingLogCapture();
+    } catch (err) {
+      throw new Error(`Simulator log capture failed: ${err.message}`);
+    }
+  }
+
+  get isCapturing () {
+    return !!(this.proc && this.proc.isRunning);
+  }
 }
 
 export { IOSLog };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -276,9 +276,14 @@ class XCUITestDriver extends BaseDriver {
 
     await this.runReset();
 
-    // handle logging
-    await this.startLogCapture();
-    this.logEvent('logCaptureStarted');
+    const startLogCapture = async () => {
+      const result = await this.startLogCapture();
+      if (result) {
+        this.logEvent('logCaptureStarted');
+      }
+      return result;
+    };
+    const isLogCaptureStarted = await startLogCapture();
 
     log.info(`Setting up ${this.isRealDevice() ? 'real device' : 'simulator'}`);
 
@@ -310,6 +315,10 @@ class XCUITestDriver extends BaseDriver {
       }
       await this.startSim();
       this.logEvent('simStarted');
+      if (!isLogCaptureStarted) {
+        // Try again if the simulator has been started for the first time
+        await startLogCapture();
+      }
       if (this.opts.app && !installAppPromise) {
         installAppPromise = this.installApp();
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "appium-base-driver": "^2.14.0",
-    "appium-ios-driver": "^1.26.1",
+    "appium-ios-driver": "^1.27.6",
     "appium-ios-simulator": "^2.6.0",
     "appium-support": "^2.4.0",
     "appium-xcode": "^3.2.0",

--- a/test/unit/log-specs.js
+++ b/test/unit/log-specs.js
@@ -43,6 +43,7 @@ describe('XCUITestDriver - startLogCapture', function () {
     startCaptureSpy.callCount.should.equal(0);
     await startLogCapture.call(fakeInstance);
     startCaptureSpy.callCount.should.equal(1);
+    fakeInstance.logs.syslog.isCapturing = true;
     await startLogCapture.call(fakeInstance);
     startCaptureSpy.callCount.should.equal(1);
   });


### PR DESCRIPTION
Xcode9 Simulator does not really like if we append anything to the system logs ourselves (it just stops logging at all). Also, the logic, which is coming from ios-driver contains some obsolete stuff for Xcode 6 and older, which we don't support anymore.