### PR TITLE
customisable WDA URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Differences are noted here:
 |`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
-|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
+|`wdaBaseUrl`| This value if specified, will be used as a prefix to build a custom WebDriverAgent url. It is different from `webDriverAgentUrl`, because if the latter is set then it expects WebDriverAgent to be already listening and skips the building phase. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Differences are noted here:
 |`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
-|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost`. We recommend not to set this if your local `ios-deploy` does not work over wireless network. | e.g., `http://192.168.1.100`|
+|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Differences are noted here:
 |`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
+|`wdaCustomBaseURL`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Differences are noted here:
 |`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
-|`wdaCustomBaseURL`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
+|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Differences are noted here:
 |`wdaStartupRetries`|Number of times to try to build and launch WebDriverAgent onto the device. Defaults to 2.|e.g., `4`|
 |`wdaStartupRetryInterval`|Time, in ms, to wait between tries to build and launch WebDriverAgent. Defaults to 10000ms.|e.g., `20000`|
 |`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
-|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost` | e.g., `http://192.168.1.100`|
+|`wdaBaseUrl`| This value if specified, will be used to listen WebDriverAgent to this URL. Defaults to `http://localhost`. We recommend not to set this if your local `ios-deploy` does not work over wireless network. | e.g., `http://192.168.1.100`|
 |`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
 |`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
 |`usePrebuiltWDA`|Skips the build phase of running the WDA app. Building is then the responsibility of the user. Only works for Xcode 8+. Defaults to `false`.|e.g., `true`|

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -239,11 +239,12 @@ commands.startRecordingScreen = async function startRecordingScreen (options = {
     suffix: MP4_EXT,
   });
 
