### PR TITLE
Fix free memory size calculation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import log from './logger';
 import _fs from 'fs';
 import url from 'url';
+import v8 from 'v8';
 
 const DEFAULT_TIMEOUT_KEY = 'default';
 
@@ -414,12 +415,12 @@ async function encodeBase64OrUpload (localFile, remotePath = null, uploadOptions
   const {size} = await fs.stat(localFile);
   log.debug(`The size of the file is ${util.toReadableSizeString(size)}`);
   if (_.isEmpty(remotePath)) {
-    const memoryUsage = process.memoryUsage();
-    const maxMemoryLimit = (memoryUsage.heapTotal - memoryUsage.heapUsed) / 2;
+    const maxMemoryLimit = v8.getHeapStatistics().total_available_size / 2;
     if (size >= maxMemoryLimit) {
       throw new Error(`Cannot read '${localFile}' to the memory, because the file is too large ` +
                       `(${util.toReadableSizeString(size)} >= ${util.toReadableSizeString(maxMemoryLimit)}). ` +
-                      `Try to provide a link to a remote writable location instead.`);
+                      `Try to provide a link to a remote writable location instead or increase the value of ` +
+                      `'max_old_space_size' server argument.`);
     }
     const content = await fs.readFile(localFile);
     return content.toString('base64');

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -7,6 +7,7 @@ import * as utils from '../../../lib/utils';
 import * as teen_process from 'teen_process';
 import sinon from 'sinon';
 import B from 'bluebird';
+import v8 from 'v8';
 
 
 chai.should();
@@ -125,7 +126,7 @@ describe('basic', withMocks({driver, fs, tempDir, utils, teen_process}, function
       mocks.fs.expects('exists').once().withExactArgs(localFile).returns(true);
       mocks.fs.expects('rimraf').once().withExactArgs(localFile);
       mocks.fs.expects('stat').once().withExactArgs(localFile)
-        .returns({size: process.memoryUsage().heapTotal});
+        .returns({size: v8.getHeapStatistics().total_available_size});
 
       await driver.stopRecordingScreen().should.eventually.be.rejectedWith(/is too large/);
     });


### PR DESCRIPTION
It looks like `process.memoryUsage()` is [not good](https://stackoverflow.com/questions/48190962/how-to-get-the-value-of-max-old-space-size-from-the-code) to check how much heap memory is left, so we use `v8.getHeapStatistics()` instead.