### PR TITLE
Setting WebDriverAgent connections to remain alive

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -258,6 +258,7 @@ class WebDriverAgent {
       port: this.url.port,
       base: '',
       timeout: this.wdaConnectionTimeout,
+      keepAlive: true,
     };
 
     this.jwproxy = new JWProxy(proxyOpts);


### PR DESCRIPTION
Setting WebDriverAgent connections to remain alive as long as they are being used