### PR TITLE
Set permissions before starting WDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Differences noted here
 |`mjpegServerPort`|The port number on which WDA broadcasts screenshots stream encoded into MJPEG format from the device under test. It might be necessary to change this value if the default port is busy because of other tests running in parallel. Default value: `9100`|e.g. `12000`|
 |`waitForQuiescence`| It allows to turn on/off waiting for application quiescence in WebDriverAgent, while performing queries. The default value is `true`. You can avoid [this kind of issues](https://github.com/appium/appium/issues/11132) if you turn it off. |e.g `false`|
 |`reduceMotion`| It allows to turn on/off reduce motion accessibility preference. Setting reduceMotion `on` helps to reduce flakiness during tests. Only fon simulators | e.g `true` |
+|`permissions`| Allows to set permissions for the specified application bundle on Simulator only. The capability value is expected to be a valid JSON string with `{<bundleId1>: {<serviceName1>: <serviceStatus1>, ...}, ...}` format. It is required that `applesimutils` package is installed and available in PATH. The list of available service names and statuses can be found at https://github.com/wix/AppleSimulatorUtils. | e. g. `{"com.apple.mobilecal": {"calendar": "YES"}}` |
 
 ## Development<a id="development"></a>
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Differences noted here
 |`mjpegServerPort`|The port number on which WDA broadcasts screenshots stream encoded into MJPEG format from the device under test. It might be necessary to change this value if the default port is busy because of other tests running in parallel. Default value: `9100`|e.g. `12000`|
 |`waitForQuiescence`| It allows to turn on/off waiting for application quiescence in WebDriverAgent, while performing queries. The default value is `true`. You can avoid [this kind of issues](https://github.com/appium/appium/issues/11132) if you turn it off. |e.g `false`|
 |`reduceMotion`| It allows to turn on/off reduce motion accessibility preference. Setting reduceMotion `on` helps to reduce flakiness during tests. Only fon simulators | e.g `true` |
-|`permissions`| Allows to set permissions for the specified application bundle on Simulator only. The capability value is expected to be a valid JSON string with `{<bundleId1>: {<serviceName1>: <serviceStatus1>, ...}, ...}` format. It is required that `applesimutils` package is installed and available in PATH. The list of available service names and statuses can be found at https://github.com/wix/AppleSimulatorUtils. | e. g. `{"com.apple.mobilecal": {"calendar": "YES"}}` |
+|`permissions`| Allows to set permissions for the specified application bundle on Simulator only. The capability value is expected to be a valid JSON string with `{"<bundleId1>": {"<serviceName1>": "<serviceStatus1>", ...}, ...}` format. It is required that `applesimutils` package is installed and available in PATH. The list of available service names and statuses can be found at https://github.com/wix/AppleSimulatorUtils. | e. g. `{"com.apple.mobilecal": {"calendar": "YES"}}` |
 
 ## Development<a id="development"></a>
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -78,7 +78,6 @@ extensions.executeMobile = async function (mobileCommand, opts = {}) {
 
     clearKeychains: 'mobileClearKeychains',
 
-    setPermission: 'mobileSetPermission',
     getPermission: 'mobileGetPermission',
   };
 

--- a/lib/commands/permissions.js
+++ b/lib/commands/permissions.js
@@ -17,7 +17,7 @@ function assertPermissionOptions (opts = {}) {
 }
 
 /**
- * @typedef {Object} SetPermissionOptions
+ * @typedef {Object} GetPermissionOptions
  *
  * @property {string} service - One of available service names. The following services are supported:
  * calendar,
@@ -32,34 +32,6 @@ function assertPermissionOptions (opts = {}) {
  * health:,
  * siri,
  * speech.
- * @property {string} bundleId - The bundle identifier of the destination app.
- * @property {?string} state [yes] - The destination permission state. The following states
- * are valid: yes, no, unset.
- */
-
-/**
- * Sets application permission on Simulator.
- *
- * @param {SetPermissionOptions} opts - Permission options.
- * @throws {Error} If permission setting fails or the device is not a Simulator.
- */
-commands.mobileSetPermission = async function (opts = {}) {
-  const {
-    service,
-    bundleId,
-    state = 'yes'
-  } = assertPermissionOptions(opts);
-
-  assertIsSimulator(this);
-
-  await this.opts.device.setPermission(bundleId, service, state);
-};
-
-/**
- * @typedef {Object} GetPermissionOptions
- *
- * @property {string} service - One of available service names. See the definition of
- * `SetPermissionOptions` for more details on possible values.
  * @property {string} bundleId - The bundle identifier of the destination app.
  */
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -148,13 +148,16 @@ let desiredCapConstraints = _.defaults({
     isBoolean: true
   },
   mjpegServerPort: {
-    isNumber: true,
+    isNumber: true
   },
   reduceMotion: {
     isBoolean: true
   },
   mjpegScreenshotUrl: {
-    isString: true,
+    isString: true
+  },
+  permissions: {
+    isString: true
   }
 }, iosDesiredCapConstraints);
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -988,8 +988,7 @@ class XCUITestDriver extends BaseDriver {
 
     if (caps.permissions) {
       try {
-        const bundlesInfo = JSON.parse(caps.permissions);
-        for (const [bundleId, perms] of _.toPairs(bundlesInfo)) {
+        for (const [bundleId, perms] of _.toPairs(JSON.parse(caps.permissions))) {
           if (!_.isString(bundleId)) {
             throw new Error(`'${bundleId}' must be a string`);
           }
@@ -997,7 +996,7 @@ class XCUITestDriver extends BaseDriver {
         }
       } catch (e) {
         log.errorAndThrow(`'${caps.permissions}' is expected to be a valid object with format ` +
-          `{<bundleId1>: {<serviceName1>: <serviceStatus1>, ...}, ...}. Original error: ${e.message}`);
+          `{"<bundleId1>": {"<serviceName1>": "<serviceStatus1>", ...}, ...}. Original error: ${e.message}`);
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -399,6 +399,18 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
+    if (this.opts.permissions) {
+      if (this.isSimulator()) {
+        log.debug('Setting the requested permissions before WDA is started');
+        for (const [bundleId, permissionsMapping] of JSON.parse(this.opts.permissions)) {
+          await this.opts.device.setPermissions(bundleId, permissionsMapping);
+        }
+      } else {
+        log.warn('Setting permissions is only supported on Simulator. ' +
+          'The "permissions" capability will be ignored.');
+      }
+    }
+
     await SHARED_RESOURCES_GUARD.acquire(XCUITestDriver.name,
       async () => await this.startWda(this.opts.sessionId, realDevice));
 
@@ -971,6 +983,21 @@ class XCUITestDriver extends BaseDriver {
       // is common with selenium grid
       if (caps.app) {
         log.warn(`The capabilities should generally not include both an 'app' and a 'browserName'`);
+      }
+    }
+
+    if (caps.permissions) {
+      try {
+        const bundlesInfo = JSON.parse(caps.permissions);
+        for (const [bundleId, perms] of _.toPairs(bundlesInfo)) {
+          if (!_.isString(bundleId)) {
+            throw new Error(`'${bundleId}' must be a string`);
+          }
+          JSON.parse(perms);
+        }
+      } catch (e) {
+        log.errorAndThrow(`'${caps.permissions}' is expected to be a valid object with format ` +
+          `{<bundleId1>: {<serviceName1>: <serviceStatus1>, ...}, ...}. Original error: ${e.message}`);
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -402,7 +402,7 @@ class XCUITestDriver extends BaseDriver {
     if (this.opts.permissions) {
       if (this.isSimulator()) {
         log.debug('Setting the requested permissions before WDA is started');
-        for (const [bundleId, permissionsMapping] of JSON.parse(this.opts.permissions)) {
+        for (const [bundleId, permissionsMapping] of _.toPairs(JSON.parse(this.opts.permissions))) {
           await this.opts.device.setPermissions(bundleId, permissionsMapping);
         }
       } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -990,9 +990,11 @@ class XCUITestDriver extends BaseDriver {
       try {
         for (const [bundleId, perms] of _.toPairs(JSON.parse(caps.permissions))) {
           if (!_.isString(bundleId)) {
-            throw new Error(`'${bundleId}' must be a string`);
+            throw new Error(`'${JSON.stringify(bundleId)}' must be a string`);
           }
-          JSON.parse(perms);
+          if (!_.isPlainObject(perms)) {
+            throw new Error(`'${JSON.stringify(perms)}' must be a JSON object`);
+          }
         }
       } catch (e) {
         log.errorAndThrow(`'${caps.permissions}' is expected to be a valid object with format ` +

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-ios-driver": "^2.4.3",
-    "appium-ios-simulator": "^3.6.0",
+    "appium-ios-simulator": "^3.8.0",
     "appium-remote-debugger": "^3.16.0",
     "appium-support": "^2.18.0",
     "appium-xcode": "^3.2.0",


### PR DESCRIPTION
Changing app permissions in runtime terminates WDA session, so it is necessary to do that before WDA is initialized.
See https://github.com/appium/appium-ios-simulator/issues/189 for more details