### PR TITLE
W3C compliance

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -162,11 +162,11 @@ class XCUITestDriver extends BaseDriver {
     return status;
   }
 
-  async createSession (caps) {
+  async createSession (...args) {
     this.lifecycleData = {}; // this is used for keeping track of the state we start so when we delete the session we can put things back
     try {
       // TODO add validation on caps
-      let [sessionId] = await super.createSession(caps);
+      let [sessionId, caps] = await super.createSession(...args);
       this.opts.sessionId = sessionId;
 
       await this.start();

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -84,5 +84,12 @@ const TOUCHIDAPP_CAPS = _.defaults({
   app: path.resolve('.', 'test', 'assets', 'TouchIDExample.app'),
 }, GENERIC_CAPS);
 
+const W3C_CAPS = {
+  capabilities: {
+    alwaysMatch: UICATALOG_CAPS,
+    firstMatch: [{}],
+  }
+};
+
 export { UICATALOG_CAPS, UICATALOG_SIM_CAPS, SAFARI_CAPS, TESTAPP_CAPS,
-         PLATFORM_VERSION, TOUCHIDAPP_CAPS, DEVICE_NAME };
+         PLATFORM_VERSION, TOUCHIDAPP_CAPS, DEVICE_NAME, W3C_CAPS };

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -298,10 +298,12 @@ describe('XCUITestDriver', function () {
       const sessionUrl = `http://${HOST}:${PORT}/wd/hub/session`;
       it('should accept w3c formatted caps', async function () {
         const { status, value, sessionId } = await request.post({url: sessionUrl, json: W3C_CAPS});
-        status.should.equal(0);
+        should.not.exist(status);
         value.should.exist;
-        sessionId.should.exist;
-        await request.delete({url: `${sessionUrl}/${sessionId}`});
+        value.capabilities.should.exists;
+        should.not.exist(sessionId);
+        should.exist(value.sessionId);
+        await request.delete({url: `${sessionUrl}/${value.sessionId}`});
       });
       it('should not accept w3c caps if missing "platformName" capability', async function () {
         await request.post({
@@ -318,12 +320,13 @@ describe('XCUITestDriver', function () {
         alwaysMatch['appium:deviceName'] = deviceName;
         const { value } = await request.post({url: sessionUrl, json: w3cCaps});
         value.should.exist;
+        await request.delete(`${sessionUrl}/${value.sessionId}`);
       });
       it('should receive 404 status code if call findElement on one that does not exist', async function () {
-        const { sessionId } = await request.post({url: sessionUrl, json: W3C_CAPS});
+        const { value } = await request.post({url: sessionUrl, json: W3C_CAPS});
         try {
           await request.post({
-            url: `${sessionUrl}/${sessionId}/element`,
+            url: `${sessionUrl}/${value.sessionId}/element`,
             json: {
               using: 'accessibility id',
               value: 'Bad Selector'
@@ -332,7 +335,7 @@ describe('XCUITestDriver', function () {
         } catch (e) {
           e.statusCode.should.equal(404);
         }
-        await request.delete({url: `${sessionUrl}/${sessionId}`});
+        await request.delete({url: `${sessionUrl}/${value.sessionId}`});
       });
     });
   } else {

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -2,13 +2,14 @@ import { startServer } from '../../..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import wd from 'wd';
+import request from 'request-promise';
 import { retryInterval } from 'asyncbox';
 import { killAllSimulators, getSimulator } from 'appium-ios-simulator';
 import { getDevices, createDevice, deleteDevice } from 'node-simctl';
 import _ from 'lodash';
 import B from 'bluebird';
 import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
-import { UICATALOG_CAPS, UICATALOG_SIM_CAPS } from '../desired';
+import { UICATALOG_CAPS, UICATALOG_SIM_CAPS, W3C_CAPS } from '../desired';
 
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
@@ -291,6 +292,47 @@ describe('XCUITestDriver', function () {
         should.exist(res.events);
         should.exist(res.events.newSessionStarted);
         res.events.newSessionStarted[0].should.be.above(res.events.newSessionRequested[0]);
+      });
+    });
+    describe('w3c compliance', () => {
+      const sessionUrl = `http://${HOST}:${PORT}/wd/hub/session`;
+      it('should accept w3c formatted caps', async function () {
+        const { status, value, sessionId } = await request.post({url: sessionUrl, json: W3C_CAPS});
+        status.should.equal(0);
+        value.should.exist;
+        sessionId.should.exist;
+        await request.delete({url: `${sessionUrl}/${sessionId}`});
+      });
+      it('should not accept w3c caps if missing "platformName" capability', async function () {
+        await request.post({
+          url: sessionUrl,
+          json: _.omit(W3C_CAPS, ['capabilities.alwaysMatch.platformName']),
+        }).should.eventually.be.rejectedWith(/platformName can\'t be blank/);
+      });
+      it('should accept the "appium:" prefix', async function () {
+        const w3cCaps = _.cloneDeep(W3C_CAPS);
+        const alwaysMatch = w3cCaps.capabilities.alwaysMatch;
+        const deviceName = alwaysMatch.deviceName;
+        delete alwaysMatch.deviceName;
+        await request.post({url: sessionUrl, json: w3cCaps}).should.eventually.be.rejected;
+        alwaysMatch['appium:deviceName'] = deviceName;
+        const { value } = await request.post({url: sessionUrl, json: w3cCaps});
+        value.should.exist;
+      });
+      it('should receive 404 status code if call findElement on one that does not exist', async function () {
+        const { sessionId } = await request.post({url: sessionUrl, json: W3C_CAPS});
+        try {
+          await request.post({
+            url: `${sessionUrl}/${sessionId}/element`,
+            json: {
+              using: 'accessibility id',
+              value: 'Bad Selector'
+            },
+          });
+        } catch (e) {
+          e.statusCode.should.equal(404);
+        }
+        await request.delete({url: `${sessionUrl}/${sessionId}`});
       });
     });
   } else {


### PR DESCRIPTION
* Edit createSession so that it passes all args to the base 'createSession' instead of just the first argument
* Added tests that call W3C endpoints to verify that it:
  * Accepts w3c formatted caps
  * Rejects it if 'platformName' is missing
  * Parses the 'appium:' prefix correctly
  * Tests that 'Element Not Found' call returns 404 status code (JSONWP always returns 500)