### PR TITLE
Make xcodebuild inherit PATH from parent process

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -226,12 +226,7 @@ class XcodeBuild {
     let {cmd, args} = this.getCommand(buildOnly);
     log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
               `in directory '${this.bootstrapPath}'`);
-    const env = {
-      USE_PORT: this.wdaRemotePort,
-    };
-    if (process.env.DEVELOPER_DIR) {
-      env.DEVELOPER_DIR = process.env.DEVELOPER_DIR;
-    }
+    const env = Object.assign({}, process.env, {USE_PORT: this.wdaRemotePort});
     let xcodebuild = new SubProcess(cmd, args, {
       cwd: this.bootstrapPath,
       env,


### PR DESCRIPTION
This can cause a problem if, for example, you use a wrapped version of clang that assumes common unix commands are available.