### PR TITLE
Prevent installd cache cleanup on Xcode10+

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -137,9 +137,10 @@ async function installToSimulator (device, app, bundleId, noReset = true) {
 
   const installdCacheRoot = path.resolve(device.getDir(), 'Library', 'Caches', INSTALL_DAEMON_CACHE);
   let tmpRoot = null;
-  if (await fs.exists(installdCacheRoot)) {
+  if (await fs.exists(installdCacheRoot) && device.xcodeVersion.major < 10) {
     // Cleanup of installd cache helps to save disk space while running multiple tests
     // without restarting the Simulator: https://github.com/appium/appium/issues/9410
+    // This bug seems to be fixed by Apple in Xcode 10+
     tmpRoot = await tempDir.openDir();
     log.debug('Cleaning installd cache to save the disk space');
     await fs.mv(installdCacheRoot, path.resolve(tmpRoot, INSTALL_DAEMON_CACHE), {mkdirp: true});


### PR DESCRIPTION
It looks like with Xcode 10 release cache cleanup feature creates more problems. I'd rather disable it completely for now on Xcode10+ and observe how the stuff behaves after that.

See https://github.com/appium/appium/issues/11741