### PR TITLE
Enforce Simulator shutdown if resetOnSessionStartOnly is set to false

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -628,7 +628,9 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this.opts.resetOnSessionStartOnly === false) {
-      await this.runReset();
+      await this.runReset(Object.assign({}, this.opts, {
+        enforceSimulatorShutdown: true,
+      }));
     }
 
     if (this.isSimulator() && !this.opts.noReset && !!this.opts.device) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -104,14 +104,14 @@ async function runSimulatorReset (device, opts) {
     // Terminate the app under test if it is still running on Simulator
     // Termination is not needed if Simulator is not running
     if (await device.isRunning()) {
-      if (device.xcodeVersion.major >= 8 && !opts.enforceSimulatorShutdown) {
+      if (opts.enforceSimulatorShutdown) {
+        await shutdownSimulator(device);
+      } else {
         try {
           await terminate(device.udid, opts.bundleId);
         } catch (err) {
           log.warn(`Reset: failed to terminate Simulator application with id "${opts.bundleId}"`);
         }
-      } else {
-        await shutdownSimulator(device);
       }
     }
     if (opts.app) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -104,7 +104,7 @@ async function runSimulatorReset (device, opts) {
     // Terminate the app under test if it is still running on Simulator
     // Termination is not needed if Simulator is not running
     if (await device.isRunning()) {
-      if (device.xcodeVersion.major >= 8) {
+      if (device.xcodeVersion.major >= 8 && !opts.enforceSimulatorShutdown) {
         try {
           await terminate(device.udid, opts.bundleId);
         } catch (err) {


### PR DESCRIPTION
It makes sense to shutdown simulator completely (along with xcodebuild) instead of just terminating the app under test if one wants reset on session deletion.