### PR TITLE
Add a possibility to set process id for perf measurement

### DIFF
--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -93,14 +93,14 @@ commands.mobileStartPerfRecord = async function (opts = {}) {
     '-w', this.opts.device.udid,
     '-t', profileName,
     '-D', localPath,
-    '-l', `${timeout}`,
+    '-l', timeout,
   ];
   if (pid) {
     if (`${pid}`.toLowerCase() === 'current') {
       const appInfo = await this.proxyCommand('/wda/activeAppInfo', 'GET');
-      args.push('-p', `${appInfo.pid}`);
-    } else if (!isNaN(parseInt(pid, 10))) {
-      args.push('-p', `${parseInt(pid, 10)}`);
+      args.push('-p', appInfo.pid);
+    } else {
+      args.push('-p', pid);
     }
   }
   const proc = new SubProcess('instruments', args);

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -45,6 +45,11 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
  * @property {?string} profileName [Activity Monitor] - The name of existing performance profile to apply.
  *                                                      Execute `instruments -s` to show the list of available profiles.
  *                                                      Note, that not all profiles are supported on mobile devices.
+ * @property {?string|number} pid - The ID of the process to meassure the performance for.
+ *                                  Set it to `current` in order to meassure the performance of
+ *                                  the process, which belongs to the currently active application.
+ *                                  All processes running on the device are meassured if
+ *                                  pid is unset (the default setting).
  */
 
 /**
@@ -62,7 +67,7 @@ commands.mobileStartPerfRecord = async function (opts = {}) {
                       `for Simulator performance measurement to work`);
   }
 
-  const {timeout=DEFAULT_TIMEOUT_MS, profileName=DEFAULT_PROFILE_NAME} = opts;
+  const {timeout=DEFAULT_TIMEOUT_MS, profileName=DEFAULT_PROFILE_NAME, pid} = opts;
 
   // Cleanup the process if it is already running
   const runningRecorders = RECORDERS_CACHE[profileName];
@@ -90,6 +95,14 @@ commands.mobileStartPerfRecord = async function (opts = {}) {
     '-D', localPath,
     '-l', `${timeout}`,
   ];
+  if (pid) {
+    if (`${pid}`.toLowerCase() === 'current') {
+      const appInfo = await this.proxyCommand('/wda/activeAppInfo', 'GET');
+      args.push('-p', `${appInfo.pid}`);
+    } else if (!isNaN(parseInt(pid, 10))) {
+      args.push('-p', `${parseInt(pid, 10)}`);
+    }
+  }
   const proc = new SubProcess('instruments', args);
   log.info(`Starting 'instruments' with arguments: ${args.join(' ')}`);
   proc.on('exit', (code) => {

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -190,7 +190,7 @@ commands.mobileStopPerfRecord = async function (opts = {}) {
 
   const zipPath = `${localPath}.zip`;
   const zipArgs = [
-    '-r', zipPath,
+    '-9', '-r', zipPath,
     path.basename(localPath),
   ];
   log.info(`Found perf trace record '${localPath}'. Compressing it with 'zip ${zipArgs.join(' ')}'`);

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -126,6 +126,9 @@ commands.mobileStartPerfRecord = async function (opts = {}) {
       intervalMs: 500,
     });
   } catch (err) {
+    try {
+      await proc.stop('SIGKILL');
+    } catch (ign) {}
     log.errorAndThrow(`Cannot start performance monitoring for '${profileName}' profile in ${START_TIMEOUT_MS}ms. ` +
                       `Make sure you can execute it manually.`);
   }

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -82,7 +82,7 @@ commands.mobileStartPerfRecord = async function (opts = {}) {
 
   if (!await fs.which('instruments')) {
     log.errorAndThrow(`Cannot start performance recording, because 'instruments' ` +
-                      `tool cannot be found in PATH`);
+                      `tool cannot be found in PATH. Are Xcode development tools installed?`);
   }
 
   const localPath = await tempDir.path({


### PR DESCRIPTION
Reports generated for the particular process id are much more compact in size in comparison to reports recorded for all running processes.