### PR TITLE
Properly handle the situation when not all of processArguments properties are defined

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -717,8 +717,16 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async startWdaSession (bundleId, processArguments) {
-    let args = processArguments ? processArguments.args : [];
-    let env = processArguments ? processArguments.env : {};
+    let args = processArguments ? (processArguments.args || []) : [];
+    if (!_.isArray(args)) {
+      throw new Error(`processArguments.args capability is expected to be an array. ` +
+                      `${JSON.stringify(args)} is given instead`);
+    }
+    let env = processArguments ? (processArguments.env || {}) : {};
+    if (!_.isPlainObject(env)) {
+      throw new Error(`processArguments.env capability is expected to be a dictionary. ` +
+                      `${JSON.stringify(env)} is given instead`);
+    }
 
     let shouldWaitForQuiescence = util.hasValue(this.opts.waitForQuiescence) ? this.opts.waitForQuiescence : true;
     let maxTypingFrequency = util.hasValue(this.opts.maxTypingFrequency) ? this.opts.maxTypingFrequency : 60;


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/9917