### PR TITLE
try to uninstall WDA if updatedWDABundleId exists

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -401,6 +401,11 @@ class XCUITestDriver extends BaseDriver {
     }
   }
 
+  /**
+   +   * Start WebDriverAgentRunner
+   +   * @param {string} sessionId - The id of the target session to launch WDA with.
+   +   * @param {boolean} realDevice - Equals to true if the test target device is a real device.
+   +   */
   async startWda (sessionId, realDevice) {
     this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
@@ -411,11 +416,17 @@ class XCUITestDriver extends BaseDriver {
       await this.wda.quit();
       await this.wda.uninstall();
       this.logEvent('wdaUninstalled');
-    } else if (!util.hasValue(this.wda.webDriverAgentUrl) && (await this.wda.isRunning())) {
-      log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
-               `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +
-               `if this is an undesired behavior.`);
-      this.wda.webDriverAgentUrl = this.wda.url.href;
+    } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
+      if (util.hasValue(this.opts.updatedWDABundleId)) {
+        log.info(`Will uninstall installed WDA to install WDA with ${this.opts.updatedWDABundleId}. ` +
+                 `Will continue even if WDA doesn't exist in the test target.`);
+        await this.wda.uninstall();
+      } else if (await this.wda.isRunning()) {
+        log.info(`Will reuse previously cached WDA instance at '${this.wda.url.href}'. ` +
+                 `Set the wdaLocalPort capability to a value different from ${this.wda.url.port} ` +
+                 `if this is an undesired behavior.`);
+        this.wda.webDriverAgentUrl = this.wda.url.href;
+      }
     }
 
     // local helper for the two places we need to uninstall wda and re-start it


### PR DESCRIPTION
re: _add checking current running WDA and making sure the bundle id isn't same as updatedWDABundleId #709_
related with: https://github.com/appium/appium/issues/10945

----

We have no way to get running WDA's `PRODUCT_BUNDLE_IDENTIFIER` [note1](https://github.com/appium/appium-xcuitest-driver/pull/709/files#r198679101), [note2](https://github.com/appium/appium-xcuitest-driver/pull/709/files#diff-dd1c1e9a4d2cba48fc21e5d2c50abcafR134). We can't compare running WDA's identifer and `updatedWDABundleId` in this case. Thus, what about uninstalling WDA so that we can install and run WDA with `updatedWDABundleId` identifier?

If `webDriverAgentUrl` exists in the capability, uninstalling never happen. Users can use installed and running WDA in the case.