### PR TITLE
return xcodebuild error message to client

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -8,6 +8,7 @@ import { fixForXcode7, fixForXcode9, setRealDeviceSecurity, generateXcodeConfigF
          WDA_RUNNER_BUNDLE_ID, getWDAUpgradeTimestamp } from './utils';
 import _ from 'lodash';
 import path from 'path';
+import { EOL } from 'os';
 
 
 const DEFAULT_SIGNING_ID = 'iPhone Developer';
@@ -266,8 +267,11 @@ class XcodeBuild {
       if (logXcodeOutput) {
         // do not log permission errors from trying to write to attachments folder
         if (!out.includes('Error writing attachment data to file')) {
-          for (const line of out.split('\n')) {
+          for (const line of out.split(EOL)) {
             xcodeLog.error(line);
+            if (line) {
+              xcodebuild._wda_error_message += `${EOL}${line}`;
+            }
           }
         }
       }
@@ -278,6 +282,8 @@ class XcodeBuild {
 
   async start (buildOnly = false) {
     this.xcodebuild = await this.createSubProcess(buildOnly);
+    // Store xcodebuild message
+    this.xcodebuild._wda_error_message = '';
 
     // wrap the start procedure in a promise so that we can catch, and report,
     // any startup errors that are thrown as events
@@ -298,7 +304,8 @@ class XcodeBuild {
         }
         this.xcodebuild.processExited = true;
         if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
-          return reject(new Error(`xcodebuild failed with code ${code}`));
+          return reject(new Error(`xcodebuild failed with code ${code}${EOL}` +
+            `xcodebuild error message:${EOL}${this.xcodebuild._wda_error_message}`));
         }
         // in the case of just building, the process will exit and that is our finish
         if (buildOnly) {


### PR DESCRIPTION
Returns xcodebuild error in error message to client. The message is in `message` and `stacktrace` in W3C error format.

Users can see WDA build error as client side message. I hope this helps users to take a look signing issue (for example).

- in Ruby client (Below is a combination of an error message and stacktrace)
```
Selenium::WebDriver::Error::UnknownError:         Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to launch WebDriverAgent because of xcodebuild failure: "xcodebuild failed with code 65
        xcodebuild error message:
        
        2019-03-08 22:54:50.731 xcodebuild[54467:791590] Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7fe1ae4bc910 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
        2019-03-08 22:54:50.731 xcodebuild[54467:791590] Error Domain=IDETestOperationsObserverErrorDomain Code=4 "Failed to install or launch the test runner" UserInfo={NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Logs/Test/Test-WebDriverAgentRunner-2019.03.08_22-54-50-+0900.xcresult, NSLocalizedDescription=Failed to install or launch the test runner, NSUnderlyingError=0x7fe1ae4ca2a0 {Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7fe1ae4bc910 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}}}
        Testing failed:
                WebDriverAgentRunner has conflicting provisioning settings. WebDriverAgentRunner is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentRunner')
                WebDriverAgentLib has conflicting provisioning settings. WebDriverAgentLib is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentLib')
                WebDriverAgentRunner-Runner.app encountered an error (Failed to install or launch the test runner. (Underlying error: The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file. The file doesn’t exist. (Underlying error: The operation couldn’t be completed. No such file or directory)))
        ** TEST EXECUTE FAILED **
        Testing started on 'Kazu's iPhone SE'".
         Make sure you follow the tutorial at https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md. Try to remove the WebDriverAgentRunner application from the device if it is installed and reboot the device.
            UnknownError: An unknown server-side error occurred while processing the command. Original error: Unable to launch WebDriverAgent because of xcodebuild failure: "xcodebuild failed with code 65
            xcodebuild error message:
            
            2019-03-08 22:54:50.731 xcodebuild[54467:791590] Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7fe1ae4bc910 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
            2019-03-08 22:54:50.731 xcodebuild[54467:791590] Error Domain=IDETestOperationsObserverErrorDomain Code=4 "Failed to install or launch the test runner" UserInfo={NSLocalizedRecoverySuggestion=If you believe this error represents a bug, please attach the result bundle at /Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Logs/Test/Test-WebDriverAgentRunner-2019.03.08_22-54-50-+0900.xcresult, NSLocalizedDescription=Failed to install or launch the test runner, NSUnderlyingError=0x7fe1ae4ca2a0 {Error Domain=NSCocoaErrorDomain Code=260 "The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/WebDriverAgent/tmp/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app, NSUnderlyingError=0x7fe1ae4bc910 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}}}
            Testing failed:
                WebDriverAgentRunner has conflicting provisioning settings. WebDriverAgentRunner is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentRunner')
                WebDriverAgentLib has conflicting provisioning settings. WebDriverAgentLib is automatically signed, but code signing identity kazu has been manually specified. Set the code signing identity value to "iPhone Developer" in the build settings editor, or switch to manual signing in the project editor. (in target 'WebDriverAgentLib')
                WebDriverAgentRunner-Runner.app encountered an error (Failed to install or launch the test runner. (Underlying error: The file “WebDriverAgentRunner-Runner.app” couldn’t be opened because there is no such file. The file doesn’t exist. (Underlying error: The operation couldn’t be completed. No such file or directory)))
            ** TEST EXECUTE FAILED **
            Testing started on 'Kazu's iPhone SE'".
             Make sure you follow the tutorial at https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md. Try to remove the WebDriverAgentRunner application from the device if it is installed and reboot the device.
                at getResponseForW3CError (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/lib/protocol/errors.js:826:9)
                at asyncHandler (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:447:37)
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/response.rb:69:in `assert_ok'
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/response.rb:32:in `initialize'
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/common.rb:84:in `new'
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/common.rb:84:in `create_response'
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/http/default.rb:104:in `request'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/common/base/http_default.rb:67:in `call'
            /Users/kazu/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/selenium-webdriver-3.141.0/lib/selenium/webdriver/remote/bridge.rb:166:in `execute'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/common/base/bridge.rb:93:in `create_session'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/common/base/bridge.rb:33:in `handshake'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/common/base/driver.rb:20:in `initialize'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/driver.rb:328:in `new'
            /Users/kazu/GitHub/ruby_lib_core/lib/appium_lib_core/driver.rb:328:in `start_driver'
            /Users/kazu/GitHub/ruby_lib_core/test/functional/ios/driver_test.rb:9:in `setup'
```