### PR TITLE
Use simctl openUrl for 12.2 sims safari tests

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -33,7 +33,7 @@ commands.getAttribute = async function getAttribute (attribute, el) {
   if (!this.isWebContext()) {
     return await this.getNativeAttribute(attribute, el);
   }
-  let atomsElement = this.getAtomsElement(el);
+  const atomsElement = this.getAtomsElement(el);
   if (_.isNull(atomsElement)) {
     throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}`);
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -434,6 +434,13 @@ class XCUITestDriver extends BaseDriver {
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
 
+    // TODO: platformVersion should be a required cap
+    // real devices will be handled later, after the web context has been initialized
+    if (this.isSafari() && !this.isRealDevice() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+      // on 12.2 the page is not opened in WDA
+      await openUrl(this.opts.device.udid, this._currentUrl);
+    }
+
     if (this.isRealDevice() && this.opts.startIWDP) {
       try {
         await this.startIWDP();
@@ -447,6 +454,12 @@ class XCUITestDriver extends BaseDriver {
       log.debug('Waiting for initial webview');
       await this.navToInitialWebview();
       this.logEvent('initialWebviewNavigated');
+    }
+
+    // TODO: platformVersion should be a required cap
+    if (this.isSafari() && this.isRealDevice() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+      // on 12.2 the page is not opened in WDA
+      await this.setUrl(this._currentUrl);
     }
 
     if (!this.isRealDevice()) {
@@ -565,15 +578,6 @@ class XCUITestDriver extends BaseDriver {
 
       if (this.opts.clearSystemFiles) {
         await markSystemFilesForCleanup(this.wda);
-      }
-
-      if (this.isSafari() && !this.isRealDevice()) {
-        // on real devices this often causes other things to open
-        // TODO: platformVersion should be a required cap
-        if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
-          // on 12.2 the page is not opened in WDA
-          await openUrl(this.opts.device.udid, this._currentUrl);
-        }
       }
 
       // we expect certain socket errors until this point, but now

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2,7 +2,7 @@ import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import { util, fs, mjpeg } from 'appium-support';
 import _ from 'lodash';
 import url from 'url';
-import { launch } from 'node-simctl';
+import { launch, openUrl } from 'node-simctl';
 import WebDriverAgent from './wda/webdriveragent';
 import log from './logger';
 import {
@@ -510,9 +510,9 @@ class XCUITestDriver extends BaseDriver {
       } catch (err) {
         this.logEvent('wdaStartFailed');
         retryCount++;
-        let errorMsg = `Unable to launch WebDriverAgent because of xcodebuild failure: "${err.message}".`;
+        let errorMsg = `Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`;
         if (this.isRealDevice()) {
-          errorMsg += ` Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
+          errorMsg += `. Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
                       `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
                       `and reboot the device.`;
         }
@@ -567,10 +567,13 @@ class XCUITestDriver extends BaseDriver {
         await markSystemFilesForCleanup(this.wda);
       }
 
-      // TODO: platformVersion should be a required cap
-      if (this.isSafari() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
-        // on 12.2 the page is not opened in WDA
-        await this.setUrl(this._currentUrl);
+      if (this.isSafari() && !this.isRealDevice()) {
+        // on real devices this often causes other things to open
+        // TODO: platformVersion should be a required cap
+        if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
+          // on 12.2 the page is not opened in WDA
+          await openUrl(this.opts.device.udid, this._currentUrl);
+        }
       }
 
       // we expect certain socket errors until this point, but now

--- a/test/functional/web/safari-nativewebtap-e2e-specs.js
+++ b/test/functional/web/safari-nativewebtap-e2e-specs.js
@@ -37,120 +37,59 @@ const SPIN_RETRIES = 25;
 const PAGE_3_LINK = 'i am a link to page 3';
 const PAGE_3_TITLE = 'Another Page: page 3';
 
