### PR TITLE
Update command timeout logic

### DIFF
--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -44,7 +44,7 @@ helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand 
   if (!cmdName) {
     // this should never happen except when adding new routes
     cmdName = 'Unknown'; // just for logging purposes below
-    log.warn(`Proxing to WDA with an unknown route: ${method}:${endpoint}`);
+    log.warn(`Proxying to WDA with an unknown route: ${method}:${endpoint}`);
   }
 
   let res = null;

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -39,8 +39,14 @@ helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand 
     throw new Error('Cannot call proxyCommand without WDA proxy active');
   }
 
-  const cmdName = wdaRouteToCommandName(endpoint, method) || routeToCommandName(endpoint, method);
+  let cmdName = wdaRouteToCommandName(endpoint, method) || routeToCommandName(endpoint, method);
   const timeout = this._getCommandTimeout(cmdName);
+  if (!cmdName) {
+    // this should never happen except when adding new routes
+    cmdName = 'Unknown'; // just for logging purposes below
+    log.warn(`Proxing to WDA with an unknown route: ${method}:${endpoint}`);
+  }
+
   let res = null;
   if (timeout) {
     log.debug(`Setting custom timeout to ${timeout} ms for '${cmdName}' command`);

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -7,6 +7,19 @@ const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE'];
 
 let helpers = {}, extensions = {};
 
+
+function wdaRouteToCommandName (endpoint, method) {
+  let commandName;
+  switch (endpoint) {
+    case '/wda/touch/perform':
+      if (method === 'POST') {
+        commandName = 'performTouch';
+      }
+      break;
+  }
+  return commandName;
+}
+
 helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand = true) {
   if (this.shutdownUnexpectedly) {
     return;
@@ -19,27 +32,27 @@ helpers.proxyCommand = async function (endpoint, method, body, isSessionCommand 
   }
 
   if (!this.wda) {
-    throw new Error("Can't call proxyCommand without WDA driver active");
+    throw new Error('Cannot call proxyCommand without WDA driver active');
   }
   const proxy = isSessionCommand ? this.wda.jwproxy : this.wda.noSessionProxy;
   if (!proxy) {
-    throw new Error("Can't call proxyCommand without WDA proxy active");
+    throw new Error('Cannot call proxyCommand without WDA proxy active');
   }
 
-  const cmdName = routeToCommandName(endpoint, method);
+  const cmdName = wdaRouteToCommandName(endpoint, method) || routeToCommandName(endpoint, method);
   const timeout = this._getCommandTimeout(cmdName);
   let res = null;
   if (timeout) {
-    log.debug(`Setting custom timeout to ${timeout} ms for "${cmdName}" command`);
+    log.debug(`Setting custom timeout to ${timeout} ms for '${cmdName}' command`);
     let isCommandExpired = false;
-    res = await B.Promise.resolve(proxy.command(endpoint, method, body))
+    res = await B.resolve(proxy.command(endpoint, method, body))
                   .timeout(timeout)
                   .catch(B.Promise.TimeoutError, () => {
                     isCommandExpired = true;
                   });
     if (isCommandExpired) {
       proxy.cancelActiveRequests();
-      const errMsg = `Appium did not get any response from "${cmdName}" command in ${timeout} ms`;
+      const errMsg = `Appium did not get any response from '${cmdName}' command in ${timeout} ms`;
       await this.startUnexpectedShutdown(new errors.TimeoutError(errMsg));
       log.errorAndThrow(errMsg);
     }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -67,7 +67,8 @@ let desiredCapConstraints = _.defaults({
     isBoolean: true
   },
   commandTimeouts: {
-    isString: true
+    // recognize the cap,
+    // but validate in the driver#validateDesiredCaps method
   },
   wdaStartupRetries: {
     isNumber: true

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -879,6 +879,10 @@ class XCUITestDriver extends BaseDriver {
     this.opts.resetOnSessionStartOnly = !util.hasValue(this.opts.resetOnSessionStartOnly) || this.opts.resetOnSessionStartOnly;
     this.opts.useNewWDA = util.hasValue(this.opts.useNewWDA) ? this.opts.useNewWDA : false;
 
+    if (caps.commandTimeouts) {
+      caps.commandTimeouts = normalizeCommandTimeouts(caps.commandTimeouts);
+    }
+
     // finally, return true since the superclass check passed, as did this
     return true;
   }
@@ -928,7 +932,6 @@ class XCUITestDriver extends BaseDriver {
   }
 
   _getCommandTimeout (cmdName) {
-    this.opts.commandTimeouts = normalizeCommandTimeouts(this.opts.commandTimeouts);
     if (this.opts.commandTimeouts) {
       if (cmdName && _.has(this.opts.commandTimeouts, cmdName)) {
         return this.opts.commandTimeouts[cmdName];


### PR DESCRIPTION
* allow `commandTimeouts` cap to be an object, which is then parsed in the validate function.
* we currently map routes to commands at the base driver level, but there are commands that WDA handles that have different routes. This just handle the single case I've come up against. More will need to be added as they present themselves (or someone has time to do an exhaustive search).
* log when the route does not map to a command name, so developers can figure out what is wrong.