### PR TITLE
Don't cleanupObsoleteProcesses if webDriverAgentUrl is passed

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -477,8 +477,10 @@ class XCUITestDriver extends BaseDriver {
   async startWda (sessionId, realDevice) {
     this.wda = new WebDriverAgent(this.xcodeVersion, this.opts);
 
-    await this.wda.cleanupObsoleteProcesses();
-
+    // Don't cleanup the processes if webDriverAgentUrl is set
+    if (!util.hasValue(this.wda.webDriverAgentUrl)) {
+      await this.wda.cleanupObsoleteProcesses();
+    }
     // Let multiple WDA binaries with different derived data folders be built in parallel
     // Concurrent WDA builds from the same source will cause xcodebuild synchronization errors
     const synchronizationKey = !this.opts.useXctestrunFile && await this.wda.isSourceFresh()


### PR DESCRIPTION
We shouldn't kill iproxy instances if webDriverAgentUrl is passed as there would be an iproxy instance already running to connect to the WDA