### PR TITLE
update checkForDependencies arguments to follow the new WDA

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -226,7 +226,7 @@ class WebDriverAgent {
       // make sure that the WDA dependencies have been built
       const synchronizationKey = path.normalize(this.bootstrapPath);
       await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
-        const didPerformUpgrade = await checkForDependencies(this.bootstrapPath, this.useCarthageSsl);
+        const didPerformUpgrade = await checkForDependencies({useSsl: this.useCarthageSsl});
         if (didPerformUpgrade) {
           // Only perform the cleanup after WDA upgrade
           await this.xcodebuild.cleanProject();


### PR DESCRIPTION
After https://github.com/appium/appium-xcuitest-driver/pull/980/files , `checkForDependencies` has been moved to WDA script,  https://github.com/appium/WebDriverAgent/blob/master/index.js#L114-L116.
Then, the argument has been an object, and it uses `opt.useSsl`.

(if we need `bootstrapPath`, we should close this PR and update `checkForDependencies` in WDA side.)