### PR TITLE
Fix temporary app detection

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -686,9 +686,7 @@ class XCUITestDriver extends BaseDriver {
       this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
     } catch (err) {
       log.error(err);
-      throw new Error(
-        `Bad app: ${this.opts.app}. App paths need to be absolute, or relative to the appium ` +
-        'server install dir, or a URL to compressed file, or a special app name.');
+      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed file`);
     }
     this.isAppTemporary = this.opts.app && await fs.exists(this.opts.app)
       && !await util.isSameDestination(originalAppPath, this.opts.app);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -690,7 +690,8 @@ class XCUITestDriver extends BaseDriver {
         `Bad app: ${this.opts.app}. App paths need to be absolute, or relative to the appium ` +
         'server install dir, or a URL to compressed file, or a special app name.');
     }
-    this.isAppTemporary = this.opts.app && !await util.isSameDestination(originalAppPath, this.opts.app);
+    this.isAppTemporary = this.opts.app && await fs.exists(this.opts.app)
+      && !await util.isSameDestination(originalAppPath, this.opts.app);
   }
 
   async determineDevice () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -683,14 +683,14 @@ class XCUITestDriver extends BaseDriver {
     const originalAppPath = this.opts.app;
     try {
       // download if necessary
-      this.opts.app = await this.helpers.configureApp(this.opts.app, '.app', this.opts.mountRoot, this.opts.windowsShareUserName, this.opts.windowsSharePassword);
+      this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
     } catch (err) {
       log.error(err);
       throw new Error(
         `Bad app: ${this.opts.app}. App paths need to be absolute, or relative to the appium ` +
         'server install dir, or a URL to compressed file, or a special app name.');
     }
-    this.isAppTemporary = this.opts.app && originalAppPath !== this.opts.app;
+    this.isAppTemporary = this.opts.app && !await util.isSameDestination(originalAppPath, this.opts.app);
   }
 
   async determineDevice () {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "appium-ios-driver": "^2.4.3",
     "appium-ios-simulator": "^3.8.0",
     "appium-remote-debugger": "^3.16.0",
-    "appium-support": "^2.18.0",
+    "appium-support": "^2.25.0",
     "appium-xcode": "^3.2.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
This should address the situation when `clearSystemFiles` cap is set to true and the given application path is a relative path rather than absolute. As the result the driver was going to delete the app on session removal, since `isAppTemporary` was set to true, because `originalAppPath` (relative path) was different from `this.opts.app` (absolute path, rewritten by `configureApp`). Now this should not happen, because `isSameDestination` can detect that two paths are pointing to the same file even if they are not equal as strings.