### PR TITLE
Filter out zero waits from W3C actions

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -53,7 +53,14 @@ commands.performActions = async function (actions) {
       parameters: {
         pointerType: 'touch'
       }
-    } : {}));
+    } : {}))
+    .map((action) => {
+      const modifiedAction = _.clone(action);
+      // Selenium API unexpectedly inserts zero pauses, which are not supported by WDA
+      modifiedAction.actions = (action.actions || [])
+        .filter((innerAction) => !(innerAction.type === 'pause' && innerAction.duration === 0));
+      return modifiedAction;
+    });
   log.debug(`Preprocessed actions: ${JSON.stringify(preprocessedActions, null, '  ')}`);
   return await this.proxyCommand('/actions', 'POST', {actions: preprocessedActions});
 };

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -55,7 +55,7 @@ commands.performActions = async function (actions) {
       }
     } : {}))
     .map((action) => {
-      const modifiedAction = _.clone(action);
+      const modifiedAction = _.clone(action) || {};
       // Selenium API unexpectedly inserts zero pauses, which are not supported by WDA
       modifiedAction.actions = (action.actions || [])
         .filter((innerAction) => !(innerAction.type === 'pause' && innerAction.duration === 0));


### PR DESCRIPTION
This should workaround the problem from https://github.com/appium/appium/issues/11273