### PR TITLE
Use bintray staging for Sauce EmuSim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,7 @@ install:
     else
       npm install --production;
       npm install --no-save gulp appium-gulp-plugins chai chai-as-promised wd unzip mocha sync-request;
+      npm run build;
     fi
 script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "babel-eslint": "^7.1.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "chai-subset": "^1.6.0",
     "eslint": "^3.18.0",
     "eslint-config-appium": "^2.0.1",
     "eslint-plugin-babel": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "ios-test-app": "^2.5.7",
     "ios-uicatalog": "^1.0.4",
     "mocha": "^5.1.1",
+    "mocha-parallel-tests": "^2.0.4",
     "moment": "^2.22.2",
     "pem": "^1.8.3",
     "pngjs": "^3.3.1",

--- a/test/env/env.js
+++ b/test/env/env.js
@@ -22,7 +22,7 @@ if (env.CLOUD) {
   const res = request('GET', 'https://api.bintray.com/packages/appium-builds/appium/appium/files', {json: true});
   const fileInfoArray = JSON.parse(res.getBody('utf8'));
   const latestFile = fileInfoArray.sort((fileInfo1, fileInfo2) => (
-    +new Date(fileInfo2.created) > +new Date(fileInfo1.created) ? 1 : -1
+    Math.sign(+new Date(fileInfo2.created), +new Date(fileInfo1.created))
   ))[0];
   const {name:bundleName} = latestFile;
 

--- a/test/env/env.js
+++ b/test/env/env.js
@@ -20,12 +20,20 @@ if (env.CLOUD) {
   // Find the latest bundle
   log.info('Getting the sha of the most recent master commit');
   const res = request('GET', 'https://api.bintray.com/packages/appium-builds/appium/appium/files', {json: true});
-  const {name:bundleName} = JSON.parse(res.getBody('utf8'))[0];
+  const fileInfoArray = JSON.parse(res.getBody('utf8'));
+  const latestFile = fileInfoArray.sort((fileInfo1, fileInfo2) => (
+    +new Date(fileInfo2.created) > +new Date(fileInfo1.created) ? 1 : -1
+  ))[0];
+  const {name:bundleName} = latestFile;
 
   // Get the URL
   const stagingUrl = `https://bintray.com/appium-builds/appium/download_file?file_path=${bundleName}`;
   log.info(`Using staging URL: ${stagingUrl}`);
   env.APPIUM_STAGING_URL = stagingUrl;
+
+  // Get the SHA
+  const sha = bundleName.match(/appium-([\w\W]*?).zip/)[1];
+  env.APPIUM_SHA = sha;
 }
 
 Object.assign(process.env, env);

--- a/test/env/env.js
+++ b/test/env/env.js
@@ -22,7 +22,7 @@ if (env.CLOUD) {
   const res = request('GET', 'https://api.bintray.com/packages/appium-builds/appium/appium/files', {json: true});
   const fileInfoArray = JSON.parse(res.getBody('utf8'));
   const latestFile = fileInfoArray.sort((fileInfo1, fileInfo2) => (
-    Math.sign(+new Date(fileInfo2.created), +new Date(fileInfo1.created))
+    Math.sign(+new Date(fileInfo2.created) - (+new Date(fileInfo1.created)))
   ))[0];
   const {name:bundleName} = latestFile;
 

--- a/test/env/ios-sim-platforms.js
+++ b/test/env/ios-sim-platforms.js
@@ -1,17 +1,21 @@
 export default {
-  '11.2': [
+  '11.3': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],
-  '11.1': [
+  /*'11.2': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
-  ],
-  '11': [
+  ],*/
+  /*'11.1': [
+    'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
+    'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
+  ],*/
+  /*'11': [
     'iPhone 5s Simulator', 'iPhone 6s Plus Simulator', 'iPhone 7 Simulator', 'iPhone X Simulator',
     'iPad Air 2 Simulator', 'iPad iPad Pro (12.9 inch) Simulator', 'iPad Pro (12.9 inch) (2nd generation) Simulator'
-  ],
-  '10.3': [
+  ],*/
+  /*'10.3': [
     'iPhone 5s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator',
     'iPhone SE Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],
@@ -22,9 +26,9 @@ export default {
   '10': [
     'iPhone 5 Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator',
     'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
-  ],
-  '9.3': [
+  ],*/
+  /*'9.3': [
     'iPhone 4s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 6 Plus Simulator',
     'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
-  ],
+  ],*/
 };

--- a/test/env/ios-sim-platforms.js
+++ b/test/env/ios-sim-platforms.js
@@ -1,13 +1,13 @@
 export default {
-  '11.3': [
+  /*'11.3': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],
-  /*'11.2': [
+  '11.2': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
-  ],*/
-  /*'11.1': [
+  ],
+  '11.1': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],*/
@@ -15,19 +15,19 @@ export default {
     'iPhone 5s Simulator', 'iPhone 6s Plus Simulator', 'iPhone 7 Simulator', 'iPhone X Simulator',
     'iPad Air 2 Simulator', 'iPad iPad Pro (12.9 inch) Simulator', 'iPad Pro (12.9 inch) (2nd generation) Simulator'
   ],*/
-  /*'10.3': [
+  '10.3': [
     'iPhone 5s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator',
     'iPhone SE Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],
-  '10.2': [
+  /*'10.2': [
     'iPhone 6s Plus Simulator', 'iPhone SE Simulator', 'iPhone 6s Simulator', 'iPhone 7 Plus Simulator',
     'iPad Pro (9.7 inch) Simulator', 'iPad Simulator', 'iPad Simulator'
   ],
   '10': [
     'iPhone 5 Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator',
     'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
-  ],*/
-  /*'9.3': [
+  ],
+  '9.3': [
     'iPhone 4s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 6 Plus Simulator',
     'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
   ],*/

--- a/test/env/ios-sim-platforms.js
+++ b/test/env/ios-sim-platforms.js
@@ -1,34 +1,7 @@
+// Which platfomrs to test on. Keep this up-to-date as SauceLabs platform support changes
 export default {
-  /*'11.3': [
+  '11.3': [
     'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
     'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
   ],
-  '11.2': [
-    'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
-    'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
-  ],
-  '11.1': [
-    'iPhone 5s Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator', 'iPhone 8 Plus Simulator',
-    'iPhone X Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
-  ],*/
-  /*'11': [
-    'iPhone 5s Simulator', 'iPhone 6s Plus Simulator', 'iPhone 7 Simulator', 'iPhone X Simulator',
-    'iPad Air 2 Simulator', 'iPad iPad Pro (12.9 inch) Simulator', 'iPad Pro (12.9 inch) (2nd generation) Simulator'
-  ],*/
-  '10.3': [
-    'iPhone 5s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator',
-    'iPhone SE Simulator', 'iPad Air 2 Simulator', 'iPad Pro (9.7 inch) Simulator'
-  ],
-  /*'10.2': [
-    'iPhone 6s Plus Simulator', 'iPhone SE Simulator', 'iPhone 6s Simulator', 'iPhone 7 Plus Simulator',
-    'iPad Pro (9.7 inch) Simulator', 'iPad Simulator', 'iPad Simulator'
-  ],
-  '10': [
-    'iPhone 5 Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 7 Simulator',
-    'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
-  ],
-  '9.3': [
-    'iPhone 4s Simulator', 'iPhone 6 Plus Simulator', 'iPhone 6s Simulator', 'iPhone 6 Plus Simulator',
-    'iPad Air 2 Simulator', 'iPad Retina Simulator', 'iPad Simulator'
-  ],*/
 };

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import chaiSubset from 'chai-subset';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
 import { UICATALOG_CAPS } from '../desired';
@@ -10,6 +11,7 @@ import { PNG } from 'pngjs';
 
 chai.should();
 chai.use(chaiAsPromised);
+chai.use(chaiSubset);
 
 describe('XCUITestDriver - basics -', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -83,7 +85,16 @@ describe('XCUITestDriver - basics -', function () {
       actual.viewportRect.height.should.be.a('number');
       actual.viewportRect.width.should.be.a('number');
       delete actual.viewportRect;
-      actual.should.eql(expected);
+
+      if (process.env.CLOUD) {
+        delete expected.app;
+        delete expected[process.env.APPIUM_BUNDLE_CAP];
+
+        // Cloud has several extraneous keys. Check if the caps contain expected subset only.
+        actual.should.containSubset(expected);
+      } else {
+        actual.should.eql(expected);
+      }
     });
   });
 

--- a/test/functional/basic/calendar-e2e-specs.js
+++ b/test/functional/basic/calendar-e2e-specs.js
@@ -7,7 +7,7 @@ import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 chai.should();
 chai.use(chaiAsPromised);
 
-if (!process.env.REAL_DEVICE) {
+if (!process.env.REAL_DEVICE && !process.env.CLOUD) {
 
   describe('XCUITestDriver - calendar', function () {
     this.timeout(MOCHA_TIMEOUT);

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -49,6 +49,7 @@ const GENERIC_CAPS = {
   maxTypingFrequency: 30,
   clearSystemFiles: true,
   showXcodeLog: SHOW_XCODE_LOG,
+  'appium-version': {"appium-url": `bintray:${process.env.APPIUM_SHA}`}
   // TODO: If it's SAUCE_EMUSIM or SAUCE_RDC add the appium staging URL
 };
 

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -50,7 +50,7 @@ const GENERIC_CAPS = {
   clearSystemFiles: true,
   showXcodeLog: SHOW_XCODE_LOG,
   'appium-version': {"appium-url": `bintray:${process.env.APPIUM_SHA}`}
-  // TODO: If it's SAUCE_EMUSIM or SAUCE_RDC add the appium staging URL
+  // TODO: If it's SAUCE_RDC add the appium staging URL
 };
 
 // on Travis, when load is high, the app often fails to build,

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -49,7 +49,8 @@ const GENERIC_CAPS = {
   maxTypingFrequency: 30,
   clearSystemFiles: true,
   showXcodeLog: SHOW_XCODE_LOG,
-  'appium-version': {"appium-url": `bintray:${process.env.APPIUM_SHA}`}
+  [process.env.APPIUM_BUNDLE_CAP]: {"appium-url": `bintray:${process.env.APPIUM_SHA}`}
+  //'appium-version': {"appium-url": `bintray:${process.env.APPIUM_SHA}`}
   // TODO: If it's SAUCE_RDC add the appium staging URL
 };
 

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -32,7 +32,7 @@ describe('Safari SSL', function () {
 
   let sslServer, driver;
   before(async function () {
-    if (process.env.REAL_DEVICE) return this.skip(); // eslint-disable-line curly
+    if (process.env.REAL_DEVICE || process.env.CLOUD) return this.skip(); // eslint-disable-line curly
 
     await killAllSimulators();
 


### PR DESCRIPTION
* Fix problem with env.js not getting the latest bintray URL
* Add appium-url bintray to CLOUD tests
* Only test 11.3 for now because it's the only one that works... once it's fixed we can add the others
* We should also make use of 'mocha-parallel-tests' once we get the tests passing.... using parallel means we can run on _several_ Simulators instead of just one

(cc: @vrunoa)