### PR TITLE
Remove submodule stuff from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,15 +188,6 @@ jobs:
     #   os: linux
     #   env: CLOUD=1 SAUCE_RDC_DEVICE_INDEX=1 TEST=functional/long
 
-git:
-  submodules: false
-before_install:
-  # Use sed to replace the SSH URL with the public URL, then initialize submodules
-  # code from http://stackoverflow.com/a/24600210/375688
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
-      git submodule update --init --recursive;
-    fi
 install:
   - npm --version
   - node --version


### PR DESCRIPTION
As we no longer have a submodule, Travis no longer needs to accommodate one.