### PR TITLE
Clean up some tests

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -298,7 +298,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (!this.opts.bundleId) {
-      this.opts.bundleId = await this.extractBundleId(this.opts.app);
+      this.opts.bundleId = await appUtils.extractBundleId(this.opts.app);
     }
 
     await this.runReset();
@@ -490,12 +490,6 @@ class XCUITestDriver extends BaseDriver {
       this.wda.fullyStarted = true;
       this.logEvent('wdaStarted');
     });
-  }
-
-  // create an alias so we can actually unit test createSession by stubbing
-  // this
-  async extractBundleId (app) {
-    return await appUtils.extractBundleId(app);
   }
 
   async runReset (opts = null) {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "appium-event-parser": "^1.0.0",
     "appium-gulp-plugins": "^2.2.0",
-    "appium-test-support": "^0.4.0",
+    "appium-test-support": "^1.0.0",
     "babel-eslint": "^7.1.1",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",

--- a/test/unit/commands/alert-specs.js
+++ b/test/unit/commands/alert-specs.js
@@ -23,13 +23,15 @@ describe('alert commands', function () {
       proxySpy.firstCall.args[1].should.eql('GET');
     });
   });
-  describe.skip('setAlertText', function () {
+  describe('setAlertText', function () {
     it('should send translated POST request to WDA', async function () {
       await driver.setAlertText('some text');
       proxySpy.calledOnce.should.be.true;
       proxySpy.firstCall.args[0].should.eql('/alert/text');
       proxySpy.firstCall.args[1].should.eql('POST');
-      proxySpy.firstCall.args[2].should.eql('some text');
+      proxySpy.firstCall.args[2].should.eql({value:
+        ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't'],
+      });
     });
   });
   describe('postAcceptAlert', function () {

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -3,8 +3,8 @@ import XCUITestDriver from '../../..';
 
 
 describe('general commands', function () {
-  let driver = new XCUITestDriver();
-  let proxySpy = sinon.stub(driver, 'proxyCommand');
+  const driver = new XCUITestDriver();
+  const proxySpy = sinon.stub(driver, 'proxyCommand');
 
   afterEach(function () {
     proxySpy.reset();

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -3,8 +3,8 @@ import XCUITestDriver from '../../..';
 
 
 describe('general commands', function () {
-  let driver = new XCUITestDriver();
-  let proxySpy = sinon.stub(driver, 'proxyCommand');
+  const driver = new XCUITestDriver();
+  const proxySpy = sinon.stub(driver, 'proxyCommand');
 
   afterEach(function () {
     proxySpy.reset();

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -4,8 +4,8 @@ import { gesturesChainToString } from '../../../lib/commands/gesture';
 
 
 describe('gesture commands', function () {
-  let driver = new XCUITestDriver();
-  let proxySpy = sinon.stub(driver, 'proxyCommand');
+  const driver = new XCUITestDriver();
+  const proxySpy = sinon.stub(driver, 'proxyCommand');
 
   afterEach(function () {
     proxySpy.reset();

--- a/test/unit/commands/proxy-helper-specs.js
+++ b/test/unit/commands/proxy-helper-specs.js
@@ -12,7 +12,7 @@ describe('proxy commands', function () {
   let driver = new XCUITestDriver();
   // give the driver a spy-able proxy object
   driver.wda = {jwproxy: {command: () => {}}};
-  let proxyStub = sinon.stub(driver.wda.jwproxy, 'command');
+  const proxyStub = sinon.stub(driver.wda.jwproxy, 'command');
 
   afterEach(function () {
     if (proxyStub) {
@@ -34,7 +34,7 @@ describe('proxy commands', function () {
       await driver.proxyCommand(null, 'POST', {some: 'stuff'}).should.eventually.be.rejectedWith(/endpoint/);
       proxyStub.callCount.should.eql(0);
     });
-    it('should throw an error if no endpoint is given', async function () {
+    it('should throw an error if no method is given', async function () {
       await driver.proxyCommand('/some/endpoint', null, {some: 'stuff'}).should.eventually.be.rejectedWith(/GET, POST/);
       proxyStub.callCount.should.eql(0);
     });

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -23,16 +23,13 @@ describe('basic', withMocks({driver, fs, tempDir, utils, teen_process}, function
     }
   };
 
+  afterEach(function () {
+    mocks.verify();
+  });
+
   describe('startRecordingScreen', function () {
     beforeEach(function () {
       driver._recentScreenRecordingPath = null;
-    });
-    afterEach(function () {
-      mocks.driver.verify();
-      mocks.utils.verify();
-      mocks.teen_process.verify();
-      mocks.tempDir.verify();
-      mocks.fs.verify();
     });
 
     it('should call simctl to start screen recording on Simulator', async function () {
@@ -88,13 +85,6 @@ describe('basic', withMocks({driver, fs, tempDir, utils, teen_process}, function
   describe('stopRecordingScreen', function () {
     beforeEach(function () {
       mocks.driver.expects('isRealDevice').returns(false);
-    });
-    afterEach(function () {
-      mocks.driver.verify();
-      mocks.utils.verify();
-      mocks.teen_process.verify();
-      mocks.tempDir.verify();
-      mocks.fs.verify();
     });
 
     it('should kill the process and get the content of the created mp4 file using ps', async function () {

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -49,19 +49,20 @@ describe('language and locale', function () {
 
   describe('send process args, language and locale json', function () {
     it('should send translated POST /session request with valid desired caps to WDA', async function () {
-
-      let processArguments = {
-        args: ["a", "b", "c"]
-        , env: { "a": "b", "c": "d" }
+      const processArguments = {
+        args: ["a", "b", "c"],
+        env: { "a": "b", "c": "d" }
       };
 
-      let augmentedProcessArgumentsWithLanguage = {
-        args: processArguments.args,
+      const augmentedProcessArgumentsWithLanguage = {
+        args: [
+          ...processArguments.args,
+          '-AppleLanguages', `(${LANGUAGE})`,
+          '-NSLanguages', `(${LANGUAGE})`,
+          '-AppleLocale', LOCALE,
+        ],
         env: processArguments.env
       };
-      augmentedProcessArgumentsWithLanguage.args.push('-AppleLanguages', `(${LANGUAGE})`);
-      augmentedProcessArgumentsWithLanguage.args.push('-NSLanguages', `(${LANGUAGE})`);
-      augmentedProcessArgumentsWithLanguage.args.push('-AppleLocale', LOCALE);
 
       const expectedWDACapabilities = {
         desiredCapabilities: {
@@ -75,7 +76,7 @@ describe('language and locale', function () {
         }
       };
 
-      let desiredCapabilities = {
+      const desiredCapabilities = {
         platformName: 'iOS',
         platformVersion: '9.3',
         deviceName: 'iPhone 6',

--- a/test/unit/log-specs.js
+++ b/test/unit/log-specs.js
@@ -11,11 +11,10 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('XCUITestDriver - startLogCapture', function () {
-
   let startCaptureSpy, crashLogStub, iosLogStub;
 
   before(function () {
-    let spy = {
+    const spy = {
       startCapture: _.noop,
     };
     startCaptureSpy = sinon.spy(spy, 'startCapture');
@@ -44,6 +43,7 @@ describe('XCUITestDriver - startLogCapture', function () {
     await startLogCapture.call(fakeInstance);
     startCaptureSpy.callCount.should.equal(1);
     fakeInstance.logs.syslog.isCapturing = true;
+
     await startLogCapture.call(fakeInstance);
     startCaptureSpy.callCount.should.equal(1);
   });

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -11,11 +11,15 @@ import B from 'bluebird';
 chai.should();
 chai.use(chaiAsPromised);
 
+const DERIVED_DATA_ROOT = '/path/to/DerivedData/WebDriverAgent-eoyoecqmiqfeodgstkwbxkfyagll';
+
 describe('utils', function () {
-  const DERIVED_DATA_ROOT = '/path/to/DerivedData/WebDriverAgent-eoyoecqmiqfeodgstkwbxkfyagll';
-  describe('clearSystemFiles', withMocks({iosUtils, fs}, (mocks) => {
+  describe('clearSystemFiles', withMocks({iosUtils, fs}, function (mocks) {
+    afterEach(function () {
+      mocks.verify();
+    });
     it('should delete logs', async function () {
-      let wda = {
+      const wda = {
         retrieveDerivedDataPath () {
           return DERIVED_DATA_ROOT;
         }
@@ -29,9 +33,8 @@ describe('utils', function () {
         .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
         .returns();
       await clearSystemFiles(wda);
-      mocks.fs.verify();
-      mocks.iosUtils.verify();
     });
+
     it('should only delete logs once if the same folder was marked twice for deletion', async function () {
       let wda = {
         retrieveDerivedDataPath () {
@@ -49,8 +52,6 @@ describe('utils', function () {
       await markSystemFilesForCleanup(wda);
       await clearSystemFiles(wda);
       await clearSystemFiles(wda);
-      mocks.fs.verify();
-      mocks.iosUtils.verify();
     });
     it('should do nothing if no derived data path is found', async function () {
       let wda = {
@@ -61,10 +62,13 @@ describe('utils', function () {
       mocks.iosUtils.expects('clearLogs')
         .never();
       await clearSystemFiles(wda);
-      mocks.iosUtils.verify();
     });
   }));
-  describe('adjustWDAAttachmentsPermissions', withMocks({fs}, (mocks) => {
+  describe('adjustWDAAttachmentsPermissions', withMocks({fs}, function (mocks) {
+    afterEach(function () {
+      mocks.verify();
+    });
+
     it('should change permissions to Attachments folder', async function () {
       let wda = {
         retrieveDerivedDataPath () {
@@ -80,7 +84,6 @@ describe('utils', function () {
         .withExactArgs(`${DERIVED_DATA_ROOT}/Logs/Test/Attachments`, '555')
         .returns();
       await adjustWDAAttachmentsPermissions(wda, '555');
-      mocks.fs.verify();
     });
     it('should not repeat permissions change with equal flags for the particular folder', async function () {
       let wda = {
@@ -99,7 +102,6 @@ describe('utils', function () {
       await adjustWDAAttachmentsPermissions(wda, '333');
       await adjustWDAAttachmentsPermissions(wda, '444');
       await adjustWDAAttachmentsPermissions(wda, '444');
-      mocks.fs.verify();
     });
     it('should not repeat permissions change with equal flags for the particular folder in parallel sessions', async function () {
       let wda = {
@@ -116,7 +118,6 @@ describe('utils', function () {
         .returns();
       await B.map([[wda, '123'], [wda, '123']], ([w, perms]) => adjustWDAAttachmentsPermissions(w, perms));
       await B.map([[wda, '234'], [wda, '234']], ([w, perms]) => adjustWDAAttachmentsPermissions(w, perms));
-      mocks.fs.verify();
     });
     it('should do nothing if no derived data path is found', async function () {
       let wda = {
@@ -127,7 +128,6 @@ describe('utils', function () {
       mocks.fs.expects('exists').never();
       mocks.fs.expects('chmod').never();
       await adjustWDAAttachmentsPermissions(wda, '777');
-      mocks.fs.verify();
     });
   }));
   describe('determineDevice', function () {

--- a/test/unit/webdriveragent-utils-specs.js
+++ b/test/unit/webdriveragent-utils-specs.js
@@ -13,6 +13,9 @@ const bootstrapPath = '/path/to/wda';
 
 describe('webdriveragent utils', function () {
   describe('checkForDependencies', withMocks({teen_process, fs}, (mocks) => {
+    afterEach(function () {
+      mocks.verify();
+    });
     it('should run script with -d argument in correct directory', async function () {
       mocks.fs.expects('which').once().returns(true);
       mocks.fs.expects('hasAccess').thrice()
@@ -23,8 +26,6 @@ describe('webdriveragent utils', function () {
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d'], {cwd: '/path/to/wda'})
         .returns('');
       await checkForDependencies(bootstrapPath);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
     it('should run script with -D argument when SSL requested', async function () {
       mocks.fs.expects('which').once().returns(true);
@@ -36,8 +37,6 @@ describe('webdriveragent utils', function () {
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d', '-D'], {cwd: '/path/to/wda'})
         .returns('');
       await checkForDependencies(bootstrapPath, true);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
     it('should not run script if Carthage directory already present', async function () {
       mocks.fs.expects('which').once().returns(true);
@@ -47,8 +46,6 @@ describe('webdriveragent utils', function () {
         .onThirdCall().returns(true);
       mocks.teen_process.expects("exec").never();
       await checkForDependencies(bootstrapPath);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
     it('should delete Carthage folder and throw error on script error', async function () {
       mocks.fs.expects('which').once().returns(true);
@@ -58,8 +55,6 @@ describe('webdriveragent utils', function () {
         .once().withExactArgs('Scripts/bootstrap.sh', ['-d'], {cwd: '/path/to/wda'})
         .throws({stdout: '', stderr: '', message: 'Bootstrap script failure'});
       await checkForDependencies(bootstrapPath).should.eventually.be.rejectedWith(/Bootstrap script failure/);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
     it('should create Resources folder if not already there', async function () {
       mocks.fs.expects('which').once().returns(true);
@@ -71,8 +66,6 @@ describe('webdriveragent utils', function () {
         .withExactArgs(`${bootstrapPath}/Resources`);
       mocks.teen_process.expects("exec").never();
       await checkForDependencies(bootstrapPath);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
     it('should create WDA bundle if not already there', async function () {
       mocks.fs.expects('which').once().returns(true);
@@ -84,8 +77,6 @@ describe('webdriveragent utils', function () {
         .withExactArgs(`${bootstrapPath}/Resources/WebDriverAgent.bundle`);
       mocks.teen_process.expects("exec").never();
       await checkForDependencies(bootstrapPath);
-      mocks.teen_process.verify();
-      mocks.fs.verify();
     });
   }));
 });


### PR DESCRIPTION
Mostly doing things like renaming mocks/stubs/spies so that the variables correspond to the test apparatus (e.g., don't name a variable with a stub in it `proxySpy`).