### PR TITLE
Fix Safari console and network log returns

### DIFF
--- a/lib/device-log/rotating-log.js
+++ b/lib/device-log/rotating-log.js
@@ -31,7 +31,7 @@ class RotatingLog {
 
   async getLogs () {
     if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
-      let result = _.clone(this.logs);
+      let result = this.logs;
       if (this.logIdxSinceLastRequest > 0) {
         result = result.slice(this.logIdxSinceLastRequest);
       }

--- a/lib/device-log/safari-console-log.js
+++ b/lib/device-log/safari-console-log.js
@@ -18,7 +18,43 @@ class SafariConsoleLog extends RotatingLog {
           this.logIdxSinceLastRequest--;
         }
       }
-      this.logs.push(out);
+
+      /*
+       * The output will be like:
+       *   {
+       *     "source": "javascript",
+       *     "level":"error",
+       *     "text":"ReferenceError: Can't find variable: s_account",
+       *     "type":"log",
+       *     "line":2,
+       *     "column":21,
+       *     "url":"https://assets.adobedtm.com/b46e318d845250834eda10c5a20827c045a4d76f/scripts/satellite-57866f8b64746d53a8000104-staging.js",
+       *     "repeatCount":1,
+       *     "stackTrace":[{
+       *       "functionName":"global code",
+       *       "url":"https://assets.adobedtm.com/b46e318d845250834eda10c5a20827c045a4d76f/scripts/satellite-57866f8b64746d53a8000104-staging.js",
+       *       "scriptId":"6",
+       *       "lineNumber":2,
+       *       "columnNumber":21
+       *     }]
+       *  }
+       *
+       * we need, at least, `level` (in accordance with Java levels
+       * (https://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html)),
+       * `timestamp`, and `message` to satisfy the java client. In order to
+       * provide all the information to the client, `message` is the full
+       * object, stringified.
+       */
+      const entry = {
+        level: {
+          error: 'SEVERE',
+          warning: 'WARNING',
+          log: 'FINE',
+        }[out.level] || 'INFO',
+        timestamp: Date.now(),
+        message: JSON.stringify(out),
+      };
+      this.logs.push(entry);
     }
 
     // format output like

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -58,13 +58,13 @@ class SafariNetworkLog extends RotatingLog {
   }
 
   addLogLine (method, out) {
-    if (['Network.dataReceived'].includes(method)) {
-      // status update, no need to handle
+    if (!this.isCapturing && !this.showLogs) {
+      // neither capturing nor displaying, so do nothing
       return;
     }
 
-    if (!this.isCapturing && !this.showLogs) {
-      // neither capturing nor displaying, so do nothing
+    if (['Network.dataReceived'].includes(method)) {
+      // status update, no need to handle
       return;
     }
 
@@ -78,6 +78,7 @@ class SafariNetworkLog extends RotatingLog {
     if (this.isCapturing) {
       // now add the output we just received to the logs for this particular entry
       outputEntry.logs = outputEntry.logs || [];
+
       outputEntry.logs.push(out);
     }
 
@@ -93,20 +94,9 @@ class SafariNetworkLog extends RotatingLog {
     }
   }
 
-  printLogLine (outputEntry) {
-    // extract and print the data
-    const {
-      requestId,
-      name,
-      status,
-      type,
-      initiator = {},
-      size = 0,
-      time = 0,
-      source,
-      errorText,
-      cancelled = false,
-    } = outputEntry.logs.reduce(function (record, entry) {
+  getLogDetails (outputEntry) {
+    // extract the data
+    const record = outputEntry.logs.reduce(function (record, entry) {
       record.requestId = entry.requestId;
       if (entry.response) {
         const url = URL.parse(entry.response.url);
@@ -140,6 +130,23 @@ class SafariNetworkLog extends RotatingLog {
       return record;
     }, {});
 
+    return record;
+  }
+
+  printLogLine (outputEntry) {
+    const {
+      requestId,
+      name,
+      status,
+      type,
+      initiator = {},
+      size = 0,
+      time = 0,
+      source,
+      errorText,
+      cancelled = false,
+    } = this.getLogDetails(outputEntry);
+
     // print out the record, formatted appropriately
     this.log.debug(`Network event:`);
     this.log.debug(`  Id: ${requestId}`);
@@ -166,6 +173,57 @@ class SafariNetworkLog extends RotatingLog {
       this.log.debug(`  Cancelled: ${cancelled}`);
     }
   }
+
+  async getLogs () {
+    if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
+      let result = _.clone(this.logs);
+      if (this.logIdxSinceLastRequest > 0) {
+        result = result.slice(this.logIdxSinceLastRequest);
+      }
+      this.logIdxSinceLastRequest = this.logs.length;
+
+      // in order to satisfy certain clients, we need to have a basic structure
+      // to the results, with `level`, `timestamp`, and `message`, which is
+      // all the information stringified
+      return result.map((entry) => {
+        return Object.assign({}, entry, {
+          level: 'INFO',
+          timestamp: Date.now(),
+          message: JSON.stringify(entry),
+        });
+      });
+    }
+    return [];
+  }
+
+  async getAllLogs () {
+    return _.clone(this.logs);
+  }
+
+  /*
+   * {
+       "requestId": "0.2",
+       "frameId": "0.1",
+       "loaderId": "0.2",
+       "documentURL": "https://imurchie.github.io/SwitchingTabsOnIPad/test-off.html",
+       "request": {
+         "url": "https://imurchie.github.io/SwitchingTabsOnIPad/test-off.html",
+         "method": "GET",
+         "headers": {
+           "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,",
+           "Referer": "http://0.0.0.0:4723/welcome",
+           "User-Agent": "Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1"
+         }
+       },
+       "timestamp": 0.7890167939476669,
+       "walltime": 1533132042.634245,
+       "initiator": {
+         "type": "other"
+       },
+       "type":"Document"
+     }
+    */
+  // const entry = Object.assign({}, out);
 }
 
 export { SafariNetworkLog };

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -175,25 +175,17 @@ class SafariNetworkLog extends RotatingLog {
   }
 
   async getLogs () {
-    if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
-      let result = _.clone(this.logs);
-      if (this.logIdxSinceLastRequest > 0) {
-        result = result.slice(this.logIdxSinceLastRequest);
-      }
-      this.logIdxSinceLastRequest = this.logs.length;
-
-      // in order to satisfy certain clients, we need to have a basic structure
-      // to the results, with `level`, `timestamp`, and `message`, which is
-      // all the information stringified
-      return result.map((entry) => {
-        return Object.assign({}, entry, {
-          level: 'INFO',
-          timestamp: Date.now(),
-          message: JSON.stringify(entry),
-        });
+    const logs = await super.getLogs();
+    // in order to satisfy certain clients, we need to have a basic structure
+    // to the results, with `level`, `timestamp`, and `message`, which is
+    // all the information stringified
+    return logs.map(function (entry) {
+      return Object.assign({}, entry, {
+        level: 'INFO',
+        timestamp: Date.now(),
+        message: JSON.stringify(entry),
       });
-    }
-    return [];
+    });
   }
 }
 

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -195,35 +195,6 @@ class SafariNetworkLog extends RotatingLog {
     }
     return [];
   }
-
-  async getAllLogs () {
-    return _.clone(this.logs);
-  }
-
-  /*
-   * {
-       "requestId": "0.2",
-       "frameId": "0.1",
-       "loaderId": "0.2",
-       "documentURL": "https://imurchie.github.io/SwitchingTabsOnIPad/test-off.html",
-       "request": {
-         "url": "https://imurchie.github.io/SwitchingTabsOnIPad/test-off.html",
-         "method": "GET",
-         "headers": {
-           "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,",
-           "Referer": "http://0.0.0.0:4723/welcome",
-           "User-Agent": "Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1"
-         }
-       },
-       "timestamp": 0.7890167939476669,
-       "walltime": 1533132042.634245,
-       "initiator": {
-         "type": "other"
-       },
-       "type":"Document"
-     }
-    */
-  // const entry = Object.assign({}, out);
 }
 
 export { SafariNetworkLog };

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -320,7 +320,7 @@ describe('Safari', function () {
 
       // there can be other things logged, so check that the text is there somewhere
       function checkTexts (logs, expectedTexts) {
-        const logText = _.map(logs, (el) => el.text).join(',');
+        const logText = _.map(logs, (el) => el.message).join(',');
         for (let line of expectedTexts) {
           logText.should.include(line);
         }


### PR DESCRIPTION
The Java client requires a particular format for the logs returned. See https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/remote/RemoteLogs.java#L80-L95 and https://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html

This PR allows this to work:
```java
LogEntries logEntries = driver.manage().logs().get("safariConsole");
for (LogEntry entry : logEntries) {
  System.out.println(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
}

logEntries = driver.manage().logs().get("safariNetwork");
for (LogEntry entry : logEntries) {
  System.out.println(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
}
```