### PR TITLE
Make platformVersion a required capability

### DIFF
--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -46,7 +46,6 @@ commands.closeWindow = async function closeWindow () {
     throw new errors.NotImplementedError();
   }
   let script = "return window.open('','_self').close();";
-  // TODO: platformVersion should be a required capability
   if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
     // on 12.2 the whole message is evaluated in the context of the page,
     // which is closed and so never returns

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -289,7 +289,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
-      throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
+      throw new Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
     }
 
     if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -18,13 +18,15 @@ import {
   checkAppPresent, getDriverInfo,
   clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
   DEFAULT_TIMEOUT_KEY, markSystemFilesForCleanup,
-  printUser, removeAllSessionWebSocketHandlers, verifyApplicationPlatform, isTvOS } from './utils';
+  printUser, removeAllSessionWebSocketHandlers, verifyApplicationPlatform, isTvOS,
+  normalizePlatformVersion } from './utils';
 import {
   getConnectedDevices, runRealDeviceReset, installToRealDevice,
   getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import path from 'path';
+import { exec } from 'child_process';
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
@@ -261,17 +263,34 @@ class XCUITestDriver extends BaseDriver {
 
     await printUser();
 
-    // TODO: platformVersion should be a required capability
-    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
-      throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
-    }
-
     const {device, udid, realDevice} = await this.determineDevice();
     log.info(`Determining device to run tests on: udid: '${udid}', real device: ${realDevice}`);
     this.opts.device = device;
     this.opts.udid = udid;
     this.opts.realDevice = realDevice;
     this.opts.iosSdkVersion = null; // For WDA and xcodebuild
+
+    if (_.isEmpty(this.opts.platformVersion) && realDevice) {
+      log.info('Trying to determine platformVersion from ideviceinfo output');
+      try {
+        const {stdout} = await exec('ideviceinfo', [
+          '-s', '-k', 'ProductVersion'
+        ]);
+        this.opts.platformVersion = util.coerceVersion(stdout.trim(), false);
+      } catch (e) {
+        log.warn(`Cannot retrieve real device platform version from ideviceinfo output. Original error: ${e.message}`);
+      }
+    }
+
+    const normalizedVersion = normalizePlatformVersion(this.opts.platformVersion);
+    if (this.opts.platformVersion !== normalizedVersion) {
+      log.info(`Normalized platformVersion capability value '${this.opts.platformVersion}' to '${normalizedVersion}'`);
+      this.opts.platformVersion = normalizedVersion;
+    }
+
+    if (util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
+      throw Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
+    }
 
     if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
@@ -423,7 +442,6 @@ class XCUITestDriver extends BaseDriver {
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
 
-    // TODO: platformVersion should be a required cap
     // real devices will be handled later, after the web context has been initialized
     if (this.isSafari() && !this.isRealDevice() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
       // on 12.2 the page is not opened in WDA
@@ -445,7 +463,6 @@ class XCUITestDriver extends BaseDriver {
       this.logEvent('initialWebviewNavigated');
     }
 
-    // TODO: platformVersion should be a required cap
     if (this.isSafari() && this.isRealDevice() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
       // on 12.2 the page is not opened in WDA
       await this.setUrl(this._currentUrl);
@@ -765,8 +782,8 @@ class XCUITestDriver extends BaseDriver {
 
     if (!this.opts.platformVersion && this.iosSdkVersion) {
       log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
-               `This may cause problems if a simulator does not exist for this platform version.`);
-      this.opts.platformVersion = this.iosSdkVersion;
+        `This may cause problems if a simulator does not exist for this platform version.`);
+      this.opts.platformVersion = normalizePlatformVersion(this.iosSdkVersion);
     }
 
     if (this.opts.enforceFreshSimulatorCreation) {
@@ -873,8 +890,7 @@ class XCUITestDriver extends BaseDriver {
     if (util.hasValue(this.opts.simpleIsVisibleCheck)) {
       shouldUseTestManagerForVisibilityDetection = this.opts.simpleIsVisibleCheck;
     }
-    // TODO: platformVersion should be a required capability
-    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '==', '9.3')) {
+    if (util.compareVersions(this.opts.platformVersion, '==', '9.3')) {
       log.info(`Forcing shouldUseSingletonTestManager capability value to true, because of known XCTest issues under 9.3 platform version`);
       shouldUseTestManagerForVisibilityDetection = true;
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -273,7 +273,9 @@ class XCUITestDriver extends BaseDriver {
       log.info('Trying to determine platformVersion from ideviceinfo output');
       try {
         const {stdout} = await exec('ideviceinfo', [
-          '-s', '-k', 'ProductVersion'
+          '-u', udid,
+          '-s',
+          '-k', 'ProductVersion',
         ]);
         this.opts.platformVersion = util.coerceVersion(stdout.trim(), false);
       } catch (e) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -174,7 +174,6 @@ class XCUITestDriver extends BaseDriver {
     this._currentUrl = null;
     this.curContext = null;
     this.xcodeVersion = {};
-    this.iosSdkVersion = null;
     this.contexts = [];
     this.implicitWaitMs = 0;
     this.asynclibWaitMs = 0;
@@ -295,9 +294,6 @@ class XCUITestDriver extends BaseDriver {
     if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
-      this.iosSdkVersion = await getAndCheckIosSdkVersion();
-      this.opts.iosSdkVersion = this.iosSdkVersion; // Pass to xcodebuild
-      log.info(`iOS SDK Version set to '${this.opts.iosSdkVersion}'`);
     }
     this.logEvent('xcodeDetailsRetrieved');
 
@@ -745,6 +741,16 @@ class XCUITestDriver extends BaseDriver {
     // if we get generic names, translate them
     this.opts.deviceName = translateDeviceName(this.opts.platformVersion, this.opts.deviceName);
 
+    const setupVersionCaps = async () => {
+      this.opts.iosSdkVersion = await getAndCheckIosSdkVersion();
+      log.info(`iOS SDK Version set to '${this.opts.iosSdkVersion}'`);
+      if (!this.opts.platformVersion && this.opts.iosSdkVersion) {
+        log.info(`No platformVersion specified. Using the latest version Xcode supports: '${this.opts.iosSdkVersion}'. ` +
+          `This may cause problems if a simulator does not exist for this platform version.`);
+        this.opts.platformVersion = normalizePlatformVersion(this.opts.iosSdkVersion);
+      }
+    };
+
     if (this.opts.udid) {
       if (this.opts.udid.toLowerCase() === 'auto') {
         try {
@@ -757,8 +763,15 @@ class XCUITestDriver extends BaseDriver {
             // No matching Simulator is found. Throw an error
             log.errorAndThrow(`Cannot detect udid for ${this.opts.deviceName} Simulator running iOS ${this.opts.platformVersion}`);
           }
+
           // Matching Simulator exists and is found. Use it
           this.opts.udid = device.udid;
+          const devicePlatform = normalizePlatformVersion(await device.getPlatformVersion());
+          if (this.opts.platformVersion !== devicePlatform) {
+            this.opts.platformVersion = devicePlatform;
+            log.info(`Set platformVersion to '${devicePlatform}' to match the device with given UDID`);
+          }
+          await setupVersionCaps();
           return {device, realDevice: false, udid: device.udid};
         }
       } else {
@@ -780,12 +793,8 @@ class XCUITestDriver extends BaseDriver {
       return {device, realDevice: true, udid: this.opts.udid};
     }
 
-    if (!this.opts.platformVersion && this.iosSdkVersion) {
-      log.info(`No platformVersion specified. Using latest version Xcode supports: '${this.iosSdkVersion}' ` +
-        `This may cause problems if a simulator does not exist for this platform version.`);
-      this.opts.platformVersion = normalizePlatformVersion(this.iosSdkVersion);
-    }
-
+    // Now we know for sure the device will be a Simulator
+    await setupVersionCaps();
     if (this.opts.enforceFreshSimulatorCreation) {
       log.debug(`New simulator is requested. If this is not wanted, set 'enforceFreshSimulatorCreation' capability to false`);
     } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -280,13 +280,11 @@ class XCUITestDriver extends BaseDriver {
         log.warn(`Cannot retrieve real device platform version from ideviceinfo output. Original error: ${e.message}`);
       }
     }
-
     const normalizedVersion = normalizePlatformVersion(this.opts.platformVersion);
     if (this.opts.platformVersion !== normalizedVersion) {
       log.info(`Normalized platformVersion capability value '${this.opts.platformVersion}' to '${normalizedVersion}'`);
       this.opts.platformVersion = normalizedVersion;
     }
-
     if (util.compareVersions(this.opts.platformVersion, '<', '9.3')) {
       throw new Error(`Platform version must be 9.3 or above. '${this.opts.platformVersion}' is not supported.`);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,7 @@ import _fs from 'fs';
 import url from 'url';
 import v8 from 'v8';
 import { PLATFORM_NAME_TVOS } from './desired-caps';
+import semver from 'semver';
 
 const DEFAULT_TIMEOUT_KEY = 'default';
 
@@ -469,10 +470,26 @@ function isLocalHost (urlString) {
   return false;
 }
 
+/**
+ * Normalizes platformVersion to a valid iOS version string
+ *
+ * @param {string} originalVersion - Loose version number, that can be parsed by semver
+ * @return {string} iOS version number in <major>.<minor> format
+ * @throws {Error} if the version number cannot be parsed
+ */
+function normalizePlatformVersion (originalVersion) {
+  const normalizedVersion = util.coerceVersion(originalVersion, false);
+  if (!normalizedVersion) {
+    throw new Error(`The platform version '${originalVersion}' should be a valid version number`);
+  }
+  const {major, minor} = new semver.SemVer(normalizedVersion);
+  return `${major}.${minor}`;
+}
+
 export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
   checkAppPresent, getDriverInfo,
   clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
   DEFAULT_TIMEOUT_KEY, resetXCTestProcesses, getPidUsingPattern,
   markSystemFilesForCleanup, printUser, printLibimobiledeviceInfo,
   getPIDsListeningOnPort, encodeBase64OrUpload, removeAllSessionWebSocketHandlers,
-  verifyApplicationPlatform, isTvOS, isLocalHost };
+  verifyApplicationPlatform, isTvOS, isLocalHost, normalizePlatformVersion };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,13 +64,11 @@ async function getAndCheckXcodeVersion () {
 }
 
 async function getAndCheckIosSdkVersion () {
-  let versionNumber;
   try {
-    versionNumber = await xcode.getMaxIOSSDK();
+    return await xcode.getMaxIOSSDK();
   } catch (err) {
     log.errorAndThrow(`Could not determine iOS SDK version: ${err.message}`);
   }
-  return versionNumber;
 }
 
 function translateDeviceName (platformVersion, devName = '') {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "portscanner": "2.2.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
+    "semver": "^5.6.0",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.14.0",
     "uuid-js": "^0.7.5",


### PR DESCRIPTION
If the `platformVersion` is not provided in caps then we will try to determine its value by querying ideviceinfo output for real devices and using the latest available SDK for simulators. In case these fail or an incorrect (e .g. semver-unparseable) version string has been provided then an exception is thrown. Also, the calculated or provided value is normalised to only include the major and minor number and ignore the patch number.

@umutuzgur FYI