### PR TITLE
Move to cookie methods through webkit

### DIFF
--- a/lib/commands/cookies.js
+++ b/lib/commands/cookies.js
@@ -1,0 +1,57 @@
+import log from '../logger';
+import { errors } from 'appium-base-driver';
+
+
+let commands = {}, helpers = {}, extensions = {};
+
+commands.getCookies = async function getCookies () {
+  if (!this.isWebContext()) {
+    throw new errors.NotImplementedError();
+  }
+
+  // get the cookies from the remote debugger, or an empty object
+  const cookies = await this.remote.getCookies() || {cookies: []};
+  // the value is URI encoded, so decode it
+  // but keep all the rest of the info intact
+  return cookies.cookies.map(function (cookie) {
+    return Object.assign({}, cookie, {
+      value: decodeURI(cookie.value),
+    });
+  });
+};
+
+commands.deleteCookie = async function deleteCookie (cookieName) {
+  if (!this.isWebContext()) {
+    throw new errors.NotImplementedError();
+  }
+
+  const cookies = await this.getCookies();
+  const cookie = cookies.find((cookie) => cookie.name === cookieName);
+  if (!cookie) {
+    log.debug(`Cookie '${cookieName}' not found. Ignoring.`);
+    return true;
+  }
+
+  await this.remote.deleteCookie(cookieName, `http://${cookie.domain}${cookie.path}`);
+  return true;
+};
+
+commands.deleteCookies = async function deleteCookies () {
+  if (!this.isWebContext()) {
+    throw new errors.NotImplementedError();
+  }
+
+  const cookies = await this.getCookies();
+  for (const cookie of cookies) {
+    await this._deleteCookie(cookie);
+  }
+  return true;
+};
+
+helpers._deleteCookie = async function _deleteCookie (cookie) {
+  return await this.remote.deleteCookie(cookie.name, `http://${cookie.domain}${cookie.path}`);
+};
+
+Object.assign(extensions, commands, helpers);
+export { commands, helpers };
+export default extensions;

--- a/lib/commands/cookies.js
+++ b/lib/commands/cookies.js
@@ -32,7 +32,7 @@ commands.deleteCookie = async function deleteCookie (cookieName) {
     return true;
   }
 
-  await this.remote.deleteCookie(cookieName, `http://${cookie.domain}${cookie.path}`);
+  await this._deleteCookie(cookie);
   return true;
 };
 
