### PR TITLE
Initialize idb and pass it to iOS Simulator

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -601,6 +601,7 @@ class XCUITestDriver extends BaseDriver {
 
     if (this.isSimulator() && (this.opts.device || {}).idb) {
       await this.opts.device.idb.disconnect();
+      this.opts.device.idb = null;
     }
 
     await this.stop();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -27,6 +27,7 @@ import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import path from 'path';
 import { exec } from 'child_process';
+import IDB from 'appium-idb';
 
 
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
@@ -389,6 +390,14 @@ class XCUITestDriver extends BaseDriver {
         }
       }
 
+      try {
+        const idb = new IDB({udid});
+        await idb.connect();
+        this.opts.device.idb = idb;
+      } catch (e) {
+        log.info(`idb will not be used for Simulator interaction. Original error: ${e.message}`);
+      }
+
       this.logEvent('simStarted');
       if (!isLogCaptureStarted) {
         // Retry log capture if Simulator was not running before
@@ -589,6 +598,10 @@ class XCUITestDriver extends BaseDriver {
 
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
+
+    if (this.isSimulator() && (this.opts.device || {}).idb) {
+      await this.opts.device.idb.disconnect();
+    }
 
     await this.stop();
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
+    "appium-idb": "^0.1.0",
     "appium-ios-driver": "^4.0.0",
-    "appium-ios-simulator": "^3.9.0",
+    "appium-ios-simulator": "^3.11.0",
     "appium-remote-debugger": "^4.0.0",
     "appium-support": "^2.26.1",
     "appium-xcode": "^3.8.0",


### PR DESCRIPTION
Now ios-simulator support idb, so lets make usage of it. In the future we could also assign idb to a driver property and use it there if necessary.