### PR TITLE
Only native tap if there is one matching element

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -145,10 +145,20 @@ async function tapWebElementNatively (driver, atomsElement) {
 
     if (text) {
       const els = await driver.findNativeElementOrElements('accessibility id', text, true);
-      if (els.length === 1) {
+      if (els.length === 1 || els.length === 2) {
         const el = els[0];
         // use tap because on iOS 11.2 and below `nativeClick` crashes WDA
         const rect = await driver.proxyCommand(`/element/${el.ELEMENT}/rect`, 'GET');
+        if (els.length === 2) {
+          const el2 = els[1];
+          const rect2 = await driver.proxyCommand(`/element/${el2.ELEMENT}/rect`, 'GET');
+
+          if ((rect.x !== rect2.x || rect.y !== rect2.y) ||
+          (rect.width !== rect2.width || rect.height !== rect2.height)) {
+            // These 2 native elements are not referring to the same web element
+            return false;
+          }
+        }
         const coords = {
           x: Math.round(rect.x + rect.width / 2),
           y: Math.round(rect.y + rect.height / 2),

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -160,15 +160,18 @@ async function tapWebElementNatively (driver, atomsElement) {
     }
 
     if (text) {
-      const el = await driver.findNativeElementOrElements('accessibility id', text, false);
-      // use tap because on iOS 11.2 and below `nativeClick` crashes WDA
-      const rect = await driver.proxyCommand(`/element/${el.ELEMENT}/rect`, 'GET');
-      const coords = {
-        x: Math.round(rect.x + rect.width / 2),
-        y: Math.round(rect.y + rect.height / 2),
-      };
-      await driver.clickCoords(coords);
-      return true;
+      const els = await driver.findNativeElementOrElements('accessibility id', text, true);
+      if (els.length === 1) {
+        const el = els[0];
+        // use tap because on iOS 11.2 and below `nativeClick` crashes WDA
+        const rect = await driver.proxyCommand(`/element/${el.ELEMENT}/rect`, 'GET');
+        const coords = {
+          x: Math.round(rect.x + rect.width / 2),
+          y: Math.round(rect.y + rect.height / 2),
+        };
+        await driver.clickCoords(coords);
+        return true;
+      }
     }
   } catch (err) {
     // any failure should fall through and trigger the more elaborate

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -5,17 +5,13 @@ import log from '../logger';
 import _ from 'lodash';
 import B from 'bluebird';
 
-
-const IPHONE_EXTRA_WEB_COORD_SCROLL_OFFSET = -15;
-const IPHONE_EXTRA_WEB_COORD_NON_SCROLL_OFFSET = 10;
-const IPHONE_WEB_COORD_OFFSET = -10;
+const IPHONE_TOP_BAR_HEIGHT = 71;
+const IPHONE_SCROLLED_TOP_BAR_HEIGHT = 41;
+const IPHONE_X_NOTCH_OFFSET = 24;
+const IPHONE_LANDSCAPE_TOP_BAR_HEIGHT = 51;
+const IPHONE_BOTTOM_BAR_OFFSET = 49;
+const TAB_BAR_OFFSET = 33;
 const IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET = 84;
-const IPHONE_X_EXTRA_WEB_COORD_SCROLL_OFFSET = -90;
-const IPHONE_X_EXTRA_WEB_COORD_NON_SCROLL_OFFSET = -10;
-const IPHONE_X_WEB_COORD_OFFSET = 40;
-const IPAD_EXTRA_WEB_COORD_SCROLL_OFFSET = -10;
-const IPAD_EXTRA_WEB_COORD_NON_SCROLL_OFFSET = 0;
-const IPAD_WEB_COORD_OFFSET = 10;
 const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
 const IPHONE_X_WIDTH = 375;
@@ -29,7 +25,7 @@ Object.assign(extensions, iosCommands.web);
 
 
 
-extensions.getSafariIsIphone = async function getSafariIsIphone () {
+extensions.getSafariIsIphone = _.memoize(async function getSafariIsIphone () {
   try {
     const userAgent = await this.execute('return navigator.userAgent');
     return userAgent.toLowerCase().includes('iphone');
@@ -38,9 +34,9 @@ extensions.getSafariIsIphone = async function getSafariIsIphone () {
     log.debug(`Error: ${err.message}`);
   }
   return true;
-};
+});
 
-extensions.getSafariIsIphoneX = async function getSafariIsIphone () {
+extensions.getSafariIsIphoneX = _.memoize(async function getSafariIsIphone () {
   try {
     const script = 'return {height: window.screen.availHeight, width: window.screen.availWidth};';
     const {height, width} = await this.execute(script);
@@ -48,25 +44,23 @@ extensions.getSafariIsIphoneX = async function getSafariIsIphone () {
     return (height === IPHONE_X_HEIGHT && width === IPHONE_X_WIDTH) ||
            (height === IPHONE_X_WIDTH && width === IPHONE_X_HEIGHT);
   } catch (err) {
-    log.warn(`Unable to find device type from useragent. Assuming not iPhone X`);
+    log.warn(`Unable to find device type from dimensions. Assuming not iPhone X`);
     log.debug(`Error: ${err.message}`);
   }
   return false;
-};
-
-const getElementHeightMemoized = _.memoize(async function getElementHeightMemoized (key, driver, el) {
-  el = util.unwrapElement(el);
-  return (await driver.getNativeRect(el)).height;
 });
 
-extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWebCoordsOffset (coords, webviewRect) {
-  let offset = 0;
+extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWebCoordsOffset (wvPos, realDims) {
+  let topOffset = 0;
+  let bottomOffset = 0;
 
   // keep track of implicit wait, and set locally to 0
   const implicitWaitMs = this.implicitWaitMs;
 
   const isIphone = await this.getSafariIsIphone();
   const isIphoneX = isIphone && await this.getSafariIsIphoneX();
+
+  const orientation = realDims.h > realDims.w ? 'PORTRAIT' : 'LANDSCAPE';
 
   try {
     this.setImplicitWait(0);
@@ -75,45 +69,43 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
     await this.findNativeElementOrElements('accessibility id', 'ReloadButton', false);
 
     // reload button found, which means scrolling has not happened
-    if (isIphoneX) {
-      offset += IPHONE_X_EXTRA_WEB_COORD_NON_SCROLL_OFFSET;
-    } else if (isIphone) {
-      offset += IPHONE_EXTRA_WEB_COORD_NON_SCROLL_OFFSET;
-    } else {
-      offset += IPAD_EXTRA_WEB_COORD_NON_SCROLL_OFFSET;
+    topOffset = IPHONE_TOP_BAR_HEIGHT + (isIphoneX ? IPHONE_X_NOTCH_OFFSET : 0);
+    if (isIphone) {
+      if (orientation === 'PORTRAIT') {
+        // The bottom bar is only visible when portrait
+        bottomOffset = IPHONE_BOTTOM_BAR_OFFSET;
+      } else {
+        topOffset = IPHONE_LANDSCAPE_TOP_BAR_HEIGHT;
+      }
     }
+    if (orientation === 'LANDSCAPE' || !isIphone) {
+      // Tabs only appear if the device is landscape or if it's an iPad so we only check visibility in this case
+      try {
+        await this.findNativeElementOrElements('-ios predicate string', `name LIKE '*, Tab' AND visible = 1`, false);
+        topOffset += TAB_BAR_OFFSET;
+      } catch (ign) {
+        // no element found, so no tabs and no need to deal with offset
+      }
+    }
+
   } catch (err) {
     // no reload button, which indicates scrolling has happened
-    // the URL bar may or may not be visible
-    try {
-      const el = await this.findNativeElementOrElements('accessibility id', 'URL', false);
-      offset -= await getElementHeightMemoized('URLBar', this, el);
-    } catch (ign) {
-      // no URL elements found, so continue
+    topOffset = IPHONE_SCROLLED_TOP_BAR_HEIGHT + (isIphoneX ? IPHONE_X_NOTCH_OFFSET : 0);
+
+    // If the iPhone is landscape then there is not top bar
+    if (orientation === 'LANDSCAPE' && isIphone) {
+      topOffset = 0;
     }
+
   } finally {
     // return implicit wait to what it was
     this.setImplicitWait(implicitWaitMs);
   }
 
-  if (coords.y > webviewRect.height) {
-    // when scrolling has happened, there is a tick more offset needed
-    if (isIphoneX) {
-      offset += IPHONE_X_EXTRA_WEB_COORD_SCROLL_OFFSET;
-    } else if (isIphone) {
-      offset += IPHONE_EXTRA_WEB_COORD_SCROLL_OFFSET;
-    } else {
-      offset += IPAD_EXTRA_WEB_COORD_SCROLL_OFFSET;
-    }
-  }
+  topOffset += await this.getExtraNativeWebTapOffset();
 
-  // extra offset necessary
-  offset += isIphone ? IPHONE_WEB_COORD_OFFSET : IPAD_WEB_COORD_OFFSET;
-
-  offset += isIphoneX ? IPHONE_X_WEB_COORD_OFFSET : 0;
-
-  log.debug(`Extra translated web coordinates offset: ${offset}`);
-  return offset;
+  wvPos.y += topOffset;
+  realDims.h -= (topOffset + bottomOffset);
 };
 
 extensions.getExtraNativeWebTapOffset = async function getExtraNativeWebTapOffset () {
@@ -124,15 +116,7 @@ extensions.getExtraNativeWebTapOffset = async function getExtraNativeWebTapOffse
   try {
     this.setImplicitWait(0);
 
-    // first try to get tab offset
-    try {
-      const el = await this.findNativeElementOrElements('-ios predicate string', `name LIKE '*, Tab' AND visible = 1`, false);
-      offset += await getElementHeightMemoized('TabBar', this, el);
-    } catch (ign) {
-      // no element found, so no tabs and no need to deal with offset
-    }
-
-    // next try to see if there is an Smart App Banner
+    // try to see if there is an Smart App Banner
     try {
       await this.findNativeElementOrElements('accessibility id', 'Close app download offer', false);
       offset += await this.getSafariIsIphone() ?
@@ -235,26 +219,14 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   const cmd = '(function () { return {w: document.documentElement.clientWidth, h: document.documentElement.clientHeight}; })()';
   const wvDims = await this.remote.execute(cmd);
 
-  // TODO: investigate where these come from. They appear to be constants in my tests
-  const urlBarHeight = 64;
-  wvPos.y += urlBarHeight;
-
-  const realDimensionHeight = 108;
-  realDims.h -= realDimensionHeight;
-
-  // add static offset for safari in landscape mode
-  let yOffset = this.opts.curOrientation === 'LANDSCAPE' ? this.landscapeWebCoordsOffset : 0;
-
-  // add extra offset for possible extra things in the top of the page
-  yOffset += await this.getExtraNativeWebTapOffset();
-  coords.y += await this.getExtraTranslateWebCoordsOffset(coords, rect);
+  await this.getExtraTranslateWebCoordsOffset(wvPos, realDims);
 
   if (wvDims && realDims && wvPos) {
     let xRatio = realDims.w / wvDims.w;
     let yRatio = realDims.h / wvDims.h;
     let newCoords = {
       x: wvPos.x + Math.round(xRatio * coords.x),
-      y: wvPos.y + yOffset + Math.round(yRatio * coords.y),
+      y: wvPos.y + Math.round(yRatio * coords.y),
     };
 
     // additional logging for coordinates, since it is sometimes broken
@@ -266,7 +238,6 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
     log.debug(`    wvDims: ${JSON.stringify(wvDims)}`);
     log.debug(`    xRatio: ${JSON.stringify(xRatio)}`);
     log.debug(`    yRatio: ${JSON.stringify(yRatio)}`);
-    log.debug(`    yOffset: ${JSON.stringify(yOffset)}`);
 
     log.debug(`Converted web coords ${JSON.stringify(coords)} ` +
               `into real coords ${JSON.stringify(newCoords)}`);

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -226,7 +226,7 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   const wvPos = {x: rect.x, y: rect.y};
   const realDims = {w: rect.width, h: rect.height};
 
-  const cmd = '(function () { return {w: document.documentElement.clientWidth, h: document.documentElement.clientHeight}; })()';
+  const cmd = '(function () { return {w: window.innerWidth, h: window.innerHeight}; })()';
   const wvDims = await this.remote.execute(cmd);
 
   await this.getExtraTranslateWebCoordsOffset(wvPos, realDims);


### PR DESCRIPTION
When trying to native web tap on an an element with the same text as another it will always try to select the first element regardless of visibility.

Here's a quick example webpage:
```
<html>
  <body>
    <div>
      <button style="position: absolute;">larger</button>
      <a>link</a>
    </div>
    <a href="about:blank">link</a>
  </body>
</html>
```
This page has 2 identical links (the href can be omitted) but `tapWebElementNatively()` will first try to match the text and search for an accessibility id with that text. The problem is that the first link, which is hidden by the button, isn't the one we want to tap on yet it is the one returned by the driver.

Here is the response of:
```
const el = await driver.findNativeElementOrElements('accessibility id', text, false);
```
```
[WD Proxy] Proxying [POST /element] to [POST http://localhost:4823/session/8CCB0F0E-74B4-42FB-BCA4-92B2B90CDD01/element] with body: {"using":"accessibility id","value":"link"}
[debug] [WD Proxy] Got response with status 200: {"value":{"ELEMENT":"0D000000-0000-0000-0DE4-000000000000"},"sessionId":"8CCB0F0E-74B4-42FB-BCA4-92B2B90CDD01","status":0}
```
Only one result is being returned here which seems to be because we send a request to get an element rather than getting all elements validating that there is only one element and selecting that if it applies.

Sending a curl request proves this:
```
erustus@ea:~ 130 $ curl -d '{"using":"accessibility id","value":"link"}' -H "Content-Type: application/json" -X POST goof.scivisum.co.uk:4723/wd/hub/session/9d71abda-7161-4c8e-911a-6dc998fc25d7/elements
{"status":0,"value":[{"element-6066-11e4-a52e-4f735466cecf":"1D000000-0000-0000-CB01-010000000000","ELEMENT":"1D000000-0000-0000-CB01-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"1E000000-0000-0000-CB01-010000000000","ELEMENT":"1E000000-0000-0000-CB01-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"1F000000-0000-0000-CB01-010000000000","ELEMENT":"1F000000-0000-0000-CB01-010000000000"}],"sessionId":"9d71abda-7161-4c8e-911a-6dc998fc25d7"}
```

My change enforces that we only use that element if it is truly unique.