### PR TITLE
Add COMPILER_INDEX_STORE_ENABLE=NO when xcodebuild runs

### DIFF
--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -204,6 +204,10 @@ class XcodeBuild {
       args.push('GCC_TREAT_WARNINGS_AS_ERRORS=0');
     }
 
+    // Below option slightly reduces build time in debug build
+    // with preventing to generate `/Index/DataStore` which is used by development
+    args.push('COMPILER_INDEX_STORE_ENABLE=NO');
+
     return {cmd, args};
   }
 


### PR DESCRIPTION
`COMPILER_INDEX_STORE_ENABLE=NO` slightly reduces build time, maybe.
With the option, clang does not generate `/Index/DataStore` like `-index-store-path /Users/kazuaki/GitHub/WebDriverAgent/tmp/Index/DataStore`.

According to https://twitter.com/steipete/status/1100404024224804871 , it could reduce build time in Travis for example.
https://reviews.llvm.org/D39050

I tested with below command on my locale, I could not observe any differences between with the potion and no the option, tho. But mine was SSD + MacBook Pro. Machine spec is much better than Travis.

> $ time xcodebuild  build-for-testing test-without-building -derivedDataPath ./tmp -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -sdk iphonesimulator -destination id=ECEDA200-9325-4E7A-9AF8-E63A2903E5A9  IPHONEOS_DEPLOYMENT_TARGET=12.1 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO