### PR TITLE
call creating simulator as Xcode 10.2 format

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { getSimulator } from 'appium-ios-simulator';
 import { createDevice, getDevices, terminate, shutdown } from 'node-simctl';
-import { resetXCTestProcesses } from './utils';
+import { resetXCTestProcesses, isTvOS } from './utils';
 import _ from 'lodash';
 import log from './logger';
 import { tempDir, fs, mkdirp } from 'appium-support';
@@ -9,6 +9,9 @@ import UUID from 'uuid-js';
 
 
 const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
+
+const SIM_RUNTIME_NAME_IOS = 'com.apple.CoreSimulator.SimRuntime.iOS';
+const SIM_RUNTIME_NAME_TVOS = 'com.apple.CoreSimulator.SimRuntime.tvOS';
 
 /**
  * Create a new simulator with `appiumTest-` prefix and return the object.
@@ -20,7 +23,17 @@ const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
  */
 async function createSim (caps) {
   const appiumTestDeviceName = `appiumTest-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`;
-  const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion);
+  let udid;
+  try {
+    const platformVersion = `${isTvOS(caps.platformName) ? SIM_RUNTIME_NAME_TVOS : SIM_RUNTIME_NAME_IOS}-${caps.platformVersion.replace('.', '-')}`;
+    // platformVersion should be 'com.apple.CoreSimulator.SimRuntime.iOS-12-2'
+    // after installing over Xcode 10.2 once
+    udid = await createDevice(appiumTestDeviceName, caps.deviceName, platformVersion);
+  } catch (err) {
+    log.debug(`Failed to create simulator with Xcode 10.2+ format: ${err.message}`);
+    log.debug('Creating a simulator with Xcode 10.1- format');
+    udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion);
+  }
   return await getSimulator(udid);
 }
 

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -55,9 +55,7 @@ describe('simulator management', function () {
                       .onSecondCall().returns('dummy-udid');
       getSimulatorStub.returns('dummy-udid');
 
-      try {
-        await createSim(caps);
-      } catch (ignore) {}
+      await createSim(caps);
 
       createDeviceStub.calledTwice.should.be.true;
       /appiumTest-[\w-]{36}-iPhone 6/.test(createDeviceStub.secondCall.args[0]).should.be.true;

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -30,10 +30,43 @@ describe('simulator management', function () {
       createDeviceStub.calledOnce.should.be.true;
       /appiumTest-[\w-]{36}-iPhone 6/.test(createDeviceStub.firstCall.args[0]).should.be.true;
       createDeviceStub.firstCall.args[1].should.eql('iPhone 6');
-      createDeviceStub.firstCall.args[2].should.eql('10.1');
+      createDeviceStub.firstCall.args[2].should.eql('com.apple.CoreSimulator.SimRuntime.iOS-10-1');
       getSimulatorStub.calledOnce.should.be.true;
       getSimulatorStub.firstCall.args[0].should.eql('dummy-udid');
     });
+
+    it('should call appiumTest prefix name with tvOS', async function () {
+      createDeviceStub.returns('dummy-udid');
+      getSimulatorStub.returns('dummy-udid');
+
+      caps.platformName = 'tvOS';
+      await createSim(caps);
+
+      createDeviceStub.calledOnce.should.be.true;
+      /appiumTest-[\w-]{36}-iPhone 6/.test(createDeviceStub.firstCall.args[0]).should.be.true;
+      createDeviceStub.firstCall.args[1].should.eql('iPhone 6');
+      createDeviceStub.firstCall.args[2].should.eql('com.apple.CoreSimulator.SimRuntime.tvOS-10-1');
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql('dummy-udid');
+    });
+
+    it('should call appiumTest prefix name with old format', async function () {
+      createDeviceStub.onFirstCall().throws('Incompatible device')
+                      .onSecondCall().returns('dummy-udid');
+      getSimulatorStub.returns('dummy-udid');
+
+      try {
+        await createSim(caps);
+      } catch (ignore) {}
+
+      createDeviceStub.calledTwice.should.be.true;
+      /appiumTest-[\w-]{36}-iPhone 6/.test(createDeviceStub.secondCall.args[0]).should.be.true;
+      createDeviceStub.secondCall.args[1].should.eql('iPhone 6');
+      createDeviceStub.secondCall.args[2].should.eql('10.1');
+      getSimulatorStub.calledOnce.should.be.true;
+      getSimulatorStub.firstCall.args[0].should.eql('dummy-udid');
+    });
+
   });
 
   describe('getExistingSim', function () {


### PR DESCRIPTION
After installing Xcode 10.2, the creating format should be `com.apple.CoreSimulator.SimRuntime.iOS-XX-X` instead of `XX.X`. The format is the same even we change the xcode version as 10.1 with `xcode-select`. Thus, I follow this logic, try to call the new format once and if an error raises, try to call old format.

- new format
```
$ xcrun simctl create 'iPhone XS 2'  com.apple.CoreSimulator.SimDeviceType.iPhone-8 com.apple.CoreSimulator.SimRuntime.iOS-12-1
7CD85972-2FB1-4236-B4E9-A2017AB00959
```

- old format
```
$ xcrun simctl create 'iPhone XS 2'  com.apple.CoreSimulator.SimDeviceType.iPhone-8 12.1
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=162):
Incompatible device
```