### PR TITLE
Added calculation for large iPhone X's.

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -16,6 +16,8 @@ const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
 const IPHONE_X_WIDTH = 375;
 const IPHONE_X_HEIGHT = 812;
+const IPHONE_XR_WIDTH = 414;
+const IPHONE_XR_HEIGHT = 896;
 
 const ATOM_WAIT_TIMEOUT = 5 * 60000;
 
@@ -41,8 +43,10 @@ extensions.getSafariIsIphoneX = _.memoize(async function getSafariIsIphone () {
     const script = 'return {height: window.screen.availHeight, width: window.screen.availWidth};';
     const {height, width} = await this.execute(script);
     // check for the correct height and width
-    return (height === IPHONE_X_HEIGHT && width === IPHONE_X_WIDTH) ||
-           (height === IPHONE_X_WIDTH && width === IPHONE_X_HEIGHT);
+    const [portraitHeight, portraitWidth] = height > width ? [height, width] : [width, height];
+    return (portraitHeight === IPHONE_X_HEIGHT && portraitWidth === IPHONE_X_WIDTH) ||
+           (portraitHeight === IPHONE_XR_HEIGHT && portraitWidth === IPHONE_XR_WIDTH);
+
   } catch (err) {
     log.warn(`Unable to find device type from dimensions. Assuming not iPhone X`);
     log.debug(`Error: ${err.message}`);


### PR DESCRIPTION
Added extra calculation so that iPhone XR's and XS Max's are considered iPhone X's. The `IPHONE_X_NOTCH_OFFSET` should still be the same on larger devices.