### PR TITLE
update createDevice

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { desiredCapConstraints as iosDesiredCapConstraints } from 'appium-ios-driver';
 
+// These platform name should be valid in simulator name
 const PLATFORM_NAME_IOS = 'iOS';
 const PLATFORM_NAME_TVOS = 'tvOS';
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { desiredCapConstraints as iosDesiredCapConstraints } from 'appium-ios-driver';
 
-// These platform name should be valid in simulator name
+// These platform names should be valid in simulator name
 const PLATFORM_NAME_IOS = 'iOS';
 const PLATFORM_NAME_TVOS = 'tvOS';
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -11,14 +11,14 @@ import {
 import { simExists, getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
 import { retryInterval, retry } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps, appUtils, IWDP } from 'appium-ios-driver';
-import desiredCapConstraints from './desired-caps';
+import { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from './desired-caps';
 import commands from './commands/index';
 import {
   detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
   adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
   clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
   DEFAULT_TIMEOUT_KEY, markSystemFilesForCleanup,
-  printUser, removeAllSessionWebSocketHandlers, verifyApplicationPlatform } from './utils';
+  printUser, removeAllSessionWebSocketHandlers, verifyApplicationPlatform, isTvOS } from './utils';
 import {
   getConnectedDevices, runRealDeviceReset, installToRealDevice,
   getRealDeviceObj } from './real-device-management';
@@ -819,8 +819,11 @@ class XCUITestDriver extends BaseDriver {
   async createSim () {
     this.lifecycleData.createSim = true;
 
+    // Get platform name from const since it must be case sensitive in creating a simulator
+    const platformName = isTvOS (this.opts.platformName) ? PLATFORM_NAME_TVOS : PLATFORM_NAME_IOS;
+
     // create sim for caps
-    let sim = await createSim(this.opts);
+    let sim = await createSim(this.opts, platformName);
     log.info(`Created simulator with udid '${sim.udid}'.`);
 
     return sim;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -820,7 +820,7 @@ class XCUITestDriver extends BaseDriver {
     this.lifecycleData.createSim = true;
 
     // Get platform name from const since it must be case sensitive in creating a simulator
-    const platformName = isTvOS (this.opts.platformName) ? PLATFORM_NAME_TVOS : PLATFORM_NAME_IOS;
+    const platformName = isTvOS(this.opts.platformName) ? PLATFORM_NAME_TVOS : PLATFORM_NAME_IOS;
 
     // create sim for caps
     let sim = await createSim(this.opts, platformName);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -819,7 +819,7 @@ class XCUITestDriver extends BaseDriver {
   async createSim () {
     this.lifecycleData.createSim = true;
 
-    // Get platform name from const since it must be case sensitive in creating a simulator
+    // Get platform name from const since it must be case sensitive to create a new simulator
     const platformName = isTvOS(this.opts.platformName) ? PLATFORM_NAME_TVOS : PLATFORM_NAME_IOS;
 
     // create sim for caps

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -22,14 +22,17 @@ const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
  * Create a new simulator with `appiumTest-` prefix and return the object.
  *
  * @param {object} SimCreationCaps - Capability set by a user. The options available are:
- * @property {string} platformName [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
+ * @property {string} platform [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
  * @returns {object} Simulator object associated with the udid passed in.
  */
-async function createSim (caps, platformName = PLATFORM_NAME_IOS) {
+async function createSim (caps, platform = PLATFORM_NAME_IOS) {
   const appiumTestDeviceName = `appiumTest-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`;
-  const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion, {
-    platform: platformName
-  });
+  const udid = await createDevice(
+    appiumTestDeviceName,
+    caps.deviceName,
+    caps.platformVersion,
+    { platform }
+  );
   return await getSimulator(udid);
 }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -6,21 +6,30 @@ import _ from 'lodash';
 import log from './logger';
 import { tempDir, fs, mkdirp } from 'appium-support';
 import UUID from 'uuid-js';
+import { PLATFORM_NAME_IOS } from './desired-caps';
 
 
 const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
 
+
+/**
+ * Capability set by a user
+ *
+ * @property {string} deviceName - A name for the device
+ * @property {string} platformVersion - The version of iOS to use
+ */
 /**
  * Create a new simulator with `appiumTest-` prefix and return the object.
  *
- * @param {object} caps - Capability set by a user. The options available are:
- *   - `deviceName` - a name for the device
- *   - `platformVersion` - the version of iOS to use
+ * @param {object} SimCreationCaps - Capability set by a user. The options available are:
+ * @property {string} platformName [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
  * @returns {object} Simulator object associated with the udid passed in.
  */
-async function createSim (caps) {
+async function createSim (caps, platformName = PLATFORM_NAME_IOS) {
   const appiumTestDeviceName = `appiumTest-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`;
-  const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion);
+  const udid = await createDevice(appiumTestDeviceName, caps.deviceName, caps.platformVersion, {
+    platform: platformName
+  });
   return await getSimulator(udid);
 }
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bluebird": "^3.1.1",
     "js2xmlparser2": "^0.2.0",
     "lodash": "^4.17.10",
-    "node-simctl": "^4.0.0",
+    "node-simctl": "^5.0.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "source-map-support": "^0.5.5",


### PR DESCRIPTION
platformName which is used in createDevice should be case sensitive.
opts.platformName can be lowercase etc, it depends on clients side.

Thus, I get platform name outside `this.opts`


originally https://github.com/appium/appium-xcuitest-driver/pull/916

--

I've tested on my local.
- create iOS simulator
- create tvOS simulator