### PR TITLE
Do not retrieve xcode command line tools version

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -276,9 +276,6 @@ class XCUITestDriver extends BaseDriver {
     if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
-      const tools = !this.xcodeVersion.toolsVersion ? '' : `(tools v${this.xcodeVersion.toolsVersion})`;
-      log.info(`Xcode version set to '${this.xcodeVersion.versionString}' ${tools}`);
-
       this.iosSdkVersion = await getAndCheckIosSdkVersion();
       this.opts.iosSdkVersion = this.iosSdkVersion; // Pass to xcodebuild
       log.info(`iOS SDK Version set to '${this.opts.iosSdkVersion}'`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,12 +53,6 @@ async function getAndCheckXcodeVersion () {
     log.errorAndThrow(`Could not determine Xcode version: ${err.message}`);
   }
 
-  if (!version.toolsVersion) {
-    try {
-      version.toolsVersion = await xcode.getCommandLineToolsVersion();
-    } catch (ign) {}
-  }
-
   // we do not support Xcodes < 7.3,
   if (version.versionFloat < 7.3) {
     log.errorAndThrow(`Xcode version '${version.versionString}'. Support for ` +


### PR DESCRIPTION
It turns out we only needed to get CLT version for logging purposes and the variable was not used anywhere else, so I removed it for good