### PR TITLE
create simulators with device name by capability

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -734,7 +734,7 @@ class XCUITestDriver extends BaseDriver {
     this.lifecycleData.createSim = true;
 
     // create sim for caps
-    let sim = await createSim(this.opts, this.sessionId);
+    let sim = await createSim(this.opts);
     log.info(`Created simulator with udid '${sim.udid}'.`);
 
     return sim;

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -6,8 +6,8 @@ import _ from 'lodash';
 import log from './logger';
 
 // returns sim for desired caps
-async function createSim (caps, sessionId) {
-  let name = `appiumTest-${sessionId}`;
+async function createSim (caps) {
+  let name = `appiumTest-${caps.deviceName}`;
   let udid = await createDevice(name, caps.deviceName, caps.platformVersion);
   return await getSimulator(udid);
 }
@@ -15,7 +15,7 @@ async function createSim (caps, sessionId) {
 async function getExistingSim (opts) {
   let devices = await getDevices(opts.platformVersion);
   for (let device of _.values(devices)) {
-    if (device.name === opts.deviceName) {
+    if ((device.name === opts.deviceName) || (device.name === `appiumTest-${opts.deviceName}`)) {
       return await getSimulator(device.udid);
     }
   }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -11,7 +11,7 @@ import log from './logger';
  * @param {object} caps - Capability set by a user. The options available are:
  *   - `deviceName` - a name for the device
  *   - `platformVersion` - the version of iOS to use
- * @returns {Promise<void>} Simulator object associated with the udid passed in.
+ * @returns {object} Simulator object associated with the udid passed in.
  */
 async function createSim (caps) {
   const appiumTestDeviceName = `appiumTest-${caps.deviceName}`;
@@ -25,7 +25,7 @@ async function createSim (caps) {
  * @param {object} opts - Capability set by a user. The options available are:
  *   - `deviceName` - a name for the device
  *   - `platformVersion` - the version of iOS to use
- * @returns {Promise<null>} Simulator object associated with the udid passed in. Or null if no device is running.
+ * @returns {?object} Simulator object associated with the udid passed in. Or null if no device is running.
  */
 async function getExistingSim (opts) {
   const devices = await getDevices(opts.platformVersion);
@@ -45,7 +45,7 @@ async function getExistingSim (opts) {
 
   if (appiumTestDevice) {
     log.warn(`Unable to find device '${opts.deviceName}'. Found '${appiumTestDevice.name}' (udid: '${appiumTestDevice.udid}') instead`);
-    return await  getSimulator(appiumTestDevice.udid);
+    return await getSimulator(appiumTestDevice.udid);
   }
   return null;
 }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -15,7 +15,13 @@ async function createSim (caps) {
 async function getExistingSim (opts) {
   let devices = await getDevices(opts.platformVersion);
   for (let device of _.values(devices)) {
-    if ((device.name === opts.deviceName) || (device.name === `appiumTest-${opts.deviceName}`)) {
+    if (device.name === opts.deviceName) {
+      return await getSimulator(device.udid);
+    }
+  }
+
+  for (let device of _.values(devices)) {
+    if (device.name === `appiumTest-${opts.deviceName}`) {
       return await getSimulator(device.udid);
     }
   }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -5,25 +5,47 @@ import { resetXCTestProcesses } from './utils';
 import _ from 'lodash';
 import log from './logger';
 
-// returns sim for desired caps
+/**
+ * Create a new simulator with `appiumTest-` prefix and return the object.
+ *
+ * @param {object} caps - Capability set by a user. The options available are:
+ *   - `deviceName` - a name for the device
+ *   - `platformVersion` - the version of iOS to use
+ * @returns {Promise<void>} Simulator object associated with the udid passed in.
+ */
 async function createSim (caps) {
-  let name = `appiumTest-${caps.deviceName}`;
-  let udid = await createDevice(name, caps.deviceName, caps.platformVersion);
+  const appiumTestDeviceName = `appiumTest-${caps.deviceName}`;
+  const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion);
   return await getSimulator(udid);
 }
 
+/**
+ * Get a simulator which is already running.
+ *
+ * @param {object} opts - Capability set by a user. The options available are:
+ *   - `deviceName` - a name for the device
+ *   - `platformVersion` - the version of iOS to use
+ * @returns {Promise<null>} Simulator object associated with the udid passed in. Or null if no device is running.
+ */
 async function getExistingSim (opts) {
-  let devices = await getDevices(opts.platformVersion);
-  for (let device of _.values(devices)) {
+  const devices = await getDevices(opts.platformVersion);
+  const appiumTestDeviceName = `appiumTest-${opts.deviceName}`;
+
+  let appiumTestDevice;
+
+  for (const device of _.values(devices)) {
     if (device.name === opts.deviceName) {
       return await getSimulator(device.udid);
     }
+
+    if (device.name === appiumTestDeviceName) {
+      appiumTestDevice = device;
+    }
   }
 
-  for (let device of _.values(devices)) {
-    if (device.name === `appiumTest-${opts.deviceName}`) {
-      return await getSimulator(device.udid);
-    }
+  if (appiumTestDevice) {
+    log.warn(`Unable to find device '${opts.deviceName}'. Found '${appiumTestDevice.name}' (udid: '${appiumTestDevice.udid}') instead`);
+    return await  getSimulator(appiumTestDevice.udid);
   }
   return null;
 }

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -15,63 +15,74 @@ describe('simulator management', function () {
   });
 
   describe('createSim', function () {
-    let createDeviceSpy = sinon.stub(simctlModule, 'createDevice');
+    let createDeviceStub = sinon.stub(simctlModule, 'createDevice');
 
     afterEach(function () {
-      createDeviceSpy.reset();
+      createDeviceStub.reset();
     });
 
     it('should call appiumTest prefix name', async function () {
-      createDeviceSpy.returns("dummy-udid");
+      createDeviceStub.returns("dummy-udid");
       getSimulatorStub.returns("dummy-udid");
 
       await createSim(caps);
 
-      createDeviceSpy.calledOnce.should.be.true;
-      createDeviceSpy.firstCall.args[0].should.eql("appiumTest-iPhone 6");
-      createDeviceSpy.firstCall.args[1].should.eql("iPhone 6");
-      createDeviceSpy.firstCall.args[2].should.eql("10.1");
+      createDeviceStub.calledOnce.should.be.true;
+      createDeviceStub.firstCall.args[0].should.eql("appiumTest-iPhone 6");
+      createDeviceStub.firstCall.args[1].should.eql("iPhone 6");
+      createDeviceStub.firstCall.args[2].should.eql("10.1");
       getSimulatorStub.calledOnce.should.be.true;
       getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
     });
   });
 
   describe('getExistingSim', function () {
-    let getDevicesSpy = sinon.stub(simctlModule, 'getDevices');
+    let createDeviceStub = sinon.stub(simctlModule, 'getDevices');
 
     afterEach(function () {
-      getDevicesSpy.reset();
+      createDeviceStub.reset();
     });
 
     it('should call default device name', async function () {
-      getDevicesSpy.returns([{name: "iPhone 6", udid: "dummy-udid"}]);
+      createDeviceStub.returns([{name: "iPhone 6", udid: "dummy-udid"}]);
       getSimulatorStub.returns("dummy-udid");
 
       await getExistingSim(caps);
-      getDevicesSpy.calledOnce.should.be.true;
-      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      createDeviceStub.calledOnce.should.be.true;
+      createDeviceStub.firstCall.args[0].should.eql("10.1");
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
+    });
+
+    it('should call non-appiumTest prefix name if device has appiumTest prefix and no prefix device name', async function () {
+      createDeviceStub.returns([{name: "appiumTest-iPhone 6", udid: "appiumTest-dummy-udid"}, {name: "iPhone 6", udid: "dummy-udid"}]);
+      getSimulatorStub.returns("dummy-udid");
+
+      await getExistingSim(caps);
+      createDeviceStub.calledOnce.should.be.true;
+      createDeviceStub.firstCall.args[0].should.eql("10.1");
       getSimulatorStub.calledOnce.should.be.true;
       getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
     });
 
     it('should call appiumTest prefix device name', async function () {
-      getDevicesSpy.returns([{name: "appiumTest-iPhone 6", udid: "dummy-udid"}]);
+      createDeviceStub.returns([{name: "appiumTest-iPhone 6", udid: "dummy-udid"}]);
       getSimulatorStub.returns("dummy-udid");
 
       await getExistingSim(caps);
-      getDevicesSpy.calledOnce.should.be.true;
-      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      createDeviceStub.calledOnce.should.be.true;
+      createDeviceStub.firstCall.args[0].should.eql("10.1");
       getSimulatorStub.calledOnce.should.be.true;
       getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
     });
 
     it('should not exist sim', async function () {
-      getDevicesSpy.returns();
+      createDeviceStub.returns();
       getSimulatorStub.returns();
 
       await getExistingSim(caps);
-      getDevicesSpy.calledOnce.should.be.true;
-      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      createDeviceStub.calledOnce.should.be.true;
+      createDeviceStub.firstCall.args[0].should.eql("10.1");
       getSimulatorStub.notCalled.should.be.true;
     });
   });

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -1,0 +1,78 @@
+import { createSim, getExistingSim } from '../../lib/simulator-management.js';
+import sinon from 'sinon';
+import chai from 'chai';
+
+chai.should();
+
+const caps = {platformName: "iOS", deviceName: "iPhone 6", platformVersion: "10.1", app: "/foo.app"};
+const simctlModule = require('node-simctl');
+const iOSSimulatorModule = require('appium-ios-simulator');
+
+describe('simulator management', function () {
+  let getSimulatorStub = sinon.stub(iOSSimulatorModule, 'getSimulator');
+  afterEach(function () {
+    getSimulatorStub.reset();
+  });
+
+  describe('createSim', function () {
+    let createDeviceSpy = sinon.stub(simctlModule, 'createDevice');
+
+    afterEach(function () {
+      createDeviceSpy.reset();
+    });
+
+    it('should call appiumTest prefix name', async function () {
+      createDeviceSpy.returns("dummy-udid");
+      getSimulatorStub.returns("dummy-udid");
+
+      await createSim(caps);
+
+      createDeviceSpy.calledOnce.should.be.true;
+      createDeviceSpy.firstCall.args[0].should.eql("appiumTest-iPhone 6");
+      createDeviceSpy.firstCall.args[1].should.eql("iPhone 6");
+      createDeviceSpy.firstCall.args[2].should.eql("10.1");
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
+    });
+  });
+
+  describe('getExistingSim', function () {
+    let getDevicesSpy = sinon.stub(simctlModule, 'getDevices');
+
+    afterEach(function () {
+      getDevicesSpy.reset();
+    });
+
+    it('should call default device name', async function () {
+      getDevicesSpy.returns([{name: "iPhone 6", udid: "dummy-udid"}]);
+      getSimulatorStub.returns("dummy-udid");
+
+      await getExistingSim(caps);
+      getDevicesSpy.calledOnce.should.be.true;
+      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
+    });
+
+    it('should call appiumTest prefix device name', async function () {
+      getDevicesSpy.returns([{name: "appiumTest-iPhone 6", udid: "dummy-udid"}]);
+      getSimulatorStub.returns("dummy-udid");
+
+      await getExistingSim(caps);
+      getDevicesSpy.calledOnce.should.be.true;
+      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql("dummy-udid");
+    });
+
+    it('should not exist sim', async function () {
+      getDevicesSpy.returns();
+      getSimulatorStub.returns();
+
+      await getExistingSim(caps);
+      getDevicesSpy.calledOnce.should.be.true;
+      getDevicesSpy.firstCall.args[0].should.eql("10.1");
+      getSimulatorStub.notCalled.should.be.true;
+    });
+  });
+});


### PR DESCRIPTION
# Before
When a new simulator is created, the device name becomes `appiumTest-${sessionId}`. It means the name changes every new session. With `noReset` capability case, new simulators are created every new session. As the result, iOS simulators can be created so much.
example (they are same device name and os versions):
![](https://user-images.githubusercontent.com/4276719/40208859-e24ebbc6-5a76-11e8-9153-2e922fc11d38.png)

The issue was fixed https://github.com/appium/appium/issues/9134.

But if we have no the simulator name on the simulator list, the same error happens. Since xcuitest driver never reachs https://github.com/appium/appium-xcuitest-driver/compare/master...KazuCocoa:create-device-without-dynamic-name?expand=1#diff-bdfd0d2726c6301f92259c6fe3d4928eL18 .

A new created device has `sessionId` in the name and the part changes in the next new session.
![image](https://user-images.githubusercontent.com/5511591/40269819-382b72d0-5bbe-11e8-8fb3-5862bd2f1b4b.png)

_no the simulator name on the simulator list_ is the below. It happens if we remove the device from the list before running appium tests.
![image](https://user-images.githubusercontent.com/5511591/40269836-77f59454-5bbe-11e8-8ece-6accc254cc71.png)

# After
The issue is `${sessionId}` part in `appiumTest-${sessionId}`. So, I replace the session id part with device name from caps.

After that, we can prevent the _before_ case since new devices are created with `appiumTest-${caps.deviceName}`. We can generate multiple simulators with same name since their identifiers are different. Thus, if we have user who handle simulators with device name and same OS versions, they can handle with `udid` as same as device name.

What do you think the change?

---

After the change, I checked it works for the normal case, _before_ case and _after_ case.