### PR TITLE
Fix writeFile calls

### DIFF
--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -81,13 +81,13 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
       log.debug(`The destination folder '${path.dirname(dstPath)}' does not exist. Creating...`);
       await mkdirp(path.dirname(dstPath));
     }
-    await fs.writeFile(dstPath, buffer, 'binary');
+    await fs.writeFile(dstPath, buffer);
     return;
   }
   const dstFolder = await tempDir.openDir();
   const dstPath = path.resolve(dstFolder, path.basename(remotePath));
   try {
-    await fs.writeFile(dstPath, buffer, 'binary');
+    await fs.writeFile(dstPath, buffer);
     await addMedia(device.udid, dstPath);
   } finally {
     await fs.rimraf(dstFolder);
@@ -133,7 +133,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
         log.debug(`The destination folder '${path.dirname(dstPath)}' does not exist. Creating...`);
         await mkdirp(path.dirname(dstPath));
       }
-      await fs.writeFile(dstPath, Buffer.from(base64Data, 'base64').toString('binary'), 'binary');
+      await fs.writeFile(dstPath, Buffer.from(base64Data, 'base64'));
     } finally {
       await exec('umount', [mntRoot]);
       isUnmountSuccessful = true;


### PR DESCRIPTION
writeFile API does not require encoding to be set if the second parameter is already of type Buffer