### PR TITLE
throw NoAlertOpenError when getAlertText fails not in web context

### DIFF
--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -11,6 +11,8 @@ commands.getAlertText = async function () {
     if (this.isWebContext()) {
       const alert = await this.getAlert();
       return await alert.getText();
+    } else {
+      throw new errors.NoAlertOpenError(err.message);
     }
     throw err;
   }


### PR DESCRIPTION
We encountered an issue running the latest appium version (1.8.2beta) on iOS when attempting to wait for an alert to appear in the appium java client. The wait step would fail immediately regardless of the time given since the exception returned was not of type `NoAlertPresentException`. The expected condition `alertIsPresent` in Selenium uses `getAlertText` under the hood to check for its presence.

After spending some time debugging, I found the `getAlertText` command was throwing an error of no specific class (not one of those defined in [here](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/errors.js#L682)), which when parsed was resulting in an unknown error (status 13) being returned to the client.

It looked like many of the other alert commands here throw the NoAlertOpenError class in the non web context case, so I couldn't see a reason why not to do that for getAlertText too. It certainly solved the problem I was seeing.

Hope this change is fine to merge - if not maybe it will start a discussion of a better solution to the problem.