### PR TITLE
tweak xcode log level when build failed

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -267,7 +267,7 @@ class XcodeBuild {
         // do not log permission errors from trying to write to attachments folder
         if (!out.includes('Error writing attachment data to file')) {
           for (const line of out.split('\n')) {
-            xcodeLog.info(line);
+            xcodeLog.error(line);
           }
         }
       }
@@ -283,17 +283,17 @@ class XcodeBuild {
     // any startup errors that are thrown as events
     return await new B((resolve, reject) => {
       this.xcodebuild.on('exit', async (code, signal) => {
-        log.info(`xcodebuild exited with code '${code}' and signal '${signal}'`);
+        log.error(`xcodebuild exited with code '${code}' and signal '${signal}'`);
         // print out the xcodebuild file if users have asked for it
         if (this.showXcodeLog && this.xcodebuild.logLocation) {
-          xcodeLog.info(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
+          xcodeLog.error(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
           try {
             let data = await fs.readFile(this.xcodebuild.logLocation, 'utf8');
             for (let line of data.split('\n')) {
-              xcodeLog.info(line);
+              xcodeLog.error(line);
             }
           } catch (err) {
-            log.debug(`Unable to access xcodebuild log file: '${err.message}'`);
+            log.error(`Unable to access xcodebuild log file: '${err.message}'`);
           }
         }
         this.xcodebuild.processExited = true;


### PR DESCRIPTION
Currently, we cannot see any error message when xcode build failed when `--log-level=warn` for example.
In this case, users can know the xcodebuild failed with ` xcodebuild failure: "xcodebuild failed with code 65"`, but not sure the cause. They must chnage log level.

Currently, we already show some lines the cause of xcodebuild as `info`. But users need them to understand the failing cause. For example, `65` error by signing issue. As below, we can see the cause message if we change the log level. (I can see this 65 issue frequesntly in our issue as well. I hope users can see them even if they set loglevel as warn or error and resolve them by themselves, hopefully.)


What do you think?

---

- current (`--log-level=warn`)

```
[BaseDriver] The following capabilities were provided, but are not recognized by appium: someCapability.
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[XCUITest] Quitting and uninstalling WebDriverAgent, then retrying
[XCUITest] Error: Unable to launch WebDriverAgent because of xcodebuild failure: "xcodebuild failed with code 65". Make sure you follow the tutorial at https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md. Try to remove the WebDriverAgentRunner application from the device if it is installed and reboot the device.
[XCUITest]     at quitAndUninstall (/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/lib/driver.js:483:13)
[BaseDriver] The following capabilities were provided, but are not recognized by appium: someCapability.
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
```

- after(`--log-level=warn`)

```
[BaseDriver] The following capabilities were provided, but are not recognized by appium: someCapability.
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[Xcode] 2019-03-07 20:54:19.919 xcodebuild[93401:4603144] Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7f97864ca5c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
[Xcode]
[Xcode] 2019-03-07 20:54:19.919 xcodebuild[93401:4603144] Error Domain=IDETestOperationsObserverErrorDomain Code=4 "Failed to install or launch the test runner" UserInfo={NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Logs/Test/Test-WebDriverAgentRunner-2019.03.07_20-54-19-+0900.xcresult, NSLocalizedDescription=Failed to install or launch the test runner, NSUnderlyingError=0x7f978be96630 {Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7f97864ca5c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}}}
[Xcode]
[Xcode]
[Xcode] Testing failed:
[Xcode]
[Xcode] 	WebDriverAgentRunner has conflicting provisioning settings. WebDriverAgentRunner is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentRunner')
[Xcode] 	WebDriverAgentLib has conflicting provisioning settings. WebDriverAgentLib is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentLib')
[Xcode] 	WebDriverAgentRunner-Runner.app encountered an error (Failed to install or launch the test runner. (Underlying error: The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file. The file doesn’t exist. (Underlying error: The operation couldn’t be completed. No such file or directory)))
[Xcode] ** TEST EXECUTE FAILED **
[Xcode]
[Xcode]
[Xcode] Testing started on 'Kazu's iPhone SE'
[Xcode]
[XCUITest] xcodebuild exited with code '65' and signal 'null'
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[WD Proxy] Got an unexpected response: {"errno":"ECONNRESET","code":"ECONNRESET","syscall":"read"}
[Xcode] 2019-03-07 20:54:26.853 xcodebuild[93410:4603372] Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7f973f05bcc0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
[Xcode]
[Xcode] 2019-03-07 20:54:26.853 xcodebuild[93410:4603372] Error Domain=IDETestOperationsObserverErrorDomain Code=4 "Failed to install or launch the test runner" UserInfo={NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Logs/Test/Test-WebDriverAgentRunner-2019.03.07_20-54-26-+0900.xcresult, NSLocalizedDescription=Failed to install or launch the test runner, NSUnderlyingError=0x7f973f838eb0 {Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7f973f05bcc0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}}}
```