### PR TITLE
Implement performance measurement with `instruments` utility

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -53,6 +53,8 @@ extensions.executeMobile = async function (mobileCommand, opts = {}) {
     activateApp: 'mobileActivateApp',
     //endregion multiple apps management
     viewportScreenshot: 'getViewportScreenshot',
+    startPerfRecord: 'mobileStartPerfRecord',
+    stopPerfRecord: 'mobileStopPerfRecord',
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -18,6 +18,7 @@ import locationExtensions from './location';
 import recordScreenExtensions from './recordscreen';
 import lockExtensions from './lock';
 import appManagementExtensions from './app-management';
+import performanceExtensions from './performance';
 
 let commands = {};
 
@@ -26,7 +27,7 @@ Object.assign(commands, contextCommands, executeExtensions,
   generalExtensions, logExtensions, webExtensions, timeoutExtensions,
   navigationExtensions, elementExtensions, fileMovementExtensions,
   alertExtensions, screenshotExtensions, pasteboardExtensions, locationExtensions,
-  lockExtensions, recordScreenExtensions, appManagementExtensions
+  lockExtensions, recordScreenExtensions, appManagementExtensions, performanceExtensions
 );
 
 export default commands;

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -1,0 +1,196 @@
+import _ from 'lodash';
+import path from 'path';
+import { fs, tempDir } from 'appium-support';
+import { SubProcess, exec } from 'teen_process';
+import log from '../logger';
+import { encodeBase64OrUpload } from '../utils';
+import { waitForCondition } from 'asyncbox';
+
+
+let commands = {};
+
+const RECORDERS_CACHE = {};
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const STOP_TIMEOUT_MS = 3 * 60 * 1000;
+const START_TIMEOUT_MS = 15 * 1000;
+const DEFAULT_PROFILE_NAME= 'Activity Monitor';
+const DEFAULT_EXT = '.trace';
+
+
+async function finishPerfRecord (proc, stopGracefully = true) {
+  if (!proc.isRunning) {
+    return;
+  }
+  if (stopGracefully) {
+    log.debug(`Sending SIGINT to the running instruments process`);
+    return await proc.stop('SIGINT', STOP_TIMEOUT_MS);
+  }
+  log.debug(`Sending SIGTERM to the running instruments process`);
+  await proc.stop();
+}
+
+async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
+  try {
+    return await encodeBase64OrUpload(localFile, remotePath, uploadOptions);
+  } finally {
+    await fs.rimraf(localFile);
+  }
+}
+
+
+/**
+ * @typedef {Object} StartPerfRecordOptions
+ *
+ * @property {?number|string} timeout [300000] - The maximum count of milliseconds to record the profiling information.
+ * @property {?string} profileName [Activity Monitor] - The name of existing performance profile to apply.
+ *                                                      Execute `instruments -s` to show the list of available profiles.
+ *                                                      Note, that not all profiles are supported on mobile devices.
+ */
+
+/**
+ * Starts performance profiling for the device under test.
+ * The `instruments` developer utility is used for this purpose under the hood.
+ * It is possible to record multiple profiles at the same time.
+ * Read https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html
+ * for more details.
+ *
+ * @param {?StartPerfRecordOptions} opts - The set of possible start record options
+ */
+commands.mobileStartPerfRecord = async function (opts = {}) {
+  if (!this.relaxedSecurityEnabled && !process.env.CI && !this.isRealDevice()) {
+    log.errorAndThrow(`Appium server must have relaxed security flag set in order ` +
+                      `for Simulator performance measurement to work`);
+  }
+
+  const {timeout=DEFAULT_TIMEOUT_MS, profileName=DEFAULT_PROFILE_NAME} = opts;
+
+  // Cleanup the process if it is already running
+  const runningRecorders = RECORDERS_CACHE[profileName];
+  if (_.isPlainObject(runningRecorders) && runningRecorders[this.opts.device.udid]) {
+    const {proc, localPath} = runningRecorders[this.opts.device.udid];
+    await finishPerfRecord(proc, false);
+    if (await fs.exists(localPath)) {
+      await fs.rimraf(localPath);
+    }
+    delete runningRecorders[this.opts.device.udid];
+  }
+
+  if (!await fs.which('instruments')) {
+    log.errorAndThrow(`Cannot start performance recording, because 'instruments' ` +
+                      `tool cannot be found in PATH`);
+  }
+
+  const localPath = await tempDir.path({
+    prefix: `appium_perf_${profileName}_${Date.now()}`.replace(/\W/g, '_'),
+    suffix: DEFAULT_EXT,
+  });
+  const args = [
+    '-w', this.opts.device.udid,
+    '-t', profileName,
+    '-D', localPath,
+    '-l', `${timeout}`,
+  ];
+  const proc = new SubProcess('instruments', args);
+  log.info(`Starting 'instruments' with arguments: ${args.join(' ')}`);
+  proc.on('exit', (code) => {
+    const msg = `instruments exited with code '${code}'`;
+    if (code) {
+      log.warn(msg);
+    } else {
+      log.debug(msg);
+    }
+  });
+  proc.on('output', (stdout, stderr) => {
+    (stdout || stderr).split('\n')
+      .filter(x => x.length)
+      .map(x => log.debug(`[instruments] ${x}`));
+  });
+
+  await proc.start(0);
+  try {
+    await waitForCondition(async () => await fs.exists(localPath), {
+      waitMs: START_TIMEOUT_MS,
+      intervalMs: 500,
+    });
+  } catch (err) {
+    log.errorAndThrow(`Cannot start performance monitoring for '${profileName}' profile in ${START_TIMEOUT_MS}ms. ` +
+                      `Make sure you can execute it manually.`);
+  }
+  RECORDERS_CACHE[profileName] = Object.assign({}, (RECORDERS_CACHE[profileName] || {}), {
+    [this.opts.device.udid]: {proc, localPath},
+  });
+};
+
+/**
+ * @typedef {Object} StopRecordingOptions
+ *
+ * @property {?string} remotePath - The path to the remote location, where the resulting zipped .trace file should be uploaded.
+ *                                  The following protocols are supported: http/https, ftp.
+ *                                  Null or empty string value (the default setting) means the content of resulting
+ *                                  file should be zipped, encoded as Base64 and passed as the endpount response value.
+ *                                  An exception will be thrown if the generated file is too big to
+ *                                  fit into the available process memory.
+ * @property {?string} user - The name of the user for the remote authentication. Only works if `remotePath` is provided.
+ * @property {?string} pass - The password for the remote authentication. Only works if `remotePath` is provided.
+ * @property {?string} method [PUT] - The http multipart upload method name. Only works if `remotePath` is provided.
+ * @property {?string} profileName [Activity Monitor] - The name of an existing performance profile for which the recording has been made.
+ */
+
+/**
+ * Stops performance profiling for the device under test.
+ * The resulting file in .trace format can be either returned
+ * directly as base64-encoded zip archive or uploaded to a remote location
+ * (such files can be pretty large). Afterwards it is possible to unarchive and
+ * open such file with Xcode Dev Tools.
+ *
+ * @param {?StopRecordingOptions} opts - The set of possible stop record options
+ * @return {string} Either an empty string if the upload wqaas successful or base-64 encoded
+ * content of zipped .trace file.
+ * @throws {Error} If no performance recording with given profile name/device udid combination
+ * has been started before or the resulting .trace file has not been generated properly.
+ */
+commands.mobileStopPerfRecord = async function (opts = {}) {
+  if (!this.relaxedSecurityEnabled && !process.env.CI && !this.isRealDevice()) {
+    log.errorAndThrow(`Appium server must have relaxed security flag set in order ` +
+                      `for Simulator performance measurement to work`);
+  }
+
+  const {remotePath, user, pass, method, profileName=DEFAULT_PROFILE_NAME} = opts;
+  const runningRecorders = RECORDERS_CACHE[profileName];
+  if (!_.isPlainObject(runningRecorders) || !runningRecorders[this.opts.device.udid]) {
+    log.errorAndThrow(`There are no records for performance profile '${profileName}' ` +
+                      `and device ${this.opts.device.udid}. ` +
+                      `Have you started the profiling before?`);
+  }
+
+  const {proc, localPath} = runningRecorders[this.opts.device.udid];
+  await finishPerfRecord(proc, true);
+  if (!await fs.exists(localPath)) {
+    log.errorAndThrow(`There is no .trace file found for performance profile '${profileName}' ` +
+                      `and device ${this.opts.device.udid}. ` +
+                      `Make sure the profile is supported on this device. ` +
+                      `You can use 'instruments -s' command to see the list of all available profiles.`);
+  }
+
+  const zipPath = `${localPath}.zip`;
+  const zipArgs = [
+    '-r', zipPath,
+    path.basename(localPath),
+  ];
+  log.info(`Found perf trace record '${localPath}'. Compressing it with 'zip ${zipArgs.join(' ')}'`);
+  try {
+    await exec('zip', zipArgs, {
+      cwd: path.dirname(localPath),
+    });
+    return await uploadTrace(zipPath, remotePath, {user, pass, method});
+  } finally {
+    delete runningRecorders[this.opts.device.udid];
+    if (await fs.exists(localPath)) {
+      await fs.rimraf(localPath);
+    }
+  }
+};
+
+
+export { commands };
+export default commands;

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -1,12 +1,10 @@
 import _ from 'lodash';
