### PR TITLE
Remove description from no alert error

### DIFF
--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -40,7 +40,7 @@ commands.postAcceptAlert = async function (opts = {}) {
     return await this.proxyCommand('/alert/accept', 'POST', params);
   } catch (err) {
     if (!this.isWebContext()) {
-      throw new errors.NoAlertOpenError(err.message);
+      throw new errors.NoAlertOpenError();
     }
 
     let alert = await this.getAlert();
@@ -60,7 +60,7 @@ commands.postDismissAlert = async function (opts = {}) {
     return await this.proxyCommand('/alert/dismiss', 'POST', params);
   } catch (err) {
     if (!this.isWebContext()) {
-      throw new errors.NoAlertOpenError(err.message);
+      throw new errors.NoAlertOpenError();
     }
 
     let alert = await this.getAlert();
@@ -75,7 +75,7 @@ commands.getAlertButtons = async function () {
   try {
     return await this.proxyCommand('/wda/alert/buttons', 'GET');
   } catch (err) {
-    throw new errors.NoAlertOpenError(err.message);
+    throw new errors.NoAlertOpenError();
   }
 };
 


### PR DESCRIPTION
These just end up as `[object Object]` (see, for instance, https://travis-ci.org/appium/appium-xcuitest-driver/jobs/452639858#L558). All the information is in the exception class anyway.