### PR TITLE
Add collection of safari network logs

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -16,7 +16,7 @@ extensions.setContext = async function (name, callback, skipReadyCheck) {
   await this._setContext(name, callback, skipReadyCheck);
 
   // start safari logging if the logs handlers are active
-  if (name && name !== NATIVE_WIN) {
+  if (name && name !== NATIVE_WIN && this.logs) {
     if (this.logs && this.logs.safariConsole) {
       await this.remote.startConsole(this.logs.safariConsole.addLogLine.bind(this.logs.safariConsole));
     }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -15,10 +15,13 @@ extensions._setContext = extensions.setContext;
 extensions.setContext = async function (name, callback, skipReadyCheck) {
   await this._setContext(name, callback, skipReadyCheck);
 
-  // start safari console logging if the logs handler is active
+  // start safari logging if the logs handlers are active
   if (name && name !== NATIVE_WIN) {
     if (this.logs && this.logs.safariConsole) {
       await this.remote.startConsole(this.logs.safariConsole.addLogLine.bind(this.logs.safariConsole));
+    }
+    if (this.logs && this.logs.safariNetwork) {
+      await this.remote.startNetwork(this.logs.safariNetwork.addLogLine.bind(this.logs.safariNetwork));
     }
   }
 };

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -17,10 +17,10 @@ extensions.setContext = async function (name, callback, skipReadyCheck) {
 
   // start safari logging if the logs handlers are active
   if (name && name !== NATIVE_WIN && this.logs) {
-    if (this.logs && this.logs.safariConsole) {
+    if (this.logs.safariConsole) {
       await this.remote.startConsole(this.logs.safariConsole.addLogLine.bind(this.logs.safariConsole));
     }
-    if (this.logs && this.logs.safariNetwork) {
+    if (this.logs.safariNetwork) {
       await this.remote.startNetwork(this.logs.safariNetwork.addLogLine.bind(this.logs.safariNetwork));
     }
   }

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -5,7 +5,8 @@ import { IOSCrashLog } from '../device-log/ios-crash-log';
 import { IOSLog } from '../device-log/ios-log';
 import log from '../logger';
 import WebSocket from 'ws';
-import { SafariConsoleLog } from '../device-log/safari-console-log';
+import SafariConsoleLog from '../device-log/safari-console-log';
+import SafariNetworkLog from '../device-log/safari-network-log';
 
 
 let extensions = {};
@@ -17,6 +18,11 @@ Object.assign(extensions, iosCommands.logging);
 extensions.supportedLogTypes.safariConsole = {
   description: 'Safari Console Logs - data written to the JS console in Safari',
   getter: async (self) => await self.extractLogs('safariConsole', self.logs),
+};
+
+extensions.supportedLogTypes.safariNetwork = {
+  description: 'Safari Network Logs - information about network operations undertaken by Safari',
+  getter: async (self) => await self.extractLogs('safariNetwork', self.logs),
 };
 
 extensions.startLogCapture = async function () {
@@ -38,6 +44,7 @@ extensions.startLogCapture = async function () {
       xcodeVersion: this.xcodeVersion,
     });
     this.logs.safariConsole = new SafariConsoleLog(!!this.opts.showSafariConsoleLog);
+    this.logs.safariNetwork = new SafariNetworkLog(!!this.opts.showSafariNetworkLog);
   }
   try {
     await this.logs.syslog.startCapture();
@@ -47,6 +54,7 @@ extensions.startLogCapture = async function () {
   }
   await this.logs.crashlog.startCapture();
   await this.logs.safariConsole.startCapture();
+  await this.logs.safariNetwork.startCapture();
 
   return true;
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -144,6 +144,9 @@ let desiredCapConstraints = _.defaults({
   showSafariConsoleLog: {
     isBoolean: true
   },
+  showSafariNetworkLog: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints };

--- a/lib/device-log/rotating-log.js
+++ b/lib/device-log/rotating-log.js
@@ -1,0 +1,61 @@
+import _ from 'lodash';
+import { logger } from 'appium-support';
+
+
+const MAX_LOG_ENTRIES_COUNT = 10000;
+
+class RotatingLog {
+  constructor (showLogs = false, label = 'Log Label') {
+    this.log = logger.getLogger(label);
+
+    this.showLogs = showLogs;
+    this.logs = [];
+    this.logIdxSinceLastRequest = 0;
+
+    this.isCapturing = false;
+  }
+
+  async startCapture () {
+    this.isCapturing = true;
+  }
+
+  async stopCapture () {
+    this.isCapturing = false;
+  }
+
+  /*
+   * @override
+   */
+  addLogLine () {
+  }
+
+  async getLogs () {
+    if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
+      let result = _.clone(this.logs);
+      if (this.logIdxSinceLastRequest > 0) {
+        result = result.slice(this.logIdxSinceLastRequest);
+      }
+      this.logIdxSinceLastRequest = this.logs.length;
+      return result;
+    }
+    return [];
+  }
+
+  async getAllLogs () {
+    return _.clone(this.logs);
+  }
+
+  get logs () {
+    if (!this._logs) {
+      this.logs = [];
+    }
+    return this._logs;
+  }
+
+  set logs (logs) {
+    this._logs = logs;
+  }
+}
+
+export { RotatingLog, MAX_LOG_ENTRIES_COUNT };
+export default RotatingLog;

--- a/lib/device-log/safari-console-log.js
+++ b/lib/device-log/safari-console-log.js
@@ -1,27 +1,12 @@
-import _ from 'lodash';
-import { logger } from 'appium-support';
+import { RotatingLog, MAX_LOG_ENTRIES_COUNT } from './rotating-log';
 
 
-const MAX_LOG_ENTRIES_COUNT = 10000;
-
-const log = logger.getLogger('SafariConsole');
-log.warning = log.warn; // js console has `warning` level, so map to `warn`
-
-class SafariConsoleLog {
+class SafariConsoleLog extends RotatingLog {
   constructor (showLogs) {
-    this.showLogs = showLogs;
-    this.logs = [];
-    this.logIdxSinceLastRequest = 0;
+    super(showLogs, 'SafariConsole');
 
-    this.isCapturing = false;
-  }
-
-  async startCapture () {
-    this.isCapturing = true;
-  }
-
-  async stopCapture () {
-    this.isCapturing = false;
+    // js console has `warning` level, so map to `warn`
+    this.log.warning = this.log.warn;
   }
 
   addLogLine (out) {
@@ -46,25 +31,9 @@ class SafariConsoleLog {
       for (const line of out.text.split('\n')) {
         // url is optional, so get formatting here
         const url = out.url ? `${out.url} ` : '';
-        log[level](`[${level.toUpperCase()}][${url}${out.line}:${out.column}] ${line}`);
+        this.log[level](`[${level.toUpperCase()}][${url}${out.line}:${out.column}] ${line}`);
       }
     }
-  }
-
-  async getLogs () {
-    if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
-      let result = _.clone(this.logs);
-      if (this.logIdxSinceLastRequest > 0) {
-        result = result.slice(this.logIdxSinceLastRequest);
-      }
-      this.logIdxSinceLastRequest = this.logs.length;
-      return result;
-    }
-    return [];
-  }
-
-  async getAllLogs () {
-    return _.clone(this.logs);
   }
 }
 

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -1,0 +1,140 @@
+import _ from 'lodash';
+import URL from 'url';
+import { RotatingLog, MAX_LOG_ENTRIES_COUNT } from './rotating-log';
+
+
+class SafariNetworkLog extends RotatingLog {
+  constructor (showLogs) {
+    super(showLogs, 'SafariNetwork');
+  }
+
+  getEntry (requestId) {
+    let outputEntry;
+    while (this.logs.length >= MAX_LOG_ENTRIES_COUNT) {
+      // pull the first entry, which is the oldest
+      const entry = this.logs.shift();
+      if (entry && entry.requestId === requestId) {
+        // we are adding to an existing entry, and it was almost removed
+        // add to the end of the list and try again
+        outputEntry = entry;
+        this.logs.push(outputEntry);
+        continue;
+      }
+      // we've removed an element, so the count is down one
+      if (this.logIdxSinceLastRequest > 0) {
+        this.logIdxSinceLastRequest--;
+      }
+    }
+
+
+    if (!outputEntry) {
+      // we do not yes have an entry to associate this bit of output with
+      // most likely the entry will be at the end of the list, so start there
+      for (let i = this.logs.length - 1; i >= 0; i--) {
+        if (this.logs[i].requestId === requestId) {
+          // found it!
+          outputEntry = this.logs[i];
+          // this is now the most current entry, so remove it from the list
+          // to be added to the end below
+          this.logs.splice(i, 1);
+          break;
+        }
+      }
+
+      // nothing has been found, so create a new entry
+      if (!outputEntry) {
+        outputEntry = {
+          requestId,
+          logs: [],
+        };
+      }
+
+      // finally, add the entry to the end of the list
+      this.logs.push(outputEntry);
+    }
+
+    return outputEntry;
+  }
+
+  addLogLine (method, out) {
+    if (['Network.dataReceived'].includes(method)) {
+      // status update, no need to handle
+      return;
+    }
+
+    // events we care about:
+    //   Network.requestWillBeSent
+    //   Network.responseReceived
+    //   Network.loadingFinished
+
+    const outputEntry = this.getEntry(out.requestId);
+    if (this.isCapturing) {
+      // now add the output we just received to the logs for this particular entry
+      outputEntry.logs = outputEntry.logs || [];
+      outputEntry.logs.push(out);
+    }
+
+    // if we want to display the logs in the stdout, there is more to do
+    if (this.showLogs) {
+      if (method === 'Network.loadingFinished') {
+        const {
+          name,
+          status,
+          type,
+          initiator = {},
+          size = 0,
+          time = 0,
+          source,
+        } = outputEntry.logs.reduce(function (record, entry) {
+          record.requestId = entry.requestId;
+          if (entry.response) {
+            const url = URL.parse(entry.response.url);
+            // get the last part of the url, along with the query string, if possible
+            record.name = `${_.last(url.pathname.split('/'))}${url.search ? `?${url.search}` : ''}` || url.host;
+            record.status = entry.response.status;
+            if (entry.response.timing) {
+              record.time = entry.response.timing.receiveHeadersEnd
+                || entry.response.timing.responseStart
+                || 0;
+            }
+            record.source = entry.response.source;
+          }
+          if (entry.type) {
+            record.type = entry.type;
+          }
+          if (entry.initiator) {
+            record.initiator = entry.initiator;
+          }
+          if (entry.metrics) {
+            // Safari has a `metrics` object on it's `Network.loadingFinished` event
+            record.size = entry.metrics.responseBodyBytesReceived || 0;
+          }
+          return record;
+        }, {});
+
+        // print out the record, formatted appropriately
+        this.log.debug(`Network event:`);
+        this.log.debug(`  Id: ${out.requestId}`);
+        this.log.debug(`  Name: ${name}`);
+        this.log.debug(`  Status: ${status}`);
+        this.log.debug(`  Type: ${type}`);
+        this.log.debug(`  Initiator: ${initiator.type}`);
+        for (const line of (initiator.stackTrace || [])) {
+          const functionName = line.functionName || '(anonymous)';
+
+          const url = (!line.url || line.url === '[native code]')
+            ? ''
+            : `@${_.last((URL.parse(line.url).pathname || '').split('/'))}:${line.lineNumber}`;
+          this.log.debug(`    ${_.truncate(functionName, {length: 20}).padEnd(21)} ${url}`);
+        }
+        // get `memory-cache` or `disk-cache`, etc., right
+        const sizeStr = source.includes('cache') ? ` (from ${source.replace('-', ' ')})` : `${size}B`;
+        this.log.debug(`  Size: ${sizeStr}`);
+        this.log.debug(`  Time: ${Math.round(time)}ms`);
+      }
+    }
+  }
+}
+
+export { SafariNetworkLog };
+export default SafariNetworkLog;

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -74,65 +74,68 @@ class SafariNetworkLog extends RotatingLog {
       outputEntry.logs.push(out);
     }
 
-    // if we want to display the logs in the stdout, there is more to do
-    if (this.showLogs) {
-      if (method === 'Network.loadingFinished') {
-        const {
-          name,
-          status,
-          type,
-          initiator = {},
-          size = 0,
-          time = 0,
-          source,
-        } = outputEntry.logs.reduce(function (record, entry) {
-          record.requestId = entry.requestId;
-          if (entry.response) {
-            const url = URL.parse(entry.response.url);
-            // get the last part of the url, along with the query string, if possible
-            record.name = `${_.last(url.pathname.split('/'))}${url.search ? `?${url.search}` : ''}` || url.host;
-            record.status = entry.response.status;
-            if (entry.response.timing) {
-              record.time = entry.response.timing.receiveHeadersEnd
-                || entry.response.timing.responseStart
-                || 0;
-            }
-            record.source = entry.response.source;
-          }
-          if (entry.type) {
-            record.type = entry.type;
-          }
-          if (entry.initiator) {
-            record.initiator = entry.initiator;
-          }
-          if (entry.metrics) {
-            // Safari has a `metrics` object on it's `Network.loadingFinished` event
-            record.size = entry.metrics.responseBodyBytesReceived || 0;
-          }
-          return record;
-        }, {});
-
-        // print out the record, formatted appropriately
-        this.log.debug(`Network event:`);
-        this.log.debug(`  Id: ${out.requestId}`);
-        this.log.debug(`  Name: ${name}`);
-        this.log.debug(`  Status: ${status}`);
-        this.log.debug(`  Type: ${type}`);
-        this.log.debug(`  Initiator: ${initiator.type}`);
-        for (const line of (initiator.stackTrace || [])) {
-          const functionName = line.functionName || '(anonymous)';
-
-          const url = (!line.url || line.url === '[native code]')
-            ? ''
-            : `@${_.last((URL.parse(line.url).pathname || '').split('/'))}:${line.lineNumber}`;
-          this.log.debug(`    ${_.truncate(functionName, {length: 20}).padEnd(21)} ${url}`);
-        }
-        // get `memory-cache` or `disk-cache`, etc., right
-        const sizeStr = source.includes('cache') ? ` (from ${source.replace('-', ' ')})` : `${size}B`;
-        this.log.debug(`  Size: ${sizeStr}`);
-        this.log.debug(`  Time: ${Math.round(time)}ms`);
-      }
+    // if we are not displaying the logs,
+    // or we are not finished getting events for this network call,
+    // we are done
+    if (!this.showLogs && method !== 'Network.loadingFinished') {
+      return;
     }
+
+    // extract and print the data
+    const {
+      name,
+      status,
+      type,
+      initiator = {},
+      size = 0,
+      time = 0,
+      source,
+    } = outputEntry.logs.reduce(function (record, entry) {
+      record.requestId = entry.requestId;
+      if (entry.response) {
+        const url = URL.parse(entry.response.url);
+        // get the last part of the url, along with the query string, if possible
+        record.name = `${_.last(url.pathname.split('/'))}${url.search ? `?${url.search}` : ''}` || url.host;
+        record.status = entry.response.status;
+        if (entry.response.timing) {
+          record.time = entry.response.timing.receiveHeadersEnd
+            || entry.response.timing.responseStart
+            || 0;
+        }
+        record.source = entry.response.source;
+      }
+      if (entry.type) {
+        record.type = entry.type;
+      }
+      if (entry.initiator) {
+        record.initiator = entry.initiator;
+      }
+      if (entry.metrics) {
+        // Safari has a `metrics` object on it's `Network.loadingFinished` event
+        record.size = entry.metrics.responseBodyBytesReceived || 0;
+      }
+      return record;
+    }, {});
+
+    // print out the record, formatted appropriately
+    this.log.debug(`Network event:`);
+    this.log.debug(`  Id: ${out.requestId}`);
+    this.log.debug(`  Name: ${name}`);
+    this.log.debug(`  Status: ${status}`);
+    this.log.debug(`  Type: ${type}`);
+    this.log.debug(`  Initiator: ${initiator.type}`);
+    for (const line of (initiator.stackTrace || [])) {
+      const functionName = line.functionName || '(anonymous)';
+
+      const url = (!line.url || line.url === '[native code]')
+        ? ''
+        : `@${_.last((URL.parse(line.url).pathname || '').split('/'))}:${line.lineNumber}`;
+      this.log.debug(`    ${_.truncate(functionName, {length: 20}).padEnd(21)} ${url}`);
+    }
+    // get `memory-cache` or `disk-cache`, etc., right
+    const sizeStr = source.includes('cache') ? ` (from ${source.replace('-', ' ')})` : `${size}B`;
+    this.log.debug(`  Size: ${sizeStr}`);
+    this.log.debug(`  Time: ${Math.round(time)}ms`);
   }
 }
 

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import URL from 'url';
+import { util } from 'appium-support';
 import { RotatingLog, MAX_LOG_ENTRIES_COUNT } from './rotating-log';
 
 
@@ -62,10 +63,16 @@ class SafariNetworkLog extends RotatingLog {
       return;
     }
 
+    if (!this.isCapturing && !this.showLogs) {
+      // neither capturing nor displaying, so do nothing
+      return;
+    }
+
     // events we care about:
     //   Network.requestWillBeSent
     //   Network.responseReceived
     //   Network.loadingFinished
+    //   Network.loadingFailed
 
     const outputEntry = this.getEntry(out.requestId);
     if (this.isCapturing) {
@@ -77,12 +84,19 @@ class SafariNetworkLog extends RotatingLog {
     // if we are not displaying the logs,
     // or we are not finished getting events for this network call,
     // we are done
-    if (!this.showLogs && method !== 'Network.loadingFinished') {
+    if (!this.showLogs) {
       return;
     }
 
+    if (method === 'Network.loadingFinished' || method === 'Network.loadingFailed') {
+      this.printLogLine(outputEntry);
+    }
+  }
+
+  printLogLine (outputEntry) {
     // extract and print the data
     const {
+      requestId,
       name,
       status,
       type,
@@ -90,6 +104,8 @@ class SafariNetworkLog extends RotatingLog {
       size = 0,
       time = 0,
       source,
+      errorText,
+      cancelled = false,
     } = outputEntry.logs.reduce(function (record, entry) {
       record.requestId = entry.requestId;
       if (entry.response) {
@@ -114,12 +130,19 @@ class SafariNetworkLog extends RotatingLog {
         // Safari has a `metrics` object on it's `Network.loadingFinished` event
         record.size = entry.metrics.responseBodyBytesReceived || 0;
       }
+      if (entry.errorText) {
+        record.errorText = entry.errorText;
+        // When a network call is cancelled, Safari returns `cancelled` as error text
+        // but has a boolean `canceled`. Normalize the two spellings in favor of
+        // the text, which will also be displayed
+        record.cancelled = entry.canceled;
+      }
       return record;
     }, {});
 
     // print out the record, formatted appropriately
     this.log.debug(`Network event:`);
-    this.log.debug(`  Id: ${out.requestId}`);
+    this.log.debug(`  Id: ${requestId}`);
     this.log.debug(`  Name: ${name}`);
     this.log.debug(`  Status: ${status}`);
     this.log.debug(`  Type: ${type}`);
@@ -136,6 +159,12 @@ class SafariNetworkLog extends RotatingLog {
     const sizeStr = source.includes('cache') ? ` (from ${source.replace('-', ' ')})` : `${size}B`;
     this.log.debug(`  Size: ${sizeStr}`);
     this.log.debug(`  Time: ${Math.round(time)}ms`);
+    if (errorText) {
+      this.log.debug(`  Error: ${errorText}`);
+    }
+    if (util.hasValue(cancelled)) {
+      this.log.debug(`  Cancelled: ${cancelled}`);
+    }
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ async function detectUdid () {
   let udid;
   try {
     let {stdout} = await exec(cmd, args, {timeout: 3000});
-    let udids = _.filter(stdout.split('\n'), Boolean);
+    let udids = _.uniq(_.filter(stdout.split('\n'), Boolean));
     udid = _.last(udids);
     if (udids.length > 1) {
       log.warn(`Multiple devices found: ${udids.join(', ')}`);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.1.1",
     "js2xmlparser2": "^0.2.0",
-    "lodash": "=4.17.9",
+    "lodash": "^4.17.10",
     "node-simctl": "^3.10.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -165,7 +165,9 @@ describe('XCUITestDriver - basics -', function () {
   describe('logging -', function () {
     describe('types -', function () {
       it('should get the list of available logs', async function () {
-        let expectedTypes = ['syslog', 'crashlog', 'performance', 'server', 'safariConsole'];
+        const expectedTypes = [
+          'syslog', 'crashlog', 'performance', 'server', 'safariConsole', 'safariNetwork'
+        ];
         (await driver.logTypes()).should.eql(expectedTypes);
       });
     });


### PR DESCRIPTION
Add the ability to listen to, and print out, the Safari network logs. This can be adjusted later, but the information displayed is in line with Chrome DevTools.