### PR TITLE
add rect for window

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -117,8 +117,10 @@ commands.getWindowSize = async function (windowHandle = 'current') {
 // For W3C
 commands.getWindowRect = async function () {
   const rect = await this.getWindowSize();
-  rect.x = 0;
-  rect.y = 0;
+  if (_.isObject(rect)) {
+    rect.x = 0;
+    rect.y = 0;
+  }
   return rect;
 };
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -114,6 +114,14 @@ commands.getWindowSize = async function (windowHandle = 'current') {
   }
 };
 
+// For W3C
+commands.getWindowRect = async function () {
+  const rect = await this.getWindowSize();
+  rect.x = 0;
+  rect.y = 0;
+  return rect;
+};
+
 commands.hideKeyboard = async function (strategy, ...possibleKeys) {
   if ((this.opts.deviceName || '').indexOf('iPhone') === -1) {
     // TODO: once WDA can handle dismissing keyboard for iphone, take away conditional

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -116,12 +116,13 @@ commands.getWindowSize = async function (windowHandle = 'current') {
 
 // For W3C
 commands.getWindowRect = async function () {
-  const rect = await this.getWindowSize();
-  if (_.isObject(rect)) {
-    rect.x = 0;
-    rect.y = 0;
-  }
-  return rect;
+  const {width, height} = await this.getWindowSize();
+  return {
+    width,
+    height,
+    x: 0,
+    y: 0
+  };
 };
 
 commands.hideKeyboard = async function (strategy, ...possibleKeys) {

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -214,6 +214,13 @@ describe('XCUITestDriver - basics', function () {
       size.width.should.be.a.number;
       size.height.should.be.a.number;
     });
+    it('should be able to get the current window size with Rect', async function () {
+      let size = await driver.getWindowRect();
+      size.width.should.be.a.number;
+      size.height.should.be.a.number;
+      size.x.should.equal(0);
+      size.y.should.equal(0);
+    });
     it('should not be able to get random window size', async function () {
       await driver.getWindowSize('something-random').should.be.rejectedWith(/Currently only getting current window size is supported/);
     });

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -214,13 +214,6 @@ describe('XCUITestDriver - basics', function () {
       size.width.should.be.a.number;
       size.height.should.be.a.number;
     });
-    it('should be able to get the current window size with Rect', async function () {
-      let size = await driver.getWindowRect();
-      size.width.should.be.a.number;
-      size.height.should.be.a.number;
-      size.x.should.equal(0);
-      size.y.should.equal(0);
-    });
     it('should not be able to get random window size', async function () {
       await driver.getWindowSize('something-random').should.be.rejectedWith(/Currently only getting current window size is supported/);
     });

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -96,6 +96,10 @@ describe('general commands', function () {
 
   describe('window size', function () {
     it('should be able to get the current window size with Rect', async function () {
+      proxySpy
+        .withArgs('/window/size', 'GET')
+        .returns({width: 100, height: 20});
+
       await driver.getWindowRect();
       proxySpy.calledOnce.should.be.true;
       proxySpy.firstCall.args[0].should.eql('/window/size');

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -94,6 +94,15 @@ describe('general commands', () => {
     });
   });
 
+  describe('window size', function () {
+    it('should be able to get the current window size with Rect', async function () {
+      await driver.getWindowRect();
+      proxySpy.calledOnce.should.be.true;
+      proxySpy.firstCall.args[0].should.eql('/window/size');
+      proxySpy.firstCall.args[1].should.eql('GET');
+    });
+  });
+
   describe('nativeWebTap as a setting', () => {
     // create new driver with no opts
     let driver, startStub;


### PR DESCRIPTION
Currently, `getWindowRect` is defined in [routes.js](https://github.com/appium/appium-base-driver/blob/master/lib/mjsonwp/routes.js#L540), but it isn't implemented in each drivers.

In this PR, XCUITest starts supporting the window rect. I've set `x` and `y` to `0` since they are not defined in mobile device itself. I mean `width` is the width of mobile devices and `height` is the height of mobile devices. (We must implement `x` and `y` against element level, though.)

for : https://github.com/jlipps/simple-wd-spec#get-window-rect
(Not for : https://github.com/jlipps/simple-wd-spec#get-element-rect )

What do you think?

## after

```
[debug] [JSONWP Proxy] Proxying [GET /window/size] to [GET http://localhost:8100/session/135A0AC6-E920-42E0-896B-7F9CDC6EB5CC/window/size] with no body
[debug] [JSONWP Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"width\" : 375,\n    \"height\" : 667\n  },\n  \"sessionId\" : \"135A0AC6-E920-42E0-896B-7F9CDC6EB5CC\",\n  \"status\" : 0\n}"
[debug] [MJSONWP] Responding to client with driver.getWindowRect() result: {"width":375,"height":667,"x":0,"y":0}
[HTTP] <-- GET /wd/hub/session/884c1706-b157-4bdf-9492-5e7a3e836925/window/rect 200 205 ms - 48
[HTTP] --> GET /wd/hub/session/884c1706-b157-4bdf-9492-5e7a3e836925/window/rect {}
[debug] [MJSONWP] Calling AppiumDriver.getWindowRect() with args: ["884c1706-b157-4bdf-9492-5e7a3e836925"]
[debug] [XCUITest] Executing command 'getWindowRect'
[debug] [JSONWP Proxy] Proxying [GET /window/size] to [GET http://localhost:8100/session/135A0AC6-E920-42E0-896B-7F9CDC6EB5CC/window/size] with no body
```

## before

```
[HTTP] --> GET /wd/hub/session/237ad8bc-5b10-488d-9623-f1ba3753a1f8/window/rect {}
[debug] [MJSONWP] Calling AppiumDriver.getWindowRect() with args: ["237ad8bc-5b10-488d-9623-f1ba3753a1f8"]
[debug] [XCUITest] Executing command 'getWindowRect'
[HTTP] <-- GET /wd/hub/session/237ad8bc-5b10-488d-9623-f1ba3753a1f8/window/rect 404 5 ms - 35
[HTTP] --> GET /wd/hub/session/237ad8bc-5b10-488d-9623-f1ba3753a1f8/window/rect {}
```

----

## ref
- https://github.com/appium/ruby_lib/issues/739