### PR TITLE
Override getLatestWebviewContextForTitle

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -104,5 +104,18 @@ extensions.mobileGetContexts = async function mobileGetContexts () {
   }
 };
 
+// override so that the case where the SDK version is not set does not fail
+extensions.getLatestWebviewContextForTitle = async function getLatestWebviewContextForTitle (regExp) {
+  const contexts = await this.getContextsAndViews();
+  let matchingCtx;
+  for (const ctx of contexts) {
+    if (ctx.view && ((ctx.view.title && ctx.view.title.match(regExp)) || (ctx.view.url && ctx.view.url.match(regExp)))) {
+      matchingCtx = ctx;
+      break;
+    }
+  }
+  return matchingCtx ? matchingCtx.id : undefined;
+};
+
 
 export default extensions;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -309,7 +309,10 @@ class XCUITestDriver extends BaseDriver {
           ? 'http://appium.io'
           : `http://${this.opts.address}:${this.opts.port}/welcome`
       );
-      this.opts.processArguments.args = ['-u', this._currentUrl];
+      if (util.compareVersions(this.opts.platformVersion, '<', '12.2')) {
+        // this option does not work on 12.2 and above
+        this.opts.processArguments.args = ['-u', this._currentUrl];
+      }
     } else {
       await this.configureApp();
     }


### PR DESCRIPTION
Override `appium-ios-driver`'s `getLatestWebviewContextForTitle` function, to remove the various conditions. This makes it possible to find Safari contexts when `webDriverAgentUrl` is set, in which case there is no iOS SDK version set.

Diff, when compared to `appium-ios-driver` version:
```diff
extensions.getLatestWebviewContextForTitle = async function getLatestWebviewContextForTitle (regExp) {
-  let contexts = await this.getContextsAndViews();
+  const contexts = await this.getContextsAndViews();
   let matchingCtx;
-  for (let ctx of contexts) {
+  for (const ctx of contexts) {
     if (ctx.view && ((ctx.view.title && ctx.view.title.match(regExp)) || (ctx.view.url && ctx.view.url.match(regExp)))) {
-      if (ctx.view.url !== 'about:blank') {
-        matchingCtx = ctx;
-      } else {
-        // in the cases of Xcode < 5 (i.e., iOS SDK Version less than 7)
-        // iOS 7.1, iOS 9.0 & iOS 9.1 in a webview (not in Safari)
-        // we can have the url be `about:blank`
-        if (parseFloat(this.iosSdkVersion) < 7 || parseFloat(this.iosSdkVersion) >= 9 ||
-            (this.opts.platformVersion === '7.1' && this.opts.app && this.opts.app.toLowerCase() !== 'safari')) {
-          matchingCtx = ctx;
-        }
-      }
+      matchingCtx = ctx;
       break;
     }
   }
```