### PR TITLE
Fix getting device orientation

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -58,8 +58,8 @@ commands.getScreenshot = async function () {
     if (this.isRealDevice()) {
       if (await isIdevicescreenshotAvailable()) {
         log.debug(`Taking screenshot with 'idevicescreenshot'`);
-        return await getScreenshotWithIdevicelib(this.opts.udid,
-          (await this.getOrientation()) === 'LANDSCAPE');
+        const orientation = await this.proxyCommand('/orientation', 'GET');
+        return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
       }
       log.info(`No 'idevicescreenshot' program found. To use, install ` +
         `using 'brew install --HEAD libimobiledevice'`);

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -46,7 +46,7 @@ describe('screenshots commands', () => {
       simctlSpy.calledOnce.should.be.true;
     });
 
-    it.only('should use idevicescreenshot to take a screenshot on real device', async function () {
+    it('should use idevicescreenshot to take a screenshot on real device', async function () {
       const toolName = 'idevicescreenshot';
       const tiffPath = '/some/file.tiff';
       const pngPath = '/some/file.png';

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -46,7 +46,7 @@ describe('screenshots commands', () => {
       simctlSpy.calledOnce.should.be.true;
     });
 
-    it('should use idevicescreenshot to take a screenshot on real device', async function () {
+    it.only('should use idevicescreenshot to take a screenshot on real device', async function () {
       const toolName = 'idevicescreenshot';
       const tiffPath = '/some/file.tiff';
       const pngPath = '/some/file.png';
@@ -63,12 +63,16 @@ describe('screenshots commands', () => {
       const pathSpy = sinon.stub(tempDir, 'path');
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
       pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
-      driver.getOrientation = () => 'LANDSCAPE';
+      proxySpy.returns('LANDSCAPE');
 
       try {
         driver.opts.realDevice = true;
         driver.opts.udid = udid;
         (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/orientation');
+        proxySpy.firstCall.args[1].should.eql('GET');
 
         fsWhichSpy.calledOnce.should.be.true;
         fsWhichSpy.firstCall.args[0].should.eql(toolName);


### PR DESCRIPTION
`this.getOrientation` command is not available inside commands context, so I need to use `proxyCommand` instead.