### PR TITLE
add checking current running WDA and making sure the bundle id isn't same as updatedWDABundleId

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -401,6 +401,11 @@ class XCUITestDriver extends BaseDriver {
     }
   }
 
+  /**
+   * Start WebDriverAgentRunner
+   * @param {string} sessionId - The id of the target session to launch WDA with.
+   * @param {boolean} realDevice - Equals to true if the test target device is a real device.
+   */
   async startWda (sessionId, realDevice) {
     this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
@@ -411,15 +416,16 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.quit();
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
-    } else if (!util.hasValue(this.wda.webDriverAgentUrl) && (await this.wda.isRunning())) {
-      let currentAppBundleID;
-      if (util.hasValue(this.opts.updatedWDABundleId)) {
-        let response = await this.proxyCommand('/status', 'GET');
-        currentAppBundleID = response.currentApp.bundleID;
-      }
-      if (this.opts.updatedWDABundleId !== currentAppBundleID) {
-        log.info(`Will stop running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
-        this.wda.quit();
+    } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
+      const currentAppBundleID = await this.wda.getCurrentBundleId;
+      if (util.hasValue(currentAppBundleID)) {
+        if (util.hasValue(this.opts.updatedWDABundleId) && (this.opts.updatedWDABundleId !== currentAppBundleID)) {
+          log.info(`Will stop running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
+          // TODO: this.wda.quit() just stops iproxy, xcodebuild  and jwproxy. Not WDA process which is already running.
+          // If we have no way to stop running WDA process, we should mention WDA must stop or be uninstalled
+          // before running tests with `updatedWDABundleId` instead of this kind of process.
+          await this.wda.quit();
+        }
       } else {
         log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
             `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -417,7 +417,7 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      const currentAppBundleID = await this.wda.getRunningBundleId;
+      const currentAppBundleID = (await this.wda.getRunningBundleId);
       if (util.hasValue(currentAppBundleID)) {
         if (util.hasValue(this.opts.updatedWDABundleId) && (this.opts.updatedWDABundleId !== currentAppBundleID)) {
           log.info(`Will uninstall running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -413,11 +413,12 @@ class XCUITestDriver extends BaseDriver {
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl) && (await this.wda.isRunning())) {
       let currentAppBundleID;
-      if (this.opts.updatedWDABundleId) {
+      if (util.hasValue(this.opts.updatedWDABundleId)) {
         let response = await this.proxyCommand('/status', 'GET');
         currentAppBundleID = response.currentApp.bundleID;
       }
-      if (this.opts.updatedWDABundleId === currentAppBundleID) {
+      if (this.opts.updatedWDABundleId !== currentAppBundleID) {
+        log.info(`Will stop running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
         this.wda.quit();
       } else {
         log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -417,10 +417,10 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      const currentAppBundleID = (await this.wda.getRunningBundleId);
+      const currentAppBundleID = (await this.wda.getRunningBundleId());
       if (util.hasValue(currentAppBundleID)) {
         if (util.hasValue(this.opts.updatedWDABundleId) && (this.opts.updatedWDABundleId !== currentAppBundleID)) {
-          log.info(`Will uninstall running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
+          log.info(`Will uninstall running WDA since it has different bundle id. The actual value is '${currentAppBundleID}'.`);
           await this.wda.uninstall();
         }
       } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -417,14 +417,11 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      const currentAppBundleID = await this.wda.getCurrentBundleId;
+      const currentAppBundleID = await this.wda.getRunningBundleId;
       if (util.hasValue(currentAppBundleID)) {
         if (util.hasValue(this.opts.updatedWDABundleId) && (this.opts.updatedWDABundleId !== currentAppBundleID)) {
-          log.info(`Will stop running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
-          // TODO: this.wda.quit() just stops iproxy, xcodebuild  and jwproxy. Not WDA process which is already running.
-          // If we have no way to stop running WDA process, we should mention WDA must stop or be uninstalled
-          // before running tests with `updatedWDABundleId` instead of this kind of process.
-          await this.wda.quit();
+          log.info(`Will uninstall running WDA since the WDA has different bundle id. The WDA is '${currentAppBundleID}'.`);
+          await this.wda.uninstall();
         }
       } else {
         log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -412,10 +412,19 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
     } else if (!util.hasValue(this.wda.webDriverAgentUrl) && (await this.wda.isRunning())) {
-      log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
-               `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +
-               `if this is an undesired behavior.`);
-      this.wda.webDriverAgentUrl = this.wda.url.href;
+      let currentAppBundleID;
+      if (this.opts.updatedWDABundleId) {
+        let response = await this.proxyCommand('/status', 'GET');
+        currentAppBundleID = response.currentApp.bundleID;
+      }
+      if (this.opts.updatedWDABundleId === currentAppBundleID) {
+        this.wda.quit();
+      } else {
+        log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
+            `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +
+            `if this is an undesired behavior.`);
+        this.wda.webDriverAgentUrl = this.wda.url.href;
+      }
     }
 
     // local helper for the two places we need to uninstall wda and re-start it

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -115,6 +115,28 @@ class WebDriverAgent {
     }
   }
 
+  /**
+   * Return current running WDA's bundle id
+   * @return {?string} bundle id
+   */
+  async getCurrentBundleId () {
+    const noSessionProxy = new NoSessionProxy({
+      server: this.url.hostname,
+      port: this.url.port,
+      base: '',
+      timeout: 3000,
+    });
+    try {
+      const status = await noSessionProxy.command('/status', 'GET');
+      if (status) {
+        return status.currentApp.bundleID;
+      }
+    } catch (err) {
+      log.debug(`WDA is not listening at '${this.url.href}'`);
+    }
+    return null;
+  }
+
   async uninstall () {
     log.debug(`Removing WDA application from device`);
     try {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -96,7 +96,11 @@ class WebDriverAgent {
     }
   }
 
-  async isRunning () {
+  /**
+   * Return current running WDA's bundle id
+   * @return {?string} bundle id
+   */
+  async getRunningBundleId () {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
@@ -108,33 +112,11 @@ class WebDriverAgent {
       if (!status) {
         throw new Error(`WDA response to /status command should be defined.`);
       }
-      return true;
+      return status.currentApp.bundleID;
     } catch (err) {
       log.debug(`WDA is not listening at '${this.url.href}'`);
-      return false;
+      return null;
     }
-  }
-
-  /**
-   * Return current running WDA's bundle id
-   * @return {?string} bundle id
-   */
-  async getCurrentBundleId () {
-    const noSessionProxy = new NoSessionProxy({
-      server: this.url.hostname,
-      port: this.url.port,
-      base: '',
-      timeout: 3000,
-    });
-    try {
-      const status = await noSessionProxy.command('/status', 'GET');
-      if (status) {
-        return status.currentApp.bundleID;
-      }
-    } catch (err) {
-      log.debug(`WDA is not listening at '${this.url.href}'`);
-    }
-    return null;
   }
 
   async uninstall () {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -97,8 +97,18 @@ class WebDriverAgent {
   }
 
   /**
+   * Return boolean if WDA is running or not
+   * @return {boolean} True if WDA is running
+   * @throws {Error} If there was invalid response code or body
+   */
+  async isRunning () {
+    return !!(await this.getRunningBundleId());
+  }
+
+  /**
    * Return current running WDA's bundle id
    * @return {?string} bundle id
+   * @throws {Error} If there was invalid response code or body
    */
   async getRunningBundleId () {
     const noSessionProxy = new NoSessionProxy({

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import url from 'url';
 import { JWProxy } from 'appium-base-driver';
-import { fs } from 'appium-support';
+import {fs, util} from 'appium-support';
 import log from '../logger';
 import { NoSessionProxy } from "./no-session-proxy";
 import { checkForDependencies } from './utils';
@@ -102,7 +102,7 @@ class WebDriverAgent {
    * @throws {Error} If there was invalid response code or body
    */
   async isRunning () {
-    return !!(await this.getRunningBundleId());
+    return !!(await this.getStatus());
   }
 
   /**
@@ -111,6 +111,19 @@ class WebDriverAgent {
    * @throws {Error} If there was invalid response code or body
    */
   async getRunningBundleId () {
+    const status = await this.getStatus();
+    if (util.hasValue(status)) {
+      return status.currentApp.bundleID;
+    }
+    return status;
+  }
+
+  /**
+   * Return current running WDA's bundle id
+   * @return {?object} State Object
+   * @throws {Error} If there was invalid response code or body
+   */
+  async getStatus () {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
@@ -118,11 +131,11 @@ class WebDriverAgent {
       timeout: 3000,
     });
     try {
-      const status = await noSessionProxy.command('/status', 'GET');
-      if (!status) {
+      const response = await noSessionProxy.command('/status', 'GET');
+      if (!response) {
         throw new Error(`WDA response to /status command should be defined.`);
       }
-      return status.currentApp.bundleID;
+      return response;
     } catch (err) {
       log.debug(`WDA is not listening at '${this.url.href}'`);
       return null;

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -131,6 +131,21 @@ class WebDriverAgent {
       timeout: 3000,
     });
     try {
+      //{
+      //   "state": "success",
+      //   "os": {
+      //     "name": "iOS",
+      //     "version": "11.4",
+      //     "sdkVersion": "11.3"
+      //   },
+      //   "ios": {
+      //     "simulatorVersion": "11.4",
+      //     "ip": "172.254.99.34"
+      //   },
+      //   "build": {
+      //     "time": "Jun 24 2018 17:08:21"
+      //   }
+      // }
       const response = await noSessionProxy.command('/status', 'GET');
       if (!response) {
         throw new Error(`WDA response to /status command should be defined.`);


### PR DESCRIPTION
related with: https://github.com/appium/appium/issues/10945

## Current
If a real device has a running WDA, this driver use the WDA even the WDA isn't `updatedWDABundleId` value. As the result, this driver never reach https://github.com/appium/appium-xcuitest-driver/blob/9dbbeb9f7a819abba76d8ce18928127d5308c02b/lib/wda/xcodebuild.js#L83 .

## So,
What about checking the running WDA's bundleId and ~~stop~~ uninstall the process if the bundleId isn't  `updatedWDABundleId`?