### PR TITLE
feat: add getting deviceInfo mobile command

### DIFF
--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -1,0 +1,32 @@
+import { util } from 'appium-support';
+
+let extensions = {}, commands = {};
+
+/**
+ * @typedef {Object} DeviceInfo
+ *
+ * @property {?string} currentLocale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
+ * @property {?string} timeZone - TZ database Time Zones format like 'US/Pacific'
+ */
+
+/**
+ * Returns device info.
+ *
+ * @returns {DeviceInfo} The current device info
+ * @throws {Error} if an error raised by command
+ */
+commands.mobileGetDeviceInfo = async function mobileGetDeviceInfo () {
+  const {ios} = await this.proxyCommand('/status', 'GET');
+  const info = {};
+  if (util.hasValue(ios.currentLocale)) {
+    info.locale = ios.currentLocale;
+  }
+  if (util.hasValue(ios.timeZone)) {
+    info.timeZone = ios.timeZone;
+  }
+  return info;
+};
+
+Object.assign(extensions, commands);
+export { commands };
+export default extensions;

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -1,30 +1,13 @@
-import { util } from 'appium-support';
-
 let extensions = {}, commands = {};
-
-/**
- * @typedef {Object} DeviceInfo
- *
- * @property {?string} locale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
- * @property {?string} timeZone - TZ database Time Zones format like 'US/Pacific'
- */
 
 /**
  * Returns device info.
  *
- * @returns {DeviceInfo} The current device info
+ * @returns {Object} The response of `/appium/device/info'`
  * @throws {Error} if an error raised by command
  */
 commands.mobileGetDeviceInfo = async function mobileGetDeviceInfo () {
-  const {ios} = await this.proxyCommand('/status', 'GET');
-  const info = {};
-  if (util.hasValue(ios.currentLocale)) {
-    info.locale = ios.currentLocale;
-  }
-  if (util.hasValue(ios.timeZone)) {
-    info.timeZone = ios.timeZone;
-  }
-  return info;
+  return await this.proxyCommand('/appium/device/info', 'GET');
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -5,7 +5,7 @@ let extensions = {}, commands = {};
 /**
  * @typedef {Object} DeviceInfo
  *
- * @property {?string} currentLocale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
+ * @property {?string} locale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
  * @property {?string} timeZone - TZ database Time Zones format like 'US/Pacific'
  */
 

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -3,11 +3,11 @@ let extensions = {}, commands = {};
 /**
  * Returns device info.
  *
- * @returns {Object} The response of `/appium/device/info'`
+ * @returns {Object} The response of `/wda/device/info'`
  * @throws {Error} if an error raised by command
  */
 commands.mobileGetDeviceInfo = async function mobileGetDeviceInfo () {
-  return await this.proxyCommand('/appium/device/info', 'GET');
+  return await this.proxyCommand('/wda/device/info', 'GET');
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -69,6 +69,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     stopLogsBroadcast: 'mobileStopLogsBroadcast',
 
     batteryInfo: 'mobileGetBatteryInfo',
+    deviceInfo: 'mobileGetDeviceInfo',
 
     pressButton: 'mobilePressButton',
 
@@ -82,6 +83,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     siriCommand: 'mobileSiriCommand',
   };
+
 
   if (!_.has(commandMap, mobileCommand)) {
     throw new errors.UnknownCommandError(`Unknown mobile command '${mobileCommand}'. Only ${_.keys(commandMap).join(', ')} commands are supported.`);

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -84,7 +84,6 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     siriCommand: 'mobileSiriCommand',
   };
 
-
   if (!_.has(commandMap, mobileCommand)) {
     throw new errors.UnknownCommandError(`Unknown mobile command '${mobileCommand}'. Only ${_.keys(commandMap).join(', ')} commands are supported.`);
   }

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -22,6 +22,7 @@ import performanceExtensions from './performance';
 import clipboardExtensions from './clipboard';
 import certificateExtensions from './certificate';
 import batteryExtensions from './battery';
+import deviceInfoExtensions from './deviceInfo';
 import cookiesExtensions from './cookies';
 import biometricExtensions from './biometric';
 import keychainsExtensions from './keychains';
@@ -36,7 +37,7 @@ Object.assign(commands, contextCommands, executeExtensions,
   alertExtensions, screenshotExtensions, pasteboardExtensions, locationExtensions,
   lockExtensions, recordScreenExtensions, appManagementExtensions, performanceExtensions,
   clipboardExtensions, certificateExtensions, batteryExtensions, cookiesExtensions,
-  biometricExtensions, keychainsExtensions, permissionsExtensions
+  biometricExtensions, keychainsExtensions, permissionsExtensions, deviceInfoExtensions
 );
 
 export default commands;

--- a/test/unit/commands/deviceinfo-specs.js
+++ b/test/unit/commands/deviceinfo-specs.js
@@ -22,47 +22,17 @@ describe('get deviceinfo commands', function () {
 
   it('get device info', async function () {
     proxyStub.returns({
-      os: {
-        name: 'iOS',
-        version: '11.4',
-        sdkVersion: '11.3',
-      },
-      ios: {
-        currentLocale: 'ja_EN',
-        timeZone: 'US/Pacific',
-        simulatorVersion: '11.4',
-        ip: 'localhost'
-      },
-      build: {
-        time: 'Jun 24 2018 17:08:21',
-        productBundleIdentifier: 'com.facebook.WebDriverAgentRunner'
-      }
+      timeZone: 'America/New_York',
+      locale: 'ja_EN',
     });
-
 
     const out = await driver.mobileGetDeviceInfo();
     out.locale.should.eq('ja_EN');
-    out.timeZone.should.eq('US/Pacific');
+    out.timeZone.should.eq('America/New_York');
   });
 
-  it('get device info, but no proper info because of old WDA', async function () {
-    proxyStub.returns({
-      os: {
-        name: 'iOS',
-        version: '11.4',
-        sdkVersion: '11.3',
-      },
-      ios: {
-        simulatorVersion: '11.4',
-        ip: 'localhost'
-      },
-      build: {
-        time: 'Jun 24 2018 17:08:21',
-        productBundleIdentifier: 'com.facebook.WebDriverAgentRunner'
-      }
-    });
-
-    const out = await driver.mobileGetDeviceInfo();
-    out.should.be.empty;
+  it('get device info raise an error if the endpoint raises error', async function () {
+    proxyStub.throws();
+    await driver.mobileGetDeviceInfo().should.eventually.be.rejected;
   });
 });

--- a/test/unit/commands/deviceinfo-specs.js
+++ b/test/unit/commands/deviceinfo-specs.js
@@ -1,0 +1,68 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import XCUITestDriver from '../../../';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('get deviceinfo commands', function () {
+  const driver = new XCUITestDriver();
+  // give the driver a spy-able proxy object
+  driver.wda = {jwproxy: {command: () => {}}};
+  let proxyStub;
+
+  this.beforeEach(function () {
+    proxyStub = sinon.stub(driver.wda.jwproxy, 'command');
+  });
+
+  afterEach(function () {
+    proxyStub.restore();
+  });
+
+  it('get device info', async function () {
+    proxyStub.returns({
+      os: {
+        name: 'iOS',
+        version: '11.4',
+        sdkVersion: '11.3',
+      },
+      ios: {
+        currentLocale: 'ja_EN',
+        timeZone: 'US/Pacific',
+        simulatorVersion: '11.4',
+        ip: 'localhost'
+      },
+      build: {
+        time: 'Jun 24 2018 17:08:21',
+        productBundleIdentifier: 'com.facebook.WebDriverAgentRunner'
+      }
+    });
+
+
+    const out = await driver.mobileGetDeviceInfo();
+    out.locale.should.eq('ja_EN');
+    out.timeZone.should.eq('US/Pacific');
+  });
+
+  it('get device info, but no proper info because of old WDA', async function () {
+    proxyStub.returns({
+      os: {
+        name: 'iOS',
+        version: '11.4',
+        sdkVersion: '11.3',
+      },
+      ios: {
+        simulatorVersion: '11.4',
+        ip: 'localhost'
+      },
+      build: {
+        time: 'Jun 24 2018 17:08:21',
+        productBundleIdentifier: 'com.facebook.WebDriverAgentRunner'
+      }
+    });
+
+    const out = await driver.mobileGetDeviceInfo();
+    out.should.be.empty;
+  });
+});


### PR DESCRIPTION
Added `deviceInfo` mobile command like `batteryInfo` command. http://appium.io/docs/en/commands/mobile-command/

It returns device condition like current locale, timezone.

```ruby
@driver.execute_script 'mobile: deviceInfo', {}
=> {"locale"=>"en_US", "timeZone"=>"Asia/Tokyo"}
```


The command returns timezone and locale after https://github.com/appium/WebDriverAgent/commit/3cf6e3309baa38f8018534986729444000b5e08f 
WDA can work independently, e.g. webDriverAgentUrl, so nothing returns if locale or timezone do not in the response.

---

I noticed android UIA2 and Espresso drivers have the same name command.
Will add locale and timezone in them for android.