### PR TITLE
Azure Pipelines for XCUITestDriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 ci-metrics
 package-lock.json*
 .nyc_output/
+test-results.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,21 @@
+# Node.js
+# Build a general Node.js project with npm.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
+
+trigger:
+- master
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '8.x'
+  displayName: 'Install Node.js'
+
+- script: |
+    npm install
+    npm run build
+  displayName: 'npm install and build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,24 @@
-# https://docs.microsoft.com/azure/devops/pipelines/languages/xcode
-pool:
-  vmImage: 'macOS-10.13'
+jobs:
+  - template: ./ci/ios/ios-e2e-template.yml
+    parameters:
+      name: e2e_basic_12
+      script: |
+        npm install --no-save mjpeg-consumer
+        npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
 
-steps:
-- task: Xcode@5
-  inputs:
-    actions: 'build'
-    scheme: ''
-    sdk: 'iphoneos'
-    configuration: 'Release'
-    xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
-    xcodeVersion: 'default' # Options: 8, 9, 10, default, specifyPath
-    signingOption: 'default' # Options: nosign, default, manual, auto
-    useXcpretty: 'false' # Makes it easier to diagnose build failures
+  - template: ./ci/ios/ios-e2e-template.yml
+    parameters:
+      name: e2e_driver_12
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
+
+  - template: ./ci/ios/ios-e2e-template.yml 
+    parameters:
+      name: e2e_web_12
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
+
+  - template: ./ci/ios/ios-e2e-template.yml
+    parameters:
+      name: e2e_long_12
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/long -g @skip-ci -i --exit
+
+  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,6 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
-#- task: NodeTool@0
-  #inputs:
-    #versionSpec: '11.x'
-  #displayName: 'Install Node.js'
-#- script: |
-    #npm install
-    #npm test
-  #displayName: 'NPM Install and Test'
 - task: Xcode@10
   inputs:
     actions: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 steps:
-- task: InstallAppleCertificate@2
-  inputs:
-    certSecureFile: 'chrisid_iOSDev_Nov2018.p12'
-    certPwd: $(P12Password)
-
-- task: InstallAppleProvisioningProfile@1
-  inputs:
-    provProfileSecureFile: '6ffac825-ed27-47d0-8134-95fcf37a666c.mobileprovision'
-
 - task: Xcode@5
   inputs:
     actions: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,14 +3,17 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
-trigger:
-- master
-
-pool:
-  vmImage: 'Ubuntu-16.04'
-
 steps:
-- task: Xcode@10
+- task: InstallAppleCertificate@2
+  inputs:
+    certSecureFile: 'chrisid_iOSDev_Nov2018.p12'
+    certPwd: $(P12Password)
+
+- task: InstallAppleProvisioningProfile@1
+  inputs:
+    provProfileSecureFile: '6ffac825-ed27-47d0-8134-95fcf37a666c.mobileprovision'
+
+- task: Xcode@5
   inputs:
     actions: 'build'
     scheme: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # Pull request validation job
 jobs:
-  - template: ci/xcuitest-e2e-template.yml
+  - template: ./ci/xcuitest-e2e-template.yml
     parameters:
       name: iPhoneX_12_1
       iosVersion: 12.1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,24 +1,8 @@
+# Pull request validation job
 jobs:
-  - template: ./ci/ios-e2e-template.yml
+  - template: ci/xcuitest-e2e-template.yml
     parameters:
-      name: e2e_basic_12_1
-      script: |
-        npm install --no-save mjpeg-consumer
-        npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
-
-  - template: ./ci/ios-e2e-template.yml
-    parameters:
-      name: e2e_driver_12_1
-      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
-
-  - template: ./ci/ios-e2e-template.yml 
-    parameters:
-      name: e2e_web_12_1
-      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
-
-  - template: ./ci/ios-e2e-template.yml
-    parameters:
-      name: e2e_long_12_1
-      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/long -g @skip-ci -i --exit
-
-  
+      name: iPhoneX_12_1
+      iosVersion: 12.1
+      xcodeVersion: 10.1
+      deviceName: "iPhone X"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,6 @@
-# Node.js
-# Build a general Node.js project with npm.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
+# https://docs.microsoft.com/azure/devops/pipelines/languages/xcode
+pool:
+  vmImage: 'macOS-10.13'
 
 steps:
 - task: Xcode@5

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
 # Pull request validation job
 jobs:
   - job: Coverage
