### PR TITLE
Use simctl tool for Simulator logs capture

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -29,8 +29,7 @@ extensions.startLogCapture = async function () {
   try {
     await this.logs.syslog.startCapture();
   } catch (err) {
-    log.warn(err.message);
-    log.debug('Continuing without capturing logs');
+    log.warn(`Continuing without capturing logs: ${err.message}`);
     return false;
   }
   await this.logs.crashlog.startCapture();

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -29,8 +29,8 @@ extensions.startLogCapture = async function () {
   try {
     await this.logs.syslog.startCapture();
   } catch (err) {
-    log.warn(`Could not capture logs from the device: ${err.message}`);
-    log.debug('Continuing without capturing logs.');
+    log.warn(err.message);
+    log.debug('Continuing without capturing logs');
     return false;
   }
   await this.logs.crashlog.startCapture();

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,7 +1,10 @@
 import { IOSLog as IOSDriverIOSLog } from 'appium-ios-driver';
+import path from 'path';
+import { fs } from 'appium-support';
 import _ from 'lodash';
 import log from '../logger';
 import { SubProcess, exec } from 'teen_process';
+import xcode from 'appium-xcode';
 
 class IOSLog extends IOSDriverIOSLog {
   async startCaptureSimulator () {
@@ -9,14 +12,30 @@ class IOSLog extends IOSDriverIOSLog {
       throw new Error(`Log capture requires a sim udid`);
     }
 
+    const xcodeVersion = await xcode.getVersion(true);
+    let tool, args;
+    if (xcodeVersion.major < 9) {
+      const systemLogPath = path.resolve(this.sim.getLogDir(), 'system.log');
+      if (!await fs.exists(systemLogPath)) {
+        throw new Error(`No logs could be found at ${systemLogPath}`);
+      }
+      log.debug(`System log path: ${systemLogPath}`);
+      tool = 'tail';
+      args = ['-f', '-n', '1', systemLogPath];
+    } else {
+      if (!await this.sim.isRunning()) {
+        throw new Error(`iOS Simulator with udid ${this.sim.udid} is not running`);
+      }
+      tool = 'xcrun';
+      args = ['simctl', 'spawn', this.sim.udid, 'log', 'stream'];
+    }
     log.debug(`Starting log capture for iOS Simulator with udid ${this.sim.udid}`);
-    const xcrunArgs = ['simctl', 'spawn', this.sim.udid, 'log', 'stream'];
     try {
       // cleanup existing listeners if the previous session has not been terminated properly
-      await exec('pkill', ['-xf', ['xcrun', ...xcrunArgs].join(' ')]);
+      await exec('pkill', ['-xf', [tool, ...args].join(' ')]);
     } catch (ign) {}
     try {
-      this.proc = new SubProcess('xcrun', xcrunArgs);
+      this.proc = new SubProcess(tool, args);
       await this.finishStartingLogCapture();
     } catch (e) {
       throw new Error(`Simulator log capture failed. Original error: ${e.message}`);

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -27,7 +27,7 @@ class IOSLog extends IOSDriverIOSLog {
         throw new Error(`iOS Simulator with udid ${this.sim.udid} is not running`);
       }
       tool = 'xcrun';
-      args = ['simctl', 'spawn', this.sim.udid, 'log', 'stream'];
+      args = ['simctl', 'spawn', this.sim.udid, 'log', 'stream', '--style', 'compact'];
     }
     log.debug(`Starting log capture for iOS Simulator with udid ${this.sim.udid}`);
     try {

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,8 +1,6 @@
 import { IOSLog as IOSDriverIOSLog } from 'appium-ios-driver';
-import path from 'path';
 import _ from 'lodash';
 import log from '../logger';
-import { fs } from 'appium-support';
 import { SubProcess, exec } from 'teen_process';
 
 class IOSLog extends IOSDriverIOSLog {
@@ -12,21 +10,16 @@ class IOSLog extends IOSDriverIOSLog {
     }
 
     log.debug(`Starting log capture for iOS Simulator with udid ${this.sim.udid}`);
-    const systemLogPath = path.resolve(this.sim.getLogDir(), 'system.log');
-    if (!await fs.exists(systemLogPath)) {
-      throw new Error(`No logs could be found at ${systemLogPath}`);
-    }
-    log.debug(`System log path: ${systemLogPath}`);
-    const tailArgs = ['-f', '-n', '1', systemLogPath];
+    const xcrunArgs = ['simctl', 'spawn', this.sim.udid, 'log', 'stream'];
     try {
       // cleanup existing listeners if the previous session has not been terminated properly
-      await exec('pkill', ['-xf', ['tail', ...tailArgs].join(' ')]);
-    } catch (e) {}
+      await exec('pkill', ['-xf', ['xcrun', ...xcrunArgs].join(' ')]);
+    } catch (ign) {}
     try {
-      this.proc = new SubProcess('tail', tailArgs);
+      this.proc = new SubProcess('xcrun', xcrunArgs);
       await this.finishStartingLogCapture();
-    } catch (err) {
-      throw new Error(`Simulator log capture failed: ${err.message}`);
+    } catch (e) {
+      throw new Error(`Simulator log capture failed. Original error: ${e.message}`);
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -5,8 +5,7 @@ import { launch } from 'node-simctl';
 import WebDriverAgent from './wda/webdriveragent';
 import log from './logger';
 import { createSim, getExistingSim, runSimulatorReset, installToSimulator } from './simulator-management';
-import { simExists, getSimulator, installSSLCert,
-         uninstallSSLCert, BOOT_COMPLETED_EVENT } from 'appium-ios-simulator';
+import { simExists, getSimulator, installSSLCert, uninstallSSLCert } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps, appUtils, IWDP } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
@@ -292,45 +291,24 @@ class XCUITestDriver extends BaseDriver {
 
     log.info(`Setting up ${this.isRealDevice() ? 'real device' : 'simulator'}`);
 
-    if (this.isRealDevice()) {
-      if (this.opts.app) {
-        await this.installApp();
-        this.logEvent('appInstalled');
-      }
-    } else {
+    if (this.isSimulator()) {
       this.localeConfig = await iosSettings.setLocale(this.opts.device, this.opts, {}, this.isSafari());
       await iosSettings.setPreferences(this.opts.device, this.opts, this.isSafari());
       // Cleanup of installd cache helps to save disk space while running multiple tests
       // without restarting the Simulator: https://github.com/appium/appium/issues/9410
       await this.opts.device.clearCaches('com.apple.mobile.installd.staging');
 
-      let installAppPromise = null;
-      if (this.opts.app && !await this.opts.device.isRunning()) {
-        // Install app asynchronously as soon as device booting is completed
-        installAppPromise = new B(async (resolve, reject) => {
-          this.opts.device.on(BOOT_COMPLETED_EVENT, async () => {
-            try {
-              await this.installApp();
-              resolve();
-            } catch (err) {
-              reject(err);
-            }
-          });
-        });
-      }
       await this.startSim();
       this.logEvent('simStarted');
       if (!isLogCaptureStarted) {
-        // Try again if the simulator has been started for the first time
+        // Retry log capture if Simulator was not running before
         await startLogCapture();
       }
-      if (this.opts.app && !installAppPromise) {
-        installAppPromise = this.installApp();
-      }
-      if (installAppPromise) {
-        await installAppPromise;
-        this.logEvent('appInstalled');
-      }
+    }
+
+    if (this.opts.app) {
+      await this.installApp();
+      this.logEvent('appInstalled');
     }
 
     // if we only have bundle identifier and no app, fail if it is not already installed

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -227,7 +227,7 @@ describe('XCUITestDriver', function () {
           udid: 'some-random-udid'
         }, UICATALOG_SIM_CAPS);
 
-        await driver.init(caps).should.be.rejectedWith('environment you requested was unavailable');
+        await driver.init(caps).should.be.rejectedWith('Unknown device or simulator UDID');
       });
 
       it('with non-existent udid: throws an error', async () => {
@@ -235,7 +235,7 @@ describe('XCUITestDriver', function () {
         let udid = 'a77841db006fb1762fee0bb6a2477b2b3e1cfa7d';
         let caps = _.defaults({udid}, UICATALOG_SIM_CAPS);
 
-        await driver.init(caps).should.be.rejectedWith('environment you requested was unavailable');
+        await driver.init(caps).should.be.rejectedWith('Unknown device or simulator UDID');
       });
 
       it('with noReset set to true: leaves sim booted', async function () {


### PR DESCRIPTION
I have observed that in the recent Xcode versions the log, which is written by Simulator to the standard log file, contains pretty limited data. However, more detailed log is available via `log stream` tool, which is a part of simctl tool set. Check http://shashikantjagtap.net/simctl-control-ios-simulators-command-line/ for more details.