-import _fs from 'fs';
-import url from 'url';
 import { retryInterval, waitForCondition } from 'asyncbox';
 import B from 'bluebird';
-import { util, fs, net, tempDir } from 'appium-support';
+import { util, fs, tempDir } from 'appium-support';
 import { exec } from 'teen_process';
 import log from '../logger';
-import { getPidUsingPattern } from '../utils';
+import { getPidUsingPattern, encodeBase64OrUpload } from '../utils';
 
 
 let commands = {};
@@ -51,51 +49,8 @@ async function finishScreenCapture (pid) {
 }
 
 async function uploadRecordedMedia (localFile, remotePath = null, uploadOptions = {}) {
-  if (!await fs.exists(localFile)) {
-    log.errorAndThrow(`The screen capture at '${localFile}' does not exist or is not accessible.` +
-                      `Does the screen capture utility work properly?`);
-  }
-
   try {
-    const {size} = await fs.stat(localFile);
-    log.debug(`The size of the recent screen recording is ${util.toReadableSizeString(size)}`);
-    if (_.isEmpty(remotePath)) {
-      const memoryUsage = process.memoryUsage();
-      const maxMemoryLimit = (memoryUsage.heapTotal - memoryUsage.heapUsed) / 2;
-      if (size >= maxMemoryLimit) {
-        throw new Error(`Cannot read the recorded media '${localFile}' to the memory, ` +
-                        `because the file is too large ` +
-                        `(${util.toReadableSizeString(size)} >= ${util.toReadableSizeString(maxMemoryLimit)}). ` +
-                        `Try to provide a link to a remote writable location instead.`);
-      }
-      const content = await fs.readFile(localFile);
-      return content.toString('base64');
-    }
-
-    const remoteUrl = url.parse(remotePath);
-    let options = {};
-    const {user, pass, method} = uploadOptions;
-    if (remoteUrl.protocol.startsWith('http')) {
-      options = {
-        url: remoteUrl.href,
-        method: method || 'PUT',
-        multipart: [{ body: _fs.createReadStream(localFile) }],
-      };
-      if (user && pass) {
-        options.auth = {user, pass};
-      }
-    } else if (remoteUrl.protocol === 'ftp') {
-      options = {
-        host: remoteUrl.hostname,
-        port: remoteUrl.port || 21,
-      };
-      if (user && pass) {
-        options.user = user;
-        options.pass = pass;
-      }
-    }
-    await net.uploadFile(localFile, remotePath, options);
-    return '';
+    return await encodeBase64OrUpload(localFile, remotePath, uploadOptions);
   } finally {
     await fs.rimraf(localFile);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,13 @@
 import B from 'bluebird';
-import { fs, util } from 'appium-support';
+import { fs, util, net } from 'appium-support';
 import path from 'path';
 import { utils as iosUtils } from 'appium-ios-driver';
 import { SubProcess, exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from './logger';
-
+import _fs from 'fs';
+import url from 'url';
 
 const DEFAULT_TIMEOUT_KEY = 'default';
 
@@ -381,9 +382,78 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
   });
 }
 
