### PR TITLE
Do not apply the implicit wait to multiple elements lookup

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -89,48 +89,39 @@ helpers.findNativeElementOrElements = async function (strategy, selector, mult, 
 helpers.doNativeFind = async function (strategy, selector, mult, context) {
   context = util.unwrapElement(context);
 
-  let endpoint = `/element${context ? `/${context}/element` : ''}${mult ? 's' : ''}`;
-
-  let body = {
+  const endpoint = `/element${context ? `/${context}/element` : ''}${mult ? 's' : ''}`;
+  const body = {
     using: strategy,
     value: selector
   };
+  const method = 'POST';
 
-  let method = 'POST';
+  if (mult) {
+    // Do not apply the implicit wait to multiple elements lookup
+    return (await this.proxyCommand(endpoint, method, body) || []);
+  }
 
-  let els;
+  let element;
   try {
     await this.implicitWaitForCondition(async () => {
       try {
-        els = await this.proxyCommand(endpoint, method, body);
-        if (mult) {
-          // we succeed if we get some elements
-          return els && els.length;
-        } else {
-          // we may not get any status, which means success
-          return !els.status || els.status === 0;
-        }
+        element = await this.proxyCommand(endpoint, method, body);
+        // we may not get any status, which means success
+        return !element.status || element.status === 0;
       } catch (err) {
-        els = undefined;
+        element = null;
         return false;
       }
     });
   } catch (err) {
-    if (err.message && err.message.match(/Condition unmet/)) {
-      // condition was not met setting res to empty array
-      els = [];
-    } else {
+    if (!(err.message && err.message.match(/Condition unmet/))) {
       throw err;
     }
   }
-  if (mult) {
-    return els;
-  } else {
-    if (!els || _.size(els) === 0) {
-      throw new errors.NoSuchElementError();
-    }
-    return els;
+  if (_.isEmpty(element)) {
+    throw new errors.NoSuchElementError();
   }
+  return element;
 };
 
 helpers.getFirstVisibleChild = async function (mult, context) {


### PR DESCRIPTION
The reason for this change is the same as in https://github.com/appium/appium-android-driver/pull/494