### PR TITLE
Record screen command: Quicktime compatibility via pixelFormat: 'yuv420p'

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -58,6 +58,10 @@ class ScreenRecorder {
     if (this.opts.videoScale) {
       args.push('-vf', `scale=${this.opts.videoScale}`);
     }
+    // Quicktime compatibility via pixelFormat: 'yuv420p'
+    if (this.opts.pixelFormat) {
+      args.push('-pix_fmt', this.opts.pixelFormat);
+    }
     args.push(
       '-vcodec', this.opts.videoType,
       '-y', this.videoPath

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -173,6 +173,8 @@ class ScreenRecorder {
  *                                is too slow or too fast. Defaults to 10.
  * @property {?string} videoScale - The scaling value to apply. Read https://trac.ffmpeg.org/wiki/Scaling for possible values.
  *                                  No scale is applied by default.
+ * @property {?string} pixelFormat - Output pixel format. Run `ffmpeg -pix_fmts` to list possible values.
+ *                                   For Quicktime compatibility, set to "yuv420p" along with videoType: "libx264".
  * @property {?boolean} forceRestart - Whether to try to catch and upload/return the currently running screen recording
  *                                     (`false`, the default setting) or ignore the result of it and start a new recording
  *                                     immediately.


### PR DESCRIPTION
This change adds a new option `pixelFormat`, which when set to `yuv420p` along with `videoType: 'libx264'` allows the resulting video files to be played back in Apple Quicktime and therefore in Finder Quick Look.