### PR TITLE
Wait for simulators shutdown when -shutdownOtherSimulators supplied

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -5,6 +5,10 @@ import { resetXCTestProcesses } from './utils';
 import _ from 'lodash';
 import log from './logger';
 import B from 'bluebird';
+import { waitForCondition } from "asyncbox";
+
+
+const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 
 // returns sim for desired caps
 async function createSim (caps, sessionId) {
@@ -116,6 +120,17 @@ async function shutdownOtherSimulators (currentDevice) {
   log.info(`Detected ${otherBootedDevices.length} other running Simulator${otherBootedDevices.length === 1 ? '' : 's'}.` +
            `Shutting ${otherBootedDevices.length === 1 ? 'it' : 'them'} down...`);
   await B.each(otherBootedDevices, async (device) => await shutdown(device.udid));
+
+
+  const waitForShutdown = async (udid) => {
+    await waitForCondition(async () => {
+      const {state} = _.flatMap(_.values(await getDevices())).filter((device) => device.udid === udid);
+      return state === 'Shutdown';
+    }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
+  };
+
+  await B.each(otherBootedDevices, async (device) => await waitForShutdown(device.udid));
+  log.info('All other simulators were shutted down');
 }
 
 export { createSim, getExistingSim, runSimulatorReset, installToSimulator, shutdownOtherSimulators };


### PR DESCRIPTION
This PR isWait until simulator switched from `Shutting Down` to 'Shutdown' state when we start new session with -shutdownOtherSimulators capability. (see #9954)
This fixes issue described below:
  Assume we need to run mobile safari tests on: iPhone, iPad, iPhone 
 We run session on iPhone. Then we are starting session with iPad simulator. Window with iPhone closes and window with iPad opens. (!)But in 2..5 seconds window with iPhone simulator appears again (don't know why, maybe xcode bug). This window sometimes automatically closes in ~ 30..60 seconds but sometimes it remains opened. (Note that at this stage safari session is correctly redirected to iPad. ) Assume that old iPhone window remains opened. Then we should start new (3rd) session on iPhone. As expected widow with iPad closes. Window with iPhone still opened  but(!)  we cannot connect to it because of error: _Could not navigate to webview! Err: connect ECONNREFUSED_ (apple bug) Every subsequent request for iPhone session will end with that error. 

 Current PR does not have such issue. I.e. when new device opened then old one does not appears again. 