### PR TITLE
Handle errors in getting session information

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1025,20 +1025,34 @@ class XCUITestDriver extends BaseDriver {
   async getSession () {
     // call super to get event timings, etc...
     const driverSession = await super.getSession();
+
     if (!this.wdaCaps) {
-      this.wdaCaps = await this.proxyCommand('/', 'GET');
+      try {
+        this.wdaCaps = await this.proxyCommand('/', 'GET');
+      } catch (err) {
+        log.warn(`Unable to get WDA capabilities: ${err.message}`);
+      }
     }
+    const wdaCaps = this.wdaCaps ? this.wdaCaps.capabilities : {};
+
     if (!this.deviceCaps) {
-      const {statusBarSize, scale} = await this.getScreenInfo();
-      this.deviceCaps = {
-        pixelRatio: scale,
-        statBarHeight: statusBarSize.height,
-        viewportRect: await this.getViewportRect(),
-      };
+      try {
+        const {statusBarSize, scale} = await this.getScreenInfo();
+        this.deviceCaps = {
+          pixelRatio: scale,
+          statBarHeight: statusBarSize.height,
+          viewportRect: await this.getViewportRect(),
+        };
+      } catch (err) {
+        log.warn(`Unable to get screen information: ${err.message}`);
+      }
     }
-    log.info("Merging WDA caps over Appium caps for session detail response");
-    return Object.assign({udid: this.opts.udid}, driverSession,
-      this.wdaCaps.capabilities, this.deviceCaps);
+    const deviceCaps = this.deviceCaps || {};
+
+    log.info('Merging WDA caps over Appium caps for session detail response');
+    return Object.assign({
+      udid: this.opts.udid,
+    }, driverSession, wdaCaps, deviceCaps);
   }
 
   async startIWDP () {


### PR DESCRIPTION
If, for some reason, proxying fails, don't fail altogether to get session information. Avoid things like https://github.com/appium/appium/issues/11146