### PR TITLE
add get a focused element as get active element method

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -81,9 +81,6 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     getPermission: 'mobileGetPermission',
 
     siriCommand: 'mobileSiriCommand',
-
-    // for tvOS
-    getFocusedElement: 'mobileGetFocusedElement'
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -83,7 +83,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     siriCommand: 'mobileSiriCommand',
 
     // for tvOS
-    focusedElement: 'mobileFocusedElement'
+    getFocusedElement: 'mobileGetFocusedElement'
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -81,6 +81,9 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     getPermission: 'mobileGetPermission',
 
     siriCommand: 'mobileSiriCommand',
+
+    // for tvOS
+    focusedElement: 'mobileFocusedElement'
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -214,10 +214,9 @@ commands.mobileSiriCommand = async function mobileSiriCommand (opts = {}) {
   return await this.proxyCommand('/wda/siri/activate', 'POST', {text});
 };
 
-// For tvOS
-// Get focused element
+// For tvOS to get focused element as tvOS term of 'focus'
 commands.mobileGetFocusedElement = async function mobileGetFocusedElement () {
-  return await this.proxyCommand('/wda/element/focused', 'GET');
+  return await this.proxyCommand('/element/active', 'GET');
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -214,6 +214,12 @@ commands.mobileSiriCommand = async function mobileSiriCommand (opts = {}) {
   return await this.proxyCommand('/wda/siri/activate', 'POST', {text});
 };
 
+// For tvOS
+// Get focused element
+commands.mobileFocusedElement = async function mobileFocusedElement () {
+  return await this.proxyCommand('/wda/element/focused', 'GET');
+};
+
 Object.assign(extensions, commands, helpers);
 
 export { commands, helpers, extensions };

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -214,11 +214,6 @@ commands.mobileSiriCommand = async function mobileSiriCommand (opts = {}) {
   return await this.proxyCommand('/wda/siri/activate', 'POST', {text});
 };
 
-// For tvOS to get focused element as tvOS term of 'focus'
-commands.mobileGetFocusedElement = async function mobileGetFocusedElement () {
-  return await this.proxyCommand('/element/active', 'GET');
-};
-
 Object.assign(extensions, commands, helpers);
 
 export { commands, helpers, extensions };

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -216,7 +216,7 @@ commands.mobileSiriCommand = async function mobileSiriCommand (opts = {}) {
 
 // For tvOS
 // Get focused element
-commands.mobileFocusedElement = async function mobileFocusedElement () {
+commands.mobileGetFocusedElement = async function mobileFocusedElement () {
   return await this.proxyCommand('/wda/element/focused', 'GET');
 };
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -216,7 +216,7 @@ commands.mobileSiriCommand = async function mobileSiriCommand (opts = {}) {
 
 // For tvOS
 // Get focused element
-commands.mobileGetFocusedElement = async function mobileFocusedElement () {
+commands.mobileGetFocusedElement = async function mobileGetFocusedElement () {
   return await this.proxyCommand('/wda/element/focused', 'GET');
 };
 


### PR DESCRIPTION
I would like to include this in the next initial tvOS support. cc @dpgraham 
On tvOS, _get active element_ does not work. Users cannot get a current focused element after `@driver.execute_script 'mobile: pressButton', { name: 'Up' }` for now if we do not provide _get focused element_ logic

https://github.com/appium/WebDriverAgent/pull/151/files#diff-1ce9f4bcc55f2133845eab148e127364R51

example:

```ruby
> @driver.execute_script 'mobile: pressButton', { name: 'Home' }
> e = @driver.execute_script 'mobile: getFocusedElement'
> e.label #=> "Settings"
```

