### PR TITLE
Move mocha-parallel-tests fix to gulp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ install:
     else
       npm install --production;
       npm install --no-save gulp appium-gulp-plugins chai chai-as-promised chai-subset wd unzip mocha mocha-parallel-tests fancy-log;
-      node ci/mpt-fix.js;
+      $(npm bin)/gulp fix-mocha-parallel-tests;
       npm run build;
     fi
 script:

--- a/ci/mpt-fix.js
+++ b/ci/mpt-fix.js
@@ -1,13 +1,34 @@
+/* eslint-disable promise/prefer-await-to-then */
+/* eslint-disable promise/prefer-await-to-callbacks */
+
 /**
  * `mocha-parallel-tests` is broken at the moment, so skipped describe blocks fail
  * the fix is simple, and this patches the error until they fix the package
  **/
-const fs = require('fs');
+const fs = require('appium-support').fs;
 const path = require('path');
+const gulp = require('gulp');
+const log = require('fancy-log');
 
 
-const filePath = path.resolve(__dirname, 'node_modules', 'mocha-parallel-tests', 'dist', 'main', 'util.js');
+/**
+ * Temporary gulp task to prove that this works. Once everything is good,
+ * this should be moved to `appium-gulp-plugins` to be available in other
+ * modules
+ */
 
-let script = fs.readFileSync(filePath, {encoding: 'utf8'});
-script = script.replace(`if (value.type === 'test') {`, `if (value.type === 'test') {\n        delete value.fn;`);
-fs.writeFileSync(filePath, script);
+gulp.task('fix-mocha-parallel-tests', function () {
+  const filePath = path.resolve(__dirname, '..', 'node_modules', 'mocha-parallel-tests', 'dist', 'main', 'util.js');
+
+  return fs.readFile(filePath, {encoding: 'utf8'})
+    .then(function (script) {
+      return script.replace(`if (value.type === 'test') {`, `if (value.type === 'test') {\n        delete value.fn;`);
+    })
+    .then(function (script) {
+      return fs.writeFile(filePath, script);
+    })
+    .catch(function (err) {
+      log.error(`Unable to fix 'mocha-parallel-tests': ${err.message}`);
+      throw err;
+    });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,10 @@
 "use strict";
 
-
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
+
+require('./ci/mpt-fix');
 require('./ci/upload-appium');
 
 boilerplate({


### PR DESCRIPTION
Move the functionality to `gulp` so it can be easily ported over to `appium-gulp-plugins` and be available to other packages once our CI is implemented there.