### PR TITLE
Reboot Simulator when install cert

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -312,9 +312,9 @@ class XCUITestDriver extends BaseDriver {
 
       if (this.opts.customSSLCert) {
         if (await hasSSLCert(this.opts.customSSLCert, this.opts.udid)) {
-          log.info(`SSL cert ${_.truncate(this.opts.customSSLCert, {length: 20})} already installed`);
+          log.info(`SSL cert '${_.truncate(this.opts.customSSLCert, {length: 20})}' already installed`);
         } else {
-          log.info(`Installing ssl cert ${_.truncate(this.opts.customSSLCert, {length: 20})}`);
+          log.info(`Installing ssl cert '${_.truncate(this.opts.customSSLCert, {length: 20})}'`);
           await installSSLCert(this.opts.customSSLCert, this.opts.udid);
           log.info(`Restarting Simulator so that SSL certificate installation takes effect`);
           await this.opts.device.shutdown();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,7 +6,7 @@ import WebDriverAgent from './wda/webdriveragent';
 import log from './logger';
 import { createSim, getExistingSim, runSimulatorReset, installToSimulator,
          shutdownOtherSimulators } from './simulator-management';
-import { simExists, getSimulator, installSSLCert, uninstallSSLCert } from 'appium-ios-simulator';
+import { simExists, getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
 import { retryInterval } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps, appUtils, IWDP } from 'appium-ios-driver';
 import desiredCapConstraints from './desired-caps';
@@ -311,13 +311,16 @@ class XCUITestDriver extends BaseDriver {
       await this.startSim();
 
       if (this.opts.customSSLCert) {
-        log.info(`Installing ssl cert ${_.truncate(this.opts.customSSLCert, 20)}`);
-        log.warn(`If a certificate from this domain was already installed this test may fail and can be fixed by
-          erasing the contents of the Simulator (Simulator > Hardware > Erase All Content and Settings) and running the tests again`);
-        await installSSLCert(this.opts.customSSLCert, this.opts.udid);
-        await this.opts.device.shutdown();
-        await this.startSim();
-        this.logEvent('customCertInstalled');
+        if (await hasSSLCert(this.opts.customSSLCert, this.opts.udid)) {
+          log.info(`SSL cert ${_.truncate(this.opts.customSSLCert, {length: 20})} already installed`);
+        } else {
+          log.info(`Installing ssl cert ${_.truncate(this.opts.customSSLCert, {length: 20})}`);
+          await installSSLCert(this.opts.customSSLCert, this.opts.udid);
+          log.info(`Restarting Simulator so that SSL certificate installation takes effect`);
+          await this.opts.device.shutdown();
+          await this.startSim();
+          this.logEvent('customCertInstalled');
+        }
       }
 
       this.logEvent('simStarted');
@@ -501,10 +504,6 @@ class XCUITestDriver extends BaseDriver {
 
     if (this.opts.resetOnSessionStartOnly === false) {
       await this.runReset();
-    }
-
-    if (this.isSimulator() && this.opts.udid && this.opts.customSSLCert) {
-      await uninstallSSLCert(this.opts.customSSLCert, this.opts.udid);
     }
 
     if (this.isSimulator() && !this.opts.noReset && !!this.opts.device) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -224,10 +224,6 @@ class XCUITestDriver extends BaseDriver {
     this.opts.udid = udid;
     this.opts.realDevice = realDevice;
 
-    if (this.isSimulator() && this.opts.customSSLCert) {
-      await installSSLCert(this.opts.customSSLCert, this.opts.udid);
-      this.logEvent('customCertInstalled');
-    }
 
     if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
       await resetXCTestProcesses(this.opts.udid, true);
@@ -313,6 +309,17 @@ class XCUITestDriver extends BaseDriver {
       await this.opts.device.clearCaches('com.apple.mobile.installd.staging');
 
       await this.startSim();
+
+      if (this.opts.customSSLCert) {
+        log.info(`Installing ssl cert ${_.truncate(this.opts.customSSLCert, 20)}`);
+        log.warn(`If a certificate from this domain was already installed this test may fail and can be fixed by
+          erasing the contents of the Simulator (Simulator > Hardware > Erase All Content and Settings) and running the tests again`);
+        await installSSLCert(this.opts.customSSLCert, this.opts.udid);
+        await this.opts.device.shutdown();
+        await this.startSim();
+        this.logEvent('customCertInstalled');
+      }
+
       this.logEvent('simStarted');
       if (!isLogCaptureStarted) {
         // Retry log capture if Simulator was not running before

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "appium-base-driver": "^2.20.3",
     "appium-ios-driver": "^1.30.0",
-    "appium-ios-simulator": "^2.6.0",
+    "appium-ios-simulator": "^2.8.0",
     "appium-support": "^2.13.0",
     "appium-xcode": "^3.2.0",
     "async-lock": "^1.0.0",

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -17,7 +17,8 @@ chai.use(chaiAsPromised);
 const HTTPS_PORT = 9762;
 
 let caps = _.defaults({
-  safariInitialUrl: `https://localhost:${HTTPS_PORT}/`
+  safariInitialUrl: `https://localhost:${HTTPS_PORT}/`,
+  noReset: false,
 }, SAFARI_CAPS);
 
 let pemCertificate;
@@ -48,29 +49,26 @@ describe('Safari SSL', function () {
   });
 
   after(async function () {
-    if (server) {
-      await server.close();
-    }
-    if (sslServer) {
-      await sslServer.close();
-    }
+    await server.close();
+    await sslServer.close();
   });
 
-  describe('ssl cert', function () {
-    afterEach(async function () {
-      if (driver) {
-        await driver.quit();
-      }
-    });
+  it('should open pages with untrusted certs if the cert was provided in desired capabilities', async function () {
+    caps.customSSLCert = pemCertificate;
+    await driver.init(caps);
+    await driver.setPageLoadTimeout(3000);
+    await driver.get(`https://localhost:${HTTPS_PORT}/`);
+    let source = await driver.source();
+    source.should.include('Arbitrary text');
+    driver.quit();
+    await B.delay(1000);
 
-    it('should open pages with untrusted certs if the cert was provided in desired capabilities', async function () {
-      caps.customSSLCert = pemCertificate;
-      await driver.init(caps);
-      await driver.setPageLoadTimeout(3000);
-      await driver.get(`https://localhost:${HTTPS_PORT}/`);
-      let source = await driver.source();
-      source.should.include('Arbitrary text');
-      driver.quit();
-    });
+    // Now do another session using the same cert to verify that it still works
+    await driver.init(caps);
+    await driver.setPageLoadTimeout(3000);
+    await driver.get(`https://localhost:${HTTPS_PORT}/`);
+    source = await driver.source();
+    source.should.include('Arbitrary text');
+    await driver.quit();
   });
 });

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -14,11 +14,14 @@ const pem = B.promisifyAll(require('pem'));
 chai.should();
 chai.use(chaiAsPromised);
 
+const HTTPS_PORT = 9762;
+
 let caps = _.defaults({
-  safariInitialUrl: "https://localhost:9758/"
+  safariInitialUrl: `https://localhost:${HTTPS_PORT}/`
 }, SAFARI_CAPS);
 
 let pemCertificate;
+
 
 describe('Safari SSL', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -41,7 +44,7 @@ describe('Safari SSL', function () {
     const serverOpts = {key: keys.serviceKey, cert: pemCertificate};
     sslServer = https.createServer(serverOpts, (req, res) => {
       res.end('Arbitrary text');
-    }).listen(9758);
+    }).listen(HTTPS_PORT);
   });
 
   after(async function () {
@@ -64,7 +67,7 @@ describe('Safari SSL', function () {
       caps.customSSLCert = pemCertificate;
       await driver.init(caps);
       await driver.setPageLoadTimeout(3000);
-      await driver.get('https://localhost:9758/');
+      await driver.get(`https://localhost:${HTTPS_PORT}/`);
       let source = await driver.source();
       source.should.include('Arbitrary text');
       driver.quit();


### PR DESCRIPTION
* Since iOS 10.3 SQLite certificate installation stopped working in XCUITestDriver
* To make it work, the order of events has to be as follows:
  * Start a simulator
  * Install the SSL certificate
  * Restart the simulator
* Moved the installSSLCert function to _after_ the simulator is started and then restart the the Simulator so that the certificate will take effect

(related to https://github.com/appium/appium/issues#boards?milestones=Robot%2021%232018-02-02&repos=7530570)