### PR TITLE
Fix test for nativeWebTap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - PLATFORM_VERSION=11.4
     - _FORCE_LOGS=1
+    - RECURSIVE=--recursive
     - secure: ls4nb5gcu0USHauJOkB9R5p86PMPJd/wCIQWjj/bhAfLNpSNNthtss2Ss9M7BjJg8lth8c85MrGfkAZOGgXknNtlQ2HHwKK4fbEiLAKLDS9diac6/OpAsxxE1/OvletYhkKLQSqb8d5Ju3S/xY6SmNDIzHUpeTYV2/5Ve+7Fh9zc1RztxsPwV1vxPtL6w0IAzNS9PQOmDXQ6x9KuZModtR7ohVKD47A91MzBlu3kk1CSaeQ4I8l7eXi4R9J6F81jkr51Vzoam4B6+4HTepSdfo02irBQWzaJ3VtRCbazFRBc/wfe4YgOPQTD9k69FiP19sa28lP9eSn6h5OCSXA9M803kju33Ml6OItRWDG0gUG1dzTroVXELEIcfnw1iTsFqKWoJLaEzEiXV8n2RsXLaLC5SHPgKwGEigGMfWDxM9leIC8hgervjQvApmx7btzq9S50tMcrzba5qwXDDrjJi1wKSjd4pQajhSj9VgOH9D5ihZBdn++VLwEvfAd4yQhjdsr9+COV1HrgK7Ro1HAHWgGnPtwBKiQdVU20QdQzNrhRdF2MLrJ4BfWpNm92JwlPxP/ojuA2l8mr9nDqlfBgXlnG32j59988gi85vaMfXssrUXtdJqsKJckI01c/mgaRh9pvG3UPX8K39quKBI5ftS8aCCa8tbF6bLq/ZuI2TRU=
 matrix:
   include:
@@ -152,7 +153,7 @@ script:
       mocha-parallel-tests -t 480000 --require build/test/env/env --recursive build/test/$TEST -g @skip-ci -i --exit;
     else
       npm run lint;
