### PR TITLE
add mjpegServerScreenshotQuality and mjpegServerFramerate

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -33,6 +33,8 @@ const DEFAULT_SETTINGS = {
   useJSONSource: false,
   shouldUseCompactResponses: true,
   elementResponseAttributes: "type,label",
+  mjpegServerScreenshotQuality: 25, // https://github.com/appium/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBConfiguration.m#L29
+  mjpegServerFramerate: 10 // https://github.com/appium/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBConfiguration.m#L30
 };
 // This lock assures, that each driver session does not
 // affect shared resources of the other parallel sessions
@@ -214,12 +216,20 @@ class XCUITestDriver extends BaseDriver {
       let wdaSettings = {
         elementResponseAttributes: DEFAULT_SETTINGS.elementResponseAttributes,
         shouldUseCompactResponses: DEFAULT_SETTINGS.shouldUseCompactResponses,
+        mjpegServerScreenshotQuality: DEFAULT_SETTINGS.mjpegServerScreenshotQuality,
+        mjpegServerFramerate: DEFAULT_SETTINGS.mjpegServerFramerate,
       };
       if (_.has(this.opts, 'elementResponseAttributes')) {
         wdaSettings.elementResponseAttributes = this.opts.elementResponseAttributes;
       }
       if (_.has(this.opts, 'shouldUseCompactResponses')) {
         wdaSettings.shouldUseCompactResponses = this.opts.shouldUseCompactResponses;
+      }
+      if (_.has(this.opts, 'mjpegServerScreenshotQuality')) {
+        wdaSettings.mjpegServerScreenshotQuality = this.opts.mjpegServerScreenshotQuality;
+      }
+      if (_.has(this.opts, 'mjpegServerFramerate')) {
+        wdaSettings.mjpegServerFramerate = this.opts.mjpegServerFramerate;
       }
       // ensure WDA gets our defaults instead of whatever its own might be
       await this.updateSettings(wdaSettings);


### PR DESCRIPTION
- Reduce warning messages like `[BaseDriver] Didn't know about setting 'mjpegServerScreenshotQuality'. Are you sure you spelled it correctly? ` for `mjpegServerScreenshotQuality` and `mjpegServerFramerate`
- Add `opts` of `mjpegServerScreenshotQuality` and `mjpegServerFramerate` like other settings

## Before

```
[HTTP] {"settings":{"mjpegServerScreenshotQuality":10,"mjpegServerFramerate":1}}
[debug] [W3C (4e529818)] Calling AppiumDriver.updateSettings() with args: [{"mjpegServerScreenshotQuality":10,"mjpegServerFramerate":1},"4e529818-8d0b-4ee8-beb5-8a817217ce85"]
[debug] [XCUITest] Executing command 'updateSettings'
[BaseDriver] Didn't know about setting 'mjpegServerScreenshotQuality'. Are you sure you spelled it correctly? Proceeding anyway. Valid settings: imageMatchThreshold,fixImageFindScreenshotDims,fixImageTemplateSize,checkForImageElementStaleness,autoUpdateImageElementPosition,imageElementTapStrategy,nativeWebTap,useJSONSource,shouldUseCompactResponses,elementResponseAttributes
[debug] [JSONWP Proxy] Matched '/appium/settings' to command name 'updateSettings'
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8100/session/7CCF2A61-DB22-475D-8A4D-F1D9434FC3E4/appium/settings] with body: {"settings":{"mjpegServerScreenshotQuality":10}}
[debug] [JSONWP Proxy] Got response with status 200: {"value":{"elementResponseAttributes":"type,label","shouldUseCompactResponses":true,"mjpegServerFramerate":10,"mjpegServerScreenshotQuality":10},"sessionId":"7CCF2A61-DB22-475D-8A4D-F1D9434FC3E4","status":0}
[BaseDriver] Didn't know about setting 'mjpegServerFramerate'. Are you sure you spelled it correctly? Proceeding anyway. Valid settings: imageMatchThreshold,fixImageFindScreenshotDims,fixImageTemplateSize,checkForImageElementStaleness,autoUpdateImageElementPosition,imageElementTapStrategy,nativeWebTap,useJSONSource,shouldUseCompactResponses,elementResponseAttributes,mjpegServerScreenshotQuality
[debug] [JSONWP Proxy] Matched '/appium/settings' to command name 'updateSettings'
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8100/session/7CCF2A61-DB22-475D-8A4D-F1D9434FC3E4/appium/settings] with body: {"settings":{"mjpegServerFramerate":1}}
```

## After
```
[HTTP] --> POST /wd/hub/session/1b4f1ff3-ad0a-40a7-a300-7d2f5076d617/appium/settings
[HTTP] {"settings":{"mjpegServerScreenshotQuality":10,"mjpegServerFramerate":1}}
[debug] [W3C (1b4f1ff3)] Calling AppiumDriver.updateSettings() with args: [{"mjpegServerScreenshotQuality":10,"mjpegServerFramerate":1},"1b4f1ff3-ad0a-40a7-a300-7d2f5076d617"]
[debug] [XCUITest] Executing command 'updateSettings'
[debug] [JSONWP Proxy] Matched '/appium/settings' to command name 'updateSettings'
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8100/session/1BC23A1D-5BE8-4431-B34F-DAA4D3DFD6B1/appium/settings] with body: {"settings":{"mjpegServerScreenshotQuality":10}}
[debug] [JSONWP Proxy] Got response with status 200: {"value":{"elementResponseAttributes":"type,label","shouldUseCompactResponses":true,"mjpegServerFramerate":10,"mjpegServerScreenshotQuality":10},"sessionId":"1BC23A1D-5BE8-4431-B34F-DAA4D3DFD6B1","status":0}
[debug] [JSONWP Proxy] Matched '/appium/settings' to command name 'updateSettings'
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8100/session/1BC23A1D-5BE8-4431-B34F-DAA4D3DFD6B1/appium/settings] with body: {"settings":{"mjpegServerFramerate":1}}
[debug] [JSONWP Proxy] Got response with status 200: {"value":{"elementResponseAttributes":"type,label","shouldUseCompactResponses":true,"mjpegServerFramerate":1,"mjpegServerScreenshotQuality":10},"sessionId":"1BC23A1D-5BE8-4431-B34F-DAA4D3DFD6B1","status":0}
[debug] [W3C (1b4f1ff3)] Responding to client with driver.updateSettings() result: null
[HTTP] <-- POST /wd/hub/session/1b4f1ff3-ad0a-40a7-a300-7d2f5076d617/appium/settings 200 55 ms - 14
[HTTP]
```