### PR TITLE
Make sure the application under test is deleted on session cleanup if  it is temporary and clearSystemFiles is set to true

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,5 +1,5 @@
 import { BaseDriver, DeviceSettings } from 'appium-base-driver';
-import { util } from 'appium-support';
+import { util, fs } from 'appium-support';
 import _ from 'lodash';
 import url from 'url';
 import { launch } from 'node-simctl';
@@ -516,6 +516,9 @@ class XCUITestDriver extends BaseDriver {
       }
 
       if (this.opts.clearSystemFiles) {
+        if (this.isAppTemporary) {
+          await fs.rimraf(this.opts.app);
+        }
         await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
       } else {
         log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
@@ -617,6 +620,7 @@ class XCUITestDriver extends BaseDriver {
       return;
     }
 
+    const originalAppPath = this.opts.app;
     try {
       // download if necessary
       this.opts.app = await this.helpers.configureApp(this.opts.app, '.app', this.opts.mountRoot, this.opts.windowsShareUserName, this.opts.windowsSharePassword);
@@ -626,6 +630,7 @@ class XCUITestDriver extends BaseDriver {
         `Bad app: ${this.opts.app}. App paths need to be absolute, or relative to the appium ` +
         'server install dir, or a URL to compressed file, or a special app name.');
     }
+    this.isAppTemporary = this.opts.app && originalAppPath !== this.opts.app;
   }
 
   async determineDevice () {


### PR DESCRIPTION
This prevents filling of temp folder with multiple temporary files, which are never cleaned up.