### PR TITLE
show ios deploy command and the stdout

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -46,11 +46,10 @@ class IOSDeploy {
   }
 
   async isAppInstalled (bundleid) {
-    let isInstalled = [`--exists`, `--id`, this.udid, `--bundle_id`, bundleid];
+    let installStatusArgs = [`--exists`, `--id`, this.udid, `--bundle_id`, bundleid];
     try {
-      logger.debug(`Calling: '${this.cmd} ${isInstalled.join(' ')}'.`);
-      let {stdout} = await exec(this.cmd, isInstalled);
-
+      logger.debug(`Calling: '${this.cmd} ${installStatusArgs.join(' ')}'`);
+      let {stdout} = await exec(this.cmd, installStatusArgs);
       logger.debug(`Stdout: '${stdout}'`);
       return (stdout && (stdout.includes('true')));
     } catch (err) {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -48,7 +48,10 @@ class IOSDeploy {
   async isAppInstalled (bundleid) {
     let isInstalled = [`--exists`, `--id`, this.udid, `--bundle_id`, bundleid];
     try {
+      logger.debug(`Calling: '${this.cmd} ${isInstalled.join(' ')}'.`);
       let {stdout} = await exec(this.cmd, isInstalled);
+
+      logger.debug(`Stdout: '${stdout}'`);
       return (stdout && (stdout.includes('true')));
     } catch (err) {
       // error 255 is just ios-deploy's way of saying it is not installed


### PR DESCRIPTION
Would like to show cmd here as debug messages since it helps users when they would like to ensure if the bundle id is in their test devices as debugging. (Since the check logic deffers in both simulator and real device)

```
[debug] [BaseDriver] Event 'logCaptureStarted' logged at 1554533069969 (15:44:29 GMT+0900 (Japan Standard Time))
[XCUITest] Setting up real device
[debug] [XCUITest] Verifying application platform
[debug] [XCUITest] CFBundleSupportedPlatforms: ["iPhoneOS"]
[debug] [XCUITest] Calling: 'ios-deploy --exists --id 242bfcc998fd156df0bd0ad1dde8ab8e0a032114 --bundle_id com.kazucocoa.apple-samplecode.UICatalog'.
[debug] [XCUITest] Stdout: '[....] Waiting for iOS device to be connected
[debug] [XCUITest] [....] Using 242bfcc998fd156df0bd0ad1dde8ab8e0a032114 (N69uAP, iPhone SE, iphoneos, arm64) a.k.a. 'Kazu's iPhone SE'.
[debug] [XCUITest] true
[debug] [XCUITest] '
[debug] [XCUITest] Reset requested. Removing app with id 'com.kazucocoa.apple-samplecode.UICatalog' from the device
[debug] [XCUITest] Installing '/Users/kazu/Library/Developer/Xcode/DerivedData/UICatalog-fsnnudbfrdqjyyfikymzltsttoad/Build/Products/Debug-iphoneos/UICatalog.app' on device with UUID '242bfcc998fd156df0bd0ad1dde8ab8e0a032114'...
```