+/**
+ * @typedef {Object} UploadOptions
+ *
+ * @property {?string} user - The name of the user for the remote authentication. Only works if `remotePath` is provided.
+ * @property {?string} pass - The password for the remote authentication. Only works if `remotePath` is provided.
+ * @property {?string} method - The http multipart upload method name. The 'PUT' one is used by default.
+ *                              Only works if `remotePath` is provided.
+ */
+
+
+/**
+ * Encodes the given local file to base64 and returns the resulting string
+ * or uploads it to a remote server using http/https or ftp protocols
+ * if `remotePath` is set
+ *
+ * @param {string} localFile - The path to an existing local file
+ * @param {?string} remotePath - The path to the remote location, where
+ *                               this file should be uploaded
+ * @param {?UploadOptions} uploadOptions - Set of upload options
+ * @returns {string} Either an empty string if the upload was successful or
+ * base64-encoded file representation if `remotePath` is falsy
+ * @throws {Error} If there was upload failure or the file content is too big
+ * to fit in the available process memory.
+ */
+async function encodeBase64OrUpload (localFile, remotePath = null, uploadOptions = {}) {
+  if (!await fs.exists(localFile)) {
+    log.errorAndThrow(`The file at '${localFile}' does not exist or is not accessible`);
+  }
+
+  const {size} = await fs.stat(localFile);
+  log.debug(`The size of the file is ${util.toReadableSizeString(size)}`);
+  if (_.isEmpty(remotePath)) {
+    const memoryUsage = process.memoryUsage();
+    const maxMemoryLimit = (memoryUsage.heapTotal - memoryUsage.heapUsed) / 2;
+    if (size >= maxMemoryLimit) {
+      throw new Error(`Cannot read '${localFile}' to the memory, because the file is too large ` +
+                      `(${util.toReadableSizeString(size)} >= ${util.toReadableSizeString(maxMemoryLimit)}). ` +
+                      `Try to provide a link to a remote writable location instead.`);
+    }
+    const content = await fs.readFile(localFile);
+    return content.toString('base64');
+  }
+
+  const remoteUrl = url.parse(remotePath);
+  let options = {};
+  const {user, pass, method} = uploadOptions;
+  if (remoteUrl.protocol.startsWith('http')) {
+    options = {
+      url: remoteUrl.href,
+      method: method || 'PUT',
+      multipart: [{ body: _fs.createReadStream(localFile) }],
+    };
+    if (user && pass) {
+      options.auth = {user, pass};
+    }
+  } else if (remoteUrl.protocol === 'ftp:') {
+    options = {
+      host: remoteUrl.hostname,
+      port: remoteUrl.port || 21,
+    };
+    if (user && pass) {
+      options.user = user;
+      options.pass = pass;
+    }
+  }
+  await net.uploadFile(localFile, remotePath, options);
+  return '';
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
          DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
          markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo,
-         getPIDsListeningOnPort };
+         getPIDsListeningOnPort, encodeBase64OrUpload };

