### PR TITLE
add .getElementRec transfer to getRect

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -46,10 +46,6 @@ commands.getText = async function (el) {
 };
 
 commands.getElementRect = async function (el) {
-  return await this.getRect(el);
-};
-
-commands.getRect = async function (el) {
   if (this.isWebContext()) {
     const {x, y} = await this.getLocation(el);
     const {width, height} = await this.getSize(el);
@@ -78,7 +74,7 @@ commands.getLocation = async function (el) {
     return loc;
   }
 
-  const rect = await this.getRect(el);
+  const rect = await this.getElementRect(el);
   return {x: rect.x, y: rect.y};
 };
 
@@ -96,7 +92,7 @@ commands.getSize = async function (el) {
     return await this.executeAtom('get_size', [atomsElement]);
   }
 
-  const rect = await this.getRect(el);
+  const rect = await this.getElementRect(el);
   return {width: rect.width, height: rect.height};
 };
 
@@ -283,24 +279,24 @@ commands.getContentSize = async function (el) {
   if (children.length === 1) {
     // if we know there's only one element, we can optimize to make just one
     // call to WDA
-    const rect = await this.getRect(_.head(children));
+    const rect = await this.getElementRect(_.head(children));
     contentHeight = rect.height;
   } else if (children.length) {
     // otherwise if we have multiple elements, logic differs based on element
     // type
     switch (type) {
       case "XCUIElementTypeTable": {
-        const firstRect = await this.getRect(_.head(children));
-        const lastRect = await this.getRect(_.last(children));
+        const firstRect = await this.getElementRect(_.head(children));
+        const lastRect = await this.getElementRect(_.last(children));
         contentHeight = lastRect.y + lastRect.height - firstRect.y;
         break;
       }
       case "XCUIElementTypeCollectionView": {
         let elsInRow = 1; // we know there must be at least one element in the row
-        let firstRect = await this.getRect(_.head(children));
+        let firstRect = await this.getElementRect(_.head(children));
         let initialRects = [firstRect];
         for (let i = 1; i < children.length; i++) {
-          const rect = await this.getRect(children[i]);
+          const rect = await this.getElementRect(children[i]);
           initialRects.push(rect);
           if (rect.y !== firstRect.y) {
             elsInRow = i;

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -45,6 +45,10 @@ commands.getText = async function (el) {
   return await this.executeAtom('get_text', [atomsElement]);
 };
 
+commands.getElementRect = async function (el) {
+  return await this.getRect(el);
+};
+
 commands.getRect = async function (el) {
   if (this.isWebContext()) {
     const {x, y} = await this.getLocation(el);

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -47,6 +47,7 @@ commands.getText = async function (el) {
 
 commands.getElementRect = async function (el) {
   if (this.isWebContext()) {
+    // Mobile safari doesn't support rect
     const {x, y} = await this.getLocation(el);
     const {width, height} = await this.getSize(el);
     return {x, y, width, height};

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -253,7 +253,7 @@ helpers.getCoordinates = async function (gesture) {
 
   // figure out the element coordinates.
   if (el) {
-    let rect = await this.getRect(el);
+    let rect = await this.getElementRect(el);
     let pos = {x: rect.x, y: rect.y};
     let size = {w: rect.width, h: rect.height};
 

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -268,4 +268,52 @@ describe('element commands', function () {
       loc.y.should.equal(fixtureYOffset);
     });
   });
+
+  describe('getElementRect', function () {
+    let driver = new XCUITestDriver();
+    const elem = {ELEMENT: '5000'};
+    const getNativeRectStub = sinon.stub(driver, 'getNativeRect').returns({x: 0, y: 50, width: 100, height: 200});
+    const getLocationStub = sinon.stub(driver, 'getLocation').returns({x: 0, y: 50});
+    const getSizeStub = sinon.stub(driver, 'getSize').returns({width: 100, height: 200});
+    let isWebContext;
+    // const proxyStub = sinon.stub(driver, 'proxyCommand');
+
+    afterEach(function () {
+      getNativeRectStub.resetHistory();
+      getLocationStub.resetHistory();
+      getSizeStub.resetHistory();
+      proxyStub.resetHistory();
+      isWebContext.restore();
+    });
+
+    it('should get element rect in native context', async function () {
+      isWebContext = sinon.stub(driver, 'isWebContext').returns(false);
+
+      const rect = await driver.getElementRect(elem);
+
+      isWebContext.calledOnce.should.be.true;
+      getNativeRectStub.calledOnce.should.be.true;
+      getLocationStub.calledOnce.should.be.false;
+      getSizeStub.calledOnce.should.be.false;
+      rect.x.should.eql(0);
+      rect.y.should.eql(50);
+      rect.width.should.eql(100);
+      rect.height.should.eql(200);
+    });
+
+    it('should get element rect in Web context', async function () {
+      isWebContext = sinon.stub(driver, 'isWebContext').returns(true);
+
+      const rect = await driver.getElementRect(elem);
+
+      isWebContext.calledOnce.should.be.true;
+      getNativeRectStub.calledOnce.should.be.false;
+      getLocationStub.calledOnce.should.be.true;
+      getSizeStub.calledOnce.should.be.true;
+      rect.x.should.eql(0);
+      rect.y.should.eql(50);
+      rect.width.should.eql(100);
+      rect.height.should.eql(200);
+    });
+  });
 });

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -84,7 +84,7 @@ describe('element commands', function () {
 
     beforeEach(function () {
       getAttrStub = S.sandbox.stub(driver, 'getAttribute');
-      getRectStub = S.sandbox.stub(driver, 'getRect');
+      getRectStub = S.sandbox.stub(driver, 'getElementRect');
       findElStub = S.sandbox.stub(driver, 'findElOrEls');
       getSizeStub = S.sandbox.stub(driver, 'getSize');
       getLocationStub = S.sandbox.stub(driver, 'getLocationInView');

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -275,23 +275,24 @@ describe('element commands', function () {
     const getNativeRectStub = sinon.stub(driver, 'getNativeRect').returns({x: 0, y: 50, width: 100, height: 200});
     const getLocationStub = sinon.stub(driver, 'getLocation').returns({x: 0, y: 50});
     const getSizeStub = sinon.stub(driver, 'getSize').returns({width: 100, height: 200});
-    let isWebContext;
-    // const proxyStub = sinon.stub(driver, 'proxyCommand');
+    let isWebContextStub;
 
     afterEach(function () {
       getNativeRectStub.resetHistory();
       getLocationStub.resetHistory();
       getSizeStub.resetHistory();
       proxyStub.resetHistory();
-      isWebContext.restore();
+      if (isWebContextStub) {
+        isWebContextStub.restore();
+      }
     });
 
     it('should get element rect in native context', async function () {
-      isWebContext = sinon.stub(driver, 'isWebContext').returns(false);
+      isWebContextStub = sinon.stub(driver, 'isWebContext').returns(false);
 
       const rect = await driver.getElementRect(elem);
 
-      isWebContext.calledOnce.should.be.true;
+      isWebContextStub.calledOnce.should.be.true;
       getNativeRectStub.calledOnce.should.be.true;
       getLocationStub.calledOnce.should.be.false;
       getSizeStub.calledOnce.should.be.false;
@@ -302,11 +303,11 @@ describe('element commands', function () {
     });
 
     it('should get element rect in Web context', async function () {
-      isWebContext = sinon.stub(driver, 'isWebContext').returns(true);
+      isWebContextStub = sinon.stub(driver, 'isWebContext').returns(true);
 
       const rect = await driver.getElementRect(elem);
 
-      isWebContext.calledOnce.should.be.true;
+      isWebContextStub.calledOnce.should.be.true;
       getNativeRectStub.calledOnce.should.be.false;
       getLocationStub.calledOnce.should.be.true;
       getSizeStub.calledOnce.should.be.true;


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/11427#issuecomment-427777847

This module has no `getElementRect` command, but it has `getRect`. The former command is called when `/element_id/rect` is called.
We must transfer the getElementRec to getRect since the `getRect` has fix in https://github.com/appium/appium-xcuitest-driver/pull/782/files . => https://github.com/appium/appium-xcuitest-driver/pull/799/commits/296df5f7f3f5c83cbfa748cad425b648ebebbbd3

BTW, can we replace `getRect` with `getElementRect`? (I'll add this change later)  => https://github.com/appium/appium-xcuitest-driver/pull/799/commits/338373b9148d868a770374b357fb5749f1f27934

```
$ git grep "getRect"
lib/commands/element.js:  return await this.getRect(el);
lib/commands/element.js:commands.getRect = async function (el) {
lib/commands/element.js:  const rect = await this.getRect(el);
lib/commands/element.js:  const rect = await this.getRect(el);
lib/commands/element.js:    const rect = await this.getRect(_.head(children));
lib/commands/element.js:        const firstRect = await this.getRect(_.head(children));
lib/commands/element.js:        const lastRect = await this.getRect(_.last(children));
lib/commands/element.js:        let firstRect = await this.getRect(_.head(children));
lib/commands/element.js:          const rect = await this.getRect(children[i]);
lib/commands/gesture.js:    let rect = await this.getRect(el);
Binary file test/assets/TouchIDExample.app/TouchIDExample matches
test/unit/commands/element-specs.js:    let getAttrStub, getRectStub, findElStub, getSizeStub, getLocationStub;
test/unit/commands/element-specs.js:      getRectStub = S.sandbox.stub(driver, 'getRect');
test/unit/commands/element-specs.js:      getRectStub.returns({x: 0, y: 0, height: 100, width: 200});
test/unit/commands/element-specs.js:      getRectStub.calledOnce.should.be.true;
test/unit/commands/element-specs.js:      getRectStub.withArgs(el1).returns({x: 0, y: 10, width: 50, height: 60});
test/unit/commands/element-specs.js:      getRectStub.withArgs(el2).returns({x: 10, y: 80, width: 60, height: 100});
test/unit/commands/element-specs.js:      getRectStub.calledTwice.should.be.true;
test/unit/commands/element-specs.js:        getRectStub.withArgs({ELEMENT: item.id}).returns(item);
test/unit/commands/element-specs.js:      getRectStub.callCount.should.equal(3);
```


# Tests
## WebContext
- client
```ruby
[1] pry(main)> e = find_element :xpath, "//*/h1"
#<Selenium::WebDriver::Element:0x59df142acddfc97c id="5000">
[2] pry(main)> e.rect
#<Struct:Selenium::WebDriver::Rectangle:0x7fa3a89cb910
    height = 38,
    width = 964,
    x = 8,
    y = 21.4375
>
[3] pry(main)> 
```

- server
```
[debug] [GENERIC] Calling AppiumDriver.getStatus() with args: []
[debug] [GENERIC] Responding to client with driver.getStatus() result: {"build":{"version":"1.9.2-beta.2","git-sha":"5409005b4f5c2b8992e884bed403c35fa05706ae","built":"2018-10-06 20:51:26 +0900"}}
[HTTP] <-- GET /wd/hub/status 200 2 ms - 163
[HTTP]
[HTTP] --> POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element
[HTTP] {"using":"xpath","value":"//*/h1"}
[debug] [W3C (b7b4626c)] Calling AppiumDriver.findElement() with args: ["xpath","//*/h1","b7b4626c-79b0-4fb8-bfef-6e082f9aec9f"]
[debug] [XCUITest] Executing command 'findElement'
[debug] [BaseDriver] Valid locator strategies for this request: xpath, id, name, class name, -ios predicate string, -ios class chain, accessibility id
[debug] [BaseDriver] Waiting up to 30000 ms for condition
[debug] [RemoteDebugger] Executing 'find_element' atom in default context
[debug] [RemoteDebugger] Garbage collecting with 5000ms timeout
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{}'
[debug] [RemoteDebugger] Original command: garbageCollect
[debug] [RemoteDebugger] Garbage collection successful
[debug] [RemoteDebugger] Sending javascript command (function(){return function(){var k=this;functi...
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{"status":0,"value":{"ELEMENT":":wdc:1538993998...'
[debug] [RemoteDebugger] Original command: sendJSCommand
[debug] [RemoteDebugger] Received result for atom 'find_element' execution: {"ELEMENT":":wdc:1538993998091"}
[debug] [W3C (b7b4626c)] Responding to client with driver.findElement() result: {"element-6066-11e4-a52e-4f735466cecf":"5000"}
[HTTP] <-- POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element 200 105 ms - 56
[HTTP]
[HTTP] --> GET /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/5000/rect
[HTTP] {}
[debug] [W3C (b7b4626c)] Calling AppiumDriver.getElementRect() with args: ["5000","b7b4626c-79b0-4fb8-bfef-6e082f9aec9f"]
[debug] [XCUITest] Executing command 'getElementRect'
[debug] [RemoteDebugger] Executing 'get_top_left_coordinates' atom in default context
[debug] [RemoteDebugger] Garbage collecting with 5000ms timeout
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{}'
[debug] [RemoteDebugger] Original command: garbageCollect
[debug] [RemoteDebugger] Garbage collection successful
[debug] [RemoteDebugger] Sending javascript command (function(){return function(){var h,l=this;func...
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{"status":0,"value":{"x":8,"y":21.4375,"toStrin...'
[debug] [RemoteDebugger] Original command: sendJSCommand
[debug] [RemoteDebugger] Received result for atom 'get_top_left_coordinates' execution: {"x":8,"y":21.4375}
[debug] [RemoteDebugger] Executing 'get_size' atom in default context
[debug] [RemoteDebugger] Garbage collecting with 5000ms timeout
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{}'
[debug] [RemoteDebugger] Original command: garbageCollect
[debug] [RemoteDebugger] Garbage collection successful
[debug] [RemoteDebugger] Sending javascript command (function(){return function(){var h=this;functi...
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to remote debugger
[debug] [RemoteDebugger] Found data handler for response
[debug] [RemoteDebugger] Received data response from socket send: '{"status":0,"value":{"width":964,"height":38}}'
[debug] [RemoteDebugger] Original command: sendJSCommand
[debug] [RemoteDebugger] Received result for atom 'get_size' execution: {"width":964,"height":38}
[debug] [W3C (b7b4626c)] Responding to client with driver.getElementRect() result: {"x":8,"y":21.4375,"width":964,"height":38}
[HTTP] <-- GET /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/5000/rect 200 187 ms - 53
[HTTP]
```

## Native
- client
```ruby
> e = find_element :name, "Appium/welcome"
#<Selenium::WebDriver::Element:0x3bc4a2bf99b9bf80 id="05000000-0000-0000-9055-010000000000">
[5] pry(main)> e.rect
#<Struct:Selenium::WebDriver::Rectangle:0x7fa3aa0e0920
    height = 560,
    width = 375,
    x = 0,
    y = 64
>
```

- server
```
[HTTP] --> POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/context
[HTTP] {"name":"NATIVE_APP"}
[debug] [W3C (b7b4626c)] Calling AppiumDriver.setContext() with args: ["NATIVE_APP","b7b4626c-79b0-4fb8-bfef-6e082f9aec9f"]
[debug] [XCUITest] Executing command 'setContext'
[debug] [iOS] Attempting to set context to 'NATIVE_APP'
[debug] [W3C (b7b4626c)] Responding to client with driver.setContext() result: null
[HTTP] <-- POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/context 200 4 ms - 14
[HTTP]
[HTTP] --> POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element
[HTTP] {"using":"name","value":"Appium/welcome"}
[debug] [W3C (b7b4626c)] Calling AppiumDriver.findElement() with args: ["name","Appium/welcome","b7b4626c-79b0-4fb8-bfef-6e082f9aec9f"]
[debug] [XCUITest] Executing command 'findElement'
[debug] [BaseDriver] Valid locator strategies for this request: xpath, id, name, class name, -ios predicate string, -ios class chain, accessibility id
[debug] [BaseDriver] Waiting up to 30000 ms for condition
[debug] [JSONWP Proxy] Matched '/element' to command name 'findElement'
[debug] [JSONWP Proxy] Proxying [POST /element] to [POST http://localhost:8100/session/99F46B02-52F8-41A5-B9ED-E73845913930/element] with body: {"using":"name","value":"Appium/welcome"}
[debug] [JSONWP Proxy] Got response with status 200: {"value":{"ELEMENT":"05000000-0000-0000-9055-010000000000"},"sessionId":"99F46B02-52F8-41A5-B9ED-E73845913930","status":0}
[debug] [W3C (b7b4626c)] Responding to client with driver.findElement() result: {"element-6066-11e4-a52e-4f735466cecf":"05000000-0000-0000-9055-010000000000"}
[HTTP] <-- POST /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element 200 335 ms - 88
[HTTP]

[HTTP] --> GET /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/05000000-0000-0000-9055-010000000000/rect
[HTTP] {}
[W3C (b7b4626c)] Driver proxy active, passing request on via HTTP proxy
[debug] [XCUITest] Executing command 'proxyReqRes'
[debug] [JSONWP Proxy] Matched '/wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/05000000-0000-0000-9055-010000000000/rect' to command name 'getElementRect'
[debug] [JSONWP Proxy] Proxying [GET /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/05000000-0000-0000-9055-010000000000/rect] to [GET http://localhost:8100/session/99F46B02-52F8-41A5-B9ED-E73845913930/element/05000000-0000-0000-9055-010000000000/rect] with body: {}
[debug] [JSONWP Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"y\" : 64,\n    \"x\" : 0,\n    \"width\" : 375,\n    \"height\" : 560\n  },\n  \"sessionId\" : \"99F46B02-52F8-41A5-B9ED-E73845913930\",\n  \"status\" : 0\n}"
[JSONWP Proxy] Replacing sessionId 99F46B02-52F8-41A5-B9ED-E73845913930 with b7b4626c-79b0-4fb8-bfef-6e082f9aec9f
[HTTP] <-- GET /wd/hub/session/b7b4626c-79b0-4fb8-bfef-6e082f9aec9f/element/05000000-0000-0000-9055-010000000000/rect 200 174 ms - 111
[HTTP]
```