### PR TITLE
Always restore installd cache if simctl error output includes MIInstallerErrorDomain

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -165,14 +165,16 @@ async function installToSimulator (device, app, bundleId, noReset = true) {
     try {
       await device.installApp(app);
     } catch (e) {
-      // on Xcode 10 sometimes this is too fast and it fails
+      // it sometimes fails on Xcode 10 because of a race condition
       log.info(`Got an error on '${app}' install: ${e.message}`);
-      if (e.message.includes('domain=MIInstallerErrorDomain, code=35') && tmpRoot) {
-        // https://github.com/appium/appium/issues/11350
+      // https://github.com/appium/appium/issues/11350
+      if (e.message.includes('MIInstallerErrorDomain') && tmpRoot) {
         log.info(`installd requires the cache to be available in order to install '${app}'. ` +
           `Restoring the cache`);
         await fs.rimraf(installdCacheRoot);
-        await fs.mv(path.resolve(tmpRoot, INSTALL_DAEMON_CACHE), installdCacheRoot, {mkdirp: true});
+        await fs.mv(path.resolve(tmpRoot, INSTALL_DAEMON_CACHE), installdCacheRoot, {
+          mkdirp: true
+        });
       }
       log.info('Retrying application install');
       await device.installApp(app);


### PR DESCRIPTION
It looks like simctl might also throw error with codes different from 35. See https://github.com/appium/appium/issues/10464?issuecomment-496517286