### PR TITLE
Fix custom certificate installation

### DIFF
--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -24,9 +24,9 @@ async function extractCommonName (certBuffer) {
   try {
     await fs.writeFile(tempCert.path, certBuffer);
     const {stdout} = await exec('openssl', ['x509', '-noout', '-subject', '-in', tempCert.path]);
-    const cnMatch = /\/CN=([^\s,]+)/.exec(stdout);
+    const cnMatch = /\/CN=([^\/]+)/.exec(stdout);
     if (cnMatch) {
-      return cnMatch[1];
+      return cnMatch[1].trim();
     }
     throw new Error(`There is no common name value in '${stdout}' output`);
   } catch (err) {
@@ -81,7 +81,7 @@ async function clickElement (driver, locator, options = {}) {
   const lookupDelay = 500;
   try {
     element = await retryInterval(timeout < lookupDelay ? 1 : timeout / lookupDelay, lookupDelay,
-      driver.findNativeElementOrElements(locator.type, locator.value, false)
+      () => driver.findNativeElementOrElements(locator.type, locator.value, false)
     );
   } catch (err) {
     if (skipIfInvisible) {


### PR DESCRIPTION
This should fix common name value parsing in case it contain spaces and elements finding in certificate installation flow