### PR TITLE
Avoid throwing an exception if heap size is too low

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -6,7 +6,7 @@ import iProxy from '../wda/iproxy';
 
 let commands = {};
 
-const MAX_RECORDING_TIME_SEC = 60 * 10;
+const MAX_RECORDING_TIME_SEC = 60 * 30;
 const DEFAULT_RECORDING_TIME_SEC = 60 * 3;
 const DEFAULT_MJPEG_SERVER_PORT = 9100;
 const MP4_EXT = '.mp4';

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -206,8 +206,8 @@ commands.startRecordingScreen = async function (options = {}) {
 
   const timeout = Math.floor(parseFloat(timeLimit) * 1000);
   if (timeout > MAX_RECORDING_TIME_SEC * 1000 || timeout <= 0) {
-    log.errorAndThrow(`The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC * 1000}] ms. ` +
-      `The value of ${timeLimit} has been passed instead.`);
+    log.errorAndThrow(`The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC}] seconds. ` +
+      `The value of '${timeLimit}' has been passed instead.`);
   }
 
   try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -404,8 +404,6 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
  * @param {?UploadOptions} uploadOptions - Set of upload options
  * @returns {string} Either an empty string if the upload was successful or
  * base64-encoded file representation if `remotePath` is falsy
- * @throws {Error} If there was upload failure or the file content is too big
- * to fit in the available process memory.
  */
 async function encodeBase64OrUpload (localFile, remotePath = null, uploadOptions = {}) {
   if (!await fs.exists(localFile)) {
@@ -417,10 +415,10 @@ async function encodeBase64OrUpload (localFile, remotePath = null, uploadOptions
   if (_.isEmpty(remotePath)) {
     const maxMemoryLimit = v8.getHeapStatistics().total_available_size / 2;
     if (size >= maxMemoryLimit) {
-      throw new Error(`Cannot read '${localFile}' to the memory, because the file is too large ` +
-                      `(${util.toReadableSizeString(size)} >= ${util.toReadableSizeString(maxMemoryLimit)}). ` +
-                      `Try to provide a link to a remote writable location instead or increase the value of ` +
-                      `'max_old_space_size' server argument.`);
+      log.info(`The file might be too large to fit into the process memory ` +
+        `(${util.toReadableSizeString(size)} >= ${util.toReadableSizeString(maxMemoryLimit)}). ` +
+        `Provide a link to a remote writable location for video upload ` +
+        `(http(s) and ftp protocols are supported) if you experience Out Of Memory errors`);
     }
     const content = await fs.readFile(localFile);
     return content.toString('base64');


### PR DESCRIPTION
This gives users more control on what they are doing. Also the maximum video duration has been synchronized with Android