### PR TITLE
Properly forward `screenshotQuality` to WebDriverAgent.

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -230,7 +230,7 @@ class XCUITestDriver extends BaseDriver {
       if (_.has(this.opts, 'mjpegServerFramerate')) {
         wdaSettings.mjpegServerFramerate = this.opts.mjpegServerFramerate;
       }
-      if (this.opts.screenshotQuality) {
+      if (_.has(this.opts, 'screenshotQuality')) {
         log.info(`Setting the quality of phone screenshot: '${this.opts.screenshotQuality}'`);
         wdaSettings.screenshotQuality = this.opts.screenshotQuality;
       }


### PR DESCRIPTION
The default value for `screenshotQuality` is 1, but 0 is also a valid value. Previously, it was just ignored.