### PR TITLE
fix: use mocha 5 for mocha-parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
       if: type = cron
       os: linux
       env: CLOUD=1
-      script: $(npm bin)/gulp sauce-storage-upload
+      script: npx gulp sauce-storage-upload
 
     # Sauce Emusim tests
     - stage: "[CRON] Sauce Emusim tests"
@@ -185,12 +185,13 @@ install:
       npm install --production;
       npm install --no-save gulp appium-gulp-plugins chai chai-as-promised chai-subset wd unzip mocha mocha-parallel-tests;
       npm install --no-save saucelabs;
-      $(npm bin)/gulp fix-mocha-parallel-tests;
+      npx gulp fix-mocha-parallel-tests;
       npm run build;
-      $(npm bin)/gulp periodic-output & export LONG_PID=$!;
+      npx gulp periodic-output & export LONG_PID=$!;
     fi
 script:
   - if [ -n "$CLOUD" ]; then
+      npm install mocha@5; # TO-DO: Take this out once `mocha-parallel-tests` supports mocha 6
       npm run mocha:parallel -- --max-parallel $MAX_PARALLEL --debug -t 480000 --require build/test/env/env --recursive build/test/$TEST;
     else
       npm run lint && npm run mocha -- -t 480000 $RECURSIVE build/test/$TEST -g @skip-ci -i --exit;


### PR DESCRIPTION
`mocha-parallel-tests` doesn't currently support `mocha@6`. This PR makes it install `mocha@5` on cron builds until it does.