### PR TITLE
Fix screenshot rotation for landscape mode

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -7,7 +7,7 @@ import { fs, tempDir } from 'appium-support';
 
 let commands = {};
 
-async function getScreenshotWithIdevicelib (udid) {
+async function getScreenshotWithIdevicelib (udid, isLandscape) {
   const pathToScreenshotTiff = await tempDir.path({prefix: `screenshot-${udid}`, suffix: '.tiff'});
   await fs.rimraf(pathToScreenshotTiff);
   const pathToResultPng = await tempDir.path({prefix: `screenshot-${udid}`, suffix: '.png'});
@@ -19,9 +19,13 @@ async function getScreenshotWithIdevicelib (udid) {
       throw new Error(`Cannot take a screenshot from the device '${udid}' using ` +
         `idevicescreenshot. Original error: ${e.message}`);
     }
+    let sipsArgs = ['-s', 'format', 'png', pathToScreenshotTiff, '--out', pathToResultPng];
+    if (isLandscape) {
+      sipsArgs = ['-r', '-90', ...sipsArgs];
+    }
     try {
       // The sips tool is only present on Mac OS
-      await exec('sips', ['-s', 'format', 'png', pathToScreenshotTiff, '--out', pathToResultPng]);
+      await exec('sips', sipsArgs);
     } catch (e) {
       throw new Error(`Cannot convert a screenshot from TIFF to PNG using sips tool. ` +
         `Original error: ${e.message}`);
@@ -54,7 +58,8 @@ commands.getScreenshot = async function () {
     if (this.isRealDevice()) {
       if (await isIdevicescreenshotAvailable()) {
         log.debug(`Taking screenshot with 'idevicescreenshot'`);
-        return await getScreenshotWithIdevicelib(this.opts.udid);
+        return await getScreenshotWithIdevicelib(this.opts.udid,
+          (await this.getOrientation()) === 'LANDSCAPE');
       }
       log.info(`No 'idevicescreenshot' program found. To use, install ` +
         `using 'brew install --HEAD libimobiledevice'`);

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -20,6 +20,8 @@ describe('screenshots commands', () => {
   describe('getScreenshot', () => {
     it('should get a screenshot from WDA if no errors are detected', async function () {
       proxySpy.returns(base64Response);
+      driver.opts.realDevice = false;
+
       await driver.getScreenshot();
 
       proxySpy.calledOnce.should.be.true;
@@ -61,13 +63,12 @@ describe('screenshots commands', () => {
       const pathSpy = sinon.stub(tempDir, 'path');
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
+      driver.getOrientation = () => 'LANDSCAPE';
 
       try {
         driver.opts.realDevice = true;
         driver.opts.udid = udid;
         (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
-
-        proxySpy.called.should.be.false;
 
         fsWhichSpy.calledOnce.should.be.true;
         fsWhichSpy.firstCall.args[0].should.eql(toolName);
@@ -76,7 +77,8 @@ describe('screenshots commands', () => {
         execSpy.firstCall.args[0].should.eql(toolName);
         execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
         execSpy.secondCall.args[0].should.eql('sips');
-        execSpy.secondCall.args[1].should.eql(['-s', 'format', 'png', tiffPath, '--out', pngPath]);
+        execSpy.secondCall.args[1].should.eql(
+          ['-r', '-90', '-s', 'format', 'png', tiffPath, '--out', pngPath]);
 
         fsRimRafSpy.callCount.should.eql(4);
 


### PR DESCRIPTION
We can do this ourselves if idevicelib is too lazy for it. The penalty - one extra call to WDA in order to detect the current  display orientation value.