### PR TITLE
Avoid showing Xcode logs if showXcodeLog is explicitly set to false

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -612,7 +612,7 @@ class XCUITestDriver extends BaseDriver {
         if (this.isAppTemporary) {
           await fs.rimraf(this.opts.app);
         }
-        await clearSystemFiles(this.wda, !!this.opts.showXcodeLog);
+        await clearSystemFiles(this.wda);
       } else {
         log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
       }

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -55,7 +55,7 @@ class WebDriverAgent {
       agentPath: this.agentPath,
       bootstrapPath: this.bootstrapPath,
       realDevice: this.realDevice,
-      showXcodeLog: !!args.showXcodeLog,
+      showXcodeLog: args.showXcodeLog,
       xcodeConfigFile: args.xcodeConfigFile,
       xcodeOrgId: args.xcodeOrgId,
       xcodeSigningId: args.xcodeSigningId,

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -16,6 +16,8 @@ const BUILD_TEST_DELAY = 1000;
 const RUNNER_SCHEME_IOS = 'WebDriverAgentRunner';
 const LIB_SCHEME_IOS = 'WebDriverAgentLib';
 
+const ERROR_WRITING_ATTACHMENT = 'Error writing attachment data to file';
+
 const RUNNER_SCHEME_TV = 'WebDriverAgentRunner_tvOS';
 const LIB_SCHEME_TV = 'WebDriverAgentLib_tvOS';
 
@@ -37,7 +39,7 @@ class XcodeBuild {
     this.platformName = args.platformName;
     this.iosSdkVersion = args.iosSdkVersion;
 
-    this.showXcodeLog = !!args.showXcodeLog;
+    this.showXcodeLog = args.showXcodeLog;
 
     this.xcodeConfigFile = args.xcodeConfigFile;
     this.xcodeOrgId = args.xcodeOrgId;
@@ -259,8 +261,11 @@ class XcodeBuild {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    let logXcodeOutput = this.showXcodeLog;
-    log.debug(`Output from xcodebuild ${logXcodeOutput ? 'will' : 'will not'} be logged. To change this, use 'showXcodeLog' desired capability`);
+    let logXcodeOutput = !!this.showXcodeLog;
+    const logMsg = _.isBoolean(this.showXcodeLog)
+      ? `Output from xcodebuild ${this.showXcodeLog ? 'will' : 'will not'} be logged`
+      : 'Output from xcodebuild will only be logged if any errors are present there';
+    log.debug(`${logMsg}. To change this, use 'showXcodeLog' desired capability`);
     xcodebuild.on('output', (stdout, stderr) => {
       let out = stdout || stderr;
       // we want to pull out the log file that is created, and highlight it
@@ -275,23 +280,21 @@ class XcodeBuild {
       // if we have an error we want to output the logs
       // otherwise the failure is inscrutible
       // but do not log permission errors from trying to write to attachments folder
-      if (out.includes('Error Domain=') &&
-          !out.includes('Error writing attachment data to file') &&
-          !out.includes('Failed to remove screenshot at path')) {
+      const ignoredErrors = [ERROR_WRITING_ATTACHMENT, 'Failed to remove screenshot at path'];
+      if (this.showXcodeLog !== false && out.includes('Error Domain=') &&
+          !ignoredErrors.some((x) => out.includes(x))) {
         logXcodeOutput = true;
 
         // terrible hack to handle case where xcode return 0 but is failing
         xcodebuild._wda_error_occurred = true;
       }
 
-      if (logXcodeOutput) {
-        // do not log permission errors from trying to write to attachments folder
-        if (!out.includes('Error writing attachment data to file')) {
-          for (const line of out.split(EOL)) {
-            xcodeLog.error(line);
-            if (line) {
-              xcodebuild._wda_error_message += `${EOL}${line}`;
-            }
+      // do not log permission errors from trying to write to attachments folder
+      if (logXcodeOutput && !out.includes(ERROR_WRITING_ATTACHMENT)) {
+        for (const line of out.split(EOL)) {
+          xcodeLog.error(line);
+          if (line) {
+            xcodebuild._wda_error_message += `${EOL}${line}`;
           }
         }
       }


### PR DESCRIPTION
If one explicitly sets the showXcodeLog to false then it makes sense not to show any logs even if they contain error messages. Related to https://github.com/appium/appium/issues/12466