### PR TITLE
Improve bad app error messgae

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -732,7 +732,7 @@ class XCUITestDriver extends BaseDriver {
       this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
     } catch (err) {
       log.error(err);
-      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed app file` + (err.message ? `: ${err.message}` : ''));
+      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed app file${err && err.message ? `: ${err.message}` : ''}`);
     }
     this.isAppTemporary = this.opts.app && await fs.exists(this.opts.app)
       && !await util.isSameDestination(originalAppPath, this.opts.app);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -732,7 +732,7 @@ class XCUITestDriver extends BaseDriver {
       this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
     } catch (err) {
       log.error(err);
-      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed file`);
+      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed app file` + (err.message ? `: ${err.message}` : ''));
     }
     this.isAppTemporary = this.opts.app && await fs.exists(this.opts.app)
       && !await util.isSameDestination(originalAppPath, this.opts.app);


### PR DESCRIPTION
If the file specified by `app` caps exists but its format is wrong (due to zip operation mistake etc), currently the error message is like `An unknown server-side error occurred while processing the command. Original error: Bad app: ***. App paths need to be absolute or an URL to a compressed app file` And if you check Appium log, you can see `App zip unzipped OK, but we could not find .app bundle(s) in it. Make sure your archive contains .app package(s) and nothing else`.

But I think if the error message itself also contains the detailed cause like `...we could not find .app bundle(s) in it..`, the user debug will be much easier (at least for me).