+  const wdaBaseUrl = this.opts.wdaBaseUrl || WDA_BASE_URL;
   const screenRecorder = new ScreenRecorder(this.opts.device.udid, videoPath, {
     remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
-    remoteUrl: this.opts.wdaBaseUrl || WDA_BASE_URL,
+    remoteUrl: wdaBaseUrl,
     usePortForwarding: this.isRealDevice() && (
-      this.opts.wdaBaseUrl === WDA_BASE_URL || this.opts.wdaBaseUrl === WDA_BASE_URL_IP),
+      wdaBaseUrl === WDA_BASE_URL || wdaBaseUrl === WDA_BASE_URL_IP),
     videoType,
     videoScale,
     videoFps

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -4,6 +4,7 @@ import { SubProcess } from 'teen_process';
 import log from '../logger';
 import { encodeBase64OrUpload } from '../utils';
 import iProxy from '../wda/iproxy';
+import { WDA_BASE_URL, WDA_BASE_URL_IP } from '../wda/webdriveragent';
 import { waitForCondition } from 'asyncbox';
 
 let commands = {};
@@ -239,7 +240,8 @@ commands.startRecordingScreen = async function startRecordingScreen (options = {
 
   const screenRecorder = new ScreenRecorder(this.opts.device.udid, videoPath, {
     remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
-    usePortForwarding: this.isRealDevice(),
+    usePortForwarding: this.isRealDevice() && (
+      this.opts.wdaBaseUrl === WDA_BASE_URL || this.opts.wdaBaseUrl === WDA_BASE_URL_IP),
     videoType,
     videoScale,
     videoFps

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -45,6 +45,7 @@ class ScreenRecorder {
     }
 
     const localPort = this.opts.remotePort;
+    const baseUrl = this.opts.remoteUrl;
     if (this.opts.usePortForwarding) {
       await this.startIproxy(localPort);
     }
@@ -56,7 +57,7 @@ class ScreenRecorder {
     if (this.opts.videoFps && this.opts.videoType === 'libx264') {
       args.push('-r', this.opts.videoFps);
     }
-    args.push('-i', `http://localhost:${localPort}`);
+    args.push('-i', `${baseUrl}:${localPort}`);
     if (this.opts.videoScale) {
       args.push('-vf', `scale=${this.opts.videoScale}`);
     }
@@ -240,6 +241,7 @@ commands.startRecordingScreen = async function startRecordingScreen (options = {
 
   const screenRecorder = new ScreenRecorder(this.opts.device.udid, videoPath, {
     remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
+    remoteUrl: this.opts.wdaBaseUrl || WDA_BASE_URL,
     usePortForwarding: this.isRealDevice() && (
       this.opts.wdaBaseUrl === WDA_BASE_URL || this.opts.wdaBaseUrl === WDA_BASE_URL_IP),
     videoType,

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -2,9 +2,9 @@ import _ from 'lodash';
 import { fs, tempDir, logger, util } from 'appium-support';
 import { SubProcess } from 'teen_process';
 import log from '../logger';
-import { encodeBase64OrUpload } from '../utils';
+import { encodeBase64OrUpload, isLocalHost } from '../utils';
 import iProxy from '../wda/iproxy';
-import { WDA_BASE_URL, WDA_BASE_URL_IP } from '../wda/webdriveragent';
+import { WDA_BASE_URL } from '../wda/webdriveragent';
 import { waitForCondition } from 'asyncbox';
 
 let commands = {};
@@ -243,7 +243,7 @@ commands.startRecordingScreen = async function startRecordingScreen (options = {
   const screenRecorder = new ScreenRecorder(this.opts.device.udid, videoPath, {
     remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
     remoteUrl: wdaBaseUrl,
-    usePortForwarding: this.isRealDevice() && [WDA_BASE_URL, WDA_BASE_URL_IP].includes(wdaBaseUrl),
+    usePortForwarding: this.isRealDevice() && isLocalHost(wdaBaseUrl),
     videoType,
     videoScale,
     videoFps

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -6,6 +6,7 @@ import { encodeBase64OrUpload, isLocalHost } from '../utils';
 import iProxy from '../wda/iproxy';
 import { WDA_BASE_URL } from '../wda/webdriveragent';
 import { waitForCondition } from 'asyncbox';
+import url from 'url';
 
 let commands = {};
 
@@ -45,7 +46,7 @@ class ScreenRecorder {
     }
 
     const localPort = this.opts.remotePort;
-    const baseUrl = this.opts.remoteUrl;
+    const {protocol, hostname} = url.parse(this.opts.remoteUrl);
     if (this.opts.usePortForwarding) {
       await this.startIproxy(localPort);
     }
@@ -57,7 +58,7 @@ class ScreenRecorder {
     if (this.opts.videoFps && this.opts.videoType === 'libx264') {
       args.push('-r', this.opts.videoFps);
     }
-    args.push('-i', `${baseUrl}:${localPort}`);
+    args.push('-i', `${protocol}//${hostname}:${localPort}`);
     if (this.opts.videoScale) {
       args.push('-vf', `scale=${this.opts.videoScale}`);
     }

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -243,8 +243,7 @@ commands.startRecordingScreen = async function startRecordingScreen (options = {
   const screenRecorder = new ScreenRecorder(this.opts.device.udid, videoPath, {
     remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
     remoteUrl: wdaBaseUrl,
-    usePortForwarding: this.isRealDevice() && (
-      wdaBaseUrl === WDA_BASE_URL || wdaBaseUrl === WDA_BASE_URL_IP),
+    usePortForwarding: this.isRealDevice() && [WDA_BASE_URL, WDA_BASE_URL_IP].includes(wdaBaseUrl),
     videoType,
     videoScale,
     videoFps

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -17,6 +17,9 @@ let desiredCapConstraints = _.defaults({
   wdaLocalPort: {
     isNumber: true
   },
+  wdaBaseUrl: {
+    isString: true
+  },
   iosInstallPause: {
     isNumber: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,7 +3,7 @@ import { util, fs, mjpeg } from 'appium-support';
 import _ from 'lodash';
 import url from 'url';
 import { launch, openUrl } from 'node-simctl';
-import WebDriverAgent from './wda/webdriveragent';
+import { WebDriverAgent, WDA_BASE_URL } from './wda/webdriveragent';
 import log from './logger';
 import {
   createSim, getExistingSim, runSimulatorReset, installToSimulator,
@@ -159,6 +159,7 @@ class XCUITestDriver extends BaseDriver {
   resetIos () {
     this.opts = this.opts || {};
     this.wda = null;
+    this.opts.wdaBaseUrl = this.opts.wdaBaseUrl || WDA_BASE_URL;
     this.opts.device = null;
     this.jwpProxyActive = false;
     this.proxyReqRes = null;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,7 +3,7 @@ import { util, fs, mjpeg } from 'appium-support';
 import _ from 'lodash';
 import url from 'url';
 import { launch, openUrl } from 'node-simctl';
-import { WebDriverAgent, WDA_BASE_URL } from './wda/webdriveragent';
+import WebDriverAgent from './wda/webdriveragent';
 import log from './logger';
 import {
   createSim, getExistingSim, runSimulatorReset, installToSimulator,
@@ -159,7 +159,6 @@ class XCUITestDriver extends BaseDriver {
   resetIos () {
     this.opts = this.opts || {};
     this.wda = null;
-    this.opts.wdaBaseUrl = this.opts.wdaBaseUrl || WDA_BASE_URL;
     this.opts.device = null;
     this.jwpProxyActive = false;
     this.proxyReqRes = null;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -507,7 +507,7 @@ function isLocalHost (urlString) {
     return hostname.includes('localhost')
       || ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
   } catch {
-    log.warn(`'${urlString}' is unable to parse`);
+    log.warn(`'${urlString}' cannot be parsed as a valid URL`);
   }
   return false;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -503,9 +503,9 @@ function isTvOS (platformName) {
  */
 function isLocalHost (urlString) {
   try {
-    const {hostname} = new URL(urlString);
+    const {hostname} = url.parse(urlString);
     return hostname.includes('localhost')
-      || ['127.0.0.1', '[::1]', '[::ffff:7f00:1]'].includes(hostname);
+      || ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
   } catch {}
   return false;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -504,8 +504,7 @@ function isTvOS (platformName) {
 function isLocalHost (urlString) {
   try {
     const {hostname} = url.parse(urlString);
-    return hostname.includes('localhost')
-      || ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
+    return ['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
   } catch {
     log.warn(`'${urlString}' cannot be parsed as a valid URL`);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -506,7 +506,9 @@ function isLocalHost (urlString) {
     const {hostname} = url.parse(urlString);
     return hostname.includes('localhost')
       || ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
-  } catch {}
+  } catch {
+    log.warn(`'${urlString}' is unable to parse`);
+  }
   return false;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -496,10 +496,24 @@ function isTvOS (platformName) {
   return _.toLower(platformName) === _.toLower(PLATFORM_NAME_TVOS);
 }
 
+/**
+ * Returns true if the urlString is localhost
+ * @param {?string} urlString
+ * @returns {boolean} Return true if the urlString is localhost
+ */
+function isLocalHost (urlString) {
+  try {
+    const {hostname} = new URL(urlString);
+    return hostname.includes('localhost')
+      || ['127.0.0.1', '[::1]', '[::ffff:7f00:1]'].includes(hostname);
+  } catch {}
+  return false;
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
   adjustWDAAttachmentsPermissions, checkAppPresent, getDriverInfo,
   clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
   DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
   markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo,
   getPIDsListeningOnPort, encodeBase64OrUpload, removeAllSessionWebSocketHandlers,
-  verifyApplicationPlatform, isTvOS };
+  verifyApplicationPlatform, isTvOS, isLocalHost };

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -20,6 +20,7 @@ const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
+const WDA_BASE_URL_IP = 'http://127.0.0.1';
 
 const SHARED_RESOURCES_GUARD = new AsyncLock();
 
@@ -222,8 +223,12 @@ class WebDriverAgent {
     await resetXCTestProcesses(this.device.udid, !this.realDevice, {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
-      this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
-      await this.iproxy.start();
+      if (this.opts.wdaBaseUrl === WDA_BASE_URL || this.opts.wdaBaseUrl === WDA_BASE_URL_IP) {
+        this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
+        await this.iproxy.start();
+      } else {
+        log.info(`Skip starting iproxy since Appium can communicate with WDA via '${this.wdaBaseUrl}'`);
+      }
     }
 
     await this.xcodebuild.init(this.noSessionProxy);
@@ -367,4 +372,4 @@ class WebDriverAgent {
 }
 
 export default WebDriverAgent;
-export { WebDriverAgent, WDA_BUNDLE_ID, BOOTSTRAP_PATH };
+export { WebDriverAgent, WDA_BUNDLE_ID, BOOTSTRAP_PATH, WDA_BASE_URL, WDA_BASE_URL_IP };

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -41,7 +41,7 @@ class WebDriverAgent {
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
     this.wdaLocalPort = args.wdaLocalPort;
-    this.wdaBaseUrl = args.wdaBaseUrl;
+    this.wdaBaseUrl = args.wdaBaseUrl || WDA_BASE_URL;
 
     this.prebuildWDA = args.prebuildWDA;
 
@@ -223,7 +223,7 @@ class WebDriverAgent {
     await resetXCTestProcesses(this.device.udid, !this.realDevice, {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
-      if (this.opts.wdaBaseUrl === WDA_BASE_URL || this.opts.wdaBaseUrl === WDA_BASE_URL_IP) {
+      if (this.wdaBaseUrl === WDA_BASE_URL || this.wdaBaseUrl === WDA_BASE_URL_IP) {
         this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
         await this.iproxy.start();
       } else {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -40,7 +40,7 @@ class WebDriverAgent {
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
     this.wdaLocalPort = args.wdaLocalPort;
-    this.wdaCustomBaseURL = args.wdaCustomBaseURL;
+    this.wdaBaseUrl = args.wdaBaseUrl;
 
     this.prebuildWDA = args.prebuildWDA;
 
@@ -290,7 +290,7 @@ class WebDriverAgent {
   get url () {
     if (!this._url) {
       const port = this.wdaLocalPort || WDA_AGENT_PORT;
-      const host = this.wdaCustomBaseURL || WDA_BASE_URL;
+      const host = this.wdaBaseUrl || WDA_BASE_URL;
       this._url = url.parse(`${host}:${port}`);
     }
     return this._url;

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -223,7 +223,7 @@ class WebDriverAgent {
     await resetXCTestProcesses(this.device.udid, !this.realDevice, {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
-      if (this.wdaBaseUrl === WDA_BASE_URL || this.wdaBaseUrl === WDA_BASE_URL_IP) {
+      if ([WDA_BASE_URL, WDA_BASE_URL_IP].includes(this.wdaBaseUrl)) {
         this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
         await this.iproxy.start();
       } else {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -294,8 +294,8 @@ class WebDriverAgent {
   get url () {
     if (!this._url) {
       const port = this.wdaLocalPort || WDA_AGENT_PORT;
-      const host = this.wdaBaseUrl || WDA_BASE_URL;
-      this._url = url.parse(`${host}:${port}`);
+      const {protocol, hostname} = url.parse(this.wdaBaseUrl || WDA_BASE_URL);
+      this._url = url.parse(`${protocol}//${hostname}:${port}`);
     }
     return this._url;
   }

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -40,6 +40,7 @@ class WebDriverAgent {
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
     this.wdaLocalPort = args.wdaLocalPort;
+    this.wdaCustomBaseURL = args.wdaCustomBaseURL;
 
     this.prebuildWDA = args.prebuildWDA;
 
@@ -288,8 +289,9 @@ class WebDriverAgent {
 
   get url () {
     if (!this._url) {
-      let port = this.wdaLocalPort || WDA_AGENT_PORT;
-      this._url = url.parse(`${WDA_BASE_URL}:${port}`);
+      const port = this.wdaLocalPort || WDA_AGENT_PORT;
+      const host = this.wdaCustomBaseURL || WDA_BASE_URL;
+      this._url = url.parse(`${host}:${port}`);
     }
     return this._url;
   }

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -8,7 +8,7 @@ import { NoSessionProxy } from './no-session-proxy';
 import {
   checkForDependencies, WDA_RUNNER_BUNDLE_ID, getWDAUpgradeTimestamp,
   CARTHAGE_ROOT } from './utils';
-import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
+import { resetXCTestProcesses, getPIDsListeningOnPort, isLocalHost } from '../utils';
 import XcodeBuild from './xcodebuild';
 import iProxy from './iproxy';
 import { exec } from 'teen_process';
@@ -20,7 +20,6 @@ const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
 const WDA_BASE_URL = 'http://localhost';
-const WDA_BASE_URL_IP = 'http://127.0.0.1';
 
 const SHARED_RESOURCES_GUARD = new AsyncLock();
 
@@ -223,11 +222,11 @@ class WebDriverAgent {
     await resetXCTestProcesses(this.device.udid, !this.realDevice, {wdaLocalPort: this.url.port});
 
     if (this.realDevice) {
-      if ([WDA_BASE_URL, WDA_BASE_URL_IP].includes(this.wdaBaseUrl)) {
+      if (isLocalHost(this.wdaBaseUrl)) {
         this.iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
         await this.iproxy.start();
       } else {
-        log.info(`Skip starting iproxy since Appium can communicate with WDA via '${this.wdaBaseUrl}'`);
+        log.info(`Skip starting iproxy since Appium will communicate with WDA via '${this.wdaBaseUrl}'`);
       }
     }
 
@@ -372,4 +371,4 @@ class WebDriverAgent {
 }
 
 export default WebDriverAgent;
-export { WebDriverAgent, WDA_BUNDLE_ID, BOOTSTRAP_PATH, WDA_BASE_URL, WDA_BASE_URL_IP };
+export { WebDriverAgent, WDA_BUNDLE_ID, BOOTSTRAP_PATH, WDA_BASE_URL };

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -156,6 +156,9 @@ describe('utils', function () {
     it('should true with ipv4 localhost', function () {
       isLocalHost('http://localhost').should.be.true;
     });
+    it('should true with ipv4 localhost with port', function () {
+      isLocalHost('http://localhost:8888').should.be.true;
+    });
     it('should true with ipv4 127.0.0.1', function () {
       isLocalHost('http://127.0.0.1').should.be.true;
     });
@@ -165,8 +168,14 @@ describe('utils', function () {
     it('should true with ipv6 ::ffff:127.0.0.1', function () {
       isLocalHost('http://[::ffff:127.0.0.1]').should.be.true;
     });
+    it('should true with ipv6 ::ffff:127.0.0.1 with port', function () {
+      isLocalHost('http://[::ffff:127.0.0.1]:8888').should.be.true;
+    });
     it('should false with ipv4 192.168.1.100', function () {
       isLocalHost('http://192.168.1.100').should.be.false;
+    });
+    it('should false with ipv4 192.168.1.100 with port', function () {
+      isLocalHost('http://192.168.1.100:8888').should.be.false;
     });
     it('should false with ipv6 2001:db8:85a3:8d3:1319:8a2e:370:7348', function () {
       isLocalHost('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]').should.be.false;

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -150,34 +150,34 @@ describe('utils', function () {
   });
 
   describe('isLocalHost', function () {
-    it('should false with invalid input, empty', function () {
+    it('should be false with invalid input, empty', function () {
       isLocalHost('').should.be.false;
     });
-    it('should true with ipv4 localhost', function () {
+    it('should be true with ipv4 localhost', function () {
       isLocalHost('http://localhost').should.be.true;
     });
-    it('should true with ipv4 localhost with port', function () {
+    it('should be true with ipv4 localhost with port', function () {
       isLocalHost('http://localhost:8888').should.be.true;
     });
-    it('should true with ipv4 127.0.0.1', function () {
+    it('should be true with ipv4 127.0.0.1', function () {
       isLocalHost('http://127.0.0.1').should.be.true;
     });
-    it('should true with ipv6 ::1', function () {
+    it('should be true with ipv6 ::1', function () {
       isLocalHost('http://[::1]').should.be.true;
     });
-    it('should true with ipv6 ::ffff:127.0.0.1', function () {
+    it('should be true with ipv6 ::ffff:127.0.0.1', function () {
       isLocalHost('http://[::ffff:127.0.0.1]').should.be.true;
     });
-    it('should true with ipv6 ::ffff:127.0.0.1 with port', function () {
+    it('should be true with ipv6 ::ffff:127.0.0.1 with port', function () {
       isLocalHost('http://[::ffff:127.0.0.1]:8888').should.be.true;
     });
-    it('should false with ipv4 192.168.1.100', function () {
+    it('should be false with ipv4 192.168.1.100', function () {
       isLocalHost('http://192.168.1.100').should.be.false;
     });
-    it('should false with ipv4 192.168.1.100 with port', function () {
+    it('should be false with ipv4 192.168.1.100 with port', function () {
       isLocalHost('http://192.168.1.100:8888').should.be.false;
     });
-    it('should false with ipv6 2001:db8:85a3:8d3:1319:8a2e:370:7348', function () {
+    it('should be false with ipv6 2001:db8:85a3:8d3:1319:8a2e:370:7348', function () {
       isLocalHost('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]').should.be.false;
     });
   });

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -150,6 +150,9 @@ describe('utils', function () {
   });
 
   describe('isLocalHost', function () {
+    it('should be false with invalid input, undefined', function () {
+      isLocalHost(undefined).should.be.false;
+    });
     it('should be false with invalid input, empty', function () {
       isLocalHost('').should.be.false;
     });

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,6 +1,6 @@
 import {
   clearSystemFiles, translateDeviceName, adjustWDAAttachmentsPermissions,
-  markSystemFilesForCleanup } from '../../lib/utils';
+  markSystemFilesForCleanup, isLocalHost } from '../../lib/utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { withMocks } from 'appium-test-support';
@@ -146,6 +146,30 @@ describe('utils', function () {
     it('should set the correct iPhone simulator generic device', function () {
       let deviceName = translateDeviceName(10.3, 'iPhone Simulator');
       deviceName.should.equal('iPhone 6');
+    });
+  });
+
+  describe('isLocalHost', function () {
+    it('should false with invalid input, empty', function () {
+      isLocalHost('').should.be.false;
+    });
+    it('should true with ipv4 localhost', function () {
+      isLocalHost('http://localhost').should.be.true;
+    });
+    it('should true with ipv4 127.0.0.1', function () {
+      isLocalHost('http://127.0.0.1').should.be.true;
+    });
+    it('should true with ipv6 ::1', function () {
+      isLocalHost('http://[::1]').should.be.true;
+    });
+    it('should true with ipv6 ::ffff:127.0.0.1', function () {
+      isLocalHost('http://[::ffff:127.0.0.1]').should.be.true;
+    });
+    it('should false with ipv4 192.168.1.100', function () {
+      isLocalHost('http://192.168.1.100').should.be.false;
+    });
+    it('should false with ipv6 2001:db8:85a3:8d3:1319:8a2e:370:7348', function () {
+      isLocalHost('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]').should.be.false;
     });
   });
 });

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -68,6 +68,26 @@ describe('launch', function () {
   });
 });
 
+describe('get url', function () {
+  it('should use default WDA listening url', function () {
+    const args = Object.assign({}, fakeConstructorArgs);
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://localhost:8100/');
+  });
+
+  it('should use customised WDA listening url', function () {
+    const wdaLocalPort = '9100';
+    const wdaCustomBaseURL = 'http://mockurl';
+
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaCustomBaseURL = wdaCustomBaseURL;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://mockurl:9100/');
+  });
+});
+
 describe('setupCaching()', function () {
   let wda;
   let wdaStub;

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -77,10 +77,10 @@ describe('get url', function () {
 
   it('should use customised WDA listening url', function () {
     const wdaLocalPort = '9100';
-    const wdaCustomBaseURL = 'http://mockurl';
+    const wdaBaseUrl = 'http://mockurl';
 
     const args = Object.assign({}, fakeConstructorArgs);
-    args.wdaCustomBaseURL = wdaCustomBaseURL;
+    args.wdaBaseUrl = wdaBaseUrl;
     args.wdaLocalPort = wdaLocalPort;
 
     const agent = new WebDriverAgent({}, args);

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -74,10 +74,31 @@ describe('get url', function () {
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('http://localhost:8100/');
   });
+  it('should use default WDA listening url with emply base url', function () {
+    const wdaLocalPort = '9100';
+    const wdaBaseUrl = '';
 
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBaseUrl = wdaBaseUrl;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://localhost:9100/');
+  });
   it('should use customised WDA listening url', function () {
     const wdaLocalPort = '9100';
     const wdaBaseUrl = 'http://mockurl';
+
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBaseUrl = wdaBaseUrl;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://mockurl:9100/');
+  });
+  it('should use customised WDA listening url with slash', function () {
+    const wdaLocalPort = '9100';
+    const wdaBaseUrl = 'http://mockurl/';
 
     const args = Object.assign({}, fakeConstructorArgs);
     args.wdaBaseUrl = wdaBaseUrl;


### PR DESCRIPTION
We have `webDriverAgentUrl` to customise WDA URL. But it skips installing and listening WDA starting status. I would like to listen to the customised URL instead of `WDA_BASE_URL` to be able to deploy and start WDA via WiFi.

Below is with `wdaCustomBaseURL = "http://192.168.1.100"` case. It affects only `WDA_BASE_URL`. This is necessary to listen WDA on Apple TV 4K (wireless) for example.

I could send basic commands to the WDA after below session creation command.

```
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[WD Proxy] Got an unexpected response: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"192.168.1.100","port":8100}
[debug] [WD Proxy] Matched '/status' to command name 'getStatus'
[debug] [WD Proxy] Proxying [GET /status] to [GET http://192.168.1.100:8100/status] with no body
[debug] [WD Proxy] Got response with status 200: "{\n  \"value\" : {\n    \"state\" : \"success\",\n    \"os\" : {\n      \"name\" : \"iOS\",\n      \"version\" : \"12.2\",\n      \"sdkVersion\" : \"12.2\"\n    },\n    \"ios\" : {\n      \"simulatorVersion\" : \"12.2\",\n      \"ip\" : \"192.168.1.100\"\n    },\n    \"build\" : {\n      \"upgradedAt\" : \"1555897340892\",\n      \"time\" : \"Apr 23 2019 21:24:48\",\n      \"productBundleIdentifier\" : \"com.kazucocoa.WebDriverAgentRunner\"\n    }\n  },\n  \"sessionId\" : \"04FA6DBB-B042-47C4-8CCE-50B07250CFAB\",\n  \"status\" : 0\n}"
[debug] [WD Proxy] Determined that the downstream protocol for proxy is MJSONWP
[debug] [XCUITest] WebDriverAgent information:
[debug] [XCUITest] {
[debug] [XCUITest]   "state": "success",
[debug] [XCUITest]   "os": {
[debug] [XCUITest]     "name": "iOS",
[debug] [XCUITest]     "version": "12.2",
[debug] [XCUITest]     "sdkVersion": "12.2"
[debug] [XCUITest]   },
[debug] [XCUITest]   "ios": {
[debug] [XCUITest]     "simulatorVersion": "12.2",
[debug] [XCUITest]     "ip": "192.168.1.100"
[debug] [XCUITest]   },
[debug] [XCUITest]   "build": {
[debug] [XCUITest]     "upgradedAt": "1555897340892",
[debug] [XCUITest]     "time": "Apr 23 2019 21:24:48",
[debug] [XCUITest]     "productBundleIdentifier": "com.kazucocoa.WebDriverAgentRunner"
[debug] [XCUITest]   }
[debug] [XCUITest] }
[debug] [XCUITest] WebDriverAgent successfully started after 46304ms
[debug] [BaseDriver] Event 'wdaSessionAttempted' logged at 1556022325188 (21:25:25 GMT+0900 (Japan Standard Time))
[debug] [XCUITest] Sending createSession command to WDA
[debug] [WD Proxy] Matched '/session' to command name 'createSession'
[debug] [WD Proxy] Proxying [POST /session] to [POST http://192.168.1.100:8100/session] with body: {"desiredCapabilities":{"bundleId":"com.kazucocoa.apple-samplecode.UICatalog","arguments":[],"environment":{},"eventloopIdleDelaySec":0,"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":60,"shouldUseSingletonTestManager":true}}
[debug] [WD Proxy] Got response with status 200: {"value":{"sessionId":"07EB9F99-BA8D-4489-A6D4-B024F543136F","capabilities":{"device":"iphone","browserName":"UICatalog","sdkVersion":"12.2","CFBundleIdentifier":"com.kazucocoa.apple-samplecode.UICatalog"}},"sessionId":"07EB9F99-BA8D-4489-A6D4-B024F543136F","status":0}
```

cc @dpgraham 
this is the last PR I would like to include this as a part of tvOS stuff.