### PR TITLE
Fix pull/push for real device via ifuse using `documents` flag

### DIFF
--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -11,7 +11,6 @@ const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
 const CONTAINER_PATH_PATTERN = new RegExp(`^${CONTAINER_PATH_MARKER}([^/]+)/(.+)`);
 const CONTAINER_TYPE_SEPARATOR = ':';
-const IFUSE_DOCUMENTS = 'Documents';
 
 
 let commands = iosCommands.file;
@@ -47,6 +46,14 @@ function verifyIsSubPath (originalPath, root) {
 }
 
 /**
+ * @typedef {Object} ContainerObject
+ *
+ * @property {string} bundleId - The parsed bundle identifier
+ * @property {string} pathInContainer - The absolute full path of the item on the local file system
+ * @property {?string} containerType - The container type
+ */
+
+/**
  * Parses the actual path and the bundle identifier from the given path string
  *
  * @param {string} remotePath - The given path string. The string should
@@ -56,9 +63,7 @@ function verifyIsSubPath (originalPath, root) {
  * full path to the mount root for real devices or a function, which accepts two parameters
  * (bundle identifier and optional container type) and returns full path to container
  * root folder on the local file system, for Simulator
- * @returns {Array<string>} - An array where the first item is the parsed bundle
- * identifier and the second one is the absolute full path of the item on the local
- * file system
+ * @returns {ContainerObject}
  */
 async function parseContainerPath (remotePath, containerRootSupplier) {
   const match = CONTAINER_PATH_PATTERN.exec(remotePath);
@@ -80,9 +85,9 @@ async function parseContainerPath (remotePath, containerRootSupplier) {
   const containerRoot = _.isFunction(containerRootSupplier)
     ? await containerRootSupplier(bundleId, containerType)
     : containerRootSupplier;
-  const resultPath = path.posix.resolve(containerRoot, relativePath);
-  verifyIsSubPath(resultPath, containerRoot);
-  return [bundleId, resultPath];
+  const pathInContainer = path.posix.resolve(containerRoot, relativePath);
+  verifyIsSubPath(pathInContainer, containerRoot);
+  return {bundleId, pathInContainer, containerType};
 }
 
 /**
@@ -106,7 +111,7 @@ async function parseContainerPath (remotePath, containerRootSupplier) {
 async function pushFileToSimulator (device, remotePath, base64Data) {
   const buffer = Buffer.from(base64Data, 'base64');
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const [bundleId, dstPath] = await parseContainerPath(remotePath,
+    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
       `Will put the data into '${dstPath}'`);
@@ -138,12 +143,11 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                          valid device ID.
  * @param {string} remotePath - The remote path on the device. This variable can be prefixed with
  *                              bundle id, so then the file will be uploaded to the corresponding
- *                              application container instead of the default media folder, for example
- *                              '@com.myapp.bla/RelativePathInContainer/111.png'. The '@' character at the
- *                              beginning of the argument is mandatory in such case.
- *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
- *                              `--documents` flag.
- *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
+ *                              application container instead of the default media folder. Use
+ *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              format to pull a file or a folder from an application container of the given type.
+ *                              Possible container types are 'documents' or other.
+ *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   Base64 encoded `111.png` will be pushed into `On My iPhone/<app name>/111.png`
  *                                   as base64 decoded data.
@@ -152,24 +156,22 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
 async function pushFileToRealDevice (device, remotePath, base64Data) {
   await verifyIFusePresence();
   const mntRoot = await tempDir.openDir();
-  let mntTarget = mntRoot;
   let isUnmountSuccessful = true;
   try {
-    let dstPath = path.resolve(mntTarget, remotePath);
-    let ifuseArgs = ['-u', device.udid, mntTarget];
+    let dstPath = path.resolve(mntRoot, remotePath);
+    let ifuseArgs = ['-u', device.udid, mntRoot];
     if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntTarget);
+      const { bundleId, pathInContainer, containerType } = await parseContainerPath(remotePath, mntRoot);
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will put the data into '${dstPath}'`);
-      if (isDocuments(remotePath)) {
-        mntTarget = await createMountDirForDocuments(mntTarget);
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntTarget];
+      if (isDocuments(containerType)) {
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
       } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntTarget];
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
       }
     } else {
-      verifyIsSubPath(dstPath, mntTarget);
+      verifyIsSubPath(dstPath, mntRoot);
     }
     await mountDevice(device, ifuseArgs);
     isUnmountSuccessful = false;
@@ -180,7 +182,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       }
       await fs.writeFile(dstPath, Buffer.from(base64Data, 'base64'));
     } finally {
-      await exec('umount', [mntTarget]);
+      await exec('umount', [mntRoot]);
       isUnmountSuccessful = true;
     }
   } finally {
@@ -211,7 +213,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
 async function pullFromSimulator (device, remotePath, isFile) {
   let pathOnServer;
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const [bundleId, dstPath] = await parseContainerPath(remotePath,
+    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
       `Will get the data from '${dstPath}'`);
@@ -240,12 +242,11 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                          valid device ID.
  * @param {string} remotePath - The path to an existing remote file on the device. This variable can be prefixed with
  *                              bundle id, so then the file will be downloaded from the corresponding
- *                              application container instead of the default media folder, for example
- *                              '@com.myapp.bla/RelativePathInContainer/111.png'. The '@' character at the
- *                              beginning of the argument is mandatory in such case.
- *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
- *                              `--documents` flag.
- *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
+ *                              application container instead of the default media folder. Use
+ *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              format to pull a file or a folder from an application container of the given type.
+ *                              Possible container types are 'documents' or other.
+ *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine
  *                                   and Appium returns the data as base64 to a client.
@@ -255,24 +256,22 @@ async function pullFromSimulator (device, remotePath, isFile) {
 async function pullFromRealDevice (device, remotePath, isFile) {
   await verifyIFusePresence();
   const mntRoot = await tempDir.openDir();
-  let mntTarget = mntRoot;
   let isUnmountSuccessful = true;
   try {
-    let dstPath = path.resolve(mntTarget, remotePath);
-    let ifuseArgs = ['-u', device.udid, mntTarget];
+    let dstPath = path.resolve(mntRoot, remotePath);
+    let ifuseArgs = ['-u', device.udid, mntRoot];
     if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntTarget);
+      const { bundleId, pathInContainer, containerType } = await parseContainerPath(remotePath, mntRoot);
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will get the data from '${dstPath}'`);
-      if (isDocuments(remotePath)) {
-        mntTarget = await createMountDirForDocuments(mntTarget);
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntTarget];
+      if (isDocuments(containerType)) {
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
       } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntTarget];
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
       }
     } else {
-      verifyIsSubPath(dstPath, mntTarget);
+      verifyIsSubPath(dstPath, mntRoot);
     }
     await mountDevice(device, ifuseArgs);
     isUnmountSuccessful = false;
@@ -285,7 +284,7 @@ async function pullFromRealDevice (device, remotePath, isFile) {
         : await zip.toInMemoryZip(dstPath);
       return Buffer.from(buffer).toString('base64');
     } finally {
-      await exec('umount', [mntTarget]);
+      await exec('umount', [mntRoot]);
       isUnmountSuccessful = true;
     }
   } finally {
@@ -297,17 +296,6 @@ async function pullFromRealDevice (device, remotePath, isFile) {
   }
 }
 
-/**
- * Join IFUSE_DOCUMENTS for the mntRoot
- * @param {string} mntRoot A path to mount
- * @returns {string} A path which have IFUSE_DOCUMENTS at the end of mntRoot
- */
-async function createMountDirForDocuments (mntRoot) {
-  const p = path.join(mntRoot, IFUSE_DOCUMENTS);
-  await mkdirp(p);
-  return p;
-}
-
 
 /**
  * If the provided `remotePath` has `Documents` prefix.
@@ -317,13 +305,8 @@ async function createMountDirForDocuments (mntRoot) {
  * @param {string} remotePath
  * @returns {boolean} True is the remotePath has Documents
  */
-function isDocuments (remotePath) {
-  const match = CONTAINER_PATH_PATTERN.exec(remotePath);
-  if (match) {
-    const [, , relativePath] = match;
-    return relativePath.startsWith(`${IFUSE_DOCUMENTS}/`) || relativePath === IFUSE_DOCUMENTS ;
-  }
-  return false;
+function isDocuments (containerType) {
+  return _.isString(containerType) && containerType.toLowerCase() === 'documents';
 }
 
 /**

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -260,8 +260,8 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              (aka --container ifuse argument)
  *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
- *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine
- *                                   and Appium returns the data as base64 to a client.
+ *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted host machine
+ *                                   and Appium returns the data as base64-encoded string to client.
  *                                   `@com.myapp.bla:documents/` means `On My iPhone/<app name>`.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @return {string} Base-64 encoded content of the remote file
@@ -320,7 +320,6 @@ async function pullFromRealDevice (device, remotePath, isFile) {
  *
  * @param {Object} udid - The udid of the target device
  * @returns {Array<string>} A list of bundle ids
- * @throws {Error} If there was an error while calling ifuse command
  */
 async function getAvailableBundleIds (udid) {
   try {

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -138,11 +138,17 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                              application container instead of the default media folder, for example
  *                              '@com.myapp.bla/RelativePathInContainer/111.png'. The '@' character at the
  *                              beginning of the argument is mandatory in such case.
+ *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
+ *                              `--documents` flag.
+ *                              e.g. `@com.myapp.bla/Documents/111.png` is provided.
+ *                                   iPhone is mounted in `(await tempDir.openDir())/Documents`.
+ *                                   The mounted path in iPhone is `On My iPhone/<app name>`
+ *                                   `/111.png` will push into `On My iPhone/<app name>/111.png`.
  * @param {string} base64Data - Base-64 encoded content of the file to be uploaded.
  */
 async function pushFileToRealDevice (device, remotePath, base64Data) {
   await verifyIFusePresence();
-  const mntRoot = await tempDir.openDir();
+  let mntRoot = await tempDir.openDir();
   let isUnmountSuccessful = true;
   try {
     let dstPath = path.resolve(mntRoot, remotePath);
@@ -152,7 +158,12 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will put the data into '${dstPath}'`);
-      ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+      if (isDocuments(remotePath)) {
+        mntRoot = await createMountDirForDocuments(mntRoot);
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
+      } else {
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+      }
     } else {
       verifyIsSubPath(dstPath, mntRoot);
     }
@@ -228,12 +239,19 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              application container instead of the default media folder, for example
  *                              '@com.myapp.bla/RelativePathInContainer/111.png'. The '@' character at the
  *                              beginning of the argument is mandatory in such case.
+ *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
+ *                              `--documents` flag.
+ *                              e.g. `@com.myapp.bla/Documents/111.png` is provided.
+ *                                   iPhone is mounted in `(await tempDir.openDir())/Documents`.
+ *                                   The mounted path in iPhone is `On My iPhone/<app name>`
+ *                                   `/111.png` in `(await tempDir.openDir())/Documents/111.png` is mapped with
+ *                                   `On My iPhone/<app name>/111.png`.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @return {string} Base-64 encoded content of the remote file
  */
 async function pullFromRealDevice (device, remotePath, isFile) {
   await verifyIFusePresence();
-  const mntRoot = await tempDir.openDir();
+  let mntRoot = await tempDir.openDir();
   let isUnmountSuccessful = true;
   try {
     let dstPath = path.resolve(mntRoot, remotePath);
@@ -243,7 +261,12 @@ async function pullFromRealDevice (device, remotePath, isFile) {
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will get the data from '${dstPath}'`);
-      ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+      if (isDocuments(remotePath)) {
+        mntRoot = await createMountDirForDocuments(mntRoot);
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
+      } else {
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+      }
     } else {
       verifyIsSubPath(dstPath, mntRoot);
     }
@@ -268,6 +291,27 @@ async function pullFromRealDevice (device, remotePath, isFile) {
       log.warn(`Umount has failed, so not removing '${mntRoot}'`);
     }
   }
+}
+
+async function createMountDirForDocuments (mntRoot) {
+  const p = path.posix.join(mntRoot, 'Documents');
+  await mkdirp(p);
+  return p;
+}
+
+/**
+ * If the provided `remotePath` has `Documents` prefix.
+ * If the path starts with `Documents`, it will be mounted by `--documents` flag in ifuse
+ *
+ * @param {string} remotePath
+ */
+function isDocuments (remotePath) {
+  const match = CONTAINER_PATH_PATTERN.exec(remotePath);
+  if (match) {
+    const [, , relativePath] = match;
+    return relativePath.startsWith('Documents');
+  }
+  return false;
 }
 
 /**
@@ -373,5 +417,6 @@ commands.pullFolder = async function pullFolder (remotePath) {
     : await pullFromRealDevice(this.opts.device, remotePath, false);
 };
 
-export { commands, getAvailableBundleIds };
+export { commands, /* for testing */ getAvailableBundleIds,
+  /* for testing */ parseContainerPath, /* for testing */ isDocuments };
 export default commands;

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -11,6 +11,7 @@ const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
 const CONTAINER_PATH_PATTERN = new RegExp(`^${CONTAINER_PATH_MARKER}([^/]+)/(.+)`);
 const CONTAINER_TYPE_SEPARATOR = ':';
+const IFUSE_DOCUMENTS = 'Documents';
 
 
 let commands = iosCommands.file;
@@ -296,22 +297,24 @@ async function pullFromRealDevice (device, remotePath, isFile) {
 }
 
 async function createMountDirForDocuments (mntRoot) {
-  const p = path.posix.join(mntRoot, 'Documents');
+  const p = path.posix.join(mntRoot, IFUSE_DOCUMENTS);
   await mkdirp(p);
   return p;
 }
+
 
 /**
  * If the provided `remotePath` has `Documents` prefix.
  * If the path starts with `Documents`, it will be mounted by `--documents` flag in ifuse
  *
  * @param {string} remotePath
+ * @returns {boolean} True is the remotePath has Documents
  */
 function isDocuments (remotePath) {
   const match = CONTAINER_PATH_PATTERN.exec(remotePath);
   if (match) {
     const [, , relativePath] = match;
-    return relativePath.startsWith('Documents');
+    return relativePath.startsWith(`${IFUSE_DOCUMENTS}/`) || relativePath === IFUSE_DOCUMENTS ;
   }
   return false;
 }
@@ -322,23 +325,19 @@ function isDocuments (remotePath) {
  * @param {Object} device - The device object, which represents the device under test.
  *                          This object is expected to have the `udid` property containing the
  *                          valid device ID.
+ * @returns {Array} A list of bundle ids
  */
 async function getAvailableBundleIds (device) {
   await verifyIFusePresence();
-  const list = [];
   try {
-    const apps = await exec('ifuse', ['-u', device.udid, '--list-apps']);
-    for (const app of apps.split(EOL)) {
-      const bundleId = app.split(',')[0].trim();
-      if (!_.isEmpty(bundleId)) {
-        list.push(bundleId);
-      }
-    }
+    const { stdout } = await exec('ifuse', ['-u', device.udid, '--list-apps']);
+    return stdout.split(EOL)
+      .map((app) => app.split(',')[0].trim())
+      .filter((app) => !_.isEmpty(app));
   } catch (e) {
     log.errorAndThrow(`Cannot get a list of bundleIds` +
                       `Error code: ${e}; stderr output: ${e.stderr}`);
   }
-  return list;
 }
 
 

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -140,10 +140,10 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                              beginning of the argument is mandatory in such case.
  *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
  *                              `--documents` flag.
- *                              e.g. `@com.myapp.bla/Documents/111.png` is provided.
- *                                   iPhone is mounted in `(await tempDir.openDir())/Documents`.
- *                                   The mounted path in iPhone is `On My iPhone/<app name>`
- *                                   `/111.png` will push into `On My iPhone/<app name>/111.png`.
+ *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
+ *                                   `On My iPhone/<app name>` in Files app will be mounted in
+ *                                   `(await tempDir.openDir())/Documents` on macOS.
+ *                                   `111.png` will be pushed into `On My iPhone/<app name>/111.png`
  * @param {string} base64Data - Base-64 encoded content of the file to be uploaded.
  */
 async function pushFileToRealDevice (device, remotePath, base64Data) {
@@ -241,11 +241,11 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              beginning of the argument is mandatory in such case.
  *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
  *                              `--documents` flag.
- *                              e.g. `@com.myapp.bla/Documents/111.png` is provided.
- *                                   iPhone is mounted in `(await tempDir.openDir())/Documents`.
- *                                   The mounted path in iPhone is `On My iPhone/<app name>`
- *                                   `/111.png` in `(await tempDir.openDir())/Documents/111.png` is mapped with
- *                                   `On My iPhone/<app name>/111.png`.
+ *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
+ *                                   `On My iPhone/<app name>` in Files app will be mounted in
+ *                                   `(await tempDir.openDir())/Documents` on macOS.
+ *                                   `On My iPhone/<app name>/111.png` wil be pulled into `(await tempDir.openDir())/Documents/111.png`
+ *                                   and Appium returns the data as base64 to a client.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @return {string} Base-64 encoded content of the remote file
  */

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -300,7 +300,7 @@ async function pullFromRealDevice (device, remotePath, isFile) {
 /**
  * Join IFUSE_DOCUMENTS for the mntRoot
  * @param {string} mntRoot A path to mount
- * @retuns A path which have IFUSE_DOCUMENTS at the end of mntRoot
+ * @returns {string} A path which have IFUSE_DOCUMENTS at the end of mntRoot
  */
 async function createMountDirForDocuments (mntRoot) {
   const p = path.join(mntRoot, IFUSE_DOCUMENTS);
@@ -332,7 +332,7 @@ function isDocuments (remotePath) {
  * @param {Object} device - The device object, which represents the device under test.
  *                          This object is expected to have the `udid` property containing the
  *                          valid device ID.
- * @returns {Array} A list of bundle ids
+ * @returns {Array<string>} A list of bundle ids
  * @throws {Error} If there was an error while calling ifuse command
  */
 async function getAvailableBundleIds (device) {
@@ -343,8 +343,8 @@ async function getAvailableBundleIds (device) {
       .map((app) => app.split(',')[0].trim())
       .filter((app) => !_.isEmpty(app));
   } catch (e) {
-    log.errorAndThrow(`Cannot get a list of bundleIds` +
-                      `Error code: ${e}; stderr output: ${e.stderr}`);
+    log.warn(`Cannot get a list of bundleIds` +
+             `Error code: ${e}; stderr output: ${e.stderr}`);
   }
 }
 

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -5,6 +5,7 @@ import { iosCommands } from 'appium-ios-driver';
 import log from '../logger';
 import { exec } from 'teen_process';
 import { addMedia, getAppContainer } from 'node-simctl';
+import { EOL } from 'os';
 
 const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
@@ -269,6 +270,31 @@ async function pullFromRealDevice (device, remotePath, isFile) {
   }
 }
 
+/**
+ * Get bundleIds which can mount
+ *
+ * @param {Object} device - The device object, which represents the device under test.
+ *                          This object is expected to have the `udid` property containing the
+ *                          valid device ID.
+ */
+async function getAvailableBundleIds (device) {
+  await verifyIFusePresence();
+  const list = [];
+  try {
+    const apps = await exec('ifuse', ['-u', device.udid, '--list-apps']);
+    for (const app of apps.split(EOL)) {
+      const bundleId = app.split(',')[0].trim();
+      if (!_.isEmpty(bundleId)) {
+        list.push(bundleId);
+      }
+    }
+  } catch (e) {
+    log.errorAndThrow(`Cannot get a list of bundleIds` +
+                      `Error code: ${e}; stderr output: ${e.stderr}`);
+  }
+  return list;
+}
+
 
 commands.pushFile = async function pushFile (remotePath, base64Data) {
   if (remotePath.endsWith('/')) {
@@ -347,5 +373,5 @@ commands.pullFolder = async function pullFolder (remotePath) {
     : await pullFromRealDevice(this.opts.device, remotePath, false);
 };
 
-export { commands };
+export { commands, getAvailableBundleIds };
 export default commands;

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -170,7 +170,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       ifuseArgs = [
         '-u',
         device.udid,
-        `${_.lowerCase(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container'}`,
+        _.toLower(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container',
         bundleId,
         mntRoot
       ];
@@ -275,7 +275,7 @@ async function pullFromRealDevice (device, remotePath, isFile) {
       ifuseArgs = [
         '-u',
         device.udid,
-        `${_.lowerCase(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container'}`,
+        _.toLower(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container',
         bundleId,
         mntRoot
       ];
@@ -320,7 +320,7 @@ async function getAvailableBundleIds (udid) {
       .map((app) => app.split(',')[0].trim())
       .filter((app) => !_.isEmpty(app));
   } catch (e) {
-    log.warn(`Cannot get a list of bundleIds` +
+    log.warn(`Cannot get a list of bundleIds.` +
              `Error code: ${e}; stderr output: ${e.stderr}`);
   }
   return [];

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -30,7 +30,7 @@ async function mountDevice (device, iFuseArgs) {
   try {
     await exec('ifuse', iFuseArgs);
   } catch (e) {
-    const bundleIds = getAvailableBundleIds(device);
+    const bundleIds = await getAvailableBundleIds(device);
     log.errorAndThrow(`Cannot mount the media folder of the device with UDID ${device.udid}. ` +
                       `Make sure osxfuse plugin has necessary permissions in System Preferences->Security & Privacy. ` +
                       `${bundleIds} might be able to mount as '@bundleId/Documents'. ` +
@@ -144,31 +144,32 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
  *                              `--documents` flag.
  *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
- *                                   `On My iPhone/<app name>` in Files app will be mounted in
- *                                   `(await tempDir.openDir())/Documents` on macOS.
- *                                   `111.png` will be pushed into `On My iPhone/<app name>/111.png`
+ *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
+ *                                   Base64 encoded `111.png` will be pushed into `On My iPhone/<app name>/111.png`
+ *                                   as base64 decoded data.
  * @param {string} base64Data - Base-64 encoded content of the file to be uploaded.
  */
 async function pushFileToRealDevice (device, remotePath, base64Data) {
   await verifyIFusePresence();
-  let mntRoot = await tempDir.openDir();
+  const mntRoot = await tempDir.openDir();
+  let mntTarget = mntRoot;
   let isUnmountSuccessful = true;
   try {
-    let dstPath = path.resolve(mntRoot, remotePath);
-    let ifuseArgs = ['-u', device.udid, mntRoot];
+    let dstPath = path.resolve(mntTarget, remotePath);
+    let ifuseArgs = ['-u', device.udid, mntTarget];
     if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntRoot);
+      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntTarget);
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will put the data into '${dstPath}'`);
       if (isDocuments(remotePath)) {
-        mntRoot = await createMountDirForDocuments(mntRoot);
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
+        mntTarget = await createMountDirForDocuments(mntTarget);
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntTarget];
       } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntTarget];
       }
     } else {
-      verifyIsSubPath(dstPath, mntRoot);
+      verifyIsSubPath(dstPath, mntTarget);
     }
     await mountDevice(device, ifuseArgs);
     isUnmountSuccessful = false;
@@ -179,7 +180,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       }
       await fs.writeFile(dstPath, Buffer.from(base64Data, 'base64'));
     } finally {
-      await exec('umount', [mntRoot]);
+      await exec('umount', [mntTarget]);
       isUnmountSuccessful = true;
     }
   } finally {
@@ -245,33 +246,33 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              If the `RelativePathInContainer` starts with `Documents`, the path will be mounted by
  *                              `--documents` flag.
  *                              e.g. If `@com.myapp.bla/Documents/111.png` is provided,
- *                                   `On My iPhone/<app name>` in Files app will be mounted in
- *                                   `(await tempDir.openDir())/Documents` on macOS.
- *                                   `On My iPhone/<app name>/111.png` wil be pulled into `(await tempDir.openDir())/Documents/111.png`
+ *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
+ *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine
  *                                   and Appium returns the data as base64 to a client.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @return {string} Base-64 encoded content of the remote file
  */
 async function pullFromRealDevice (device, remotePath, isFile) {
   await verifyIFusePresence();
-  let mntRoot = await tempDir.openDir();
+  const mntRoot = await tempDir.openDir();
+  let mntTarget = mntRoot;
   let isUnmountSuccessful = true;
   try {
-    let dstPath = path.resolve(mntRoot, remotePath);
-    let ifuseArgs = ['-u', device.udid, mntRoot];
+    let dstPath = path.resolve(mntTarget, remotePath);
+    let ifuseArgs = ['-u', device.udid, mntTarget];
     if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntRoot);
+      const [bundleId, pathInContainer] = await parseContainerPath(remotePath, mntTarget);
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will get the data from '${dstPath}'`);
       if (isDocuments(remotePath)) {
-        mntRoot = await createMountDirForDocuments(mntRoot);
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
+        mntTarget = await createMountDirForDocuments(mntTarget);
+        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntTarget];
       } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
+        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntTarget];
       }
     } else {
-      verifyIsSubPath(dstPath, mntRoot);
+      verifyIsSubPath(dstPath, mntTarget);
     }
     await mountDevice(device, ifuseArgs);
     isUnmountSuccessful = false;
@@ -284,7 +285,7 @@ async function pullFromRealDevice (device, remotePath, isFile) {
         : await zip.toInMemoryZip(dstPath);
       return Buffer.from(buffer).toString('base64');
     } finally {
-      await exec('umount', [mntRoot]);
+      await exec('umount', [mntTarget]);
       isUnmountSuccessful = true;
     }
   } finally {
@@ -296,8 +297,13 @@ async function pullFromRealDevice (device, remotePath, isFile) {
   }
 }
 
+/**
+ * Join IFUSE_DOCUMENTS for the mntRoot
+ * @param {string} mntRoot A path to mount
+ * @retuns A path which have IFUSE_DOCUMENTS at the end of mntRoot
+ */
 async function createMountDirForDocuments (mntRoot) {
-  const p = path.posix.join(mntRoot, IFUSE_DOCUMENTS);
+  const p = path.join(mntRoot, IFUSE_DOCUMENTS);
   await mkdirp(p);
   return p;
 }
@@ -305,7 +311,8 @@ async function createMountDirForDocuments (mntRoot) {
 
 /**
  * If the provided `remotePath` has `Documents` prefix.
- * If the path starts with `Documents`, it will be mounted by `--documents` flag in ifuse
+ * If the path starts with `Documents`, it will be mounted by `--documents` flag in ifuse.
+ * If the path is only `Documents`, ifuse mounts the root of `--documents` flag.
  *
  * @param {string} remotePath
  * @returns {boolean} True is the remotePath has Documents
@@ -326,6 +333,7 @@ function isDocuments (remotePath) {
  *                          This object is expected to have the `udid` property containing the
  *                          valid device ID.
  * @returns {Array} A list of bundle ids
+ * @throws {Error} If there was an error while calling ifuse command
  */
 async function getAvailableBundleIds (device) {
   await verifyIFusePresence();

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -321,7 +321,6 @@ function isDocuments (containerType) {
  * @throws {Error} If there was an error while calling ifuse command
  */
 async function getAvailableBundleIds (device) {
-  await verifyIFusePresence();
   try {
     const { stdout } = await exec('ifuse', ['-u', device.udid, '--list-apps']);
     return stdout.split(EOL)
@@ -331,6 +330,7 @@ async function getAvailableBundleIds (device) {
     log.warn(`Cannot get a list of bundleIds` +
              `Error code: ${e}; stderr output: ${e.stderr}`);
   }
+  return [];
 }
 
 

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -29,8 +29,10 @@ async function mountDevice (device, iFuseArgs) {
   try {
     await exec('ifuse', iFuseArgs);
   } catch (e) {
+    const bundleIds = getAvailableBundleIds(device);
     log.errorAndThrow(`Cannot mount the media folder of the device with UDID ${device.udid}. ` +
                       `Make sure osxfuse plugin has necessary permissions in System Preferences->Security & Privacy. ` +
+                      `${bundleIds} might be able to mount as '@bundleId/Documents'. ` +
                       `Error code: ${e.code}; stderr output: ${e.stderr}`);
   }
 }

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -149,7 +149,9 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                              application container instead of the default media folder. Use
  *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
  *                              format to pull a file or a folder from an application container of the given type.
- *                              Possible container types are 'documents' or other. Other means do not specify the container.
+ *                              The only supported container type is 'documents'. If the container type is not set
+ *                              explicitly for a bundle id, then the default application container is going to be mounted
+ *                              (aka --container ifuse argument)
  *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   Base64 encoded `111.png` will be pushed into `On My iPhone/<app name>/111.png`

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -6,6 +6,7 @@ import log from '../logger';
 import { exec } from 'teen_process';
 import { addMedia, getAppContainer } from 'node-simctl';
 import { EOL } from 'os';
+import { retry } from 'asyncbox';
 
 const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
@@ -186,7 +187,10 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       }
       await fs.writeFile(dstPath, Buffer.from(base64Data, 'base64'));
     } finally {
-      await exec('umount', [mntRoot]);
+      // Rarely umount fails, so retry once
+      retry(2, async function () {
+        await exec('umount', [mntRoot]);
+      });
       isUnmountSuccessful = true;
     }
   } finally {
@@ -293,7 +297,10 @@ async function pullFromRealDevice (device, remotePath, isFile) {
         : await zip.toInMemoryZip(dstPath);
       return Buffer.from(buffer).toString('base64');
     } finally {
-      await exec('umount', [mntRoot]);
+      // Rarely umount fails, so retry once
+      retry(2, async function () {
+        await exec('umount', [mntRoot]);
+      });
       isUnmountSuccessful = true;
     }
   } finally {

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -11,6 +11,7 @@ const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
 const CONTAINER_PATH_PATTERN = new RegExp(`^${CONTAINER_PATH_MARKER}([^/]+)/(.*)`);
 const CONTAINER_TYPE_SEPARATOR = ':';
+const IFUSE_CONTAINER_DOCUMENTS = 'documents';
 
 
 let commands = iosCommands.file;
@@ -29,10 +30,10 @@ async function mountDevice (device, iFuseArgs) {
   try {
     await exec('ifuse', iFuseArgs);
   } catch (e) {
-    const bundleIds = await getAvailableBundleIds(device);
+    const bundleIds = await getAvailableBundleIds(device.udid);
     log.errorAndThrow(`Cannot mount the media folder of the device with UDID ${device.udid}. ` +
                       `Make sure osxfuse plugin has necessary permissions in System Preferences->Security & Privacy. ` +
-                      `${bundleIds} might be able to mount as '@bundleId/Documents'. ` +
+                      `${bundleIds} might be able to mount as '@bundleId:documents/'. ` +
                       `Error code: ${e.code}; stderr output: ${e.stderr}`);
   }
 }
@@ -166,11 +167,13 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will put the data into '${dstPath}'`);
-      if (isDocuments(containerType)) {
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
-      } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
-      }
+      ifuseArgs = [
+        '-u',
+        device.udid,
+        `${_.lowerCase(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container'}`,
+        bundleId,
+        mntRoot
+      ];
     } else {
       verifyIsSubPath(dstPath, mntRoot);
     }
@@ -246,7 +249,9 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              application container instead of the default media folder. Use
  *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
  *                              format to pull a file or a folder from an application container of the given type.
- *                              Possible container types are 'documents' or other. Other means do not specify the container.
+ *                              The only supported container type is 'documents'. If the container type is not set
+ *                              explicitly for a bundle id, then the default application container is going to be mounted
+ *                              (aka --container ifuse argument)
  *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine
@@ -267,11 +272,13 @@ async function pullFromRealDevice (device, remotePath, isFile) {
       dstPath = pathInContainer;
       log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
         `Will get the data from '${dstPath}'`);
-      if (isDocuments(containerType)) {
-        ifuseArgs = ['-u', device.udid, '--documents', bundleId, mntRoot];
-      } else {
-        ifuseArgs = ['-u', device.udid, '--container', bundleId, mntRoot];
-      }
+      ifuseArgs = [
+        '-u',
+        device.udid,
+        `${_.lowerCase(containerType) === IFUSE_CONTAINER_DOCUMENTS ? '--documents' : '--container'}`,
+        bundleId,
+        mntRoot
+      ];
     } else {
       verifyIsSubPath(dstPath, mntRoot);
     }
@@ -300,29 +307,15 @@ async function pullFromRealDevice (device, remotePath, isFile) {
 
 
 /**
- * If the provided `remotePath` has `Documents` prefix.
- * If the path starts with `Documents`, it will be mounted by `--documents` flag in ifuse.
- * If the path is only `Documents`, ifuse mounts the root of `--documents` flag.
- *
- * @param {string} remotePath
- * @returns {boolean} True is the remotePath has Documents
- */
-function isDocuments (containerType) {
-  return _.isString(containerType) && containerType.toLowerCase() === 'documents';
-}
-
-/**
  * Get bundleIds which can mount by `--documents` flag
  *
- * @param {Object} device - The device object, which represents the device under test.
- *                          This object is expected to have the `udid` property containing the
- *                          valid device ID.
+ * @param {Object} udid - The udid of the target device
  * @returns {Array<string>} A list of bundle ids
  * @throws {Error} If there was an error while calling ifuse command
  */
-async function getAvailableBundleIds (device) {
+async function getAvailableBundleIds (udid) {
   try {
-    const { stdout } = await exec('ifuse', ['-u', device.udid, '--list-apps']);
+    const { stdout } = await exec('ifuse', ['-u', udid, '--list-apps']);
     return stdout.split(EOL)
       .map((app) => app.split(',')[0].trim())
       .filter((app) => !_.isEmpty(app));
@@ -412,5 +405,5 @@ commands.pullFolder = async function pullFolder (remotePath) {
 };
 
 export { commands, /* for testing */ getAvailableBundleIds,
-  /* for testing */ parseContainerPath, /* for testing */ isDocuments };
+  /* for testing */ parseContainerPath };
 export default commands;

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -146,7 +146,7 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  *                              application container instead of the default media folder. Use
  *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
  *                              format to pull a file or a folder from an application container of the given type.
- *                              Possible container types are 'documents' or other.
+ *                              Possible container types are 'documents' or other. Other means do not specify the container.
  *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   Base64 encoded `111.png` will be pushed into `On My iPhone/<app name>/111.png`
@@ -245,7 +245,7 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                              application container instead of the default media folder. Use
  *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
  *                              format to pull a file or a folder from an application container of the given type.
- *                              Possible container types are 'documents' or other.
+ *                              Possible container types are 'documents' or other. Other means do not specify the container.
  *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -9,7 +9,7 @@ import { EOL } from 'os';
 
 const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
-const CONTAINER_PATH_PATTERN = new RegExp(`^${CONTAINER_PATH_MARKER}([^/]+)/(.+)`);
+const CONTAINER_PATH_PATTERN = new RegExp(`^${CONTAINER_PATH_MARKER}([^/]+)/(.*)`);
 const CONTAINER_TYPE_SEPARATOR = ':';
 
 
@@ -40,7 +40,8 @@ async function mountDevice (device, iFuseArgs) {
 function verifyIsSubPath (originalPath, root) {
   const normalizedRoot = path.normalize(root);
   const normalizedPath = path.normalize(path.dirname(originalPath));
-  if (!normalizedPath.startsWith(normalizedRoot)) {
+  // If originalPath is root, `/`, originalPath should equal to normalizedRoot
+  if (normalizedRoot !== originalPath && !normalizedPath.startsWith(normalizedRoot)) {
     log.errorAndThrow(`'${normalizedPath}' is expected to be a subpath of '${normalizedRoot}'`);
   }
 }
@@ -250,6 +251,7 @@ async function pullFromSimulator (device, remotePath, isFile) {
  *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
  *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted hos machine
  *                                   and Appium returns the data as base64 to a client.
+ *                                   `@com.myapp.bla:documents/` means `On My iPhone/<app name>`.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @return {string} Base-64 encoded content of the remote file
  */

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -317,7 +317,7 @@ function isDocuments (remotePath) {
 }
 
 /**
- * Get bundleIds which can mount
+ * Get bundleIds which can mount by `--documents` flag
  *
  * @param {Object} device - The device object, which represents the device under test.
  *                          This object is expected to have the `udid` property containing the

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -1,0 +1,57 @@
+import { getAvailableBundleIds } from '../../../lib/commands/file-movement';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import * as teen_process from 'teen_process';
+import { withMocks } from 'appium-test-support';
+import { fs } from 'appium-support';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('file-movement', function () {
+  describe('getAvailableBundleIds', withMocks({teen_process, fs}, (mocks) => {
+    afterEach(function () {
+      mocks.verify();
+    });
+
+    it('get available bundleIds with items', async function () {
+      mocks.fs.expects('which')
+        .withExactArgs('ifuse').once().returns(true);
+      mocks.teen_process.expects('exec')
+        .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
+        .returns(`
+com.apple.Keynote, "6383", "Keynote"
+io.appium.example, "1.0.205581.0.10", "Appium"
+        `);
+      await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([
+        'com.apple.Keynote', 'io.appium.example'
+      ]);
+    });
+    it('get available bundleIds without items', async function () {
+      mocks.fs.expects('which')
+        .withExactArgs('ifuse').once().returns(true);
+      mocks.teen_process.expects('exec')
+        .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
+        .returns('');
+      await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([]);
+    });
+    it('raises no ifuse error', async function () {
+      mocks.fs.expects('which')
+        .withExactArgs('ifuse').once().returns(false);
+      mocks.teen_process.expects('exec')
+        .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
+        .returns('');
+      await getAvailableBundleIds({ udid: '12345' })
+        .should.eventually.be.rejectedWith(/tool is required/);
+    });
+    it('raises no ifuse error', async function () {
+      mocks.fs.expects('which')
+        .withExactArgs('ifuse').once().returns(true);
+      mocks.teen_process.expects('exec')
+        .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
+        .throws();
+      await getAvailableBundleIds({ udid: '12345' })
+        .should.eventually.rejectedWith(/Cannot get a list of bundleIds/);
+    });
+  }));
+});

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -1,14 +1,34 @@
-import { getAvailableBundleIds } from '../../../lib/commands/file-movement';
+import { getAvailableBundleIds, parseContainerPath, isDocuments } from '../../../lib/commands/file-movement';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as teen_process from 'teen_process';
 import { withMocks } from 'appium-test-support';
-import { fs } from 'appium-support';
+import { fs, tempDir } from 'appium-support';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('file-movement', function () {
+  describe('parseContainerPath', function () {
+    it('should parse', async function () {
+      const mntRoot = await tempDir.openDir();
+      const [bundleId, pathInContainer] = await parseContainerPath('@io.appium.example/Documents/file.txt', mntRoot);
+
+      bundleId.should.eql('io.appium.example');
+      pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
+    });
+  });
+
+  describe('isDocuments', function () {
+    it('should true', function () {
+      isDocuments('@io.appium.example/Documents/file.txt').should.be.true;
+    });
+    it('should false', function () {
+      isDocuments('@io.appium.example/Photo/photo.png').should.be.false;
+    });
+  });
+
+
   describe('getAvailableBundleIds', withMocks({teen_process, fs}, (mocks) => {
     afterEach(function () {
       mocks.verify();

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -34,9 +34,9 @@ describe('file-movement', function () {
       pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
       should.equal(containerType, null);
     });
-    it('should rase an error if no container path', async function () {
+    it('should raise an error if no container path', async function () {
       const mntRoot = await tempDir.openDir();
-      await parseContainerPath('@io.appium.example:documents', mntRoot).should.eventually.rejected;
+      await parseContainerPath('@io.appium.example:documents', mntRoot).should.eventually.be.rejected;
     });
   });
 

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -5,29 +5,41 @@ import * as teen_process from 'teen_process';
 import { withMocks } from 'appium-test-support';
 import { fs, tempDir } from 'appium-support';
 
-chai.should();
+const should = chai.should();
 chai.use(chaiAsPromised);
 
 describe('file-movement', function () {
   describe('parseContainerPath', function () {
-    it('should parse', async function () {
+    it('should parse with container', async function () {
       const mntRoot = await tempDir.openDir();
-      const [bundleId, pathInContainer] = await parseContainerPath('@io.appium.example/Documents/file.txt', mntRoot);
+      const {bundleId, pathInContainer, containerType} = await parseContainerPath('@io.appium.example:app/Documents/file.txt', mntRoot);
 
       bundleId.should.eql('io.appium.example');
       pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
+      containerType.should.eql('app');
+    });
+    it('should parse without container', async function () {
+      const mntRoot = await tempDir.openDir();
+      const {bundleId, pathInContainer, containerType} = await parseContainerPath('@io.appium.example/Documents/file.txt', mntRoot);
+
+      bundleId.should.eql('io.appium.example');
+      pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
+      should.equal(containerType, null);
     });
   });
 
   describe('isDocuments', function () {
     it('should true', function () {
-      isDocuments('@io.appium.example/Documents/file.txt').should.be.true;
+      isDocuments('documents').should.be.true;
     });
-    it('should true but only documents', function () {
-      isDocuments('@io.appium.example/Documents').should.be.true;
+    it('should true with upper', function () {
+      isDocuments('DOCUMENTS').should.be.true;
     });
-    it('should false', function () {
-      isDocuments('@io.appium.example/Photo/photo.png').should.be.false;
+    it('should false with non documents', function () {
+      isDocuments('app').should.be.false;
+    });
+    it('should false with null', function () {
+      isDocuments(null).should.be.false;
     });
   });
 

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -23,6 +23,9 @@ describe('file-movement', function () {
     it('should true', function () {
       isDocuments('@io.appium.example/Documents/file.txt').should.be.true;
     });
+    it('should true but only documents', function () {
+      isDocuments('@io.appium.example/Documents').should.be.true;
+    });
     it('should false', function () {
       isDocuments('@io.appium.example/Photo/photo.png').should.be.false;
     });
@@ -39,10 +42,10 @@ describe('file-movement', function () {
         .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
-        .returns(`
+        .returns({stdout: `
 com.apple.Keynote, "6383", "Keynote"
 io.appium.example, "1.0.205581.0.10", "Appium"
-        `);
+        `, stderr: ''});
       await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([
         'com.apple.Keynote', 'io.appium.example'
       ]);
@@ -52,7 +55,7 @@ io.appium.example, "1.0.205581.0.10", "Appium"
         .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
-        .returns('');
+        .returns({stdout: '', stderr: ''});
       await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([]);
     });
     it('raises no ifuse error', async function () {
@@ -60,7 +63,7 @@ io.appium.example, "1.0.205581.0.10", "Appium"
         .withExactArgs('ifuse').once().returns(false);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
-        .returns('');
+        .returns({stdout: '', stderr: ''});
       await getAvailableBundleIds({ udid: '12345' })
         .should.eventually.be.rejectedWith(/tool is required/);
     });

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -67,14 +67,14 @@ io.appium.example, "1.0.205581.0.10", "Appium"
       await getAvailableBundleIds({ udid: '12345' })
         .should.eventually.be.rejectedWith(/tool is required/);
     });
-    it('raises no ifuse error', async function () {
+    it('should nothing happen', async function () {
       mocks.fs.expects('which')
         .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .throws();
       await getAvailableBundleIds({ udid: '12345' })
-        .should.eventually.rejectedWith(/Cannot get a list of bundleIds/);
+        .should.eventually.be.undefined;
     });
   }));
 });

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -18,6 +18,14 @@ describe('file-movement', function () {
       pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
       containerType.should.eql('app');
     });
+    it('should parse with container root', async function () {
+      const mntRoot = await tempDir.openDir();
+      const {bundleId, pathInContainer, containerType} = await parseContainerPath('@io.appium.example:documents/', mntRoot);
+
+      bundleId.should.eql('io.appium.example');
+      pathInContainer.should.eql(mntRoot);
+      containerType.should.eql('documents');
+    });
     it('should parse without container', async function () {
       const mntRoot = await tempDir.openDir();
       const {bundleId, pathInContainer, containerType} = await parseContainerPath('@io.appium.example/Documents/file.txt', mntRoot);

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -34,6 +34,10 @@ describe('file-movement', function () {
       pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
       should.equal(containerType, null);
     });
+    it('should rase an error if no container path', async function () {
+      const mntRoot = await tempDir.openDir();
+      await parseContainerPath('@io.appium.example:documents', mntRoot).should.eventually.rejected;
+    });
   });
 
   describe('isDocuments', function () {
@@ -58,8 +62,6 @@ describe('file-movement', function () {
     });
 
     it('get available bundleIds with items', async function () {
-      mocks.fs.expects('which')
-        .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .returns({stdout: `
@@ -71,30 +73,17 @@ io.appium.example, "1.0.205581.0.10", "Appium"
       ]);
     });
     it('get available bundleIds without items', async function () {
-      mocks.fs.expects('which')
-        .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .returns({stdout: '', stderr: ''});
       await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([]);
     });
-    it('raises no ifuse error', async function () {
-      mocks.fs.expects('which')
-        .withExactArgs('ifuse').once().returns(false);
-      mocks.teen_process.expects('exec')
-        .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
-        .returns({stdout: '', stderr: ''});
-      await getAvailableBundleIds({ udid: '12345' })
-        .should.eventually.be.rejectedWith(/tool is required/);
-    });
     it('should nothing happen', async function () {
-      mocks.fs.expects('which')
-        .withExactArgs('ifuse').once().returns(true);
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .throws();
       await getAvailableBundleIds({ udid: '12345' })
-        .should.eventually.be.undefined;
+        .should.eventually.be.eql([]);
     });
   }));
 });

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -1,4 +1,4 @@
-import { getAvailableBundleIds, parseContainerPath, isDocuments } from '../../../lib/commands/file-movement';
+import { getAvailableBundleIds, parseContainerPath } from '../../../lib/commands/file-movement';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as teen_process from 'teen_process';
@@ -40,22 +40,6 @@ describe('file-movement', function () {
     });
   });
 
-  describe('isDocuments', function () {
-    it('should true', function () {
-      isDocuments('documents').should.be.true;
-    });
-    it('should true with upper', function () {
-      isDocuments('DOCUMENTS').should.be.true;
-    });
-    it('should false with non documents', function () {
-      isDocuments('app').should.be.false;
-    });
-    it('should false with null', function () {
-      isDocuments(null).should.be.false;
-    });
-  });
-
-
   describe('getAvailableBundleIds', withMocks({teen_process, fs}, (mocks) => {
     afterEach(function () {
       mocks.verify();
@@ -68,7 +52,7 @@ describe('file-movement', function () {
 com.apple.Keynote, "6383", "Keynote"
 io.appium.example, "1.0.205581.0.10", "Appium"
         `, stderr: ''});
-      await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([
+      await getAvailableBundleIds('12345').should.eventually.eql([
         'com.apple.Keynote', 'io.appium.example'
       ]);
     });
@@ -76,13 +60,13 @@ io.appium.example, "1.0.205581.0.10", "Appium"
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .returns({stdout: '', stderr: ''});
-      await getAvailableBundleIds({ udid: '12345' }).should.eventually.eql([]);
+      await getAvailableBundleIds('12345').should.eventually.eql([]);
     });
     it('should nothing happen', async function () {
       mocks.teen_process.expects('exec')
         .withExactArgs('ifuse', ['-u', '12345', '--list-apps'])
         .throws();
-      await getAvailableBundleIds({ udid: '12345' })
+      await getAvailableBundleIds('12345')
         .should.eventually.be.eql([]);
     });
   }));


### PR DESCRIPTION
for https://github.com/appium/appium/issues/12283#issuecomment-497384996

I would like to put a couple of examples as documentation in https://github.com/appium/appium/tree/master/docs/en

summary:

- `--container` can work if the target app has UIFileSharingEnabled flag
- `--documents` can work without the flag
    - Thus, I tried to mount by `--documents` if the provided `remotePath` starts with `Documents` after the bundle id
    - The mounted target on iPhone is in _On My Phone/app name_ in Files app

I tested they worked with https://github.com/appium/ruby_lib_core/pull/216/files for real device