### PR TITLE
Move check for existent sim

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -696,12 +696,6 @@ class XCUITestDriver extends BaseDriver {
     // if we get generic names, translate them
     this.opts.deviceName = translateDeviceName(this.opts.platformVersion, this.opts.deviceName);
 
-    // check for a particular simulator
-    if (this.opts.udid && (await simExists(this.opts.udid))) {
-      const device = await getSimulator(this.opts.udid);
-      return {device, realDevice: false, udid: this.opts.udid};
-    }
-
     if (this.opts.udid) {
       if (this.opts.udid.toLowerCase() === 'auto') {
         try {
@@ -723,6 +717,12 @@ class XCUITestDriver extends BaseDriver {
         const devices = await getConnectedDevices();
         log.debug(`Available devices: ${devices.join(', ')}`);
         if (devices.indexOf(this.opts.udid) === -1) {
+          // check for a particular simulator
+          if (await simExists(this.opts.udid)) {
+            const device = await getSimulator(this.opts.udid);
+            return {device, realDevice: false, udid: this.opts.udid};
+          }
+
           throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
         }
       }


### PR DESCRIPTION
Move the udid check for sims to after the check for real devices. This allows a real device test to work without having any simctl calls.