### PR TITLE
Remove webkitDebugProxyPort constraint, in favor of appium-ios-driver

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -115,9 +115,6 @@ let desiredCapConstraints = _.defaults({
   isHeadless: {
     isBoolean: true
   },
-  webkitDebugProxyPort: {
-    isNumber: true
-  },
   useXctestrunFile: {
     isBoolean: true
   },


### PR DESCRIPTION
Cap constraint moved to `appium-ios-driver` (https://github.com/appium/appium-ios-driver/pull/358)