### PR TITLE
Add tv check to verifyApplicationPlatform

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1102,7 +1102,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     try {
-      await verifyApplicationPlatform(this.opts.app, this.isSimulator());
+      await verifyApplicationPlatform(this.opts.app, this.isSimulator(), isTvOS(this.opts.platformName));
     } catch (err) {
       // TODO: Let it throw after we confirm the architecture verification algorithm is stable
       log.warn(`*********************************`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -437,7 +437,7 @@ async function removeAllSessionWebSocketHandlers (server, sessionId) {
  * `true` is returned if the bundle architecture matches the device architecture.
  * @throws {Error} If bundle architecture does not match the device architecture.
  */
-async function verifyApplicationPlatform (app, isSimulator) {
+async function verifyApplicationPlatform (app, isSimulator, isTvOS) {
   log.debug('Verifying application platform');
 
   const infoPlist = path.resolve(app, 'Info.plist');
@@ -453,8 +453,11 @@ async function verifyApplicationPlatform (app, isSimulator) {
     return null;
   }
 
-  const isAppSupported = (isSimulator && CFBundleSupportedPlatforms.includes('iPhoneSimulator'))
-    || (!isSimulator && CFBundleSupportedPlatforms.includes('iPhoneOS'));
+  const expectedPlatform = isSimulator
+    ? isTvOS ? 'AppleTVSimulator' : 'iPhoneSimulator'
+    : isTvOS ? 'AppleTVOS' : 'iPhoneOS';
+
+  const isAppSupported = CFBundleSupportedPlatforms.includes(expectedPlatform);
   if (isAppSupported) {
     return true;
   }

--- a/lib/wda/xcodebuild.js
+++ b/lib/wda/xcodebuild.js
@@ -17,6 +17,12 @@ const RUNNER_SCHEME_IOS = 'WebDriverAgentRunner';
 const LIB_SCHEME_IOS = 'WebDriverAgentLib';
 
 const ERROR_WRITING_ATTACHMENT = 'Error writing attachment data to file';
+const ERROR_COPYING_ATTACHMENT = 'Error copying testing attachment';
+const IGNORED_ERRORS = [
+  ERROR_WRITING_ATTACHMENT,
+  ERROR_COPYING_ATTACHMENT,
+  'Failed to remove screenshot at path',
+];
 
 const RUNNER_SCHEME_TV = 'WebDriverAgentRunner_tvOS';
 const LIB_SCHEME_TV = 'WebDriverAgentLib_tvOS';
@@ -280,9 +286,8 @@ class XcodeBuild {
       // if we have an error we want to output the logs
       // otherwise the failure is inscrutible
       // but do not log permission errors from trying to write to attachments folder
-      const ignoredErrors = [ERROR_WRITING_ATTACHMENT, 'Failed to remove screenshot at path'];
-      if (this.showXcodeLog !== false && out.includes('Error Domain=') &&
-          !ignoredErrors.some((x) => out.includes(x))) {
+      const ignoreError = IGNORED_ERRORS.some((x) => out.includes(x));
+      if (this.showXcodeLog !== false && out.includes('Error Domain=') && !ignoreError) {
         logXcodeOutput = true;
 
         // terrible hack to handle case where xcode return 0 but is failing
@@ -290,7 +295,7 @@ class XcodeBuild {
       }
 
       // do not log permission errors from trying to write to attachments folder
-      if (logXcodeOutput && !out.includes(ERROR_WRITING_ATTACHMENT)) {
+      if (logXcodeOutput && !ignoreError) {
         for (const line of out.split(EOL)) {
           xcodeLog.error(line);
           if (line) {


### PR DESCRIPTION
Add parameter to `verifyApplicationPlatform` so that tvos builds can be recognized when appropriate.

Also add another expected log line to the list.