### PR TITLE
 Do not block WDA initialization if a unique derived data path is set for each instance

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -473,7 +473,7 @@ class XCUITestDriver extends BaseDriver {
     // Let multiple WDA binaries with different derived data folders be built in parallel
     // Concurrent WDA builds from the same source will cause xcodebuild synchronization errors
     const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
-    log.debug(`Starting WDA initilization with the synchronization key '${synchronizationKey}'`);
+    log.debug(`Starting WebDriverAgent initialization with the synchronization key '${synchronizationKey}'`);
     if (SHARED_RESOURCES_GUARD.isBusy() && !this.opts.derivedDataPath && !this.opts.bootstrapPath) {
       log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance to avoid conflicts and speed up the building process`);
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -477,7 +477,7 @@ class XCUITestDriver extends BaseDriver {
     if (SHARED_RESOURCES_GUARD.isBusy() && !this.opts.derivedDataPath && !this.opts.bootstrapPath) {
       log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance to avoid conflicts and speed up the building process`);
     }
-    await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+    return await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
       if (this.opts.useNewWDA) {
         log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
         await this.wda.quitAndUninstall();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -24,6 +24,7 @@ import {
   getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
+import path from 'path';
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
@@ -417,8 +418,7 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    await SHARED_RESOURCES_GUARD.acquire(XCUITestDriver.name,
-      async () => await this.startWda(this.opts.sessionId, realDevice));
+    await this.startWda(this.opts.sessionId, realDevice);
 
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
@@ -470,109 +470,118 @@ class XCUITestDriver extends BaseDriver {
 
     await this.wda.cleanupObsoleteProcesses();
 
-    if (this.opts.useNewWDA) {
-      log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
-      await this.wda.quitAndUninstall();
-      this.logEvent('wdaUninstalled');
-    } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
-      await this.wda.setupCaching(this.opts.updatedWDABundleId);
+    // Let multiple WDA binaries with different derived data folders be built in parallel
+    // Concurrent WDA builds from the same source will cause xcodebuild synchronization errors
+    const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
+    log.debug(`Starting WDA initilization with the synchronization key '${synchronizationKey}'`);
+    if (SHARED_RESOURCES_GUARD.isBusy() && !this.opts.derivedDataPath && !this.opts.bootstrapPath) {
+      log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance to avoid conflicts and speed up the building process`);
     }
+    await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+      if (this.opts.useNewWDA) {
+        log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
+        await this.wda.quitAndUninstall();
+        this.logEvent('wdaUninstalled');
+      } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
+        await this.wda.setupCaching(this.opts.updatedWDABundleId);
+      }
 
-    // local helper for the two places we need to uninstall wda and re-start it
-    const quitAndUninstall = async (msg) => {
-      log.debug(msg);
-      if (this.opts.webDriverAgentUrl) {
-        log.debug('Not quitting/uninstalling WebDriverAgent since webDriverAgentUrl capability is provided');
+      // local helper for the two places we need to uninstall wda and re-start it
+      const quitAndUninstall = async (msg) => {
+        log.debug(msg);
+        if (this.opts.webDriverAgentUrl) {
+          log.debug('Not quitting/uninstalling WebDriverAgent since webDriverAgentUrl capability is provided');
+          throw new Error(msg);
+        }
+        log.warn('Quitting and uninstalling WebDriverAgent');
+        await this.wda.quitAndUninstall();
+
         throw new Error(msg);
-      }
-      log.warn('Quitting and uninstalling WebDriverAgent');
-      await this.wda.quitAndUninstall();
+      };
 
-      throw new Error(msg);
-    };
-
-    const startupRetries = this.opts.wdaStartupRetries || (this.isRealDevice() ? WDA_REAL_DEV_STARTUP_RETRIES : WDA_SIM_STARTUP_RETRIES);
-    const startupRetryInterval = this.opts.wdaStartupRetryInterval || WDA_STARTUP_RETRY_INTERVAL;
-    log.debug(`Trying to start WebDriverAgent ${startupRetries} times with ${startupRetryInterval}ms interval`);
-    if (!util.hasValue(this.opts.wdaStartupRetries) && !util.hasValue(this.opts.wdaStartupRetryInterval)) {
-      log.debug(`These values can be customized by changing wdaStartupRetries/wdaStartupRetryInterval capabilities`);
-    }
-    let retryCount = 0;
-    await retryInterval(startupRetries, startupRetryInterval, async () => {
-      this.logEvent('wdaStartAttempted');
-      if (retryCount > 0) {
-        log.info(`Retrying WDA startup (${retryCount + 1} of ${startupRetries})`);
+      const startupRetries = this.opts.wdaStartupRetries || (this.isRealDevice() ? WDA_REAL_DEV_STARTUP_RETRIES : WDA_SIM_STARTUP_RETRIES);
+      const startupRetryInterval = this.opts.wdaStartupRetryInterval || WDA_STARTUP_RETRY_INTERVAL;
+      log.debug(`Trying to start WebDriverAgent ${startupRetries} times with ${startupRetryInterval}ms interval`);
+      if (!util.hasValue(this.opts.wdaStartupRetries) && !util.hasValue(this.opts.wdaStartupRetryInterval)) {
+        log.debug(`These values can be customized by changing wdaStartupRetries/wdaStartupRetryInterval capabilities`);
       }
-      try {
-        // on xcode 10 installd will often try to access the app from its staging
-        // directory before fully moving it there, and fail. Retrying once
-        // immediately helps
-        const retries = this.xcodeVersion.major >= 10 ? 2 : 1;
-        this.cachedWdaStatus = await retry(retries, this.wda.launch.bind(this.wda), sessionId, realDevice);
-      } catch (err) {
-        this.logEvent('wdaStartFailed');
-        retryCount++;
-        let errorMsg = `Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`;
-        if (this.isRealDevice()) {
-          errorMsg += `. Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
-                      `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
-                      `and reboot the device.`;
+      let retryCount = 0;
+      await retryInterval(startupRetries, startupRetryInterval, async () => {
+        this.logEvent('wdaStartAttempted');
+        if (retryCount > 0) {
+          log.info(`Retrying WDA startup (${retryCount + 1} of ${startupRetries})`);
         }
-        await quitAndUninstall(errorMsg);
-      }
-
-      this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
-      this.jwpProxyActive = true;
-
-      let originalStacktrace = null;
-      try {
-        await retryInterval(15, 1000, async () => {
-          this.logEvent('wdaSessionAttempted');
-          log.debug('Sending createSession command to WDA');
-          try {
-            this.cachedWdaStatus = this.cachedWdaStatus || await this.proxyCommand('/status', 'GET');
-            await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
-          } catch (err) {
-            originalStacktrace = err.stack;
-            log.debug(`Failed to create WDA session (${err.message}). Retrying...`);
-            throw err;
+        try {
+          // on xcode 10 installd will often try to access the app from its staging
+          // directory before fully moving it there, and fail. Retrying once
+          // immediately helps
+          const retries = this.xcodeVersion.major >= 10 ? 2 : 1;
+          this.cachedWdaStatus = await retry(retries, this.wda.launch.bind(this.wda), sessionId, realDevice);
+        } catch (err) {
+          this.logEvent('wdaStartFailed');
+          retryCount++;
+          let errorMsg = `Unable to launch WebDriverAgent because of xcodebuild failure: ${err.message}`;
+          if (this.isRealDevice()) {
+            errorMsg += `. Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
+                        `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
+                        `and reboot the device.`;
           }
-        });
-        this.logEvent('wdaSessionStarted');
-      } catch (err) {
-        if (originalStacktrace) {
-          log.debug(originalStacktrace);
+          await quitAndUninstall(errorMsg);
         }
-        let errorMsg = `Unable to start WebDriverAgent session because of xcodebuild failure: ${err.message}`;
-        if (this.isRealDevice()) {
-          errorMsg += ` Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
-                      `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
-                      `and reboot the device.`;
-        }
-        await quitAndUninstall(errorMsg);
-      }
 
-      if (!util.hasValue(this.opts.preventWDAAttachments)) {
-        // XCTest prior to Xcode 9 SDK has no native way to disable attachments
-        this.opts.preventWDAAttachments = this.xcodeVersion.major < 9;
+        this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
+        this.jwpProxyActive = true;
+
+        let originalStacktrace = null;
+        try {
+          await retryInterval(15, 1000, async () => {
+            this.logEvent('wdaSessionAttempted');
+            log.debug('Sending createSession command to WDA');
+            try {
+              this.cachedWdaStatus = this.cachedWdaStatus || await this.proxyCommand('/status', 'GET');
+              await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
+            } catch (err) {
+              originalStacktrace = err.stack;
+              log.debug(`Failed to create WDA session (${err.message}). Retrying...`);
+              throw err;
+            }
+          });
+          this.logEvent('wdaSessionStarted');
+        } catch (err) {
+          if (originalStacktrace) {
+            log.debug(originalStacktrace);
+          }
+          let errorMsg = `Unable to start WebDriverAgent session because of xcodebuild failure: ${err.message}`;
+          if (this.isRealDevice()) {
+            errorMsg += ` Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
+                        `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
+                        `and reboot the device.`;
+          }
+          await quitAndUninstall(errorMsg);
+        }
+
+        if (!util.hasValue(this.opts.preventWDAAttachments)) {
+          // XCTest prior to Xcode 9 SDK has no native way to disable attachments
+          this.opts.preventWDAAttachments = this.xcodeVersion.major < 9;
+          if (this.opts.preventWDAAttachments) {
+            log.info('Enabled WDA attachments prevention by default to save the disk space. ' +
+                     `Set 'preventWDAAttachments' capability to false if this is an undesired behavior.`);
+          }
+        }
         if (this.opts.preventWDAAttachments) {
-          log.info('Enabled WDA attachments prevention by default to save the disk space. ' +
-                   `Set 'preventWDAAttachments' capability to false if this is an undesired behavior.`);
+          await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');
+          this.logEvent('wdaPermsAdjusted');
         }
-      }
-      if (this.opts.preventWDAAttachments) {
-        await adjustWDAAttachmentsPermissions(this.wda, this.opts.preventWDAAttachments ? '555' : '755');
-        this.logEvent('wdaPermsAdjusted');
-      }
 
-      if (this.opts.clearSystemFiles) {
-        await markSystemFilesForCleanup(this.wda);
-      }
+        if (this.opts.clearSystemFiles) {
+          await markSystemFilesForCleanup(this.wda);
+        }
 
-      // we expect certain socket errors until this point, but now
-      // mark things as fully working
-      this.wda.fullyStarted = true;
-      this.logEvent('wdaStarted');
+        // we expect certain socket errors until this point, but now
+        // mark things as fully working
+        this.wda.fullyStarted = true;
+        this.logEvent('wdaStarted');
+      });
     });
   }
 
@@ -589,7 +598,8 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
 
-    await SHARED_RESOURCES_GUARD.acquire(XCUITestDriver.name, async () => {
+    const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
+    await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
       await this.stop();
 
       // reset the permissions on the derived data folder, if necessary

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -472,10 +472,15 @@ class XCUITestDriver extends BaseDriver {
 
     // Let multiple WDA binaries with different derived data folders be built in parallel
     // Concurrent WDA builds from the same source will cause xcodebuild synchronization errors
-    const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
+    const synchronizationKey = !this.opts.useXctestrunFile && await this.wda.isSourceFresh()
+      // First-time compilation is an expensive operation, which is done faster if executed
+      // sequentially. Xcodebuild spreads the load caused by the clang compiler to all available CPU cores
+      ? XCUITestDriver.name
+      : path.normalize(await this.wda.retrieveDerivedDataPath());
     log.debug(`Starting WebDriverAgent initialization with the synchronization key '${synchronizationKey}'`);
     if (SHARED_RESOURCES_GUARD.isBusy() && !this.opts.derivedDataPath && !this.opts.bootstrapPath) {
-      log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance to avoid conflicts and speed up the building process`);
+      log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance ` +
+        `to avoid conflicts and speed up the building process`);
     }
     return await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
       if (this.opts.useNewWDA) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -598,24 +598,27 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
 
-    const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
-    await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
-      await this.stop();
+    await this.stop();
 
-      // reset the permissions on the derived data folder, if necessary
-      if (this.opts.preventWDAAttachments) {
-        await adjustWDAAttachmentsPermissions(this.wda, '755');
-      }
+    if (this.opts.clearSystemFiles && this.isAppTemporary) {
+      await fs.rimraf(this.opts.app);
+    }
 
-      if (this.opts.clearSystemFiles) {
-        if (this.isAppTemporary) {
-          await fs.rimraf(this.opts.app);
+    if (this.wda) {
+      const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
+      await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+        // reset the permissions on the derived data folder, if necessary
+        if (this.opts.preventWDAAttachments) {
+          await adjustWDAAttachmentsPermissions(this.wda, '755');
         }
-        await clearSystemFiles(this.wda);
-      } else {
-        log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
-      }
-    });
+
+        if (this.opts.clearSystemFiles) {
+          await clearSystemFiles(this.wda);
+        } else {
+          log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+        }
+      });
+    }
 
     if (this.isWebContext()) {
       log.debug('In a web session. Removing remote debugger');

--- a/lib/wda/utils.js
+++ b/lib/wda/utils.js
@@ -350,4 +350,4 @@ export { updateProjectFile, resetProjectFile, checkForDependencies,
   setRealDeviceSecurity, fixForXcode7, fixForXcode9, getAdditionalRunContent,
   getXctestrunFileName, generateXcodeConfigFile, setXctestrunFile,
   getXctestrunFilePath, killProcess, randomInt, WDA_RUNNER_BUNDLE_ID,
-  getWDAUpgradeTimestamp };
+  getWDAUpgradeTimestamp, CARTHAGE_ROOT };

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -10,6 +10,7 @@ import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
 import { exec } from 'teen_process';
+import AsyncLock from 'async-lock';
 
 
 const BOOTSTRAP_PATH = path.resolve(__dirname, '..', '..', '..', 'WebDriverAgent');
@@ -17,6 +18,8 @@ const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
+
+const SHARED_RESOURCES_GUARD = new AsyncLock();
 
 
 class WebDriverAgent {
@@ -201,11 +204,14 @@ class WebDriverAgent {
 
     if (!this.useXctestrunFile) {
       // make sure that the WDA dependencies have been built
-      const didPerformUpgrade = await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
-      if (didPerformUpgrade) {
-        // Only perform the cleanup after WDA upgrade
-        await this.xcodebuild.cleanProject();
-      }
+      const synchronizationKey = path.normalize(this.bootstrapPath);
+      await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+        const didPerformUpgrade = await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
+        if (didPerformUpgrade) {
+          // Only perform the cleanup after WDA upgrade
+          await this.xcodebuild.cleanProject();
+        }
+      });
     }
     // We need to provide WDA local port, because it might be occupied with
     // iproxy instance initiated by some preceeding run with a real device

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -5,7 +5,9 @@ import { JWProxy } from 'appium-base-driver';
 import { fs, util } from 'appium-support';
 import log from '../logger';
 import { NoSessionProxy } from './no-session-proxy';
-import { checkForDependencies, WDA_RUNNER_BUNDLE_ID, getWDAUpgradeTimestamp } from './utils';
+import {
+  checkForDependencies, WDA_RUNNER_BUNDLE_ID, getWDAUpgradeTimestamp,
+  CARTHAGE_ROOT } from './utils';
 import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
@@ -230,6 +232,19 @@ class WebDriverAgent {
       await this.xcodebuild.prebuild();
     }
     return await this.xcodebuild.start();
+  }
+
+  async isSourceFresh () {
+    for (const subPath of [
+      CARTHAGE_ROOT,
+      'Resources',
+      `Resources${path.sep}WebDriverAgent.bundle`,
+    ]) {
+      if (!await fs.exists(path.resolve(this.bootstrapPath, subPath))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   setupProxies (sessionId) {


### PR DESCRIPTION
Currently we always block WDA session startup for parallel sessions, although it would be faster to let the stuff be running in parallel if a unique derivedDataPath cap is set for each instance.