### PR TITLE
Changed default Install button to only select the visible one

### DIFF
--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -351,7 +351,7 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
 
     return (await fs.readFile(configPath)).toString('base64');
   } finally {
-    await tmpServer.stop();
+    await tmpServer.close();
     await fs.rimraf(tmpRoot);
   }
 };

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -37,8 +37,8 @@ const Settings = {
 };
 const Button = {
   Install: {
-    type: '-ios predicate string',
-    value: `type = 'XCUIElementTypeButton' AND visible = 1 AND label = 'Install'`,
+    type: 'accessibility id',
+    value: 'Install',
   },
   Allow: {
     type: 'accessibility id',
@@ -51,6 +51,12 @@ const Button = {
   Return_to_Settings: {
     type: 'accessibility id',
     value: 'Return to Settings',
+  },
+};
+const Alert = {
+  Install: {
+    type: '-ios class chain',
+    value: '**/XCUIElementTypeAny[`type == \'XCUIElementTypeAlert\' OR type == \'XCUIElementTypeSheet\'`]/**/XCUIElementTypeButton[`label == \'Install\'`]',
   },
 };
 
@@ -151,8 +157,8 @@ async function installPre122Certificate (driver) {
   // The second one confirms the previous
   await B.delay(1500);
   await clickElement(driver, Button.Install);
-  // Accept sheet/alert
-  await clickElement(driver, Button.Install);
+  // Accept alert
+  await clickElement(driver, Alert.Install);
   // Finish adding certificate
   await clickElement(driver, Button.Done);
   return true;
@@ -233,8 +239,8 @@ async function installPost122Certificate (driver, name) {
   await B.delay(1500);
   // Confirm untrusted cert install
   await clickElement(driver, Button.Install);
-  // Accept sheet/alert
-  await clickElement(driver, Button.Install);
+  // Accept alert
+  await clickElement(driver, Alert.Install);
   // Finish adding certificate
   await clickElement(driver, Button.Done);
 
@@ -274,7 +280,7 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
   const configName = `appium.${CONFIG_EXTENSION}`;
   const configPath = path.resolve(tmpRoot, configName);
   const tmpServer = http.createServer(async function (_, res) {
-    let configFile = await fs.readFile(configPath);
+    const configFile = await fs.readFile(configPath);
     res.end(configFile);
   });
   try {

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -7,8 +7,9 @@ import B from 'bluebird';
 import log from '../logger';
 import os from 'os';
 import path from 'path';
+import http from 'http';
 import UUID from 'uuid-js';
-import { exec, SubProcess } from 'teen_process';
+import { exec } from 'teen_process';
 import { findAPortNotInUse, checkPortStatus } from 'portscanner';
 
 let extensions = {}, commands = {};
@@ -270,12 +271,13 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
 
   const tmpRoot = await tempDir.openDir();
   const tmpPort = await findAPortNotInUse(HOST_PORT_RANGE[0], HOST_PORT_RANGE[1]);
-  const tmpServer = new SubProcess('python3', ['-m', 'http.server', tmpPort], {
-    cwd: tmpRoot,
+  const configName = `appium.${CONFIG_EXTENSION}`;
+  const configPath = path.resolve(tmpRoot, configName);
+  const tmpServer = http.createServer(async function (_, res) {
+    let configFile = await fs.readFile(configPath);
+    res.end(configFile);
   });
   try {
-    const configName = `appium.${CONFIG_EXTENSION}`;
-    const configPath = path.resolve(tmpRoot, configName);
     const certBuffer = Buffer.from(content, 'base64');
     const cn = commonName || await extractCommonName(certBuffer);
     const mobileConfig = toMobileConfig(certBuffer, cn);
@@ -289,7 +291,7 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
     try {
       const host = os.hostname();
       const certUrl = `http://${host}:${tmpPort}/${configName}`;
-      await tmpServer.start(0);
+      await tmpServer.listen(tmpPort);
       try {
         await waitForCondition(async () => {
           try {
@@ -303,8 +305,7 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
         });
         log.debug(`The temporary web server is running at http://${host}:${tmpPort}`);
       } catch (e) {
-        throw new Error(`The temporary web server cannot be started at http://${host}:${tmpPort}. ` +
-          `Is python3 installed?`);
+        throw new Error(`The temporary web server cannot be started at http://${host}:${tmpPort}.`);
       }
       if (this.isRealDevice()) {
         try {

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -36,8 +36,8 @@ const Settings = {
 };
 const Button = {
   Install: {
-    type: 'accessibility id',
-    value: 'Install',
+    type: '-ios predicate string',
+    value: `type = 'XCUIElementTypeButton' AND visible = 1 AND label = 'Install'`,
   },
   Allow: {
     type: 'accessibility id',
@@ -50,12 +50,6 @@ const Button = {
   Return_to_Settings: {
     type: 'accessibility id',
     value: 'Return to Settings',
-  },
-};
-const Sheet = {
-  Install: {
-    type: '-ios class chain',
-    value: '**/XCUIElementTypeSheet/**/XCUIElementTypeButton[`label == \'Install\'`]',
   },
 };
 
@@ -156,8 +150,8 @@ async function installPre122Certificate (driver) {
   // The second one confirms the previous
   await B.delay(1500);
   await clickElement(driver, Button.Install);
-  // Accept sheet alert
-  await clickElement(driver, Sheet.Install);
+  // Accept sheet/alert
+  await clickElement(driver, Button.Install);
   // Finish adding certificate
   await clickElement(driver, Button.Done);
   return true;
@@ -238,8 +232,8 @@ async function installPost122Certificate (driver, name) {
   await B.delay(1500);
   // Confirm untrusted cert install
   await clickElement(driver, Button.Install);
-  // Accept sheet alert
-  await clickElement(driver, Sheet.Install);
+  // Accept sheet/alert
+  await clickElement(driver, Button.Install);
   // Finish adding certificate
   await clickElement(driver, Button.Done);
 


### PR DESCRIPTION
Removed Sheet.Install in favour of using a visible check for the button. This is because on iPad the button is within an Alert not within a sheet. Thus making the certificate unable to be installed on iPad.