### PR TITLE
Remove visibility check from webview.

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -215,7 +215,7 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   try {
     this.setImplicitWait(0);
     webview = await retryInterval(5, 100, async () => {
-      return await this.findNativeElementOrElements('class-name', 'XCUIElementTypeWebView', false);
+      return await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false);
     });
   } finally {
     this.setImplicitWait(implicitWaitMs);

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -215,7 +215,7 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   try {
     this.setImplicitWait(0);
     webview = await retryInterval(5, 100, async () => {
-      return await this.findNativeElementOrElements('-ios predicate string', `type = 'XCUIElementTypeWebView' AND visible = 1`, false);
+      return await this.findNativeElementOrElements('-ios predicate string', `type = 'XCUIElementTypeWebView'`, false);
     });
   } finally {
     this.setImplicitWait(implicitWaitMs);

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -215,7 +215,7 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   try {
     this.setImplicitWait(0);
     webview = await retryInterval(5, 100, async () => {
-      return await this.findNativeElementOrElements('-ios predicate string', `type = 'XCUIElementTypeWebView'`, false);
+      return await this.findNativeElementOrElements('class-name', 'XCUIElementTypeWebView', false);
     });
   } finally {
     this.setImplicitWait(implicitWaitMs);


### PR DESCRIPTION
We only get the webview if it exists and it's visible but in some cases the webview will not be determined visible by the driver. As seen here I try to locate the webview with both strategies but only the one where I don't specify if it is visible actually returns an element.
```
[debug] [WD Proxy] Proxying [POST /element] to [POST http://localhost:4823/session/D16313A4-7D07-449D-904F-EF563AA85853/element] with body: {"using":"predicate string","value":"type = 'XCUIElementTypeWebView'"}
[debug] [WD Proxy] Got response with status 200: {"value":{"ELEMENT":"26000000-0000-0000-0C3B-000000000000"},"sessionId":"D16313A4-7D07-449D-904F-EF563AA85853","status":0}
[debug] [BaseDriver] Waiting up to 0 ms for condition
[debug] [WD Proxy] Matched '/element' to command name 'findElement'
[debug] [WD Proxy] Proxying [POST /element] to [POST http://localhost:4823/session/D16313A4-7D07-449D-904F-EF563AA85853/element] with body: {"using":"predicate string","value":"type = 'XCUIElementTypeWebView' AND visible = 1"}
[debug] [WD Proxy] Got response with status 200: {"value":{"using":"predicate string","value":"type = 'XCUIElementTypeWebView' AND visible = 1","description":"unable to find an element"},"sessionId":"D16313A4-7D07-449D-904F-EF563AA85853","status":7}
[WD Proxy] Got an unexpected response: {"value":{"using":"predicate string","value":"type = 'XCUIElementTypeWebView' AND visible = 1","description":"unable to find an element"},"sessionId":"D16313A4-7D07-449D-904F-EF563AA85853","status":7}
[debug] [MJSONWP] Matched JSONWP error code 7 to NoSuchElementError
```
I don't think it's necessary to check whether the webview is visible or not because if it is present then we can get the dimensions from it which is all we're using it for in this case.

As for why it isn't deemed visible the webview is the root node of the webpage so it should always be visible, this seems like a bug in how the driver determines whether elements are visible or not.