### PR TITLE
Add postinstall step to init WDA and remove the derived data

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "coverage": "gulp coveralls",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
-    "lint": "gulp eslint"
+    "lint": "gulp eslint",
+    "postinstall": "git submodule update --init && rm -rf ~/Library/Developer/Xcode/DerivedData/WebDriverAgent-*"
   },
   "pre-commit": [
     "precommit-msg",


### PR DESCRIPTION
Initialize WDA (so on first install you don't need to manually get the submodule).

Remove any WDA derived data folders, to decrease the chance of not picking up the changed to WDA.