### PR TITLE
fix multiple xcode versions handling: pass DEVELOPER_DIR envvar to xc…

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -228,7 +228,7 @@ class XcodeBuild {
               `in directory '${this.bootstrapPath}'`);
     let xcodebuild = new SubProcess(cmd, args, {
       cwd: this.bootstrapPath,
-      env: {USE_PORT: this.wdaRemotePort},
+      env: {USE_PORT: this.wdaRemotePort, DEVELOPER_DIR: process.env.DEVELOPER_DIR},
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -226,9 +226,15 @@ class XcodeBuild {
     let {cmd, args} = this.getCommand(buildOnly);
     log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
+    const env = {
+      USE_PORT: this.wdaRemotePort,
+    };
+    if (process.env.DEVELOPER_DIR) {
+      env.DEVELOPER_DIR = process.env.DEVELOPER_DIR;
+    }
     let xcodebuild = new SubProcess(cmd, args, {
       cwd: this.bootstrapPath,
-      env: {USE_PORT: this.wdaRemotePort, DEVELOPER_DIR: process.env.DEVELOPER_DIR},
+      env,
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
…odebuild subprocess call

**DESCRIPTION**
Fixes `CoreSimulator detected Xcode.app relocation or CoreSimulatorService version change. ` error when multiple XCode versions are installed and DEVELOPER_DIR differs from default xcode chosen with `xcode-select -s`.

**USEFULLNESS**
Very useful for CI builds, since it's useful to has multiple XCode versions installed on CI agents, but it's not good (or sometimes just impossible) to change default Xcode directory with `xcode-select -s`, so appium should fully support `DEVELOPER_DIR`

**STEPS TO REPRODUCE THE PROBLEM**
1. install two different XCode instances side by side
2. choose one Xcode as default Xcode:
`sudo xcode-select -s /Applications/Xcode9.app/Contents/Developer`
3. run appium with DEVELOPER_DIR set to different xcode:
DEVELOPER_DIR=/Applications/Xcode8.3.2.app/Contents/Developer appium
4. run tests

Now appium-driver thinks Xcode is 8.3.2 and starts simulator with 8.3.2 tools. But when it tries to install wda on simulator via `xcodebuild`, it calls xcodebuild from default Xcode, and it leads to conflict, so you will get something like this:
```
[debug] [XCUITest] Unable to launch WebDriverAgent because of xcodebuild failure: "xcodebuild failed with code 70".
[01:03:34][debug] [XCUITest] Quitting and uninstalling WebDriverAgent, then retrying
[01:03:34][XCUITest] Shutting down sub-processes
[01:03:34][debug] [XCUITest] Removing WDA application from device
[01:03:34][simctl] Error: simctl error running 'uninstall': 2017-11-07 01:03:34.192 simctl[96420:78503056] CoreSimulator detected Xcode.app relocation or CoreSimulatorService version change.  Framework path (/Applications/Xcode8.3.2.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework) and version (375.21) does not match existing job path (/Applications/Xcode8.2.1.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework/Versions/A/XPCServices/com.apple.CoreSimulator.CoreSimulatorService.xpc) and version (338.16).  Attempting to remove the stale service in order to add the expected version.
[01:03:34]An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=53):
[01:03:34]Error returned in reply: Connection interrupted
[01:03:34]Software caused connection abort
[01:03:34]    at Object.wrappedLogger.errorAndThrow (../../lib/logging.js:63:13)
[01:03:34]    at simCommand$ (../../lib/simctl.js:50:11)
[01:03:34]    at tryCatch (/Users/teamcity/buildAgent/work/7c7cb539f1e7f9a3/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
[01:03:34]    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/teamcity/buildAgent/work/7c7cb539f1e7f9a3/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
[01:03:34]    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/teamcity/buildAgent/work/7c7cb539f1e7f9a3/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
[01:03:34]    at GeneratorFunctionPrototype.invoke (/Users/teamcity/buildAgent/work/7c7cb539f1e7f9a3/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
[01:03:34]    at process._tickCallback (internal/process/next_tick.js:103:7)
```