+    pool:
+      vmImage: 'macOS 10.13'
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,21 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
-- task: NodeTool@0
+#- task: NodeTool@0
+  #inputs:
+    #versionSpec: '11.x'
+  #displayName: 'Install Node.js'
+#- script: |
+    #npm install
+    #npm test
+  #displayName: 'NPM Install and Test'
+- task: NodeTool@0, Xcode@10
   inputs:
-    versionSpec: '8.x'
-  displayName: 'Install Node.js'
-
-- script: |
-    npm install
-    npm run build
-  displayName: 'npm install and build'
+    actions: 'build'
+    scheme: ''
+    sdk: 'iphoneos'
+    configuration: 'Release'
+    xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace'
+    xcodeVersion: 'default' # Options: 8, 9, 10, default, specifyPath
+    signingOption: 'default' # Options: nosign, default, manual, auto
+    useXcpretty: 'false' # Makes it easier to diagnose build failures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,23 +1,5 @@
 # Pull request validation job
 jobs:
-  - job: Coverage
-    pool:
-      vmImage: 'macOS 10.13'
-    steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 11.x
-      - script: |
-          sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
-          git submodule update --init --recursive;
-        displayName: Checkout WDA submodule
-      - script: npm install
-        displayName: Install node dependencies
-      - script: npx gulp coverage
-        displayName: Test with coverage
-      - task: PublishCodeCoverageResults@1
-        inputs:
-          summaryFileLocation: coverage/lcov.info
   - template: ./ci/xcuitest-e2e-template.yml
     parameters:
       name: iPhoneX_12_1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,21 @@
 # Pull request validation job
 jobs:
+  - job: Coverage
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 11.x
+      - script: |
+          sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
+          git submodule update --init --recursive;
+        displayName: Checkout WDA submodule
+      - script: npm install
+        displayName: Install node dependencies
+      - script: npx gulp coverage
+        displayName: Test with coverage
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          summaryFileLocation: coverage/lcov.info
   - template: ./ci/xcuitest-e2e-template.yml
     parameters:
       name: iPhoneX_12_1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,24 +1,24 @@
 jobs:
   - template: ./ci/ios-e2e-template.yml
     parameters:
-      name: e2e_basic_12
+      name: e2e_basic_12_1
       script: |
         npm install --no-save mjpeg-consumer
         npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
 
   - template: ./ci/ios-e2e-template.yml
     parameters:
-      name: e2e_driver_12
+      name: e2e_driver_12_1
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
 
   - template: ./ci/ios-e2e-template.yml 
     parameters:
-      name: e2e_web_12
+      name: e2e_web_12_1
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
 
   - template: ./ci/ios-e2e-template.yml
     parameters:
-      name: e2e_long_12
+      name: e2e_long_12_1
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/long -g @skip-ci -i --exit
 
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,22 +1,22 @@
 jobs:
-  - template: ./ci/ios/ios-e2e-template.yml
+  - template: ./ci/ios-e2e-template.yml
     parameters:
       name: e2e_basic_12
       script: |
         npm install --no-save mjpeg-consumer
         npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
 
-  - template: ./ci/ios/ios-e2e-template.yml
+  - template: ./ci/ios-e2e-template.yml
     parameters:
       name: e2e_driver_12
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
 
-  - template: ./ci/ios/ios-e2e-template.yml 
+  - template: ./ci/ios-e2e-template.yml 
     parameters:
       name: e2e_web_12
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
 
-  - template: ./ci/ios/ios-e2e-template.yml
+  - template: ./ci/ios-e2e-template.yml
     parameters:
       name: e2e_long_12
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/long -g @skip-ci -i --exit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
     #npm install
     #npm test
   #displayName: 'NPM Install and Test'
-- task: NodeTool@0, Xcode@10
+- task: Xcode@10
   inputs:
     actions: 'build'
     scheme: ''

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -3,8 +3,8 @@ parameters:
     script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
     name: ios-e2e-test
     dependsOn: ''
