### PR TITLE
Remove SDK version verification

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -300,17 +300,6 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (!this.opts.webDriverAgentUrl && this.iosSdkVersion && this.opts.platformVersion) {
-      // make sure that the xcode we are using can handle the platform
-      if (util.compareVersions(this.opts.platformVersion, '>', this.iosSdkVersion)) {
-        let msg = `Xcode ${this.xcodeVersion.versionString} has a maximum SDK version of ${this.iosSdkVersion}. ` +
-                  `It does not support iOS version ${this.opts.platformVersion}`;
-        log.errorAndThrow(msg);
-      }
-    } else {
-      log.debug('Xcode version will not be validated against iOS SDK version.');
-    }
-
     if ((this.opts.browserName || '').toLowerCase() === 'safari') {
       log.info('Safari test requested');
       this.safari = true;


### PR DESCRIPTION
I find this verification not very precise. Also, a test will fail anyway if matching SDK cannot be found.

Addresses https://github.com/appium/appium/issues/12504