### PR TITLE
Fix getting xcode version flow

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -243,7 +243,7 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (!this.opts.webDriverAgentUrl) {
+    if (!this.opts.webDriverAgentUrl && this.iosSdkVersion) {
       // make sure that the xcode we are using can handle the platform
       if (parseFloat(this.opts.platformVersion) > parseFloat(this.iosSdkVersion)) {
         let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +
@@ -251,7 +251,7 @@ class XCUITestDriver extends BaseDriver {
         log.errorAndThrow(msg);
       }
     } else {
-      log.debug(`Xcode version will not be validated against iOS SDK version because webDriverAgentUrl capability is set (${this.opts.webDriverAgentUrl}).`);
+      log.debug('Xcode version will not be validated against iOS SDK version.');
     }
 
     if ((this.opts.browserName || '').toLowerCase() === 'safari') {
@@ -657,7 +657,7 @@ class XCUITestDriver extends BaseDriver {
 
     // no device of this type exists, so create one
     log.info('Simulator udid not provided, using desired caps to create a new simulator');
-    if (!this.opts.platformVersion) {
+    if (!this.opts.platformVersion && this.iosSdkVersion) {
       log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
                `This may cause problems if a simulator does not exist for this platform version.`);
       this.opts.platformVersion = this.iosSdkVersion;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -144,7 +144,7 @@ class XCUITestDriver extends BaseDriver {
     this.webElementIds = [];
     this._currentUrl = null;
     this.curContext = null;
-    this.xcodeVersion = null;
+    this.xcodeVersion = {};
     this.iosSdkVersion = null;
     this.contexts = [];
     this.implicitWaitMs = 0;
@@ -208,6 +208,16 @@ class XCUITestDriver extends BaseDriver {
       throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
     }
 
+    if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
+      // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
+      this.xcodeVersion = await getAndCheckXcodeVersion();
+      let tools = !this.xcodeVersion.toolsVersion ? '' : `(tools v${this.xcodeVersion.toolsVersion})`;
+      log.debug(`Xcode version set to '${this.xcodeVersion.versionString}' ${tools}`);
+
+      this.iosSdkVersion = await getAndCheckIosSdkVersion();
+      log.debug(`iOS SDK Version set to '${this.iosSdkVersion}'`);
+    }
+
     this.logEvent('xcodeDetailsRetrieved');
 
     let {device, udid, realDevice} = await this.determineDevice();
@@ -215,21 +225,6 @@ class XCUITestDriver extends BaseDriver {
     this.opts.device = device;
     this.opts.udid = udid;
     this.opts.realDevice = realDevice;
-
-    if (!this.xcodeVersion) {
-      if (!this.opts.webDriverAgentUrl || !this.opts.realDevice) {
-        // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
-        this.xcodeVersion = await getAndCheckXcodeVersion();
-        let tools = !this.xcodeVersion.toolsVersion ? '' : `(tools v${this.xcodeVersion.toolsVersion})`;
-        log.debug(`Xcode version set to '${this.xcodeVersion.versionString}' ${tools}`);
-
-        this.iosSdkVersion = await getAndCheckIosSdkVersion();
-        log.debug(`iOS SDK Version set to '${this.iosSdkVersion}'`);
-      } else {
-        // `webDriverAgentUrl` has been set on real device, so no need to have an Xcode version
-        this.xcodeVersion = {};
-      }
-    }
 
     if (this.opts.enableAsyncExecuteFromHttps && !this.isRealDevice()) {
       await resetXCTestProcesses(this.opts.udid, true);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,9 +91,6 @@ async function translateDeviceName (xcodeVersion, platformVersion, devName = '')
     case 'iphone 8':
     case 'iphone 8 plus':
     case 'iphone x':
-      if (_.isEmpty(xcodeVersion)) {
-        break;
-      }
       // Xcode 9.0(.0) mis-named the new devices
       if (xcodeVersion.major === 9 &&
           xcodeVersion.minor === 0 &&


### PR DESCRIPTION
It is necessary to init `xcodeversion` property before `determineDevice` is called. Also, it would be safer to assign it to an empty object from the beginning.