-      npm run mocha -- -t 480000 --recursive build/test/$TEST -g @skip-ci -i --exit;
+      npm run mocha -- -t 480000 $RECURSIVE build/test/$TEST -g @skip-ci -i --exit;
     fi
   - if [ -n "$COVERALLS" ]; then npm run coverage; fi
   - if [ -n "$CI_METRICS" ]; then

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -42,7 +42,7 @@ extensions.getSafariIsIphone = async function getSafariIsIphone () {
 
 extensions.getSafariIsIphoneX = async function getSafariIsIphone () {
   try {
-    const script = 'height: window.screen.availHeight, width: window.screen.availWidth};';
+    const script = 'return {height: window.screen.availHeight, width: window.screen.availWidth};';
     const {height, width} = await this.execute(script);
     // check for the correct height and width
     return (height === IPHONE_X_HEIGHT && width === IPHONE_X_WIDTH) ||
@@ -164,8 +164,8 @@ async function tapWebElementNatively (driver, atomsElement) {
       // use tap because on iOS 11.2 and below `nativeClick` crashes WDA
       const rect = await driver.proxyCommand(`/element/${el.ELEMENT}/rect`, 'GET');
       const coords = {
-        x: rect.x + rect.width / 2,
-        y: rect.y + rect.height / 2,
+        x: parseInt(rect.x + rect.width / 2, 10),
+        y: parseInt(rect.y + rect.height / 2, 10),
       };
       await driver.clickCoords(coords);
       return true;

--- a/test/functional/web/safari-nativewebtap-e2e-specs.js
+++ b/test/functional/web/safari-nativewebtap-e2e-specs.js
@@ -7,7 +7,6 @@ import { spinTitleEquals, GUINEA_PIG_PAGE, GUINEA_PIG_SCROLLABLE_PAGE,
          GUINEA_PIG_APP_BANNER_PAGE } from './helpers';
 import { killAllSimulators } from '../helpers/simulator';
 import { retryInterval } from 'asyncbox';
-import wd from 'wd';
 import B from 'bluebird';
 
 
@@ -19,6 +18,9 @@ const caps = _.defaults({
   nativeWebTap: true,
 }, SAFARI_CAPS);
 const spinRetries = 5;
+
+const PAGE_3_LINK = 'i am a link to page 3';
+const PAGE_3_TITLE = 'Another Page: page 3';
 
 describe('Safari', function () {
   this.timeout(MOCHA_TIMEOUT * 2);
@@ -40,7 +42,7 @@ describe('Safari', function () {
             noReset: false,
           }, caps));
         } catch (err) {
-          if (err.message.includes('Invalid device type: iPhone X')) {
+          if (err.message.includes('Invalid device type')) {
             skipped = true;
             return this.skip();
           }
@@ -55,29 +57,29 @@ describe('Safari', function () {
       it('should be able to tap on an element', async function () {
         await driver.get(GUINEA_PIG_PAGE);
 
-        let el = await driver.elementByLinkText('i am a link to page 3');
+        let el = await driver.elementByLinkText(PAGE_3_LINK);
         await el.click();
 
-        await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+        await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
       });
 
       it('should be able to tap on an element when the app banner is up', async function () {
         await driver.get(GUINEA_PIG_APP_BANNER_PAGE);
 
-        let el = await driver.elementByLinkText('i am a link to page 3');
+        let el = await driver.elementByLinkText(PAGE_3_LINK);
         await el.click();
 
-        await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+        await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
       });
 
       it('should be able to tap on an element after scrolling', async function () {
         await driver.get(GUINEA_PIG_SCROLLABLE_PAGE);
         await driver.execute('mobile: scroll', {direction: 'down'});
 
-        let el = await driver.elementByLinkText('i am a link to page 3');
+        let el = await driver.elementByLinkText(PAGE_3_LINK);
         await el.click();
 
-        await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+        await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
       });
 
       it('should be able to tap on a button', async function () {
@@ -115,56 +117,56 @@ describe('Safari', function () {
         it('should be able to tap on an element', async function () {
           await driver.get(GUINEA_PIG_PAGE);
 
-          let el = await driver.elementByLinkText('i am a link to page 3');
+          let el = await driver.elementByLinkText(PAGE_3_LINK);
           await el.click();
 
-          await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+          await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
 
           await driver.back();
 
           // try again, just to make sure
-          el = await driver.elementByLinkText('i am a link to page 3');
+          el = await driver.elementByLinkText(PAGE_3_LINK);
           await el.click();
 
-          await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+          await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
         });
         it('should be able to tap on an element after scrolling', async function () {
           await driver.get(GUINEA_PIG_SCROLLABLE_PAGE);
           await driver.execute('mobile: scroll', {direction: 'down'});
 
-          let el = await driver.elementByLinkText('i am a link to page 3');
+          let el = await driver.elementByLinkText(PAGE_3_LINK);
           await el.click();
 
-          await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+          await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
         });
         it('should be able to tap on an element after scrolling, when the url bar is present', async function () {
-          // this test can be flakey on Travis
-          this.retries(4);
-
           await driver.get(GUINEA_PIG_SCROLLABLE_PAGE);
           await driver.execute('mobile: scroll', {direction: 'down'});
 
-          // to get the url bar, click at the top
+          // to get the url bar, click on the URL bar
           const ctx = await driver.currentContext();
           try {
             await driver.context('NATIVE_APP');
-            const action = new wd.TouchAction(driver);
-            action.tap({
-              x: 10,
-              y: 5,
-            });
-            await action.perform();
+
+            // get the reload button, as multi-element find to bypass
+            // the implicit wait
+            const els = driver.elementsByAccessibilityId('ReloadButton');
+            if (els.length === 0) {
+              // when there is no reload button, the URL bar is minimized
+              // so tap on it to bring it up
+              await driver.elementByAccessibilityId('URL').click();
+            }
 
             // time for things to happen
-            await B.delay(1000);
+            await B.delay(500);
           } finally {
             await driver.context(ctx);
           }
 
-          const el = await driver.elementByLinkText('i am a link to page 3');
+          const el = await driver.elementByLinkText(PAGE_3_LINK);
           await el.click();
 
-          await spinTitleEquals(driver, 'Another Page: page 3', spinRetries);
+          await spinTitleEquals(driver, PAGE_3_TITLE, spinRetries);
         });
       });
     });
@@ -192,12 +194,12 @@ describe('Safari', function () {
   //                      'iPad (5th generation)',
   //                      'iPad Pro (9.7-inch)', 'iPad Pro (12.9-inch)', 'iPad Pro (12.9-inch) (2nd generation)', 'iPad Pro (10.5-inch)'];
 
-  let deviceNames = ['iPad Simulator', 'iPhone 6', 'iPhone X'];
+  let deviceNames = ['iPad Simulator', 'iPhone 6', 'iPhone X', 'iPhone XS Max'];
   if (process.env.DEVICE_NAME) {
     deviceNames = [process.env.DEVICE_NAME];
   }
 
-  for (let deviceName of deviceNames) {
+  for (const deviceName of deviceNames) {
     runTests(deviceName);
   }
 });


### PR DESCRIPTION
When scrolling down on the device `iPhone XS Max`, at the bottom of the page the URL bar comes back to full visibility. Tapping the top to get the URL bar open then causes the page to scroll to the top and the test will fail.

Adjust to check that the URL bar is not open before trying to open it.

Fixes https://github.com/appium/appium/issues/11364