### PR TITLE
Update WDA and real device screenshot logic

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -55,18 +55,8 @@ commands.getScreenshot = async function () {
   };
 
   try {
-    if (this.isRealDevice()) {
-      if (await isIdevicescreenshotAvailable()) {
-        log.debug(`Taking screenshot with 'idevicescreenshot'`);
-        const orientation = await this.proxyCommand('/orientation', 'GET');
-        return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
-      }
-      log.info(`No 'idevicescreenshot' program found. To use, install ` +
-        `using 'brew install --HEAD libimobiledevice'`);
-    } else {
-      log.debug(`Taking screenshot with WDA`);
-      return await getScreenshotFromWDA();
-    }
+    log.debug(`Taking screenshot with WDA`);
+    return await getScreenshotFromWDA();
   } catch (err) {
     log.warn(`Error getting screenshot: ${err.message}`);
 
@@ -79,6 +69,20 @@ commands.getScreenshot = async function () {
       log.info(`Falling back to 'simctl io screenshot' API`);
       return await getScreenshot(this.opts.udid);
     }
+  }
+
+  // all simulator scenarios are finished
+  // real device, so try idevicescreenshot if possible
+  try {
+    if (await isIdevicescreenshotAvailable()) {
+      log.debug(`Taking screenshot with 'idevicescreenshot'`);
+      const orientation = await this.proxyCommand('/orientation', 'GET');
+      return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
+    }
+    log.info(`No 'idevicescreenshot' program found. To use, install ` +
+             `using 'brew install --HEAD libimobiledevice'`);
+  } catch (err) {
+    log.warn(`Error getting screenshot through 'idevicescreenshot': ${err.message}`);
   }
 
   // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -129,7 +129,7 @@ async function fixFBSessionFile (bootstrapPath, initial = true) {
   const file = path.resolve(bootstrapPath, FBSESSION_FILE);
 
   let oldLine = 'return [FBApplication fb_activeApplication] ?: self.testedApplication;';
