### PR TITLE
Add keyboard presence verification endpoint

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -325,6 +325,14 @@ commands.getContentSize = async function (el) {
   });
 };
 
+commands.isKeyboardShown = async function () {
+  try {
+    await this.findNativeElementOrElements('class name', 'XCUIElementTypeKeyboard', false);
+    return true;
+  } catch (ign) {
+    return false;
+  }
+};
 
 Object.assign(extensions, commands);
 export { commands };


### PR DESCRIPTION
This endpoint exists in Android. It would be also useful to have it in iOS.