### PR TITLE
Remove comment from bash block in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ install:
     fi
 script:
   - if [ -n "$CLOUD" ]; then
-      npm install mocha@5; # TO-DO: Take this out once `mocha-parallel-tests` supports mocha 6
+      npm install mocha@5;
       npm run mocha:parallel -- --max-parallel $MAX_PARALLEL --debug -t 480000 --require build/test/env/env --recursive build/test/$TEST;
     else
       npm run lint && npm run mocha -- -t 480000 $RECURSIVE build/test/$TEST -g @skip-ci -i --exit;


### PR DESCRIPTION
We cannot have comments in bash blocks, in the Travis config, as this is invalid YAML. This is why builds are not running on master right now.