### PR TITLE
make loglevel about xcode env to info

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -271,10 +271,10 @@ class XCUITestDriver extends BaseDriver {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
       const tools = !this.xcodeVersion.toolsVersion ? '' : `(tools v${this.xcodeVersion.toolsVersion})`;
-      log.debug(`Xcode version set to '${this.xcodeVersion.versionString}' ${tools}`);
+      log.info(`Xcode version set to '${this.xcodeVersion.versionString}' ${tools}`);
 
       this.iosSdkVersion = await getAndCheckIosSdkVersion();
-      log.debug(`iOS SDK Version set to '${this.iosSdkVersion}'`);
+      log.info(`iOS SDK Version set to '${this.iosSdkVersion}'`);
     }
     this.logEvent('xcodeDetailsRetrieved');
 


### PR DESCRIPTION
tiny changes.

Currently, xcode version only appears as debug level.
We can set an arbitrary xcode version like `DEVELOPER_DIR=/Applications/Xcode_941.app/Contents/Developer appium` to use it in Appium process.
In the case, we can determin the xcode version via `ps` & `grep` for example, but it is helpful to show current xcode version as a part of Appium log as info level.
(I would like to know it in non-debug level)