### PR TITLE
Add random suffix to the temporary video name to avoid concurrent sessions conflicts

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -165,7 +165,10 @@ commands.startRecordingScreen = async function (options = {}) {
     this._recentScreenRecordingPath = null;
   }
 
-  const localPath = await tempDir.path({prefix: 'appium', suffix: DEFAULT_EXT});
+  const localPath = await tempDir.path({
+    prefix: `appium_${Math.random().toString(16).substring(2, 8)}`,
+    suffix: DEFAULT_EXT
+  });
 
   let binaryName;
   let args;


### PR DESCRIPTION
It might be that if one is running parallel sessions then these two will try to create a video recording with the same name, which is the undesired behaviour. This patch fixes it.