-    platformVersion: 12.1
-    deviceName: 'iPhone X'
+    platformVersion: 10
+    deviceName: 'iPhone 5s'
     testResultsFiles: 'junit-test-results.xml'
 
 jobs:
@@ -35,4 +35,4 @@ jobs:
     - task: PublishTestResults@2
       condition: always()
       inputs:
-        testResultsFiles: ${{ parameters.workingDirectory }}/${{ parameters.testResultsFiles }}
+        testResultsFiles: ${{ parameters.testResultsFiles }}

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -4,7 +4,7 @@ parameters:
     name: ios-e2e-test
     dependsOn: ''
     iosVersion: 12.0
-    xcodeVersion: 10
+    xcodeVersion: 10.1
     deviceName: 'iPhone X'
     testResultsFiles: 'junit-test-results.xml'
 

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -12,7 +12,7 @@ jobs:
     variables:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
-      MOCHA_FILE: '${{ parameters.name }}-tests.xml'
+      MOCHA_FILE: '${{ parameters.name }}-tests.xml' 
       CI: true
       DEVELOPER_DIR: /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
     pool:

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -3,7 +3,7 @@ parameters:
     script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
     name: ios-e2e-test
     dependsOn: ''
-    iosVersion: 12.0
+    iosVersion: 12.1
     xcodeVersion: 10.1
     deviceName: 'iPhone X'
     testResultsFiles: 'junit-test-results.xml'
@@ -23,6 +23,8 @@ jobs:
     - script: |
         ls /Applications/
         sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+        xcodebuild -version
+      displayName: XcodeSelect
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - task: Xcode@5
-      inputs:
-        xcodeVersion: 10
+    - script: xcodebuild -version
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
     - checkout: self
       submodules: true
+    - task: Xcode@5
+      inputs:
+        xcodeVersion: 10
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -6,14 +6,13 @@ parameters:
     iosVersion: 12.1
     xcodeVersion: 10.1
     deviceName: 'iPhone X'
-    testResultsFiles: 'junit-test-results.xml'
 
 jobs:
   - job: ${{ parameters.name }}
     variables:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
-      MOCHA_FILE: 'junit-test-results.xml'
+      MOCHA_FILE: '${{ parameters.name }}-tests.xml'
       CI: true
     pool:
       vmImage: 'macOS 10.13'
@@ -24,6 +23,7 @@ jobs:
         ls /Applications/
         sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
         xcodebuild -version
+        xcrun simctl list
       displayName: XcodeSelect
     - task: NodeTool@0
       inputs:

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -1,0 +1,43 @@
+# https://docs.microsoft.com/azure/devops/pipelines/languages/android
+parameters:
+    script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
+    workingDirectory: ''
+    name: ios-e2e-test
+    dependsOn: ''
+    platformVersion: 12.1
+    deviceName: 'iPhone X'
+    testResultsFiles: 'junit-test-results.xml'
+
+jobs:
+  - job: ${{ parameters.name }}
+    variables:
+      PLATFORM_VERSION: ${{ parameters.platformVersion }}
+      DEVICE_NAME: ${{ parameters.deviceName }}
+      MOCHA_FILE: 'junit-test-results.xml'
+      CI: true
+    pool:
+      vmImage: 'macOS 10.13'
+    steps:
+    - checkout: self
+      submodules: true
+    - task: NodeTool@0
+      inputs:
+        versionSpec: 11.x
+    - script: |
+        sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
+        git submodule update --init --recursive;
+      workingDirectory: packages/appium-xcuitest-driver
+      displayName: Checkout WDA submodule
+    - script: npm install
+      workingDirectory: packages/appium-xcuitest-driver
+      displayName: Install node dependencies
+    - script: npm run build
+      workingDirectory: packages/appium-xcuitest-driver
+      displayName: Build
+    - script: ${{ parameters.script }}
+      workingDirectory: packages/appium-xcuitest-driver
+      displayName: Run functional tests
+    - task: PublishTestResults@2
+      condition: always()
+      inputs:
+        testResultsFiles: ${{ parameters.workingDirectory }}/${{ parameters.testResultsFiles }}

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -3,14 +3,15 @@ parameters:
     script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
     name: ios-e2e-test
     dependsOn: ''
-    platformVersion: 10.0
-    deviceName: 'iPhone 5s'
+    iosVersion: 12.0
+    xcodeVersion: 10
+    deviceName: 'iPhone X'
     testResultsFiles: 'junit-test-results.xml'
 
 jobs:
   - job: ${{ parameters.name }}
     variables:
-      PLATFORM_VERSION: ${{ parameters.platformVersion }}
+      PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
       MOCHA_FILE: 'junit-test-results.xml'
       CI: true
@@ -21,7 +22,7 @@ jobs:
       submodules: true
     - script: |
         ls /Applications/
-        xcode-select -s /Applications/Xcode_${{ parameters.platformVersion }}.app/Contents/Developer
+        xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -41,4 +41,4 @@ jobs:
     - task: PublishTestResults@2
       condition: always()
       inputs:
-        testResultsFiles: ${{ parameters.testResultsFiles }}
+        testResultsFiles: $(MOCHA_FILE)

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -3,7 +3,7 @@ parameters:
     script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
     name: ios-e2e-test
     dependsOn: ''
-    platformVersion: 10
+    platformVersion: 10.0
     deviceName: 'iPhone 5s'
     testResultsFiles: 'junit-test-results.xml'
 

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -22,7 +22,7 @@ jobs:
       submodules: true
     - script: |
         ls /Applications/
-        xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
     - checkout: self
       submodules: true
-    - script: xcodebuild -version
+    - script: |
+        ls /Applications/
+        xcode-select -s /Applications/Xcode_${{ parameters.platformVersion }}.app/Contents/Developer
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -12,22 +12,23 @@ jobs:
     variables:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
-      MOCHA_FILE: '${{ parameters.name }}-tests.xml' 
+      MOCHA_FILE: '${{ parameters.name }}-tests.xml'
       CI: true
-      DEVELOPER_DIR: /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
     pool:
       vmImage: 'macOS 10.13'
     steps:
     - checkout: self
       submodules: true
     - script: |
-        echo "INSTALLED APPLICATIONS:""
+        echo "INSTALLED APPLICATIONS:"
         ls /Applications/
+        echo "CHANGING TO Xcode_${{ paramaters.xcodeVersion }}"
+        sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
         echo "XCODE VERSION:"
         xcodebuild -version
         echo "IOS SIMULATORS:"
         xcrun simctl list
-      displayName: Log Environment Info
+      displayName: XcodeSelect
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -14,17 +14,20 @@ jobs:
       DEVICE_NAME: ${{ parameters.deviceName }}
       MOCHA_FILE: '${{ parameters.name }}-tests.xml'
       CI: true
+      DEVELOPER_DIR: /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
     pool:
       vmImage: 'macOS 10.13'
     steps:
     - checkout: self
       submodules: true
     - script: |
+        echo "INSTALLED APPLICATIONS:""
         ls /Applications/
-        sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
+        echo "XCODE VERSION:"
         xcodebuild -version
+        echo "IOS SIMULATORS:"
         xcrun simctl list
-      displayName: XcodeSelect
+      displayName: Log Environment Info
     - task: NodeTool@0
       inputs:
         versionSpec: 11.x

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -22,7 +22,7 @@ jobs:
     - script: |
         echo "INSTALLED APPLICATIONS:"
         ls /Applications/
-        echo "CHANGING TO Xcode_${{ paramaters.xcodeVersion }}"
+        echo "CHANGING TO Xcode_${{ parameters.xcodeVersion }}"
         sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
         echo "XCODE VERSION:"
         xcodebuild -version

--- a/ci/ios-e2e-template.yml
+++ b/ci/ios-e2e-template.yml
@@ -1,7 +1,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
 parameters:
     script: 'npx mocha --timeout 480000 build/test/functional/ -g @skip-ci -i --exit'
-    workingDirectory: ''
     name: ios-e2e-test
     dependsOn: ''
     platformVersion: 12.1
@@ -26,16 +25,12 @@ jobs:
     - script: |
         sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
         git submodule update --init --recursive;
-      workingDirectory: packages/appium-xcuitest-driver
       displayName: Checkout WDA submodule
     - script: npm install
-      workingDirectory: packages/appium-xcuitest-driver
       displayName: Install node dependencies
     - script: npm run build
-      workingDirectory: packages/appium-xcuitest-driver
       displayName: Build
     - script: ${{ parameters.script }}
