### PR TITLE
Select safe options by default if platformVersion is not set in caps to keep the backward compatibility

### DIFF
--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -319,7 +319,7 @@ commands.getSimFileFullPath = async function getSimFileFullPath (remotePath) {
 
   if (remotePath.startsWith(appName)) {
     let findPath = basePath;
-    if (util.compareVersions(this.opts.platformVersion, '>=', '8.0')) {
+    if (!this.opts.platformVersion || util.compareVersions(this.opts.platformVersion, '>=', '8.0')) {
       // the .app file appears in /Containers/Data and /Containers/Bundle both. We only want /Bundle
       findPath = path.resolve(basePath, 'Containers', 'Bundle');
     }

--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -46,7 +46,9 @@ commands.closeWindow = async function closeWindow () {
     throw new errors.NotImplementedError();
   }
   let script = "return window.open('','_self').close();";
-  if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+  // TODO: platformVersion should be a required capability
+  if (this.opts.platformVersion &&
+      util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
     // on 12.2 the whole message is evaluated in the context of the page,
     // which is closed and so never returns
     script = `setTimeout(function () {window.open('','_self').close();}, 0); return true;`;

--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -47,8 +47,7 @@ commands.closeWindow = async function closeWindow () {
   }
   let script = "return window.open('','_self').close();";
   // TODO: platformVersion should be a required capability
-  if (this.opts.platformVersion &&
-      util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+  if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
     // on 12.2 the whole message is evaluated in the context of the page,
     // which is closed and so never returns
     script = `setTimeout(function () {window.open('','_self').close();}, 0); return true;`;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -562,7 +562,8 @@ class XCUITestDriver extends BaseDriver {
         await markSystemFilesForCleanup(this.wda);
       }
 
-      if (this.isSafari() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+      // TODO: platformVersion should be a required cap
+      if (this.isSafari() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
         // on 12.2 the page is not opened in WDA
         await this.setUrl(this._currentUrl);
       }
@@ -866,6 +867,7 @@ class XCUITestDriver extends BaseDriver {
     if (util.hasValue(this.opts.simpleIsVisibleCheck)) {
       shouldUseTestManagerForVisibilityDetection = this.opts.simpleIsVisibleCheck;
     }
+    // TODO: platformVersion should be a required capability
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '==', '9.3')) {
       log.info(`Forcing shouldUseSingletonTestManager capability value to true, because of known XCTest issues under 9.3 platform version`);
       shouldUseTestManagerForVisibilityDetection = true;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -260,7 +260,8 @@ class XCUITestDriver extends BaseDriver {
 
     await printUser();
 
-    if (util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
+    // TODO: platformVersion should be a required capability
+    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
       throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
     }
 
@@ -299,7 +300,7 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (!this.opts.webDriverAgentUrl && this.iosSdkVersion) {
+    if (!this.opts.webDriverAgentUrl && this.iosSdkVersion && this.opts.platformVersion) {
       // make sure that the xcode we are using can handle the platform
       if (util.compareVersions(this.opts.platformVersion, '>', this.iosSdkVersion)) {
         let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +
@@ -561,11 +562,9 @@ class XCUITestDriver extends BaseDriver {
         await markSystemFilesForCleanup(this.wda);
       }
 
-      if (this.isSafari()) {
-        if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
-          // on 12.2 the page is not opened in WDA
-          await this.setUrl(this._currentUrl);
-        }
+      if (this.isSafari() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+        // on 12.2 the page is not opened in WDA
+        await this.setUrl(this._currentUrl);
       }
 
       // we expect certain socket errors until this point, but now

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -955,6 +955,11 @@ class XCUITestDriver extends BaseDriver {
       log.errorAndThrow(msg);
     }
 
+    if (!util.coerceVersion(caps.platformVersion, false)) {
+      log.warn(`'platformVersion' capability ('${caps.platformVersion}') is not a valid version number. ` +
+        `Consider fixing it or be ready to experience an inconsistent driver behavior.`);
+    }
+
     let verifyProcessArgument = (processArguments) => {
       const {args, env} = processArguments;
       if (!_.isNil(args) && !_.isArray(args)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -563,7 +563,7 @@ class XCUITestDriver extends BaseDriver {
       }
 
       // TODO: platformVersion should be a required cap
-      if (this.isSafari() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+      if (this.isSafari() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
         // on 12.2 the page is not opened in WDA
         await this.setUrl(this._currentUrl);
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,7 @@ function translateDeviceName (platformVersion, devName = '') {
     case 'ipad simulator':
       // iPad Retina is no longer available for ios 10.3
       //   so we pick another iPad to use as default
-      deviceName = util.compareVersions(platformVersion, '<', '10.3') ? 'iPad Retina' : 'iPad Air';
+      deviceName = platformVersion && util.compareVersions(platformVersion, '<', '10.3') ? 'iPad Retina' : 'iPad Air';
       break;
   }
 


### PR DESCRIPTION
Previously the platformVersion cap could be ignored for real devices, even though such behaviour is not quite correct. For now I will just keep TODOs there to not break the backward compatibility completely.