### PR TITLE
Add await to reduce motion call

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -346,11 +346,12 @@ class XCUITestDriver extends BaseDriver {
 
       // set reduceMotion if capability is set
       if (util.hasValue(this.opts.reduceMotion)) {
-        this.opts.device.setReduceMotion(this.opts.reduceMotion);
+        await this.opts.device.setReduceMotion(this.opts.reduceMotion);
       }
 
       this.localConfig = await iosSettings.setLocaleAndPreferences(this.opts.device, this.opts, this.isSafari(), async (sim) => {
         await shutdownSimulator(sim);
+
         // we don't know if there needs to be changes a priori, so change first.
         // sometimes the shutdown process changes the settings, so reset them,
         // knowing that the sim is already shut

--- a/test/functional/driver/motion-e2e-specs.js
+++ b/test/functional/driver/motion-e2e-specs.js
@@ -21,7 +21,6 @@ const deleteDeviceWithRetry = async function (udid) {
 
 describe('ReduceMotion', function () {
   this.timeout(MOCHA_TIMEOUT);
-  this.retries(3);
 
   let baseCaps;
   let caps;


### PR DESCRIPTION
And see if the test needs the retries anymore.

Without this the sim _always_ crashes while waiting to boot. And we add yet another sim boot to the startup flow.