### PR TITLE
Perform WebDriverAgent project cleanup after each upgrade

### DIFF
--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -72,11 +72,13 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
       `The current PATH value: '${process.env.PATH ? process.env.PATH : "<not defined for the Appium process>"}'`);
   }
   const carthageRoot = `${bootstrapPath}/Carthage`;
+  let areDependenciesUpdated = false;
   if (!await fs.hasAccess(carthageRoot)) {
     log.debug('Running WebDriverAgent bootstrap script to install dependencies');
     try {
       let args = useSsl ? ['-d', '-D'] : ['-d'];
       await exec('Scripts/bootstrap.sh', args, {cwd: bootstrapPath});
+      areDependenciesUpdated = true;
     } catch (err) {
       // print out the stdout and stderr reports
       for (let std of ['stdout', 'stderr']) {
@@ -97,11 +99,14 @@ async function checkForDependencies (bootstrapPath, useSsl = false) {
   if (!await fs.hasAccess(`${bootstrapPath}/Resources`)) {
     log.debug('Creating WebDriverAgent resources directory');
     await fs.mkdir(`${bootstrapPath}/Resources`);
+    areDependenciesUpdated = true;
   }
   if (!await fs.hasAccess(`${bootstrapPath}/Resources/WebDriverAgent.bundle`)) {
     log.debug('Creating WebDriverAgent resource bundle directory');
     await fs.mkdir(`${bootstrapPath}/Resources/WebDriverAgent.bundle`);
+    areDependenciesUpdated = true;
   }
+  return areDependenciesUpdated;
 }
 
 async function setRealDeviceSecurity (keychainPath, keychainPassword) {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -173,7 +173,11 @@ class WebDriverAgent {
 
     if (!this.useXctestrunFile) {
       // make sure that the WDA dependencies have been built
-      await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
+      const didPerformUpgrade = await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
+      if (didPerformUpgrade) {
+        // Only perform the cleanup after WDA upgrade
+        await this.xcodebuild.cleanProject();
+      }
     }
     // We need to provide WDA local port, because it might be occupied with
     // iproxy instance initiated by some preceeding run with a real device

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -11,6 +11,8 @@ import path from 'path';
 
 const DEFAULT_SIGNING_ID = "iPhone Developer";
 const BUILD_TEST_DELAY = 1000;
+const RUNNER_SCHEME = 'WebDriverAgentRunner';
+const LIB_SCHEME = 'WebDriverAgentLib';
 
 const xcodeLog = logger.getLogger('Xcode');
 
@@ -138,6 +140,17 @@ class XcodeBuild {
     await B.delay(BUILD_TEST_DELAY);
   }
 
+  async cleanProject () {
+    for (const scheme of [LIB_SCHEME, RUNNER_SCHEME]) {
+      log.debug(`Cleaning the project scheme '${scheme}' to make sure there are no leftovers from previous installs`);
+      await exec('xcodebuild', [
+        'clean',
+        '-project', this.agentPath,
+        '-scheme', scheme,
+      ]);
+    }
+  }
+
   getCommand (buildOnly = false) {
     let cmd = 'xcodebuild';
     let args;
@@ -162,7 +175,7 @@ class XcodeBuild {
     if (this.useXctestrunFile) {
       args.push('-xctestrun', this.xctestrunFilePath);
     } else {
-      args.push('-project', this.agentPath, '-scheme', 'WebDriverAgentRunner');
+      args.push('-project', this.agentPath, '-scheme', RUNNER_SCHEME);
       if (this.derivedDataPath) {
         args.push('-derivedDataPath', this.derivedDataPath);
       }


### PR DESCRIPTION
Sometimes Xcode caches outdated WDA libs and builds/installs outdated binary after component upgrade. We must perform the cleanup after each upgrade to make sure there are no such leftovers.