### PR TITLE
return current status to ensure appium uses cached WDA

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -185,7 +185,7 @@ class WebDriverAgent {
       log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
       this.url = this.webDriverAgentUrl;
       this.setupProxies(sessionId);
-      return this.getStatus();
+      return await this.getStatus();
     }
 
     log.info('Launching WebDriverAgent on the device');

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -176,7 +176,8 @@ class WebDriverAgent {
    *   }
    * }
    *
-   * @return {string} sessionId
+   * @param {string} sessionId Launch WDA and establish the session with this sessionId
+   * @return {?object} State Object
    * @throws {Error} If there was invalid response code or body
    */
   async launch (sessionId) {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -156,12 +156,35 @@ class WebDriverAgent {
     }
   }
 
+
+  /**
+   * Return current running WDA's status like below after launching WDA
+   * {
+   *   "state": "success",
+   *   "os": {
+   *     "name": "iOS",
+   *     "version": "11.4",
+   *     "sdkVersion": "11.3"
+   *   },
+   *   "ios": {
+   *     "simulatorVersion": "11.4",
+   *     "ip": "172.254.99.34"
+   *   },
+   *   "build": {
+   *     "time": "Jun 24 2018 17:08:21",
+   *     "productBundleIdentifier": "com.facebook.WebDriverAgentRunner"
+   *   }
+   * }
+   *
+   * @return {string} sessionId
+   * @throws {Error} If there was invalid response code or body
+   */
   async launch (sessionId) {
     if (this.webDriverAgentUrl) {
       log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
       this.url = this.webDriverAgentUrl;
       this.setupProxies(sessionId);
-      return;
+      return this.getStatus();
     }
 
     log.info('Launching WebDriverAgent on the device');

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -8,7 +8,6 @@ import sinon from 'sinon';
 
 chai.should();
 chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 const fakeConstructorArgs = {
   device: 'some sim',
@@ -53,15 +52,19 @@ describe('Constructor', function () {
 });
 
 describe('launch', function () {
-  it('should use webDriverAgentUrl override', async function () {
+  it('should use webDriverAgentUrl override and return current status', async function () {
     let override = 'http://mockurl:8100/';
     let args = Object.assign({}, fakeConstructorArgs);
     args.webDriverAgentUrl = override;
     let agent = new WebDriverAgent({}, args);
+    let wdaStub = sinon.stub(agent, 'getStatus');
+    wdaStub.callsFake(function () {
+      return {build: 'data'};
+    });
 
-    expect(await agent.launch('sessionId')).to.be.undefined;
-
+    await agent.launch('sessionId').should.eventually.eql({build: 'data'});
     agent.url.href.should.eql(override);
+    wdaStub.reset();
   });
 });
 


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/12259

Based on current behaviour in re-use WDA is below. Try to call `[XCUITest] Using provided WebdriverAgent at 'http://localhost:8100/'` even if Appium already ensured the response like `Got response with status 200`.

```
debug] [XCUITest] No obsolete cached processes from previous WDA sessions listening on port 8100 have been found
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[debug] [WD Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"state\" : \"success\",\n    \"os\" : {\n      \"name\" : \"iOS\",\n      \"version\" : \"12.1.4\",\n      \"sdkVersion\" : \"12.0\"\n    },\n    \"ios\" : {\n      \"simulatorVersion\" : \"12.1.4\",\n      \"ip\" : \"172.254.99.33\"\n    },\n    \"build\" : {\n      \"upgradedAt\" : \"1552566621411\",\n      \"time\" : \"Mar 23 2019 14:00:27\",\n      \"productBundleIdentifier\" : \"com.trident.WebDriverAgentRunner\"\n    }\n  },\n  \"sessionId\" : \"EC8A8715-502E-4087-A282-98ED454CD050\",\n  \"status\" : 0\n}"
[debug] [XCUITest] Upgrade timestamp of the currently bundled WDA: 1552566621411
[debug] [XCUITest] Upgrade timestamp of the WDA on the device: 1552566621411
[XCUITest] Will reuse previously cached WDA instance at 'http://localhost:8100/' with 'com.trident.WebDriverAgentRunner'. Set the wdaLocalPort capability to a value different from 8100 if this is an undesired behavior.
[debug] [XCUITest] Trying to start WebDriverAgent 1 times with 10000ms interval
[debug] [XCUITest] These values can be customized by changing wdaStartupRetries/wdaStartupRetryInterval capabilities
[debug] [BaseDriver] Event 'wdaStartAttempted' logged at 1553318314574 (14:18:34 GMT+0900 (Japan Standard Time))
[XCUITest] Using provided WebdriverAgent at 'http://localhost:8100/'
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553318314575 (14:18:34 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8100}
[debug] [XCUITest] Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to remote server. Original error: Error: connect ECONNREFUSED 127.0.0.1:8100). Retrying...
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553318315591 (14:18:35 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8100}
[debug] [XCUITest] Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to remote server. Original error: Error: connect ECONNREFUSED 127.0.0.1:8100). Retrying...
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553318316600 (14:18:36 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8100}
[debug] [XCUITest] Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to remote server. Original error: Error: connect ECONNREFUSED 127.0.0.1:8100). Retrying...
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553318317609 (14:18:37 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8100}
[debug] [XCUITest] Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to remote server. Original error: Error: connect ECONNREFUSED 127.0.0.1:8100). Retrying...
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553318318616 (14:18:38 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8100}
```

---

`return await this.xcodebuild.start();` called in `async launch (sessionId) {` returns current `/status`, but the `launch` function does not retun such status if `this.webDriverAgentUrl` is set.

It means `this.cachedWdaStatus` in https://github.com/appium/appium-xcuitest-driver/blob/30d8cef4eaac3b1133ef203f2c3b47e19235a27f/lib/driver.js#L485 never be not undefined if `await this.wda.setupCaching(this.opts.updatedWDABundleId);` in https://github.com/appium/appium-xcuitest-driver/blob/30d8cef4eaac3b1133ef203f2c3b47e19235a27f/lib/driver.js#L459 works.


After this PR, the `this.cachedWdaStatus` can get current running WDA status like below. As the result, xcuitest-driver can use existing WDA instance in the new session.

```
[XCUITest] Setting up real device
[XCUITest] Using WDA path: '/Users/kazu/GitHub/ruby_lib_core/tmp/9U4PT397Q4/Build/Products'
[XCUITest] Using WDA agent: '/Users/kazu/GitHub/ruby_lib_core/tmp/9U4PT397Q4/Build/Products/WebDriverAgent.xcodeproj'
[debug] [XCUITest] No obsolete cached processes from previous WDA sessions listening on port 8100 have been found
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[debug] [XCUITest] recv failed: Operation not permitted
[debug] [XCUITest] Connection to WDA timed out
[debug] [iProxy] recv failed: Operation not permitted
[debug] [WD Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"state\" : \"success\",\n    \"os\" : {\n      \"name\" : \"iOS\",\n      \"version\" : \"12.1.4\",\n      \"sdkVersion\" : \"12.0\"\n    },\n    \"ios\" : {\n      \"simulatorVersion\" : \"12.1.4\",\n      \"ip\" : \"172.254.99.33\"\n    },\n    \"build\" : {\n      \"upgradedAt\" : \"1552566621411\",\n      \"time\" : \"Mar 23 2019 13:54:25\",\n      \"productBundleIdentifier\" : \"com.trident.WebDriverAgentRunner\"\n    }\n  },\n  \"sessionId\" : \"07F6E3F2-AE16-46A8-BF50-4AED358BB064\",\n  \"status\" : 0\n}"
[debug] [XCUITest] Upgrade timestamp of the currently bundled WDA: null
[debug] [XCUITest] Upgrade timestamp of the WDA on the device: 1552566621411
[XCUITest] Will reuse previously cached WDA instance at 'http://localhost:8100/' with 'com.trident.WebDriverAgentRunner'. Set the wdaLocalPort capability to a value different from 8100 if this is an undesired behavior.
[debug] [XCUITest] Trying to start WebDriverAgent 1 times with 10000ms interval
[debug] [XCUITest] These values can be customized by changing wdaStartupRetries/wdaStartupRetryInterval capabilities
[debug] [BaseDriver] Event 'wdaStartAttempted' logged at 1553319931916 (14:45:31 GMT+0900 (Japan Standard Time))
[XCUITest] Using provided WebdriverAgent at 'http://localhost:8100/'
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://localhost:8100/status] with no body
[debug] [WD Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"state\" : \"success\",\n    \"os\" : {\n      \"name\" : \"iOS\",\n      \"version\" : \"12.1.4\",\n      \"sdkVersion\" : \"12.0\"\n    },\n    \"ios\" : {\n      \"simulatorVersion\" : \"12.1.4\",\n      \"ip\" : \"172.254.99.33\"\n    },\n    \"build\" : {\n      \"upgradedAt\" : \"1552566621411\",\n      \"time\" : \"Mar 23 2019 13:54:25\",\n      \"productBundleIdentifier\" : \"com.trident.WebDriverAgentRunner\"\n    }\n  },\n  \"sessionId\" : \"07F6E3F2-AE16-46A8-BF50-4AED358BB064\",\n  \"status\" : 0\n}"
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1553319931935 (14:45:31 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/session' to command name 'createSession'
```