### PR TITLE
Add application platform verification

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -930,7 +930,17 @@ class XCUITestDriver extends BaseDriver {
       return;
     }
 
-    await verifyApplicationPlatform(this.opts.app, this.isSimulator());
+    try {
+      await verifyApplicationPlatform(this.opts.app, this.isSimulator());
+    } catch (err) {
+      // TODO: Let it throw after we confirm the architecture verification algorithm is stable
+      log.warn(`*********************************`);
+      log.warn(`${this.isSimulator() ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
+               `by the '${this.opts.app}' application. ` +
+               `Make sure the correct deployment target has been selected for its compilation in Xcode.`);
+      log.warn('Don\'t be surprised if the application fails to launch.');
+      log.warn(`*********************************`);
+    }
 
     if (this.isRealDevice()) {
       await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -16,7 +16,7 @@ import { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
          DEFAULT_TIMEOUT_KEY, markSystemFilesForCleanup,
-         printUser, removeAllSessionWebSocketHandlers } from './utils';
+         printUser, removeAllSessionWebSocketHandlers, verifyApplicationPlatform } from './utils';
 import { getConnectedDevices, runRealDeviceReset, installToRealDevice,
          getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
@@ -929,6 +929,8 @@ class XCUITestDriver extends BaseDriver {
     if (this.opts.autoLaunch === false) {
       return;
     }
+
+    await verifyApplicationPlatform(this.opts.app, this.isSimulator());
 
     if (this.isRealDevice()) {
       await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -475,14 +475,16 @@ async function removeAllSessionWebSocketHandlers (server, sessionId) {
  * Verify whether the given application is compatible to the
  * platform where it is going to be installed and tested.
  *
- * @param {string} app - the actual path to the application bundle
+ * @param {string} app - The actual path to the application bundle
  * @param {boolean} isSimulator - Should be set to `true` if the test will be executed on Simulator
  * @param {?boolean} shouldThrow [false] - Set it to `true` if you want this function
  *                                         to throw an exception if the bundle architecture does not match
  *                                         to the device architecture
- * @returns {?boolean} The function return `null` if the application does not exist or there is no
- * `CFBundleSupportedPlatforms` key in its Info.plist manifest. `true` is returned if everything is OK
- * and an exception is thrown or `false is returned depending on `shouldThrow` parameter value.
+ * @returns {?boolean} The function returns `null` if the application does not exist or there is no
+ * `CFBundleSupportedPlatforms` key in its Info.plist manifest.
+ * `true` is returned if bundle architecture matched device architecture.
+ * An exception is thrown or `false is returned (depending on `shouldThrow` parameter value) if
+ * bundle architecture does not match the device architecture.
  */
 async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false) {
   log.debug('Verifying application platform');
@@ -508,7 +510,7 @@ async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false)
 
   const errMessage = `${isSimulator ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
     `by the '${app}' application. Make sure the correct deployment target has been selected for its compilation in Xcode. ` +
-    `Don't be surprised if it fails to launch.`;
+    `Don't be surprised if the application fails to launch.`;
   if (shouldThrow) {
     log.errorAndThrow(errMessage);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -509,13 +509,13 @@ async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false)
   }
 
   const errMessage = `${isSimulator ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
-    `by the '${app}' application. Make sure the correct deployment target has been selected for its compilation in Xcode. ` +
-    `Don't be surprised if the application fails to launch.`;
+    `by the '${app}' application. Make sure the correct deployment target has been selected for its compilation in Xcode.`;
   if (shouldThrow) {
     log.errorAndThrow(errMessage);
   }
   log.warn(`*********************************`);
   log.warn(errMessage);
+  log.warn('Don\'t be surprised if the application fails to launch.');
   log.warn(`*********************************`);
   return false;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -477,16 +477,12 @@ async function removeAllSessionWebSocketHandlers (server, sessionId) {
  *
  * @param {string} app - The actual path to the application bundle
  * @param {boolean} isSimulator - Should be set to `true` if the test will be executed on Simulator
- * @param {?boolean} shouldThrow [false] - Set it to `true` if you want this function
- *                                         to throw an exception if the bundle architecture does not match
- *                                         to the device architecture
  * @returns {?boolean} The function returns `null` if the application does not exist or there is no
  * `CFBundleSupportedPlatforms` key in its Info.plist manifest.
- * `true` is returned if bundle architecture matched device architecture.
- * An exception is thrown or `false is returned (depending on `shouldThrow` parameter value) if
- * bundle architecture does not match the device architecture.
+ * `true` is returned if the bundle architecture matches the device architecture.
+ * @throws {Error} If bundle architecture does not match the device architecture.
  */
-async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false) {
+async function verifyApplicationPlatform (app, isSimulator) {
   log.debug('Verifying application platform');
 
   const infoPlist = path.resolve(app, 'Info.plist');
@@ -507,17 +503,8 @@ async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false)
   if (isAppSupported) {
     return true;
   }
-
-  const errMessage = `${isSimulator ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
-    `by the '${app}' application. Make sure the correct deployment target has been selected for its compilation in Xcode.`;
-  if (shouldThrow) {
-    log.errorAndThrow(errMessage);
-  }
-  log.warn(`*********************************`);
-  log.warn(errMessage);
-  log.warn('Don\'t be surprised if the application fails to launch.');
-  log.warn(`*********************************`);
-  return false;
+  throw new Error(`${isSimulator ? 'Simulator' : 'Real device'} architecture is unsupported by the '${app}' application. ` +
+                  `Make sure the correct deployment target has been selected for its compilation in Xcode.`);
 }
 
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 import B from 'bluebird';
-import { fs, util, net } from 'appium-support';
+import { fs, util, net, plist } from 'appium-support';
 import path from 'path';
 import { utils as iosUtils } from 'appium-ios-driver';
 import { SubProcess, exec } from 'teen_process';
@@ -471,9 +471,57 @@ async function removeAllSessionWebSocketHandlers (server, sessionId) {
   }
 }
 
+/**
+ * Verify whether the given application is compatible to the
+ * platform where it is going to be installed and tested.
+ *
+ * @param {string} app - the actual path to the application bundle
+ * @param {boolean} isSimulator - Should be set to `true` if the test will be executed on Simulator
+ * @param {?boolean} shouldThrow [false] - Set it to `true` if you want this function
+ *                                         to throw an exception if the bundle architecture does not match
+ *                                         to the device architecture
+ * @returns {?boolean} The function return `null` if the application does not exist or there is no
+ * `CFBundleSupportedPlatforms` key in its Info.plist manifest. `true` is returned if everything is OK
+ * and an exception is thrown or `false is returned depending on `shouldThrow` parameter value.
+ */
+async function verifyApplicationPlatform (app, isSimulator, shouldThrow = false) {
+  log.debug('Verifying application platform');
+
+  const infoPlist = path.resolve(app, 'Info.plist');
+  if (!await fs.exists(infoPlist)) {
+    log.debug(`'${infoPlist}' does not exist`);
+    return null;
+  }
+
+  const {CFBundleSupportedPlatforms} = await plist.parsePlistFile(infoPlist);
+  log.debug(`CFBundleSupportedPlatforms: ${JSON.stringify(CFBundleSupportedPlatforms)}`);
+  if (!_.isArray(CFBundleSupportedPlatforms)) {
+    log.debug(`CFBundleSupportedPlatforms key does not exist in '${infoPlist}'`);
+    return null;
+  }
+
+  const isAppSupported = (isSimulator && CFBundleSupportedPlatforms.includes('iPhoneSimulator'))
+    || (!isSimulator && CFBundleSupportedPlatforms.includes('iPhoneOS'));
+  if (isAppSupported) {
+    return true;
+  }
+
+  const errMessage = `${isSimulator ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
+    `by the '${app}' application. Make sure the correct deployment target has been selected for its compilation in Xcode. ` +
+    `Don't be surprised if it fails to launch.`;
+  if (shouldThrow) {
+    log.errorAndThrow(errMessage);
+  }
+  log.warn(`*********************************`);
+  log.warn(errMessage);
+  log.warn(`*********************************`);
+  return false;
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
          adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
          clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
          DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
          markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo,
-         getPIDsListeningOnPort, encodeBase64OrUpload, removeAllSessionWebSocketHandlers };
+         getPIDsListeningOnPort, encodeBase64OrUpload, removeAllSessionWebSocketHandlers,
+         verifyApplicationPlatform };


### PR DESCRIPTION
There are still enough people that don't know the difference between emulator and simulator and think that the same application binary could be shared between real devices and simulators. This gonna make them not so self confident.