### PR TITLE
Add `enforceFreshSimulatorCreation` capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -130,6 +130,9 @@ let desiredCapConstraints = _.defaults({
   useJSONSource: {
     isBoolean: true
   },
+  useNewSimulator: {
+    isBoolean: true
+  },
   shutdownOtherSimulators: {
     isBoolean: true
   },

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -130,7 +130,7 @@ let desiredCapConstraints = _.defaults({
   useJSONSource: {
     isBoolean: true
   },
-  useNewSimulator: {
+  enforceFreshSimulatorCreation: {
     isBoolean: true
   },
   shutdownOtherSimulators: {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -734,6 +734,12 @@ class XCUITestDriver extends BaseDriver {
       return {device, realDevice: true, udid: this.opts.udid};
     }
 
+    if (!this.opts.platformVersion && this.iosSdkVersion) {
+      log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
+               `This may cause problems if a simulator does not exist for this platform version.`);
+      this.opts.platformVersion = this.iosSdkVersion;
+    }
+
     if (this.opts.enforceFreshSimulatorCreation) {
       log.debug(`New simulator is requested. If this is not wanted, set 'enforceFreshSimulatorCreation' capability to false`);
     } else {
@@ -750,12 +756,6 @@ class XCUITestDriver extends BaseDriver {
 
     // no device of this type exists, or they request new sim, so create one
     log.info('Using desired caps to create a new simulator');
-    if (!this.opts.platformVersion && this.iosSdkVersion) {
-      log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
-               `This may cause problems if a simulator does not exist for this platform version.`);
-      this.opts.platformVersion = this.iosSdkVersion;
-    }
-
     const device = await this.createSim();
     return {device, realDevice: false, udid: device.udid};
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -734,31 +734,29 @@ class XCUITestDriver extends BaseDriver {
       return {device, realDevice: true, udid: this.opts.udid};
     }
 
-    // figure out the correct simulator to use, given the desired capabilities
-    let device = await getExistingSim(this.opts);
+    if (this.opts.useNewSimulator) {
+      log.debug(`New simulator is requested. If this is not wanted, set 'useNewSimulator' capability to false`);
+    } else {
+      // figure out the correct simulator to use, given the desired capabilities
+      let device = await getExistingSim(this.opts);
 
-    // check for an existing simulator
-    if (device) {
-      return {device, realDevice: false, udid: device.udid};
+      // check for an existing simulator
+      if (device) {
+        return {device, realDevice: false, udid: device.udid};
+      }
+
+      log.info('Simulator udid not provided');
     }
 
-    // no device of this type exists, so create one
-    log.info('Simulator udid not provided, using desired caps to create a new simulator');
+    // no device of this type exists, or they request new sim, so create one
+    log.info('Using desired caps to create a new simulator');
     if (!this.opts.platformVersion && this.iosSdkVersion) {
       log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
                `This may cause problems if a simulator does not exist for this platform version.`);
       this.opts.platformVersion = this.iosSdkVersion;
     }
 
-    if (this.opts.noReset) {
-      // Check for existing simulator just with correct capabilities
-      let device = await getExistingSim(this.opts);
-      if (device) {
-        return {device, realDevice: false, udid: device.udid};
-      }
-    }
-
-    device = await this.createSim();
+    let device = await this.createSim();
     return {device, realDevice: false, udid: device.udid};
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -734,11 +734,11 @@ class XCUITestDriver extends BaseDriver {
       return {device, realDevice: true, udid: this.opts.udid};
     }
 
-    if (this.opts.useNewSimulator) {
-      log.debug(`New simulator is requested. If this is not wanted, set 'useNewSimulator' capability to false`);
+    if (this.opts.enforceFreshSimulatorCreation) {
+      log.debug(`New simulator is requested. If this is not wanted, set 'enforceFreshSimulatorCreation' capability to false`);
     } else {
       // figure out the correct simulator to use, given the desired capabilities
-      let device = await getExistingSim(this.opts);
+      const device = await getExistingSim(this.opts);
 
       // check for an existing simulator
       if (device) {
@@ -756,7 +756,7 @@ class XCUITestDriver extends BaseDriver {
       this.opts.platformVersion = this.iosSdkVersion;
     }
 
-    let device = await this.createSim();
+    const device = await this.createSim();
     return {device, realDevice: false, udid: device.udid};
   }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -5,6 +5,8 @@ import { resetXCTestProcesses } from './utils';
 import _ from 'lodash';
 import log from './logger';
 import { tempDir, fs, mkdirp } from 'appium-support';
+import UUID from 'uuid-js';
+
 
 const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
 
@@ -17,7 +19,7 @@ const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
  * @returns {object} Simulator object associated with the udid passed in.
  */
 async function createSim (caps) {
-  const appiumTestDeviceName = `appiumTest-${caps.deviceName}`;
+  const appiumTestDeviceName = `appiumTest-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`;
   const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion);
   return await getSimulator(udid);
 }

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -148,7 +148,7 @@ describe('XCUITestDriver', function () {
       });
 
       it('default: creates sim and deletes it afterwards', async function () {
-        const caps = Object.assign({}, UICATALOG_SIM_CAPS, {useNewSimulator: true});
+        const caps = Object.assign({}, UICATALOG_SIM_CAPS, {enforceFreshSimulatorCreation: true});
 
         const simsBefore = await getNumSims();
         await initSession(caps);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -15,14 +15,15 @@ const SIM_DEVICE_NAME = 'xcuitestDriverTest';
 const should = chai.should();
 chai.use(chaiAsPromised);
 
-const getNumSims = async () => {
+async function getNumSims () {
   return (await getDevices())[UICATALOG_SIM_CAPS.platformVersion].length;
-};
-const deleteDeviceWithRetry = async function (udid) {
+}
+
+async function deleteDeviceWithRetry (udid) {
   try {
     await retryInterval(10, 1000, deleteDevice, udid);
   } catch (ign) {}
-};
+}
 
 describe('XCUITestDriver', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -146,17 +147,16 @@ describe('XCUITestDriver', function () {
         });
       });
 
-      it.skip('default: creates sim and deletes it afterwards', async function () {
-        let caps = UICATALOG_SIM_CAPS;
+      it('default: creates sim and deletes it afterwards', async function () {
+        const caps = Object.assign({}, UICATALOG_SIM_CAPS, {useNewSimulator: true});
 
-        await killAllSimulators();
-        let simsBefore = await getNumSims();
+        const simsBefore = await getNumSims();
         await initSession(caps);
 
-        let simsDuring = await getNumSims();
+        const simsDuring = await getNumSims();
 
         await deleteSession();
-        let simsAfter = await getNumSims();
+        const simsAfter = await getNumSims();
 
         simsDuring.should.equal(simsBefore + 1);
         simsAfter.should.equal(simsBefore);

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -28,7 +28,7 @@ describe('simulator management', function () {
       await createSim(caps);
 
       createDeviceStub.calledOnce.should.be.true;
-      createDeviceStub.firstCall.args[0].should.eql('appiumTest-iPhone 6');
+      /appiumTest-[\w-]{36}-iPhone 6/.test(createDeviceStub.firstCall.args[0]).should.be.true;
       createDeviceStub.firstCall.args[1].should.eql('iPhone 6');
       createDeviceStub.firstCall.args[2].should.eql('10.1');
       getSimulatorStub.calledOnce.should.be.true;


### PR DESCRIPTION
If the system on which Appium is being run has no simulator with the required platform version and name, Appium will create one, and then delete it at the end of the session. If there is a simulator, though, it will just use it, which can cause problems (see https://github.com/appium/appium/issues/12025). 

This PR introduces a capability, `useNewSimulator`, which will force the use of a new sim if no UDID is specified in the caps.