-      workingDirectory: packages/appium-xcuitest-driver
       displayName: Run functional tests
     - task: PublishTestResults@2
       condition: always()

--- a/ci/xcuitest-e2e-template.yml
+++ b/ci/xcuitest-e2e-template.yml
@@ -1,0 +1,41 @@
+parameters:
+  name: ''
+  iosVersion: ''
+  xcodeVersion: ''
+  deviceName: ''
+jobs:
+  - template: ./ci/ios-e2e-template.yml
+    parameters:
+      name: e2e_basic_${{ parameters.name }}
+      iosVersion: ${{ parameters.iosVersion }}
+      xcodeVersion: ${{ parameters.xcodeVersion }}
+      deviceName: ${{ parameters.deviceName }}
+      script: |
+        npm install --no-save mjpeg-consumer
+        npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
+
+  - template: ./ci/ios-e2e-template.yml
+    parameters:
+      name: e2e_driver_${{ parameters.name }}
+      iosVersion: ${{ parameters.iosVersion }}
+      xcodeVersion: ${{ parameters.xcodeVersion }}
+      deviceName: ${{ parameters.deviceName }}
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
+
+  - template: ./ci/ios-e2e-template.yml 
+    parameters:
+      name: e2e_web_${{ parameters.name }}
+      iosVersion: ${{ parameters.iosVersion }}
+      xcodeVersion: ${{ parameters.xcodeVersion }}
+      deviceName: ${{ parameters.deviceName }}
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
+
+  - template: ./ci/ios-e2e-template.yml
+    parameters:
+      name: e2e_long_${{ parameters.name }}
+      iosVersion: ${{ parameters.iosVersion }}
+      xcodeVersion: ${{ parameters.xcodeVersion }}
+      deviceName: ${{ parameters.deviceName }}
+      script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/long -g @skip-ci -i --exit
+
+  

--- a/ci/xcuitest-e2e-template.yml
+++ b/ci/xcuitest-e2e-template.yml
@@ -4,7 +4,7 @@ parameters:
   xcodeVersion: ''
   deviceName: ''
 jobs:
-  - template: ./ci/ios-e2e-template.yml
+  - template: ./ios-e2e-template.yml
     parameters:
       name: e2e_basic_${{ parameters.name }}
       iosVersion: ${{ parameters.iosVersion }}
@@ -14,7 +14,7 @@ jobs:
         npm install --no-save mjpeg-consumer
         npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/basic -g @skip-ci -i --exit
 
-  - template: ./ci/ios-e2e-template.yml
+  - template: ./ios-e2e-template.yml
     parameters:
       name: e2e_driver_${{ parameters.name }}
       iosVersion: ${{ parameters.iosVersion }}
@@ -22,7 +22,7 @@ jobs:
       deviceName: ${{ parameters.deviceName }}
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/driver -g @skip-ci -i --exit
 
-  - template: ./ci/ios-e2e-template.yml 
+  - template: ./ios-e2e-template.yml 
     parameters:
       name: e2e_web_${{ parameters.name }}
       iosVersion: ${{ parameters.iosVersion }}
@@ -30,7 +30,7 @@ jobs:
       deviceName: ${{ parameters.deviceName }}
       script: npx mocha --timeout 480000 --reporter mocha-junit-reporter --recursive build/test/functional/web -g @skip-ci -i --exit
 
-  - template: ./ci/ios-e2e-template.yml
+  - template: ./ios-e2e-template.yml
     parameters:
       name: e2e_long_${{ parameters.name }}
       iosVersion: ${{ parameters.iosVersion }}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "ios-test-app": "^3.0.0",
     "ios-uicatalog": "^1.0.4",
     "mocha": "^6.0.0",
+    "mocha-junit-reporter": "^1.18.0",
     "mocha-parallel-tests": "^2.0.4",
     "moment": "^2.22.2",
     "pem": "^1.8.3",


### PR DESCRIPTION
I got Azure Pipelines working for XCUITestDriver too!

It runs on Xcode 10.1, iOS 12.1.... the tests all take under 25 minutes: https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=1001

The hosted Mac agents also have Xcode betas installed, so in the future when betas are released, we can test them on CI. Not sure how quickly the betas are added to the agents though.