### PR TITLE
Add cap to use idevicescreenshot for real device screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Differences noted here
 |`shutdownOtherSimulators`|If this capability set to `true` and the current device under test is an iOS Simulator then Appium will try to shutdown all the other running Simulators before to start a new session. This might be useful while executing webview tests on different devices, since only one device can be debugged remotely at once due to an Apple bug. The capability only has an effect if `--relaxed-security` command line argument is provided to the server. Defaults to `false`.|e.g. `true`|
 |`keepKeyChains`|Set the capability to `true` in order to preserve Simulator keychains folder after full reset. This feature has no effect on real devices. Defaults to `false`|e.g. `true`|
 |`keychainsExcludePatterns`|This capability accepts comma-separated path patterns, which are going to be excluded from keychains restore while full reset is being performed on Simulator. It might be useful if you want to exclude only particular keychain types from being restored, like the applications keychain. This feature has no effect on real devices.|e.g. `*keychain*.db*` to exclude applications keychain from being restored|
+|`realDeviceScreenshotter`|Name of the alternative screenshot system to use for real devices. Defaults to the XCUITest screenshot functionality through WebDriverAgent. Possible value is `idevicescreenshot` to use the screenshot program from libimobiledevice.|e.g., `idevicescreenshot`|
 
 ## Development<a id="development"></a>
 

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -46,7 +46,17 @@ async function isIdevicescreenshotAvailable () {
 }
 
 commands.getScreenshot = async function () {
+  const getScreenshotFromLIMD = async () => {
+    if (!await isIdevicescreenshotAvailable()) {
+      throw new Error(`No 'idevicescreenshot' program found. To use, install ` +
+                      `using 'brew install --HEAD libimobiledevice'`);
+    }
+    log.debug(`Taking screenshot with 'idevicescreenshot'`);
+    const orientation = await this.proxyCommand('/orientation', 'GET');
+    return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
+  };
   const getScreenshotFromWDA = async () => {
+    log.debug(`Taking screenshot with WDA`);
     const data = await this.proxyCommand('/screenshot', 'GET');
     if (!_.isString(data)) {
       throw new Error(`Unable to take screenshot. WDA returned '${JSON.stringify(data)}'`);
@@ -54,9 +64,11 @@ commands.getScreenshot = async function () {
     return data;
   };
 
+  const useIdeviceScreenshot = this.opts.realDeviceScreenshotter &&
+    this.opts.realDeviceScreenshotter.toLowerCase() === 'idevicescreenshot';
+  const screenshotFunction = useIdeviceScreenshot ? getScreenshotFromLIMD : getScreenshotFromWDA;
   try {
-    log.debug(`Taking screenshot with WDA`);
-    return await getScreenshotFromWDA();
+    return await screenshotFunction();
   } catch (err) {
     log.warn(`Error getting screenshot: ${err.message}`);
 
@@ -74,20 +86,13 @@ commands.getScreenshot = async function () {
   // all simulator scenarios are finished
   // real device, so try idevicescreenshot if possible
   try {
-    if (await isIdevicescreenshotAvailable()) {
-      log.debug(`Taking screenshot with 'idevicescreenshot'`);
-      const orientation = await this.proxyCommand('/orientation', 'GET');
-      return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
-    }
-    log.info(`No 'idevicescreenshot' program found. To use, install ` +
-             `using 'brew install --HEAD libimobiledevice'`);
+    return await getScreenshotFromLIMD();
   } catch (err) {
     log.warn(`Error getting screenshot through 'idevicescreenshot': ${err.message}`);
   }
 
   // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected
-  log.debug('Retrying screenshot through WDA');
-  return await retryInterval(2, 1000, getScreenshotFromWDA);
+  return await retryInterval(2, 1000, screenshotFunction);
 };
 
 commands.getElementScreenshot = async function (el) {

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -53,6 +53,7 @@ async function isIdevicescreenshotAvailable () {
 commands.getScreenshot = async function () {
   const getScreenshotFromLIMD = async () => {
     log.debug(`Taking screenshot with 'idevicescreenshot'`);
+    await isIdevicescreenshotAvailable();
     const orientation = await this.proxyCommand('/orientation', 'GET');
     return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
   };
@@ -68,13 +69,11 @@ commands.getScreenshot = async function () {
   const useIdeviceScreenshot = this.opts.realDeviceScreenshotter &&
     this.opts.realDeviceScreenshotter.toLowerCase() === 'idevicescreenshot';
   if (useIdeviceScreenshot) {
-    // throw an error if the program is not there
-    await isIdevicescreenshotAvailable();
+    return await getScreenshotFromLIMD();
   }
 
-  const screenshotFunction = useIdeviceScreenshot ? getScreenshotFromLIMD : getScreenshotFromWDA;
   try {
-    return await screenshotFunction();
+    return await getScreenshotFromWDA();
   } catch (err) {
     log.warn(`Error getting screenshot: ${err.message}`);
   }
@@ -93,14 +92,13 @@ commands.getScreenshot = async function () {
   // all simulator scenarios are finished
   // real device, so try idevicescreenshot if possible
   try {
-    await isIdevicescreenshotAvailable();
     return await getScreenshotFromLIMD();
   } catch (err) {
     log.warn(`Error getting screenshot through 'idevicescreenshot': ${err.message}`);
   }
 
   // Retry for real devices only. Fail fast on Simulator if simctl does not work as expected
-  return await retryInterval(2, 1000, screenshotFunction);
+  return await retryInterval(2, 1000, getScreenshotFromWDA);
 };
 
 commands.getElementScreenshot = async function (el) {

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -42,15 +42,16 @@ async function getScreenshotWithIdevicelib (udid, isLandscape) {
 }
 
 async function isIdevicescreenshotAvailable () {
-  return !!(await fs.which('idevicescreenshot'));
+  try {
+    await fs.which('idevicescreenshot');
+  } catch (err) {
+    throw new Error(`No 'idevicescreenshot' program found. To use, install ` +
+                    `using 'brew install --HEAD libimobiledevice'`);
+  }
 }
 
 commands.getScreenshot = async function () {
   const getScreenshotFromLIMD = async () => {
-    if (!await isIdevicescreenshotAvailable()) {
-      throw new Error(`No 'idevicescreenshot' program found. To use, install ` +
-                      `using 'brew install --HEAD libimobiledevice'`);
-    }
     log.debug(`Taking screenshot with 'idevicescreenshot'`);
     const orientation = await this.proxyCommand('/orientation', 'GET');
     return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
@@ -66,26 +67,33 @@ commands.getScreenshot = async function () {
 
   const useIdeviceScreenshot = this.opts.realDeviceScreenshotter &&
     this.opts.realDeviceScreenshotter.toLowerCase() === 'idevicescreenshot';
+  if (useIdeviceScreenshot) {
+    // throw an error if the program is not there
+    await isIdevicescreenshotAvailable();
+  }
+
   const screenshotFunction = useIdeviceScreenshot ? getScreenshotFromLIMD : getScreenshotFromWDA;
   try {
     return await screenshotFunction();
   } catch (err) {
     log.warn(`Error getting screenshot: ${err.message}`);
+  }
 
-    if (this.isSimulator()) {
-      if (this.xcodeVersion.versionFloat < 8.1) {
-        log.errorAndThrow(`No command line screenshot ability with Xcode ` +
-                 `${this.xcodeVersion.versionFloat}. Please upgrade to ` +
-                 `at least Xcode 8.1`);
-      }
-      log.info(`Falling back to 'simctl io screenshot' API`);
-      return await getScreenshot(this.opts.udid);
+  // simulator attempt
+  if (this.isSimulator()) {
+    if (this.xcodeVersion.versionFloat < 8.1) {
+      log.errorAndThrow(`No command line screenshot ability with Xcode ` +
+               `${this.xcodeVersion.versionFloat}. Please upgrade to ` +
+               `at least Xcode 8.1`);
     }
+    log.info(`Falling back to 'simctl io screenshot' API`);
+    return await getScreenshot(this.opts.udid);
   }
 
   // all simulator scenarios are finished
   // real device, so try idevicescreenshot if possible
   try {
+    await isIdevicescreenshotAvailable();
     return await getScreenshotFromLIMD();
   } catch (err) {
     log.warn(`Error getting screenshot through 'idevicescreenshot': ${err.message}`);

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -41,7 +41,7 @@ async function getScreenshotWithIdevicelib (udid, isLandscape) {
   }
 }
 
-async function isIdevicescreenshotAvailable () {
+async function verifyIdeviceScreenshotAvailable () {
   try {
     await fs.which('idevicescreenshot');
   } catch (err) {
@@ -51,9 +51,9 @@ async function isIdevicescreenshotAvailable () {
 }
 
 commands.getScreenshot = async function () {
-  const getScreenshotFromLIMD = async () => {
+  const getScreenshotFromIDS = async () => {
     log.debug(`Taking screenshot with 'idevicescreenshot'`);
-    await isIdevicescreenshotAvailable();
+    await verifyIdeviceScreenshotAvailable();
     const orientation = await this.proxyCommand('/orientation', 'GET');
     return await getScreenshotWithIdevicelib(this.opts.udid, orientation === 'LANDSCAPE');
   };
@@ -66,10 +66,9 @@ commands.getScreenshot = async function () {
     return data;
   };
 
-  const useIdeviceScreenshot = this.opts.realDeviceScreenshotter &&
-    this.opts.realDeviceScreenshotter.toLowerCase() === 'idevicescreenshot';
+  const useIdeviceScreenshot = _.lowerCase(this.opts.realDeviceScreenshotter) === 'idevicescreenshot';
   if (useIdeviceScreenshot) {
-    return await getScreenshotFromLIMD();
+    return await getScreenshotFromIDS();
   }
 
   try {
@@ -92,7 +91,7 @@ commands.getScreenshot = async function () {
   // all simulator scenarios are finished
   // real device, so try idevicescreenshot if possible
   try {
-    return await getScreenshotFromLIMD();
+    return await getScreenshotFromIDS();
   } catch (err) {
     log.warn(`Error getting screenshot through 'idevicescreenshot': ${err.message}`);
   }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -133,6 +133,11 @@ let desiredCapConstraints = _.defaults({
   keychainsExcludePatterns: {
     isString: true
   },
+  realDeviceScreenshotter: {
+    isString: true,
+    presence: false,
+    inclusionCaseInsensitive: ['idevicescreenshot']
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -6,39 +6,43 @@ const simctlModule = require('node-simctl');
 const teenProcessModule = require('teen_process');
 
 describe('screenshots commands', function () {
-  let driver = new XCUITestDriver();
-  let proxySpy = sinon.stub(driver, 'proxyCommand');
+  let driver;
+  let proxyStub;
 
   const base64Response = 'aGVsbG8=';
 
+  beforeEach(function () {
+    driver = new XCUITestDriver();
+    proxyStub = sinon.stub(driver, 'proxyCommand');
+  });
   afterEach(function () {
-    proxySpy.reset();
+    proxyStub.reset();
   });
 
   describe('getScreenshot', function () {
     describe('simulator', function () {
-      let simctlSpy = sinon.stub(simctlModule, 'getScreenshot');
+      let simctlStub = sinon.stub(simctlModule, 'getScreenshot');
 
       afterEach(function () {
-        simctlSpy.reset();
+        simctlStub.reset();
       });
 
       it('should get a screenshot from WDA if no errors are detected', async function () {
-        proxySpy.returns(base64Response);
+        proxyStub.returns(base64Response);
         driver.opts.realDevice = false;
 
         await driver.getScreenshot();
 
-        proxySpy.calledOnce.should.be.true;
-        proxySpy.firstCall.args[0].should.eql('/screenshot');
-        proxySpy.firstCall.args[1].should.eql('GET');
+        proxyStub.calledOnce.should.be.true;
+        proxyStub.firstCall.args[0].should.eql('/screenshot');
+        proxyStub.firstCall.args[1].should.eql('GET');
 
-        simctlSpy.notCalled.should.be.true;
+        simctlStub.notCalled.should.be.true;
       });
 
       it('should get a screenshot from simctl if WDA call fails and Xcode version >= 8.1', async function () {
-        proxySpy.returns(null);
-        simctlSpy.returns(base64Response);
+        proxyStub.returns(null);
+        simctlStub.returns(base64Response);
 
         driver.opts.realDevice = false;
         driver.xcodeVersion = {
@@ -47,83 +51,102 @@ describe('screenshots commands', function () {
         const result = await driver.getScreenshot();
         result.should.equal(base64Response);
 
-        proxySpy.calledOnce.should.be.true;
-        simctlSpy.calledOnce.should.be.true;
+        proxyStub.calledOnce.should.be.true;
+        simctlStub.calledOnce.should.be.true;
       });
     });
 
     describe('real device', function () {
       it('should get a screenshot from WDA if no errors are detected', async function () {
-        proxySpy.returns(base64Response);
+        proxyStub.returns(base64Response);
         driver.opts.realDevice = true;
 
         await driver.getScreenshot();
 
-        proxySpy.calledOnce.should.be.true;
-        proxySpy.firstCall.args[0].should.eql('/screenshot');
-        proxySpy.firstCall.args[1].should.eql('GET');
+        proxyStub.calledOnce.should.be.true;
+        proxyStub.firstCall.args[0].should.eql('/screenshot');
+        proxyStub.firstCall.args[1].should.eql('GET');
       });
 
-      it('should use idevicescreenshot if WDA fails', async function () {
+      describe('idevicescreenshot', function () {
         const tiffPath = '/some/file.tiff';
         const pngPath = '/some/file.png';
         const udid = '1234';
-
-        const fsExistsSpy = sinon.stub(fs, 'exists');
-        fsExistsSpy.returns(true);
-
         const toolName = 'idevicescreenshot';
-        const fsWhichSpy = sinon.stub(fs, 'which');
-        fsWhichSpy.returns(toolName);
-
-        const fsRimRafSpy = sinon.stub(fs, 'rimraf');
-
         const pngFileContent = 'blabla';
-        const fsReadFileSpy = sinon.stub(fs, 'readFile');
-        fsReadFileSpy.returns(pngFileContent);
 
-        const execSpy = sinon.stub(teenProcessModule, 'exec');
+        let fsExistsStub;
+        let fsWhichStub;
+        let fsRimRafStub;
+        let fsReadFileStub;
+        let execStub;
+        let pathStub;
 
-        const pathSpy = sinon.stub(tempDir, 'path');
-        pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
-        pathSpy.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
-
-        proxySpy.onFirstCall().returns(null);
-        proxySpy.onSecondCall().returns('LANDSCAPE');
-
-        try {
+        beforeEach(function () {
           driver.opts.realDevice = true;
           driver.opts.udid = udid;
-          (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
 
-          proxySpy.calledTwice.should.be.true;
-          proxySpy.firstCall.args.should.eql(['/screenshot', 'GET']);
-          proxySpy.secondCall.args.should.eql(['/orientation', 'GET']);
+          fsExistsStub = sinon.stub(fs, 'exists');
+          fsExistsStub.returns(true);
 
-          fsWhichSpy.calledOnce.should.be.true;
-          fsWhichSpy.firstCall.args[0].should.eql(toolName);
+          fsWhichStub = sinon.stub(fs, 'which');
+          fsWhichStub.returns(toolName);
 
-          execSpy.calledTwice.should.be.true;
-          execSpy.firstCall.args[0].should.eql(toolName);
-          execSpy.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
-          execSpy.secondCall.args[0].should.eql('sips');
-          execSpy.secondCall.args[1].should.eql(
+          fsRimRafStub = sinon.stub(fs, 'rimraf');
+
+          fsReadFileStub = sinon.stub(fs, 'readFile');
+          fsReadFileStub.returns(pngFileContent);
+
+          execStub = sinon.stub(teenProcessModule, 'exec');
+
+          pathStub = sinon.stub(tempDir, 'path');
+          pathStub.withArgs({prefix: `screenshot-${udid}`, suffix: '.tiff'}).returns(tiffPath);
+          pathStub.withArgs({prefix: `screenshot-${udid}`, suffix: '.png'}).returns(pngPath);
+        });
+        afterEach(function () {
+          fsWhichStub.calledOnce.should.be.true;
+          fsWhichStub.firstCall.args[0].should.eql(toolName);
+
+          execStub.calledTwice.should.be.true;
+          execStub.firstCall.args[0].should.eql(toolName);
+          execStub.firstCall.args[1].should.eql(['-u', udid, tiffPath]);
+          execStub.secondCall.args[0].should.eql('sips');
+          execStub.secondCall.args[1].should.eql(
             ['-r', '-90', '-s', 'format', 'png', tiffPath, '--out', pngPath]);
 
-          fsRimRafSpy.callCount.should.eql(4);
+          fsRimRafStub.callCount.should.eql(4);
 
-          fsReadFileSpy.calledOnce.should.be.true;
-          fsReadFileSpy.firstCall.args[0].should.eql(pngPath);
+          fsReadFileStub.calledOnce.should.be.true;
+          fsReadFileStub.firstCall.args[0].should.eql(pngPath);
 
-          pathSpy.calledTwice.should.be.true;
-        } finally {
-          fsExistsSpy.restore();
-          fsWhichSpy.restore();
-          fsReadFileSpy.restore();
-          fsRimRafSpy.restore();
-          execSpy.restore();
-          pathSpy.restore();
-        }
+          pathStub.calledTwice.should.be.true;
+
+          fsExistsStub.restore();
+          fsWhichStub.restore();
+          fsReadFileStub.restore();
+          fsRimRafStub.restore();
+          execStub.restore();
+          pathStub.restore();
+        });
+
+        it('should use idevicescreenshot if WDA fails', async function () {
+          proxyStub.onFirstCall().returns(null);
+          proxyStub.onSecondCall().returns('LANDSCAPE');
+
+          (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+
+          proxyStub.callCount.should.eql(2);
+          proxyStub.firstCall.args.should.eql(['/screenshot', 'GET']);
+          proxyStub.secondCall.args.should.eql(['/orientation', 'GET']);
+        });
+        it('should use idevicescreenshot if specified in realDeviceScreenshotter cap', async function () {
+          proxyStub.onFirstCall().returns('LANDSCAPE');
+          driver.opts.realDeviceScreenshotter = 'idevicescreenshot';
+
+          (await driver.getScreenshot()).should.eql(pngFileContent.toString('base64'));
+
+          proxyStub.callCount.should.eql(1);
+        });
       });
     });
   });


### PR DESCRIPTION
The flow for screenshotting on real devices as it currently stands:
1. Try WDA method (i.e., `GET` request to `/screenshot` on WDA)
2. Try `idevicescreenshot` if available
3. Try WDA method an additional two times

However, there are reported cases where WDA still crashes when getting screenshots

This PR
* Adds `realDeviceScreenshotter` cap to specify the program to use preferentially (for now, either nothing, to use WDA first, or `idevicescreenshot` to use the `libimobiledevice` program). In the former case, the flow remains as above. In the case of using `idevicescreenshot` the flow becomes
    1. Try `idevicescreenshot` if available
* Fixes handling of existence of `idevicescreenshot` (`fs.which` throws an error when program not found)

Resolves https://github.com/appium/appium/issues/10590