### PR TITLE
Add caps compatibility verification

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -889,12 +889,14 @@ class XCUITestDriver extends BaseDriver {
           caps.processArguments = JSON.parse(caps.processArguments);
           verifyProcessArgument(caps.processArguments);
         } catch (err) {
-          log.errorAndThrow(`processArguments must be a json format or an object with format {args : [], env : {a:b, c:d}}. Both environment and argument can be null. Error: ${err}`);
+          log.errorAndThrow(`processArguments must be a json format or an object with format {args : [], env : {a:b, c:d}}. ` +
+            `Both environment and argument can be null. Error: ${err}`);
         }
       } else if (_.isObject(caps.processArguments)) {
         verifyProcessArgument(caps.processArguments);
       } else {
-        log.errorAndThrow('processArguments must be an object, or a string JSON object with format {args : [], env : {a:b, c:d}}. Both environment and argument can be null.');
+        log.errorAndThrow(`'processArguments must be an object, or a string JSON object with format {args : [], env : {a:b, c:d}}. ` +
+          `Both environment and argument can be null.`);
       }
     }
 
@@ -923,6 +925,10 @@ class XCUITestDriver extends BaseDriver {
         log.errorAndThrow(`webDriverAgentUrl capability is expected to contain a valid WebDriverAgent server URL. ` +
                           `'${caps.webDriverAgentUrl}' is given instead`);
       }
+    }
+
+    if (!_.isEmpty(caps.browserName) && (!_.isEmpty(caps.app) || !_.isEmpty(caps.bundleId))) {
+      log.errorAndThrow(`'browserName' cannot be set together with 'app' or 'bundleId' capabilities`);
     }
 
     // finally, return true since the superclass check passed, as did this

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -858,25 +858,22 @@ class XCUITestDriver extends BaseDriver {
   }
 
   validateDesiredCaps (caps) {
-    // check with the base class, and return if it fails
-    let res = super.validateDesiredCaps(caps);
-    if (!res) {
-      return res;
+    if (!super.validateDesiredCaps(caps)) {
+      return false;
     }
 
     // make sure that the capabilities have one of `app` or `bundleId`
-    if ((caps.browserName || '').toLowerCase() !== 'safari' &&
-        !caps.app && !caps.bundleId) {
+    if ((caps.browserName || '').toLowerCase() !== 'safari' && !caps.app && !caps.bundleId) {
       let msg = 'The desired capabilities must include either an app or a bundleId for iOS';
       log.errorAndThrow(msg);
     }
 
     let verifyProcessArgument = (processArguments) => {
-      if (!_.isNil(processArguments.args) && !_.isArray(processArguments.args)) {
+      const {args, env} = processArguments;
+      if (!_.isNil(args) && !_.isArray(args)) {
         log.errorAndThrow('processArguments.args must be an array of strings');
       }
-
-      if (!_.isNil(processArguments.env) && !_.isPlainObject(caps.processArguments.env)) {
+      if (!_.isNil(env) && !_.isPlainObject(env)) {
         log.errorAndThrow('processArguments.env must be an object <key,value> pair {a:b, c:d}');
       }
     };
@@ -907,8 +904,7 @@ class XCUITestDriver extends BaseDriver {
 
     if (caps.autoAcceptAlerts || caps.autoDismissAlerts) {
       log.warn(`The capabilities 'autoAcceptAlerts' and 'autoDismissAlerts' ` +
-               `do not work for XCUITest-based tests. Please adjust your ` +
-               `alert handling accordingly.`);
+        `do not work for XCUITest-based tests. Please adjust your alert handling accordingly.`);
     }
 
     // `resetOnSessionStartOnly` should be set to true by default
@@ -922,19 +918,19 @@ class XCUITestDriver extends BaseDriver {
     if (_.isString(caps.webDriverAgentUrl)) {
       const {protocol, host} = url.parse(caps.webDriverAgentUrl);
       if (_.isEmpty(protocol) || _.isEmpty(host)) {
-        log.errorAndThrow(`webDriverAgentUrl capability is expected to contain a valid WebDriverAgent server URL. ` +
+        log.errorAndThrow(`'webDriverAgentUrl' capability is expected to contain a valid WebDriverAgent server URL. ` +
                           `'${caps.webDriverAgentUrl}' is given instead`);
       }
     }
 
-    if (!_.isEmpty(caps.browserName)) {
-      if (!_.isEmpty(caps.bundleId)) {
+    if (caps.browserName) {
+      if (caps.bundleId) {
         log.errorAndThrow(`'browserName' cannot be set together with 'bundleId' capability`);
       }
       // warn if the capabilities have both `app` and `browser, although this
       // is common with selenium grid
-      if (!_.isEmpty(caps.app)) {
-        log.warn('The capabilities should generally not include both an app and a browserName');
+      if (caps.app) {
+        log.warn(`The capabilities should generally not include both an 'app' and a 'browserName'`);
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -927,8 +927,15 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (!_.isEmpty(caps.browserName) && (!_.isEmpty(caps.app) || !_.isEmpty(caps.bundleId))) {
-      log.errorAndThrow(`'browserName' cannot be set together with 'app' or 'bundleId' capabilities`);
+    if (!_.isEmpty(caps.browserName)) {
+      if (!_.isEmpty(caps.bundleId)) {
+        log.errorAndThrow(`'browserName' cannot be set together with 'bundleId' capability`);
+      }
+      // warn if the capabilities have both `app` and `browser, although this
+      // is common with selenium grid
+      if (!_.isEmpty(caps.app)) {
+        log.warn('The capabilities should generally not include both an app and a browserName');
+      }
     }
 
     // finally, return true since the superclass check passed, as did this

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -873,10 +873,10 @@ class XCUITestDriver extends BaseDriver {
 
     let verifyProcessArgument = (processArguments) => {
       if (!_.isNil(processArguments.args) && !_.isArray(processArguments.args)) {
-        log.errorAndThrow('processArguments.args must be an array of string');
+        log.errorAndThrow('processArguments.args must be an array of strings');
       }
 
-      if (!_.isNil(processArguments.env) && !_.isObject(caps.processArguments.env)) {
+      if (!_.isNil(processArguments.env) && !_.isPlainObject(caps.processArguments.env)) {
         log.errorAndThrow('processArguments.env must be an object <key,value> pair {a:b, c:d}');
       }
     };
@@ -892,7 +892,7 @@ class XCUITestDriver extends BaseDriver {
           log.errorAndThrow(`processArguments must be a json format or an object with format {args : [], env : {a:b, c:d}}. ` +
             `Both environment and argument can be null. Error: ${err}`);
         }
-      } else if (_.isObject(caps.processArguments)) {
+      } else if (_.isPlainObject(caps.processArguments)) {
         verifyProcessArgument(caps.processArguments);
       } else {
         log.errorAndThrow(`'processArguments must be an object, or a string JSON object with format {args : [], env : {a:b, c:d}}. ` +


### PR DESCRIPTION
Throw an error if one tries to set application attributes while browserName capability is already defined. Unfortunately users tend to do this and then complain something does not work...