--- a/test/functional/basic/performance-e2e-specs.js
+++ b/test/functional/basic/performance-e2e-specs.js
@@ -24,7 +24,7 @@ describe('XCUITestDriver - perfomance', function () {
 
     it('should return recorded trace file on stop', async function () {
       if (process.env.CI) {
-        // It looks like Travis is just way to slow to execute it properly
+        // It looks like Travis is just way too slow
         return this.skip();
       }
       await driver.execute('mobile: startPerfRecord', {});

--- a/test/functional/basic/performance-e2e-specs.js
+++ b/test/functional/basic/performance-e2e-specs.js
@@ -1,0 +1,35 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import B from 'bluebird';
+import { UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('XCUITestDriver - perfomance', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let driver;
+
+  describe('record performance metrics', function () {
+    before(async function () {
+      driver = await initSession(UICATALOG_CAPS);
+      driver.relaxedSecurityEnabled = true;
+    });
+    after(async function () {
+      await deleteSession();
+    });
+
+    it('should return recorded trace file on stop', async function () {
+      if (process.env.CI) {
+        // It looks like Travis is just way to slow to execute it properly
+        return this.skip();
+      }
+      await driver.execute('mobile: startPerfRecord', {});
+      await B.delay(5000);
+      (await driver.execute('mobile: stopPerfRecord', {})).should.not.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
Based on https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html

I've added `relaxedSecurityEnabled` verification, since by default the `instruments` utility adds metrics for all the processes running on the host machine, and not only these, which are running inside the simulator.