### PR TITLE
fix: the control flow of perf record

### DIFF
--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -64,7 +64,7 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
  */
 commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}) {
   this.ensureFeatureEnabled(PERF_RECORD_FEAT_NAME);
-  if (!this.isRealDevice()) {
+  if (this.isRealDevice()) {
     log.errorAndThrow('Performance measurement is for simulators only');
   }
 
@@ -172,7 +172,7 @@ commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}
  */
 commands.mobileStopPerfRecord = async function mobileStopPerfRecord (opts = {}) {
   this.ensureFeatureEnabled(PERF_RECORD_FEAT_NAME);
-  if (!this.isRealDevice()) {
+  if (this.isRealDevice()) {
     log.errorAndThrow('Performance measurement is for simulators only');
   }
 

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -10,6 +10,9 @@ import { waitForCondition } from 'asyncbox';
 let commands = {};
 
 const PERF_RECORD_FEAT_NAME = 'perf_record';
+const PERF_RECORD_SECURITY_MESSAGE = 'Performance measurement requires relaxing security for simulator. ' +
+  `Please set '--relaxed-security' or '--allow-insecure' with '${PERF_RECORD_FEAT_NAME}' ` +
+  'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.';
 const RECORDERS_CACHE = {};
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const STOP_TIMEOUT_MS = 3 * 60 * 1000;
@@ -46,10 +49,10 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
  * @property {?string} profileName [Activity Monitor] - The name of existing performance profile to apply.
  *                                                      Execute `instruments -s` to show the list of available profiles.
  *                                                      Note, that not all profiles are supported on mobile devices.
- * @property {?string|number} pid - The ID of the process to meassure the performance for.
- *                                  Set it to `current` in order to meassure the performance of
+ * @property {?string|number} pid - The ID of the process to measure the performance for.
+ *                                  Set it to `current` in order to measure the performance of
  *                                  the process, which belongs to the currently active application.
- *                                  All processes running on the device are meassured if
+ *                                  All processes running on the device are measured if
  *                                  pid is unset (the default setting).
  */
 
@@ -66,9 +69,7 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
  */
 commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}) {
   if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
-    log.errorAndThrow('Performance measurement requires relaxing security for simulator. ' +
-     `Please set '--relaxed-security' or '--allow-insecure' with '${PERF_RECORD_FEAT_NAME}' ` +
-     'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.');
+    log.errorAndThrow(PERF_RECORD_SECURITY_MESSAGE);
   }
 
   const {
@@ -151,7 +152,7 @@ commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}
  * @property {?string} remotePath - The path to the remote location, where the resulting zipped .trace file should be uploaded.
  *                                  The following protocols are supported: http/https, ftp.
  *                                  Null or empty string value (the default setting) means the content of resulting
- *                                  file should be zipped, encoded as Base64 and passed as the endpount response value.
+ *                                  file should be zipped, encoded as Base64 and passed as the endpoint response value.
  *                                  An exception will be thrown if the generated file is too big to
  *                                  fit into the available process memory.
  * @property {?string} user - The name of the user for the remote authentication. Only works if `remotePath` is provided.
@@ -168,16 +169,14 @@ commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}
  * open such file with Xcode Dev Tools.
  *
  * @param {?StopRecordingOptions} opts - The set of possible stop record options
- * @return {string} Either an empty string if the upload wqaas successful or base-64 encoded
+ * @return {string} Either an empty string if the upload was successful or base-64 encoded
  * content of zipped .trace file.
  * @throws {Error} If no performance recording with given profile name/device udid combination
  * has been started before or the resulting .trace file has not been generated properly.
  */
 commands.mobileStopPerfRecord = async function mobileStopPerfRecord (opts = {}) {
   if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
-    log.errorAndThrow('Performance measurement requires relaxing security for simulator. ' +
-     `Please set '--relaxed-security' or '--allow-insecure' with '${PERF_RECORD_FEAT_NAME}' ` +
-     'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.');
+    log.errorAndThrow(PERF_RECORD_SECURITY_MESSAGE);
   }
 
   const {

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -55,6 +55,8 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
 
 /**
  * Starts performance profiling for the device under test.
+ * Relaxing security is mandatory for simulators. It can always work for real devices.
+ *
  * The `instruments` developer utility is used for this purpose under the hood.
  * It is possible to record multiple profiles at the same time.
  * Read https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html
@@ -63,9 +65,10 @@ async function uploadTrace (localFile, remotePath = null, uploadOptions = {}) {
  * @param {?StartPerfRecordOptions} opts - The set of possible start record options
  */
 commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}) {
-  this.ensureFeatureEnabled(PERF_RECORD_FEAT_NAME);
-  if (this.isRealDevice()) {
-    log.errorAndThrow('Performance measurement is for simulators only');
+  if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
+    log.errorAndThrow('Performance measurement requires relaxing security for simulator. ' +
+     `Please set '--relaxed-security' or '--allow-insecure' with '${PERF_RECORD_FEAT_NAME}' ` +
+     'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.');
   }
 
   const {
@@ -171,9 +174,10 @@ commands.mobileStartPerfRecord = async function mobileStartPerfRecord (opts = {}
  * has been started before or the resulting .trace file has not been generated properly.
  */
 commands.mobileStopPerfRecord = async function mobileStopPerfRecord (opts = {}) {
-  this.ensureFeatureEnabled(PERF_RECORD_FEAT_NAME);
-  if (this.isRealDevice()) {
-    log.errorAndThrow('Performance measurement is for simulators only');
+  if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
+    log.errorAndThrow('Performance measurement requires relaxing security for simulator. ' +
+     `Please set '--relaxed-security' or '--allow-insecure' with '${PERF_RECORD_FEAT_NAME}' ` +
+     'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.');
   }
 
   const {


### PR DESCRIPTION
After https://github.com/appium/appium-xcuitest-driver/pull/989, performance record feature does not work for simulators. It should raise an error when the test device real devices.
(Founded in ruby lib core's [CI](https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=879))

```
=================‌00D‌RROR[&quot;test_start_performance_record_and_stop&quot;, #&lt;Minitest::Reporters::Suite:0x00007f8a472253e8 @name=&quot;AppiumLibCoreTest::Ios::DeviceTest&quot;&gt;, 443.211323]‌
 test_start_performance_record_and_stop#AppiumLibCoreTest::Ios::DeviceTest (443.21s)
Selenium::WebDriver::Error::UnknownError:         Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Performance measurement is for simulators only
            UnknownError: An unknown server-side error occurred while processing the command. Original error: Performance measurement is for simulators only
                at getResponseForW3CError (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/errors.js:826:9)
                at asyncHandler (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:447:37)
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/response.rb:72:in `assert_ok'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/response.rb:34:in `initialize'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/common.rb:88:in `new'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/common.rb:88:in `create_response'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/default.rb:114:in `request'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/common/base/http_default.rb:81:in `call'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/bridge.rb:167:in `execute'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/w3c/bridge.rb:567:in `execute'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/w3c/bridge.rb:305:in `execute_script'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/ios/xcuitest/device/performance.rb:29:in `start_performance_record'
            /Users/vsts/agent/2.153.2/work/1/s/test/functional/ios/ios/device_test.rb:275:in `test_start_performance_record_and_stop'
```