### PR TITLE
Move optional dependencies back to dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,12 +121,21 @@ before_install:
       sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
       git submodule update --init --recursive;
     fi
+install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      npm install;
+    else
+      npm install --production;
+      npm install --no-save gulp appium-gulp-plugins chai chai-as-promised wd unzip mocha sync-request;
+    fi
 script:
-  - npm run lint && npm run mocha -- -t 480000 --require build/test/env/env --recursive build/test/$TEST -g @skip-ci -i --exit
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      npm run lint;
+    fi
+  - npm run mocha -- -t 480000 --require build/test/env/env --recursive build/test/$TEST -g @skip-ci -i --exit
   - if [ -n "$COVERALLS" ]; then npm run coverage; fi
   - if [ -n "$CI_METRICS" ]; then
       mkdir -p ./ci-metrics && ls -la ./ci-metrics;
-      nvm install 7;
       npm install -g appium-event-parser;
       appium-event-parser -s -i ./ci-metrics;
     fi

--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "eslint-plugin-promise": "^3.3.1",
     "glob": "^7.1.0",
     "gulp": "^3.8.11",
+    "ios-test-app": "^2.5.7",
+    "ios-uicatalog": "^1.0.4",
     "mocha": "^5.1.1",
     "moment": "^2.22.2",
     "pem": "^1.8.3",
@@ -97,10 +99,6 @@
     "through2": "^2.0.0",
     "unzip": "^0.1.11",
     "wd": "^1.5.0"
-  },
-  "optionalDependencies": {
-    "ios-test-app": "^2.5.7",
-    "ios-uicatalog": "^1.0.4"
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
This seems like a minimal Travis config to allow tests to run on Linux but not need the full dev deps.