### PR TITLE
Do not turn on safari console logging when moving to native context

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -1,4 +1,4 @@
-import { iosCommands } from 'appium-ios-driver';
+import { iosCommands, NATIVE_WIN } from 'appium-ios-driver';
 import { RemoteDebugger } from 'appium-remote-debugger';
 
 
@@ -16,8 +16,10 @@ extensions.setContext = async function (name, callback, skipReadyCheck) {
   await this._setContext(name, callback, skipReadyCheck);
 
   // start safari console logging if the logs handler is active
-  if (this.logs && this.logs.safariConsole) {
-    await this.remote.startConsole(this.logs.safariConsole.addLogLine.bind(this.logs.safariConsole));
+  if (name && name !== NATIVE_WIN) {
+    if (this.logs && this.logs.safariConsole) {
+      await this.remote.startConsole(this.logs.safariConsole.addLogLine.bind(this.logs.safariConsole));
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "appium-base-driver": "^2.28.0",
-    "appium-ios-driver": "^2.2.1",
+    "appium-ios-driver": "^2.4.3",
     "appium-ios-simulator": "^2.9.0",
     "appium-remote-debugger": "^3.10.0",
     "appium-support": "^2.13.0",


### PR DESCRIPTION
On real devices we lose the web socket connection, so this fails.