### PR TITLE
Add derivedDataPath capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -51,6 +51,9 @@ let desiredCapConstraints = _.defaults({
   webDriverAgentUrl: {
     isString: true
   },
+  derivedDataPath: {
+    isString: true
+  },
   useNewWDA: {
     isBoolean: true
   },

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -52,6 +52,7 @@ class XcodeBuild {
     this.wdaRemotePort = args.wdaRemotePort;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
+    this.derivedDataPath = args.derivedDataPath;
   }
 
   async init (noSessionProxy) {
@@ -90,6 +91,10 @@ class XcodeBuild {
   }
 
   async retrieveDerivedDataPath () {
+    if (this.derivedDataPath) {
+      this._derivedDataPath = this.derivedDataPath;
+      return this._derivedDataPath;
+    }
     if (this._derivedDataPath) {
       return this._derivedDataPath;
     }
@@ -192,6 +197,9 @@ class XcodeBuild {
       args.push('-xctestrun', this.xctestrunFilePath);
     } else {
       args.push('-project', this.agentPath, '-scheme', 'WebDriverAgentRunner');
+      if (this.derivedDataPath) {
+        args.push('-derivedDataPath', this.derivedDataPath);
+      }
     }
     args.push('-destination', `id=${this.device.udid}`);
 


### PR DESCRIPTION
Im trying to use an existing agentPath but is not choosing the derivedDataPath to run WDA withtou building. I found that if you set `-derivedDataPath` in xcodebuild you can change the default folder and use anyone you want and in that case it uses the existing build.
 
Im still not sure if we should merge both `_derivedDataPath` and `derivedDataPath` @mykola-mokhnach @imurchie what do you guys think ?