@@ -49,7 +49,8 @@ commands.deleteCookies = async function deleteCookies () {
 };
 
 helpers._deleteCookie = async function _deleteCookie (cookie) {
-  return await this.remote.deleteCookie(cookie.name, `http://${cookie.domain}${cookie.path}`);
+  const url = `http${cookie.secure ? 's' : ''}://${cookie.domain}${cookie.path}`;
+  return await this.remote.deleteCookie(cookie.name, url);
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -22,6 +22,8 @@ import performanceExtensions from './performance';
 import clipboardExtensions from './clipboard';
 import certificateExtensions from './certificate';
 import batteryExtensions from './battery';
+import cookiesExtensions from './cookies';
+
 
 let commands = {};
 
@@ -31,7 +33,7 @@ Object.assign(commands, contextCommands, executeExtensions,
   navigationExtensions, elementExtensions, fileMovementExtensions,
   alertExtensions, screenshotExtensions, pasteboardExtensions, locationExtensions,
   lockExtensions, recordScreenExtensions, appManagementExtensions, performanceExtensions,
-  clipboardExtensions, certificateExtensions, batteryExtensions
+  clipboardExtensions, certificateExtensions, batteryExtensions, cookiesExtensions
 );
 
 export default commands;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "appium-base-driver": "^3.0.0",
     "appium-ios-driver": "^2.4.3",
     "appium-ios-simulator": "^3.0.0",
-    "appium-remote-debugger": "^3.10.0",
+    "appium-remote-debugger": "^3.16.0",
     "appium-support": "^2.13.0",
     "appium-xcode": "^3.2.0",
     "async-lock": "^1.0.0",

--- a/test/functional/web/safari-cookie-e2e-specs.js
+++ b/test/functional/web/safari-cookie-e2e-specs.js
@@ -9,6 +9,28 @@ import { GUINEA_PIG_PAGE, GUINEA_PIG_IFRAME_PAGE } from './helpers';
 chai.should();
 chai.use(chaiAsPromised);
 
+const doesIncludeCookie = function (cookies, cookie) {
+  cookies.map((c) => c.name).should.include(cookie.name);
+  cookies.map((c) => c.value).should.include(cookie.value);
+};
+const doesNotIncludeCookie = function (cookies, cookie) {
+  cookies.map((c) => c.name).should.not.include(cookie.name);
+  cookies.map((c) => c.value).should.not.include(cookie.value);
+};
+
+const newCookie = {
+  name: 'newcookie',
+  value: 'i am new here'
+};
+const oldCookie1 = {
+  name: 'guineacookie1',
+  value: 'i am a cookie value'
+};
+const oldCookie2 = {
+  name: 'guineacookie2',
+  value: 'cookié2'
+};
+
 describe('safari - cookies', function () {
   this.timeout(MOCHA_TIMEOUT);
 
@@ -36,104 +58,83 @@ describe('safari - cookies', function () {
   });
 
   describe('within webview', function () {
-    const newCookie = {
-      name: 'newcookie',
-      value: 'i am new here'
-    };
-    const oldCookie1 = {
-      name: 'guineacookie1',
-      value: 'i am a cookie value'
-    };
-    const oldCookie2 = {
-      name: 'guineacookie2',
-      value: 'cookié2'
-    };
+    describe('insecure', function () {
+      beforeEach(async function () {
+        await driver.get(GUINEA_PIG_PAGE);
+        await driver.deleteCookie(newCookie.name);
+      });
 
-    let doesIncludeCookie = function (cookies, cookie) {
-      cookies.map((c) => c.name).should.include(cookie.name);
-      cookies.map((c) => c.value).should.include(cookie.value);
-    };
-    let doesNotIncludeCookie = function (cookies, cookie) {
-      cookies.map((c) => c.name).should.not.include(cookie.name);
-      cookies.map((c) => c.value).should.not.include(cookie.value);
-    };
+      it('should be able to get cookies for a page', async function () {
+        let cookies = await driver.allCookies();
+        cookies.length.should.equal(2);
+        doesIncludeCookie(cookies, oldCookie1);
+        doesIncludeCookie(cookies, oldCookie2);
+      });
 
-    beforeEach(async function () {
-      await driver.get(GUINEA_PIG_PAGE);
+      it('should be able to set a cookie for a page', async function () {
+        await driver.setCookie(newCookie);
+        const cookies = await driver.allCookies();
+        doesIncludeCookie(cookies, newCookie);
+
+        // should not clobber old cookies
+        doesIncludeCookie(cookies, oldCookie1);
+        doesIncludeCookie(cookies, oldCookie2);
+      });
+
+      it('should be able to set a cookie with expiry', async function () {
+        const expiredCookie = Object.assign({}, newCookie, {
+          expiry: parseInt(Date.now() / 1000, 10) - 1000, // set cookie in past
+          name: 'expiredcookie',
+        });
+
+        let cookies = await driver.allCookies();
+        doesNotIncludeCookie(cookies, expiredCookie);
+
+        await driver.setCookie(expiredCookie);
+        cookies = await driver.allCookies();
+        // should not include cookie we just added because of expiry
+        doesNotIncludeCookie(cookies, expiredCookie);
+
+        // should not clobber old cookies
+        doesIncludeCookie(cookies, oldCookie1);
+        doesIncludeCookie(cookies, oldCookie2);
+
+        await driver.deleteCookie(expiredCookie.name);
+      });
+
+      it('should be able to delete one cookie', async function () {
+        await driver.setCookie(newCookie);
+        let cookies = await driver.allCookies();
+        doesIncludeCookie(cookies, newCookie);
+
+        await driver.deleteCookie(newCookie.name);
+        cookies = await driver.allCookies();
+        doesNotIncludeCookie(cookies, newCookie);
+
+        doesIncludeCookie(cookies, oldCookie1);
+        doesIncludeCookie(cookies, oldCookie2);
+      });
+
+      it('should be able to delete all cookies', async function () {
+        await driver.setCookie(newCookie);
+        let cookies = await driver.allCookies();
+        doesIncludeCookie(cookies, newCookie);
+
+        await driver.deleteAllCookies();
+        cookies = await driver.allCookies();
+        cookies.length.should.equal(0);
+
+        doesNotIncludeCookie(cookies, oldCookie1);
+        doesNotIncludeCookie(cookies, oldCookie2);
+      });
     });
 
-    it('should be able to get cookies for a page', async function () {
-      let cookies = await driver.allCookies();
-      cookies.length.should.equal(2);
-      doesIncludeCookie(cookies, oldCookie1);
-      doesIncludeCookie(cookies, oldCookie2);
-    });
-
-    it('should be able to set a cookie for a page', async function () {
-      await driver.deleteCookie(newCookie.name);
-      let cookies = await driver.allCookies();
-      doesNotIncludeCookie(cookies, newCookie);
-
-      await driver.setCookie(newCookie);
-      cookies = await driver.allCookies();
-      doesIncludeCookie(cookies, newCookie);
-
-      // should not clobber old cookies
-      doesIncludeCookie(cookies, oldCookie1);
-      doesIncludeCookie(cookies, oldCookie2);
-    });
-
-    it('should be able to set a cookie with expiry', async function () {
-      let expiredCookie = _.defaults({
-        expiry: parseInt(Date.now() / 1000, 10) - 1000 // set cookie in past
-      }, newCookie);
-
-      await driver.deleteCookie(expiredCookie.name);
-      let cookies = await driver.allCookies();
-      doesNotIncludeCookie(cookies, expiredCookie);
-
-      await driver.setCookie(expiredCookie);
-      cookies = await driver.allCookies();
-      // should not include cookie we just added because of expiry
-      doesNotIncludeCookie(cookies, expiredCookie);
-
-      // should not clobber old cookies
-      doesIncludeCookie(cookies, oldCookie1);
-      doesIncludeCookie(cookies, oldCookie2);
-    });
-
-    it('should be able to delete one cookie', async function () {
-      await driver.deleteCookie(newCookie.name);
-      let cookies = await driver.allCookies();
-      doesNotIncludeCookie(cookies, newCookie);
-
-      await driver.setCookie(newCookie);
-      cookies = await driver.allCookies();
-      doesIncludeCookie(cookies, newCookie);
-
-      await driver.deleteCookie(newCookie.name);
-      cookies = await driver.allCookies();
-      doesNotIncludeCookie(cookies, newCookie);
-
-      doesIncludeCookie(cookies, oldCookie1);
-      doesIncludeCookie(cookies, oldCookie2);
-    });
-
-    it('should be able to delete all cookies', async function () {
-      await driver.deleteCookie(newCookie.name);
-      let cookies = await driver.allCookies();
-      doesNotIncludeCookie(cookies, newCookie);
-
-      await driver.setCookie(newCookie);
-      cookies = await driver.allCookies();
-      doesIncludeCookie(cookies, newCookie);
-
-      await driver.deleteAllCookies();
-      cookies = await driver.allCookies();
-      cookies.length.should.equal(0);
-
-      doesNotIncludeCookie(cookies, oldCookie1);
-      doesNotIncludeCookie(cookies, oldCookie2);
+    describe('secure', function () {
+      /*
+       * secure cookie tests are in `./safari-ssl-e2e-specs.js`
+       */
     });
   });
 });
+
+export { doesIncludeCookie, doesNotIncludeCookie, newCookie, oldCookie1, oldCookie2 };

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 import B from 'bluebird';
 import { killAllSimulators } from '../helpers/simulator';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
+import { doesIncludeCookie, doesNotIncludeCookie,
+         newCookie, oldCookie1 } from './safari-cookie-e2e-specs';
 import { SAFARI_CAPS } from '../desired';
 import https from 'https';
 
@@ -15,8 +17,10 @@ chai.use(chaiAsPromised);
 
 const HTTPS_PORT = 9762;
 
+const LOCAL_HTTPS_URL = `https://localhost:${HTTPS_PORT}/`;
+
 let caps = _.defaults({
-  safariInitialUrl: `https://localhost:${HTTPS_PORT}/`,
+  safariInitialUrl: LOCAL_HTTPS_URL,
   noReset: false,
 }, SAFARI_CAPS);
 
@@ -42,6 +46,8 @@ describe('Safari SSL', function () {
     sslServer = https.createServer(serverOpts, (req, res) => {
       res.end('Arbitrary text');
     }).listen(HTTPS_PORT);
+
+    caps.customSSLCert = pemCertificate;
   });
   after(async function () {
     await deleteSession();
@@ -49,9 +55,8 @@ describe('Safari SSL', function () {
   });
 
   it('should open pages with untrusted certs if the cert was provided in desired capabilities', async function () {
-    caps.customSSLCert = pemCertificate;
     driver = await initSession(caps);
-    await driver.get(`https://localhost:${HTTPS_PORT}/`);
+    await driver.get(LOCAL_HTTPS_URL);
     let source = await driver.source();
     source.should.include('Arbitrary text');
     await driver.quit();
@@ -59,8 +64,53 @@ describe('Safari SSL', function () {
 
     // Now do another session using the same cert to verify that it still works
     await driver.init(caps);
-    await driver.get(`https://localhost:${HTTPS_PORT}/`);
+    await driver.get(LOCAL_HTTPS_URL);
     source = await driver.source();
     source.should.include('Arbitrary text');
+  });
+
+  describe('cookies', function () {
+    const secureCookie = Object.assign({}, newCookie, {
+      secure: true,
+      name: 'securecookie',
+      value: 'this is a secure cookie',
+    });
+
+    before(async function () {
+      driver = await initSession(caps);
+    });
+
+    beforeEach(async function () {
+      await driver.get(LOCAL_HTTPS_URL);
+      await driver.setCookie(oldCookie1);
+      await driver.deleteCookie(secureCookie.name);
+    });
+
+    it('should be able to set a secure cookie', async function () {
+      let cookies = await driver.allCookies();
+      doesNotIncludeCookie(cookies, secureCookie);
+
+      await driver.setCookie(secureCookie);
+      cookies = await driver.allCookies();
+
+      doesIncludeCookie(cookies, secureCookie);
+
+      // should not clobber old cookie
+      doesIncludeCookie(cookies, oldCookie1);
+    });
+    it('should be able to set a secure cookie', async function () {
+      await driver.setCookie(secureCookie);
+      let cookies = await driver.allCookies();
+
+      doesIncludeCookie(cookies, secureCookie);
+
+      // should not clobber old cookie
+      doesIncludeCookie(cookies, oldCookie1);
+
+      await driver.deleteCookie(secureCookie.name);
+
+      cookies = await driver.allCookies();
+      doesNotIncludeCookie(cookies, secureCookie);
+    });
   });
 });

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -67,6 +67,8 @@ describe('Safari SSL', function () {
     await driver.get(LOCAL_HTTPS_URL);
     source = await driver.source();
     source.should.include('Arbitrary text');
+
+    await deleteSession();
   });
 
   describe('cookies', function () {


### PR DESCRIPTION
`appium-remote-debugger` now supports getting cookies and deleting cookies, so use those instead of JS.

This ought to fix https://github.com/appium/appium/issues/6797