-describe('Safari - coordinate conversion -', function () {
-  this.timeout(MOCHA_TIMEOUT * 2);
+if (!process.env.REAL_DEVICE) {
+  describe('Safari - coordinate conversion -', function () {
+    this.timeout(MOCHA_TIMEOUT * 2);
 
-  let devices = [];
-  before(async function () {
-    await killAllSimulators();
+    let devices = [];
+    before(async function () {
+      await killAllSimulators();
 
-    if (process.env.ALL_DEVICES) {
-      // get all the iPhone and iPad devices available
-      devices = await getDeviceTypes();
-      devices = devices.filter((device) => device.includes('iPhone') || device.includes('iPad'));
-    } else if (process.env.DEVICE_NAME) {
-      devices = [process.env.DEVICE_NAME];
-    } else {
-      devices = ['iPad Simulator', 'iPhone 6', 'iPhone X'];
-    }
+      if (process.env.ALL_DEVICES) {
+        // get all the iPhone and iPad devices available
+        devices = await getDeviceTypes();
+        devices = devices.filter((device) => device.includes('iPhone') || device.includes('iPad'));
+      } else if (process.env.DEVICE_NAME) {
+        devices = [process.env.DEVICE_NAME];
+      } else {
+        devices = ['iPad Simulator', 'iPhone 6', 'iPhone X'];
+      }
 
-    async function loadPage (driver, url) {
-      await retryInterval(5, 1000, async function () {
-        await openPage(driver, url);
-        const title = await spinTitle(driver);
-        title.should.not.include('Cannot Open Page');
-      });
-    }
-
-    // define the tests, for each device
-    for (const deviceName of devices) {
-      describe(`${deviceName} -`, function () {
-        this.timeout(MOCHA_TIMEOUT * 2);
-
-        let driver;
-        let skipped = false;
-
-        before(async function () {
-          skipped = false;
-          try {
-            driver = await initSession(_.defaults({
-              deviceName,
-              fullReset: true,
-              noReset: false,
-            }, caps));
-          } catch (err) {
-            if (err.message.includes('Invalid device type') || err.message.includes('Incompatible device')) {
-              skipped = true;
-              return this.skip();
-            }
-            throw err;
-          }
+      async function loadPage (driver, url) {
+        await retryInterval(5, 1000, async function () {
+          await openPage(driver, url);
+          const title = await spinTitle(driver);
+          title.should.not.include('Cannot Open Page');
         });
-        after(async function () {
-          await deleteSession();
-          await killAllSimulators();
-        });
+      }
 
-        it('should be able to tap on an element', async function () {
-          await loadPage(driver, GUINEA_PIG_PAGE);
+      // define the tests, for each device
+      for (const deviceName of devices) {
+        describe(`${deviceName} -`, function () {
+          this.timeout(MOCHA_TIMEOUT * 2);
 
-          let el = await driver.elementByLinkText(PAGE_3_LINK);
-          await el.click();
+          let driver;
+          let skipped = false;
 
-          await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
-        });
-
-        it('should be able to tap on an element when the app banner is up', async function () {
-          await loadPage(driver, GUINEA_PIG_APP_BANNER_PAGE);
-
-          let el = await driver.elementByLinkText(PAGE_3_LINK);
-          await el.click();
-
-          await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
-        });
-
-        it('should be able to tap on an element after scrolling', async function () {
-          await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
-          await driver.execute('mobile: scroll', {direction: 'down'});
-
-          let el = await driver.elementByLinkText(PAGE_3_LINK);
-          await el.click();
-
-          await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
-        });
-
-        it('should be able to tap on a button', async function () {
-          this.retries(5);
-
-          await loadPage(driver, GUINEA_PIG_PAGE);
-
-          (await driver.source()).should.not.include('Your comments: Hello');
-
-          let textArea = await driver.elementByName('comments');
-          await textArea.type('Hello');
-
-          let el = await driver.elementByName('submit');
-          await el.click();
-
-          await retryInterval(5, 500, async function () {
-            const src = await driver.source();
-            return src.should.include('Your comments: Hello');
-          });
-        });
-
-        describe('with tabs -', function () {
-          beforeEach(async function () {
-            await loadPage(driver, GUINEA_PIG_PAGE);
-          });
           before(async function () {
-            if (skipped) {
-              return this.skip();
+            skipped = false;
+            try {
+              driver = await initSession(_.defaults({
+                deviceName,
+                fullReset: true,
+                noReset: false,
+              }, caps));
+            } catch (err) {
+              if (err.message.includes('Invalid device type') || err.message.includes('Incompatible device')) {
+                skipped = true;
+                return this.skip();
+              }
+              throw err;
             }
-            await loadPage(driver, GUINEA_PIG_PAGE);
-
-            // open a new tab and go to it
-            let el = await driver.elementByLinkText('i am a new window link');
-            await el.click();
+          });
+          after(async function () {
+            await deleteSession();
+            await killAllSimulators();
           });
 
           it('should be able to tap on an element', async function () {
@@ -160,15 +99,17 @@ describe('Safari - coordinate conversion -', function () {
             await el.click();
 
             await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+          });
 
-            await driver.back();
+          it('should be able to tap on an element when the app banner is up', async function () {
+            await loadPage(driver, GUINEA_PIG_APP_BANNER_PAGE);
 
-            // try again, just to make sure
-            el = await driver.elementByLinkText(PAGE_3_LINK);
+            let el = await driver.elementByLinkText(PAGE_3_LINK);
             await el.click();
 
             await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
           });
+
           it('should be able to tap on an element after scrolling', async function () {
             await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
             await driver.execute('mobile: scroll', {direction: 'down'});
@@ -178,41 +119,102 @@ describe('Safari - coordinate conversion -', function () {
 
             await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
           });
-          it('should be able to tap on an element after scrolling, when the url bar is present', async function () {
-            await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
-            await driver.execute('mobile: scroll', {direction: 'down'});
 
-            // to get the url bar, click on the URL bar
-            const ctx = await driver.currentContext();
-            try {
-              await driver.context('NATIVE_APP');
+          it('should be able to tap on a button', async function () {
+            this.retries(5);
 
-              // get the reload button, as multi-element find to bypass
-              // the implicit wait
-              if (_.isEmpty(await driver.elementsByAccessibilityId('ReloadButton'))) {
-                // when there is no reload button, the URL bar is minimized
-                // so tap on it to bring it up
-                await driver.elementByAccessibilityId('URL').click();
-              }
+            await loadPage(driver, GUINEA_PIG_PAGE);
 
-              // time for things to happen
-              await B.delay(500);
-            } finally {
-              await driver.context(ctx);
-            }
+            (await driver.source()).should.not.include('Your comments: Hello');
 
-            const el = await driver.elementByLinkText(PAGE_3_LINK);
+            let textArea = await driver.elementByName('comments');
+            await textArea.type('Hello');
+
+            let el = await driver.elementByName('submit');
             await el.click();
 
-            await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+            await retryInterval(5, 500, async function () {
+              const src = await driver.source();
+              return src.should.include('Your comments: Hello');
+            });
+          });
+
+          describe('with tabs -', function () {
+            beforeEach(async function () {
+              await loadPage(driver, GUINEA_PIG_PAGE);
+            });
+            before(async function () {
+              if (skipped) {
+                return this.skip();
+              }
+              await loadPage(driver, GUINEA_PIG_PAGE);
+
+              // open a new tab and go to it
+              let el = await driver.elementByLinkText('i am a new window link');
+              await el.click();
+            });
+
+            it('should be able to tap on an element', async function () {
+              await loadPage(driver, GUINEA_PIG_PAGE);
+
+              let el = await driver.elementByLinkText(PAGE_3_LINK);
+              await el.click();
+
+              await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+
+              await driver.back();
+
+              // try again, just to make sure
+              el = await driver.elementByLinkText(PAGE_3_LINK);
+              await el.click();
+
+              await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+            });
+            it('should be able to tap on an element after scrolling', async function () {
+              await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
+              await driver.execute('mobile: scroll', {direction: 'down'});
+
+              let el = await driver.elementByLinkText(PAGE_3_LINK);
+              await el.click();
+
+              await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+            });
+            it('should be able to tap on an element after scrolling, when the url bar is present', async function () {
+              await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
+              await driver.execute('mobile: scroll', {direction: 'down'});
+
+              // to get the url bar, click on the URL bar
+              const ctx = await driver.currentContext();
+              try {
+                await driver.context('NATIVE_APP');
+
+                // get the reload button, as multi-element find to bypass
+                // the implicit wait
+                if (_.isEmpty(await driver.elementsByAccessibilityId('ReloadButton'))) {
+                  // when there is no reload button, the URL bar is minimized
+                  // so tap on it to bring it up
+                  await driver.elementByAccessibilityId('URL').click();
+                }
+
+                // time for things to happen
+                await B.delay(500);
+              } finally {
+                await driver.context(ctx);
+              }
+
+              const el = await driver.elementByLinkText(PAGE_3_LINK);
+              await el.click();
+
+              await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
+            });
           });
         });
-      });
-    }
-  });
+      }
+    });
 
-  it.skip('should have devices array set', function () {
-    // this block is just here so that the `before` block is run
-    // it does not, however, need to actually run. Mocha FTW!
+    it.skip('should have devices array set', function () {
+      // this block is just here so that the `before` block is run
+      // it does not, however, need to actually run. Mocha FTW!
+    });
   });
-});
+}


### PR DESCRIPTION
Rather than use our web technology to open the URL, use simctl so it can happen before we listen to the Web Inspector.