-  let newLine = '  FBApplication *application = [FBApplication fb_activeApplication] ?: self.testedApplication;' +
+  let newLine = 'FBApplication *application = [FBApplication fb_activeApplication] ?: self.testedApplication;\n' +
                 '  return application;';
   if (!initial) {
     [oldLine, newLine] = [newLine, oldLine];
@@ -137,8 +137,10 @@ async function fixFBSessionFile (bootstrapPath, initial = true) {
   await replaceInFile(file, oldLine, newLine);
 }
 
-async function fixForXcode7 (bootstrapPath, initial = true) {
-  await fixForXcode9(bootstrapPath, !initial);
+async function fixForXcode7 (bootstrapPath, initial = true, fixXcode9 = true) {
+  if (fixXcode9) {
+    await fixForXcode9(bootstrapPath, !initial, false);
+  }
   await fixXCUICoordinateFile(bootstrapPath, initial);
   await fixFBSessionFile(bootstrapPath, initial);
 }
@@ -165,8 +167,10 @@ async function fixXCUIApplicationFile (bootstrapPath, initial = true) {
   await replaceInFile(file, oldDef, newDef);
 }
 
-async function fixForXcode9 (bootstrapPath, initial = true) {
-  await fixForXcode7(bootstrapPath, !initial);
+async function fixForXcode9 (bootstrapPath, initial = true, fixXcode7 = true) {
+  if (fixXcode7) {
+    await fixForXcode7(bootstrapPath, !initial, false);
+  }
   await fixFBMacrosFile(bootstrapPath, initial);
   await fixXCUIApplicationFile(bootstrapPath, initial);
 }

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -10,6 +10,7 @@ const PROJECT_FILE = 'project.pbxproj';
 const XCUICOORDINATE_FILE = 'PrivateHeaders/XCTest/XCUICoordinate.h';
 const FBMACROS_FILE = 'WebDriverAgentLib/Utilities/FBMacros.h';
 const XCUIAPPLICATION_FILE = 'PrivateHeaders/XCTest/XCUIApplication.h';
+const FBSESSION_FILE = 'WebDriverAgentLib/Routing/FBSession.m';
 
 async function replaceInFile (file, find, replace) {
   let contents = await fs.readFile(file, 'utf-8');
@@ -124,8 +125,22 @@ async function fixXCUICoordinateFile (bootstrapPath, initial = true) {
   await replaceInFile(file, oldDef, newDef);
 }
 
+async function fixFBSessionFile (bootstrapPath, initial = true) {
+  const file = path.resolve(bootstrapPath, FBSESSION_FILE);
+
+  let oldLine = 'return [FBApplication fb_activeApplication] ?: self.testedApplication;';
+  let newLine = '  FBApplication *application = [FBApplication fb_activeApplication] ?: self.testedApplication;' +
+                '  return application;';
+  if (!initial) {
+    [oldLine, newLine] = [newLine, oldLine];
+  }
+  await replaceInFile(file, oldLine, newLine);
+}
+
 async function fixForXcode7 (bootstrapPath, initial = true) {
+  await fixForXcode9(bootstrapPath, !initial);
   await fixXCUICoordinateFile(bootstrapPath, initial);
+  await fixFBSessionFile(bootstrapPath, initial);
 }
 
 async function fixFBMacrosFile (bootstrapPath, initial = true) {
@@ -151,6 +166,7 @@ async function fixXCUIApplicationFile (bootstrapPath, initial = true) {
 }
 
 async function fixForXcode9 (bootstrapPath, initial = true) {
+  await fixForXcode7(bootstrapPath, !initial);
   await fixFBMacrosFile(bootstrapPath, initial);
   await fixXCUIApplicationFile(bootstrapPath, initial);
 }

--- a/test/functional/web/helpers.js
+++ b/test/functional/web/helpers.js
@@ -10,7 +10,7 @@ const GUINEA_PIG_SCROLLABLE_PAGE = `${GUINEA_PIG_PAGE}-scrollable`;
 const GUINEA_PIG_APP_BANNER_PAGE = `${GUINEA_PIG_PAGE}-app-banner`;
 const GUINEA_PIG_FRAME_PAGE = `${TEST_END_POINT}/frameset.html`;
 const GUINEA_PIG_IFRAME_PAGE = `${TEST_END_POINT}/iframes.html`;
-const PHISHING_END_POINT = TEST_END_POINT.replace('http://', 'http://foo:bar@');
+const PHISHING_END_POINT = 'http://malware.testing.google.test/testing/malware/*';
 const APPIUM_IMAGE = `${BASE_END_POINT}/appium.png`;
 
 async function spinTitle (driver) {

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -329,7 +329,7 @@ describe('Safari', function () {
       });
 
       it('should display a phishing warning', async () => {
-        await driver.get(`${PHISHING_END_POINT}/guinea-pig2.html`);
+        await driver.get(PHISHING_END_POINT);
         (await driver.source()).toLowerCase().should.include('phishing');
       });
     });
@@ -344,7 +344,7 @@ describe('Safari', function () {
       });
 
       it('should display a phishing warning', async () => {
-        await driver.get(`${PHISHING_END_POINT}/guinea-pig2.html`);
+        await driver.get(PHISHING_END_POINT);
         (await driver.source()).toLowerCase().should.not.include('phishing');
       });
     });

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -5,99 +5,126 @@ import { fs, tempDir } from 'appium-support';
 const simctlModule = require('node-simctl');
 const teenProcessModule = require('teen_process');
 
-describe('screenshots commands', () => {
+describe('screenshots commands', function () {
   let driver = new XCUITestDriver();
   let proxySpy = sinon.stub(driver, 'proxyCommand');
-  let simctlSpy = sinon.stub(simctlModule, 'getScreenshot');
 
   const base64Response = 'aGVsbG8=';
 
-  afterEach(() => {
+  afterEach(function () {
     proxySpy.reset();
-    simctlSpy.reset();
   });
 
-  describe('getScreenshot', () => {
-    it('should get a screenshot from WDA if no errors are detected', async function () {
-      proxySpy.returns(base64Response);
-      driver.opts.realDevice = false;
+  describe('getScreenshot', function () {
+    describe('simulator', function () {
+      let simctlSpy = sinon.stub(simctlModule, 'getScreenshot');
 
-      await driver.getScreenshot();
+      afterEach(function () {
+        simctlSpy.reset();
+      });
 
-      proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/screenshot');
-      proxySpy.firstCall.args[1].should.eql('GET');
+      it('should get a screenshot from WDA if no errors are detected', async function () {
+        proxySpy.returns(base64Response);
+        driver.opts.realDevice = false;
 
-      simctlSpy.notCalled.should.be.true;
-    });
-
-    it('should get a screenshot from simctl for simulator if WDA call fails and Xcode version >= 8.1', async function () {
-      proxySpy.returns(null);
-      simctlSpy.returns(base64Response);
-
-      driver.opts.realDevice = false;
-      driver.xcodeVersion = {
-        versionFloat: 8.3
-      };
-      const result = await driver.getScreenshot();
-      result.should.equal(base64Response);
-
-      proxySpy.calledOnce.should.be.true;
-      simctlSpy.calledOnce.should.be.true;
-    });
-
-    it('should use idevicescreenshot to take a screenshot on real device', async function () {
-      const toolName = 'idevicescreenshot';
-      const tiffPath = '/some/file.tiff';
-      const pngPath = '/some/file.png';
-      const udid = '1234';
-      const pngFileContent = 'blabla';
-      const fsExistsSpy = sinon.stub(fs, 'exists');
-      fsExistsSpy.returns(true);
-      const fsWhichSpy = sinon.stub(fs, 'which');
-      fsWhichSpy.returns(toolName);
-      const fsRimRafSpy = sinon.stub(fs, 'rimraf');
-      const fsReadFileSpy = sinon.stub(fs, 'readFile');
-      fsReadFileSpy.returns(pngFileContent);
-      const execSpy = sinon.stub(teenProcessModule, 'exec');
-      const pathSpy = sinon.stub(tempDir, 'path');
-      pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
-      pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
-      proxySpy.returns('LANDSCAPE');
-
-      try {
-        driver.opts.realDevice = true;
-        driver.opts.udid = udid;
-        (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+        await driver.getScreenshot();
 
         proxySpy.calledOnce.should.be.true;
-        proxySpy.firstCall.args[0].should.eql('/orientation');
+        proxySpy.firstCall.args[0].should.eql('/screenshot');
         proxySpy.firstCall.args[1].should.eql('GET');
 
-        fsWhichSpy.calledOnce.should.be.true;
-        fsWhichSpy.firstCall.args[0].should.eql(toolName);
+        simctlSpy.notCalled.should.be.true;
+      });
 
-        execSpy.calledTwice.should.be.true;
-        execSpy.firstCall.args[0].should.eql(toolName);
-        execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
-        execSpy.secondCall.args[0].should.eql('sips');
-        execSpy.secondCall.args[1].should.eql(
-          ['-r', '-90', '-s', 'format', 'png', tiffPath, '--out', pngPath]);
+      it('should get a screenshot from simctl if WDA call fails and Xcode version >= 8.1', async function () {
+        proxySpy.returns(null);
+        simctlSpy.returns(base64Response);
 
-        fsRimRafSpy.callCount.should.eql(4);
+        driver.opts.realDevice = false;
+        driver.xcodeVersion = {
+          versionFloat: 8.3
+        };
+        const result = await driver.getScreenshot();
+        result.should.equal(base64Response);
 
-        fsReadFileSpy.calledOnce.should.be.true;
-        fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
+        proxySpy.calledOnce.should.be.true;
+        simctlSpy.calledOnce.should.be.true;
+      });
+    });
 
-        pathSpy.calledTwice.should.be.true;
-      } finally {
-        fsExistsSpy.restore();
-        fsWhichSpy.restore();
-        fsReadFileSpy.restore();
-        fsRimRafSpy.restore();
-        execSpy.restore();
-        pathSpy.restore();
-      }
+    describe('real device', function () {
+      it('should get a screenshot from WDA if no errors are detected', async function () {
+        proxySpy.returns(base64Response);
+        driver.opts.realDevice = true;
+
+        await driver.getScreenshot();
+
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/screenshot');
+        proxySpy.firstCall.args[1].should.eql('GET');
+      });
+
+      it('should use idevicescreenshot if WDA fails', async function () {
+        const tiffPath = '/some/file.tiff';
+        const pngPath = '/some/file.png';
+        const udid = '1234';
+
+        const fsExistsSpy = sinon.stub(fs, 'exists');
+        fsExistsSpy.returns(true);
+
+        const toolName = 'idevicescreenshot';
+        const fsWhichSpy = sinon.stub(fs, 'which');
+        fsWhichSpy.returns(toolName);
+
+        const fsRimRafSpy = sinon.stub(fs, 'rimraf');
+
+        const pngFileContent = 'blabla';
+        const fsReadFileSpy = sinon.stub(fs, 'readFile');
+        fsReadFileSpy.returns(pngFileContent);
+
+        const execSpy = sinon.stub(teenProcessModule, 'exec');
+
+        const pathSpy = sinon.stub(tempDir, 'path');
+        pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
+        pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
+
+        proxySpy.onFirstCall().returns(null);
+        proxySpy.onSecondCall().returns('LANDSCAPE');
+
+        try {
+          driver.opts.realDevice = true;
+          driver.opts.udid = udid;
+          (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+
+          proxySpy.calledTwice.should.be.true;
+          proxySpy.firstCall.args.should.eql(['/screenshot', 'GET']);
+          proxySpy.secondCall.args.should.eql(['/orientation', 'GET']);
+
+          fsWhichSpy.calledOnce.should.be.true;
+          fsWhichSpy.firstCall.args[0].should.eql(toolName);
+
+          execSpy.calledTwice.should.be.true;
+          execSpy.firstCall.args[0].should.eql(toolName);
+          execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
+          execSpy.secondCall.args[0].should.eql('sips');
+          execSpy.secondCall.args[1].should.eql(
+            ['-r', '-90', '-s', 'format', 'png', tiffPath, '--out', pngPath]);
+
+          fsRimRafSpy.callCount.should.eql(4);
+
+          fsReadFileSpy.calledOnce.should.be.true;
+          fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
+
+          pathSpy.calledTwice.should.be.true;
+        } finally {
+          fsExistsSpy.restore();
+          fsWhichSpy.restore();
+          fsReadFileSpy.restore();
+          fsRimRafSpy.restore();
+          execSpy.restore();
+          pathSpy.restore();
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Update WDA and add https://github.com/facebook/WebDriverAgent/pull/787

This means that we can go to WDA for screenshots first, then fall back to `idevicescreenshot` if necessary. Blurgh.