### PR TITLE
Skip checking wda dependencies when usePrebuiltWDA is enabled

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -53,6 +53,7 @@ class WebDriverAgent {
 
     this.useXctestrunFile = args.useXctestrunFile;
     this.usePrebuiltWDA = args.usePrebuiltWDA;
+    this.derivedDataPath = args.derivedDataPath;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
       platformVersion: this.platformVersion,
@@ -225,7 +226,7 @@ class WebDriverAgent {
 
     // useXctestrunFile and usePrebuiltWDA use existing dependencies
     // It depends on user side
-    if (this.useXctestrunFile || this.usePrebuiltWDA) {
+    if (this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
       log.info('Skip resolving WDA dependencies');
     } else {
       // make sure that the WDA dependencies have been built

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -227,7 +227,7 @@ class WebDriverAgent {
     // useXctestrunFile and usePrebuiltWDA use existing dependencies
     // It depends on user side
     if (this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
-      log.info('Skip resolving WDA dependencies');
+      log.info('Skipped WDA dependencies resolution according to the provided capabilities');
     } else {
       // make sure that the WDA dependencies have been built
       const synchronizationKey = path.normalize(this.bootstrapPath);

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -52,6 +52,7 @@ class WebDriverAgent {
     this.useCarthageSsl = _.isBoolean(args.useCarthageSsl) && args.useCarthageSsl;
 
     this.useXctestrunFile = args.useXctestrunFile;
+    this.usePrebuiltWDA = args.usePrebuiltWDA;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
       platformVersion: this.platformVersion,
@@ -222,7 +223,11 @@ class WebDriverAgent {
                       'file does not exist');
     }
 
-    if (!this.useXctestrunFile) {
+    // useXctestrunFile and usePrebuiltWDA use existing dependencies
+    // It depends on user side
+    if (this.useXctestrunFile || this.usePrebuiltWDA) {
+      log.info('Skip resolving WDA dependencies');
+    } else {
       // make sure that the WDA dependencies have been built
       const synchronizationKey = path.normalize(this.bootstrapPath);
       await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {

--- a/test/unit/wda/webdriveragent-specs.js
+++ b/test/unit/wda/webdriveragent-specs.js
@@ -1,0 +1,80 @@
+import { WebDriverAgent } from '../../../lib/wda/webdriveragent';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { withMocks } from 'appium-test-support';
+import { fs } from 'appium-support';
+const appium_wda = require('appium-webdriveragent');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('WebDriverAgent', function () {
+  const wda = new WebDriverAgent('12.1');
+  const wda_xcodebuild = wda.xcodebuild;
+  describe('#launch', withMocks({wda, fs, appium_wda, wda_xcodebuild}, function (mocks) {
+
+    afterEach(function () {
+      mocks.verify();
+    });
+
+    it('should call checkForDependencies', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = false;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.appium_wda.expects('checkForDependencies').once().returns(false);
+      mocks.wda_xcodebuild.expects('init').once().returns();
+      mocks.wda_xcodebuild.expects('start').once().returns();
+      await wda.launch();
+    });
+
+    it('should call checkForDependencies since only usePrebuiltWDA', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = true;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.appium_wda.expects('checkForDependencies').once().returns(false);
+      mocks.wda_xcodebuild.expects('init').once().returns();
+      mocks.wda_xcodebuild.expects('start').once().returns();
+      await wda.launch();
+    });
+
+    it('should not call checkForDependencies with usePrebuiltWDA and derivedDataPath', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = true;
+      wda.derivedDataPath = 'path/to/data';
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.appium_wda.expects('checkForDependencies').never();
+      mocks.wda_xcodebuild.expects('init').once().returns();
+      mocks.wda_xcodebuild.expects('start').once().returns();
+      await wda.launch();
+    });
+
+    it('should not call checkForDependencies with useXctestrunFile', async function () {
+      wda.useXctestrunFile = true;
+      wda.usePrebuiltWDA = false;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.appium_wda.expects('checkForDependencies').never();
+      mocks.wda_xcodebuild.expects('init').once().returns();
+      mocks.wda_xcodebuild.expects('start').once().returns();
+      await wda.launch();
+    });
+  }));
+});


### PR DESCRIPTION
https://github.com/appium/appium/issues/12836

@dpgraham 
What about skipping the checking process if `usePrebuiltWDA` is enabled?
In the case, we do not need to check WDA dependencies. So, simply skip it.

Will add test later if this works well