### PR TITLE
Remove restriction on logging tests

### DIFF
--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -77,9 +77,5 @@ const TOUCHIDAPP_CAPS = _.defaults({
   app: path.resolve('.', 'test', 'assets', 'TouchIDExample.app'),
 }, GENERIC_CAPS);
 
-function isIOS11 () {
-  return PLATFORM_VERSION === '11.0';
-}
-
 export { UICATALOG_CAPS, UICATALOG_SIM_CAPS, SAFARI_CAPS, TESTAPP_CAPS,
-         PLATFORM_VERSION, TOUCHIDAPP_CAPS, DEVICE_NAME, isIOS11 };
+         PLATFORM_VERSION, TOUCHIDAPP_CAPS, DEVICE_NAME };

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -8,7 +8,7 @@ import { getDevices, createDevice, deleteDevice } from 'node-simctl';
 import _ from 'lodash';
 import B from 'bluebird';
 import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
-import { UICATALOG_CAPS, UICATALOG_SIM_CAPS, isIOS11 } from '../desired';
+import { UICATALOG_CAPS, UICATALOG_SIM_CAPS } from '../desired';
 
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
@@ -97,24 +97,27 @@ describe('XCUITestDriver', function () {
 
     describe('WebdriverAgent port', function () {
       it('should run on default port if no other specified', async function () {
-        let localCaps = Object.assign({}, caps, {fullReset: true, showIOSLog: true});
+        let localCaps = Object.assign({}, caps, {
+          fullReset: true,
+          showIOSLog: true,
+          useNewWDA: true,
+        });
         localCaps.wdaLocalPort = null;
         await driver.init(localCaps);
         let logs = await driver.log('syslog');
-        if (!isIOS11()) {
-          // currently on iOS 11 there is no device log
-          logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.true;
-        }
+        logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.true;
       });
       it('should run on port specified', async function () {
-        let localCaps = Object.assign({}, caps, {fullReset: true, showIOSLog: true, wdaLocalPort: 6000});
+        let localCaps = Object.assign({}, caps, {
+          fullReset: true,
+          showIOSLog: true,
+          wdaLocalPort: 6000,
+          useNewWDA: true,
+        });
         await driver.init(localCaps);
         let logs = await driver.log('syslog');
-        if (!isIOS11()) {
-          // currently on iOS 11 there is no device log
-          logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.false;
-          logs.some((line) => line.message.indexOf(':6000<-') !== -1).should.be.true;
-        }
+        logs.some((line) => line.message.indexOf(':8100<-') !== -1).should.be.false;
+        logs.some((line) => line.message.indexOf(':6000<-') !== -1).should.be.true;
       });
     });
 


### PR DESCRIPTION
Recent work from @mykola-mokhnach (see 063b320efbcb85517f4ff395bf2295bfac4044e0) makes logging work on iOS 11.

Finally remove the last vestiges of the switches for iOS 11 in the tests.