### PR TITLE
Better handle broken crash reports

### DIFF
--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -36,14 +36,18 @@ class IOSCrashLog extends IOSDriverIOSCrashLog {
       log.debug(`Crash reports root '${crashLogsRoot}' does not exist. Got nothing to gather.`);
       return [];
     }
-    const foundFiles = await fs.glob(`${crashLogsRoot}/**/*.crash`, {realpath: true});
+    const foundFiles = await fs.glob(`${crashLogsRoot}/**/*.crash`);
     if (this.udid) {
       return foundFiles;
     }
     // For Simulator only include files, that contain current UDID
     return await B.filter(foundFiles, async (x) => {
-      const content = await fs.readFile(x, 'utf8');
-      return content.toUpperCase().includes(this.sim.udid.toUpperCase());
+      try {
+        const content = await fs.readFile(x, 'utf8');
+        return content.toUpperCase().includes(this.sim.udid.toUpperCase());
+      } catch (err) {
+        return false;
+      }
     });
   }
 


### PR DESCRIPTION
My computer recently crashed and generated a file like
```
-rw-------   1 isaac staff  69647 Jan 29 07:24  contactsdonationagent_2018-01-02-175430_Isaac-Murchie-SL0219.crash
-??????????  ? ?     ?          ?            ?  contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash
-rw-------   1 isaac staff  69213 Jan 29 07:24  contactsdonationagent_2018-01-06-015159_Isaac-Murchie-SL0219.crash
```

This, in turn, caused the start up to fail with the following:
```js
ERR! XCUITest Error: ENOENT: no such file or directory, lstat '/Users/isaac/Library/Logs/DiagnosticReports/contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash'
ERR! XCUITest     at Error (native)
ERR! XCUITest  { Error: ENOENT: no such file or directory, lstat '/Users/isaac/Library/Logs/DiagnosticReports/contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash'
ERR! XCUITest     at Error (native)
ERR! XCUITest   cause:
ERR! XCUITest    { Error: ENOENT: no such file or directory, lstat '/Users/isaac/Library/Logs/DiagnosticReports/contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash'
ERR! XCUITest        at Error (native)
ERR! XCUITest      errno: -2,
ERR! XCUITest      code: 'ENOENT',
ERR! XCUITest      syscall: 'lstat',
ERR! XCUITest      path: '/Users/isaac/Library/Logs/DiagnosticReports/contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash' },
ERR! XCUITest   isOperational: true,
ERR! XCUITest   errno: -2,
ERR! XCUITest   code: 'ENOENT',
ERR! XCUITest   syscall: 'lstat',
ERR! XCUITest   path: '/Users/isaac/Library/Logs/DiagnosticReports/contactsdonationagent_2018-01-05-165658_Isaac-Murchie-SL0219.crash' }
```

This patch fixes that.