### PR TITLE
Perform obsolete cached processes cleanup if multiple simulators are used on a single machine

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -18,7 +18,6 @@ import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          printUser, printLibimobiledeviceInfo } from './utils';
 import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
          getRealDeviceObj } from './real-device-management';
-import { NoSessionProxy } from "./wda/no-session-proxy";
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
 
@@ -374,31 +373,18 @@ class XCUITestDriver extends BaseDriver {
   async startWda (sessionId, realDevice) {
     this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
+    await this.wda.cleanupObsoleteProcesses();
+
     if (this.opts.useNewWDA) {
       log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
       await this.wda.quit();
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
-    } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      log.debug(`Capability 'useNewWDA' set to false, so trying to reuse currently running WDA instance at '${this.wda.url.href}'`);
-      const noSessionProxy = new NoSessionProxy({
-        server: this.wda.url.hostname,
-        port: this.wda.url.port,
-        base: '',
-        timeout: 3000,
-      });
-      try {
-        const status = await noSessionProxy.command('/status', 'GET');
-        if (!status) {
-          throw new Error(`WDA response to /status command should be defined.`);
-        }
-        log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'.` +
-                 `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} if this is an undesired behavior ` +
-                 `(for example, if the other device/Simulator is used on the same port).`);
-        this.wda.webDriverAgentUrl = this.wda.url.href;
-      } catch (err) {
-        log.debug(`WDA is not listening at '${this.wda.url.href}'. Rebuilding...`);
-      }
+    } else if (!util.hasValue(this.wda.webDriverAgentUrl) && (await this.wda.isRunning())) {
+      log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
+               `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +
+               `if this is an undesired behavior.`);
+      this.wda.webDriverAgentUrl = this.wda.url.href;
     }
 
     // local helper for the two places we need to uninstall wda and re-start it

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -367,7 +367,7 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
   try {
     // This only works since Mac OS X El Capitan
     const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
-    result.push(...(stdout.trim().split(/\s+/)));
+    result.push(...(stdout.trim().split(/\n+/)));
   } catch (e) {
     return result;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -349,6 +349,19 @@ async function printLibimobiledeviceInfo () {
   }
 }
 
+/**
+ * Get the IDs of processes listening on the particular system port.
+ * It is also possible to apply additional filtering based on the
+ * process command line.
+ *
+ * @param {string|number} port - The port number.
+ * @param {?Function} filteringFunc - Optional lambda function, which
+ *                                    receives command line string of the particular process
+ *                                    listening on given port, and is expected to return
+ *                                    either true or false to include/exclude the corresponding PID
+ *                                    from the resulting array.
+ * @returns {Array<string>} - the list of matched process ids.
+ */
 async function getPIDsListeningOnPort (port, filteringFunc = null) {
   const result = [];
   try {
@@ -356,7 +369,6 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
     const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
     result.push(...(stdout.trim().split(/\s+/)));
   } catch (e) {
-    log.warn(`Cannot receive process IDs, which are listening on port ${port}. Original error: ${e.message}`);
     return result;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -349,8 +349,29 @@ async function printLibimobiledeviceInfo () {
   }
 }
 
+async function getPIDsListeningOnPort (port, filteringFunc = null) {
+  const result = [];
+  try {
+    // This only works since Mac OS X El Capitan
+    const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
+    result.push(...(stdout.trim().split(/\s+/)));
+  } catch (e) {
+    log.warn(`Cannot receive process IDs, which are listening on port ${port}. Original error: ${e.message}`);
+    return result;
+  }
+
+  if (!_.isFunction(filteringFunc)) {
+    return result;
+  }
+  return await B.filter(result, async (x) => {
+    const {stdout} = await exec('ps', ['-p', x, '-o', 'command']);
+    return await filteringFunc(stdout);
+  });
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
          DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
-         markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo };
+         markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo,
+         getPIDsListeningOnPort };

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -6,9 +6,10 @@ import { fs } from 'appium-support';
 import log from '../logger';
 import { NoSessionProxy } from "./no-session-proxy";
 import { checkForDependencies } from './utils';
-import { resetXCTestProcesses } from '../utils';
+import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
+import { exec } from 'teen_process';
 
 
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', '..', 'WebDriverAgent');
@@ -72,6 +73,45 @@ class WebDriverAgent {
     // for backward compatibility we need to be able to specify agentPath too
     this.agentPath = agentPath || path.resolve(this.bootstrapPath, 'WebDriverAgent.xcodeproj');
     log.info(`Using WDA agent: '${this.agentPath}'`);
+  }
+
+  async cleanupObsoleteProcesses () {
+    const pids = await getPIDsListeningOnPort(this.url.port,
+      (cmdLine) => (cmdLine.includes('/WebDriverAgentRunner') || cmdLine.includes('/iproxy')) &&
+        !cmdLine.toLowerCase().includes(this.device.udid.toLowerCase()));
+    if (!pids.length) {
+      log.debug(`No obsolete cached processes from previous WDA sessions ` +
+                `listening on port ${this.url.port} have been found`);
+      return;
+    }
+
+    log.info(`Detected ${pids.length} obsolete cached process${pids.length === 1 ? '' : 'es'} ` +
+             `from previous WDA sessions. Cleaning up...`);
+    try {
+      await exec('kill', pids);
+    } catch (e) {
+      log.warn(`Failed to kill obsolete cached process${pids.length === 1 ? '' : 'es'} '${pids}'. ` +
+               `Original error: ${e.message}`);
+    }
+  }
+
+  async isRunning () {
+    const noSessionProxy = new NoSessionProxy({
+      server: this.url.hostname,
+      port: this.url.port,
+      base: '',
+      timeout: 3000,
+    });
+    try {
+      const status = await noSessionProxy.command('/status', 'GET');
+      if (!status) {
+        throw new Error(`WDA response to /status command should be defined.`);
+      }
+      return true;
+    } catch (err) {
+      log.debug(`WDA is not listening at '${this.url.href}'`);
+      return false;
+    }
   }
 
   async uninstall () {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -9,7 +9,7 @@ import { checkForDependencies } from './utils';
 import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
-import { exec } from 'teen_process';
+import fkill from 'fkill';
 
 
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', '..', 'WebDriverAgent');
@@ -88,7 +88,7 @@ class WebDriverAgent {
     log.info(`Detected ${pids.length} obsolete cached process${pids.length === 1 ? '' : 'es'} ` +
              `from previous WDA sessions. Cleaning up...`);
     try {
-      await exec('kill', pids);
+      await fkill(pids);
     } catch (e) {
       log.warn(`Failed to kill obsolete cached process${pids.length === 1 ? '' : 'es'} '${pids}'. ` +
                `Original error: ${e.message}`);


### PR DESCRIPTION
This PR should resolve an issue when people try to use different simulator types on the same machine and the driver automatically picks up the previously cached session from the previous run, which results in non-expected behaviour.