### PR TITLE
Update appium-ios-driver to 4.0.0

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1100,7 +1100,11 @@ class XCUITestDriver extends BaseDriver {
 
   async startIWDP () {
     this.logEvent('iwdpStarting');
-    this.iwdpServer = new IWDP(this.opts.webkitDebugProxyPort, this.opts.udid);
+    this.iwdpServer = new IWDP({
+      webkitDebugProxyPort: this.opts.webkitDebugProxyPort,
+      udid: this.opts.udid,
+      logStdout: !!this.opts.showIWDPLog,
+    });
     await this.iwdpServer.start();
     this.logEvent('iwdpStarted');
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
-    "appium-ios-driver": "^3.0.0",
+    "appium-ios-driver": "^4.0.0",
     "appium-ios-simulator": "^3.8.0",
     "appium-remote-debugger": "^3.16.0",
     "appium-support": "^2.25.0",


### PR DESCRIPTION
Greenkeeper seems to not catch major releases.