### PR TITLE
add location setting functionality for real devices

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import { iosCommands } from 'appium-ios-driver';
 import log from '../logger';
-import { util } from 'appium-support';
 
 let commands = {};
 
@@ -187,17 +186,6 @@ commands.setUrl = async function (url) {
     return await this.proxyCommand('/url', 'POST', {url});
   }
   return await iosCommands.general.setUrl.call(this, url);
-};
-
-commands.setGeoLocation = async function (location) {
-  if (!this.isSimulator()) {
-    throw new errors.UnknownError('Setting geolocation is not supported on real devices');
-  }
-  let {latitude, longitude} = location;
-  if (!util.hasValue(latitude) || !util.hasValue(longitude)) {
-    log.errorAndThrow(`Both latitude and longitude should be set`);
-  }
-  await this.opts.device.setGeolocation(`${latitude}`, `${longitude}`);
 };
 
 export { commands };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -15,6 +15,7 @@ import elementExtensions from './element';
 import fileMovementExtensions from './file-movement';
 import screenshotExtensions from './screenshots';
 import pasteboardExtensions from './pasteboard';
+import locationExtensions from './location';
 
 
 let commands = {};
@@ -23,6 +24,6 @@ Object.assign(commands, actionsCommands, contextCommands, executeExtensions,
   gestureExtensions, findExtensions, proxyHelperExtensions, sourceExtensions,
   generalExtensions, logExtensions, webExtensions, timeoutExtensions,
   navigationExtensions, elementExtensions, fileMovementExtensions,
-  alertExtensions, screenshotExtensions, pasteboardExtensions);
+  alertExtensions, screenshotExtensions, pasteboardExtensions, locationExtensions);
 
 export default commands;

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -1,0 +1,29 @@
+import { exec } from 'teen_process';
+import { fs, util } from 'appium-support';
+import log from '../logger';
+
+let commands = {};
+
+commands.setGeoLocation = async function (location) {
+  let {latitude, longitude} = location;
+
+  if (!util.hasValue(latitude) || !util.hasValue(longitude)) {
+    log.errorAndThrow(`Both latitude and longitude should be set`);
+  }
+
+  if (this.isRealDevice()) {
+    if (!(await fs.which('idevicelocation'))) {
+      log.errorAndThrow(`idevicelocation doesn't exist on the host`);
+    }
+    try {
+      await exec('idevicelocation', ['-u', this.opts.udid, `${latitude}`, `${longitude}`]);
+    } catch (e) {
+      throw new Error(`Can't set the location on device '${this.opts.udid}'. Original error: ${e.message}`);
+    }
+  } else {
+    await this.opts.device.setGeolocation(`${latitude}`, `${longitude}`);
+  }
+};
+
+export { commands };
+export default commands;

--- a/test/unit/commands/location-specs.js
+++ b/test/unit/commands/location-specs.js
@@ -1,0 +1,68 @@
+import sinon from 'sinon';
+import XCUITestDriver from '../../..';
+import { fs } from 'appium-support';
+
+const teenProcessModule = require('teen_process');
+
+describe('location commands', function () {
+  let driver = new XCUITestDriver();
+  let proxySpy = sinon.stub(driver, 'proxyCommand');
+
+  afterEach(function () {
+    proxySpy.reset();
+  });
+
+  describe('setLocation', function () {
+    const location = {latitude: '1', longitude: '2'};
+    let execSpy;
+    let fsWhichSpy;
+
+    beforeEach(function () {
+      execSpy = sinon.stub(teenProcessModule, 'exec');
+      fsWhichSpy = sinon.stub(fs, 'which');
+    });
+
+    afterEach(function () {
+      execSpy.restore();
+      fsWhichSpy.restore();
+    });
+
+    it('fail when location object is wrong', async function () {
+      await driver.setGeoLocation({}).should.be.rejectedWith('Both latitude and longitude should be set');
+    });
+
+    it('use idevicelocation to set the location on real devices', async function () {
+      const udid = '1234';
+
+      driver.opts.udid = udid;
+      driver.opts.realDevice = true;
+
+      const toolName = 'idevicelocation';
+
+      fsWhichSpy.returns(toolName);
+      await driver.setGeoLocation(location);
+
+      execSpy.calledOnce.should.be.true;
+      execSpy.firstCall.args[0].should.eql(toolName);
+      execSpy.firstCall.args[1].should.eql(['-u', udid, location.latitude, location.longitude]);
+    });
+
+    it('fail when idevicelocation doesnt exist on the host for real devices', async function () {
+      driver.opts.realDevice = true;
+      await driver.setGeoLocation(location).should.be.rejectedWith(`idevicelocation doesn't exist on the host`);
+    });
+
+    it('set geo location on simulator', async function () {
+      driver.opts.realDevice = false;
+      let deviceStub = sinon.mock(driver.opts, 'device');
+      deviceStub.object.device = {
+        setGeolocation: () => {},
+      };
+      let setGeolocationSpy = sinon.spy(driver.opts.device, 'setGeolocation');
+
+      await driver.setGeoLocation(location);
+      setGeolocationSpy.firstCall.args[0].should.eql(location.latitude);
+      setGeolocationSpy.firstCall.args[1].should.eql(location.longitude);
+    });
+  });
+});


### PR DESCRIPTION
* Move location setting logic to location.js
* Add location setting for real devices
* Add unit tests for simulators and real devices

The idevicelocation tool can be found in this PR [idevicelocation PR](https://github.com/libimobiledevice/libimobiledevice/pull/480). It maybe makes sense for appium to fork libimobiledevice or port libimobiledevice code base to nodejs for faster development