### PR TITLE
test: add tests for runSimulatorReset in order to clarify the behaviour

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1112,9 +1112,7 @@ class XCUITestDriver extends BaseDriver {
     if (this.isRealDevice()) {
       await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     } else {
-      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, {
-        noReset: this.opts.noReset, fullReset: this.opts.fullReset
-      });
+      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     }
 
     if (util.hasValue(this.opts.iosInstallPause)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1112,7 +1112,9 @@ class XCUITestDriver extends BaseDriver {
     if (this.isRealDevice()) {
       await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     } else {
-      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset, this.opts.fullReset);
+      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, {
+        noReset: this.opts.noReset, fullReset: this.opts.fullReset
+      });
     }
 
     if (util.hasValue(this.opts.iosInstallPause)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1112,7 +1112,7 @@ class XCUITestDriver extends BaseDriver {
     if (this.isRealDevice()) {
       await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
     } else {
-      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset);
+      await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, this.opts.noReset, this.opts.fullReset);
     }
 
     if (util.hasValue(this.opts.iosInstallPause)) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -122,9 +122,9 @@ async function runSimulatorReset (device, opts) {
       if (isSafari) {
         await device.cleanSafari();
       } else {
-        // TODO: Should we allow to scrubCustomApp only bundleId?
-        // As simulator, we do not need the `app` to clean the local data
-        await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
+        // path is optional for iOS8+ simulators
+        const path = opts.app ? path.basename(opts.app) : null;
+        await device.scrubCustomApp(path, opts.bundleId);
       }
     } catch (err) {
       log.warn(err.message);
@@ -164,10 +164,12 @@ async function installToSimulator (device, app, bundleId, resetOptions = {}) {
         return;
       }
       if (fullReset) {
-        log.debug(`Full reset requested. Removing app with id '${bundleId}' from the device`);
+        log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
         await device.removeApp(bundleId);
       }
       // noRest === false && fullRest === false (=== fastReset)
+      // We can expect local data has been cleaned.
+      // We can override with the given app as clean install without removing the app.
     }
   }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -122,6 +122,8 @@ async function runSimulatorReset (device, opts) {
       if (isSafari) {
         await device.cleanSafari();
       } else {
+        // TODO: Should we allow to scrubCustomApp only bundleId?
+        // As simulator, we do not need the `app` to clean the local data
         await device.scrubCustomApp(path.basename(opts.app), opts.bundleId);
       }
     } catch (err) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -116,12 +116,10 @@ async function runSimulatorReset (device, opts) {
         }
       }
     }
-
     if (opts.app) {
       log.info('Not scrubbing third party app in anticipation of uninstall');
       return;
     }
-
     const isSafari = (opts.browserName || '').toLowerCase() === 'safari';
     try {
       if (isSafari) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -117,6 +117,11 @@ async function runSimulatorReset (device, opts) {
       }
     }
 
+    if (opts.app) {
+      log.info('Not scrubbing third party app in anticipation of uninstall');
+      return;
+    }
+
     const isSafari = (opts.browserName || '').toLowerCase() === 'safari';
     try {
       if (isSafari) {
@@ -133,24 +138,13 @@ async function runSimulatorReset (device, opts) {
 }
 
 /**
- * @typedef {Object} ResetOptions
- *
- * @property {bool} noReset Whether keep the app installed
- *                          without deleting locale data
- * @property {bool} fullReset Whether uninstall and install the app
- *
- */
-
-/**
  * @param {object} device The simulator device object
  * @param {?string} app The app to the path
  * @param {string} bundleId The bundle id to ensure
  *                          it is already installed and uninstall it
- * @param {ResetOptions} reset
+ * @param {bool} noReset Whether noReset
  */
-async function installToSimulator (device, app, bundleId, resetOptions = {}) {
-  const { noReset = true, fullReset = false } = resetOptions;
-
+async function installToSimulator (device, app, bundleId, noReset = true) {
   if (!app) {
     log.debug('No app path is given. Nothing to install.');
     return;
@@ -162,13 +156,8 @@ async function installToSimulator (device, app, bundleId, resetOptions = {}) {
         log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
         return;
       }
-      if (fullReset) {
-        log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
-        await device.removeApp(bundleId);
-      }
-      // noRest === false && fullRest === false (=== fastReset)
-      // We can override with the given app without removing the app,
-      // since the local data should be cleaned.
+      log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
+      await device.removeApp(bundleId);
     }
   }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -122,9 +122,8 @@ async function runSimulatorReset (device, opts) {
       if (isSafari) {
         await device.cleanSafari();
       } else {
-        // path is optional for iOS8+ simulators
-        const path = opts.app ? path.basename(opts.app) : null;
-        await device.scrubCustomApp(path, opts.bundleId);
+        // iOS 8+ does not need basename
+        await device.scrubCustomApp(path.basename(opts.app || ''), opts.bundleId);
       }
     } catch (err) {
       log.warn(err.message);
@@ -168,8 +167,8 @@ async function installToSimulator (device, app, bundleId, resetOptions = {}) {
         await device.removeApp(bundleId);
       }
       // noRest === false && fullRest === false (=== fastReset)
-      // We can expect local data has been cleaned.
-      // We can override with the given app as clean install without removing the app.
+      // We can override with the given app without removing the app,
+      // since the local data should be cleaned.
     }
   }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -101,6 +101,8 @@ async function runSimulatorReset (device, opts) {
                'the backup operation did not succeed');
     }
   } else if (opts.bundleId) {
+    // fastReset or noReset
+
     // Terminate the app under test if it is still running on Simulator
     // Termination is not needed if Simulator is not running
     if (await device.isRunning()) {
@@ -114,10 +116,7 @@ async function runSimulatorReset (device, opts) {
         }
       }
     }
-    if (opts.app) {
-      log.info('Not scrubbing third party app in anticipation of uninstall');
-      return;
-    }
+
     const isSafari = (opts.browserName || '').toLowerCase() === 'safari';
     try {
       if (isSafari) {
@@ -132,7 +131,7 @@ async function runSimulatorReset (device, opts) {
   }
 }
 
-async function installToSimulator (device, app, bundleId, noReset = true) {
+async function installToSimulator (device, app, bundleId, noReset = true, fullReset = false) {
   if (!app) {
     log.debug('No app path is given. Nothing to install.');
     return;
@@ -144,8 +143,11 @@ async function installToSimulator (device, app, bundleId, noReset = true) {
         log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
         return;
       }
-      log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
-      await device.removeApp(bundleId);
+      if (fullReset) {
+        log.debug(`Full reset requested. Removing app with id '${bundleId}' from the device`);
+        await device.removeApp(bundleId);
+      }
+      // noRest === false && fullRest === false (=== fastReset)
     }
   }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -133,7 +133,25 @@ async function runSimulatorReset (device, opts) {
   }
 }
 
-async function installToSimulator (device, app, bundleId, noReset = true, fullReset = false) {
+/**
+ * @typedef {Object} ResetOptions
+ *
+ * @property {bool} noReset Whether keep the app installed
+ *                          without deleting locale data
+ * @property {bool} fullReset Whether uninstall and install the app
+ *
+ */
+
+/**
+ * @param {object} device The simulator device object
+ * @param {?string} app The app to the path
+ * @param {string} bundleId The bundle id to ensure
+ *                          it is already installed and uninstall it
+ * @param {ResetOptions} reset
+ */
+async function installToSimulator (device, app, bundleId, resetOptions = {}) {
+  const { noReset = true, fullReset = false } = resetOptions;
+
   if (!app) {
     log.debug('No app path is given. Nothing to install.');
     return;

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -161,5 +161,13 @@ describe('simulator management', function () {
       await runSimulatorReset(stoppedDeviceDummy, opts);
       result.should.eql('cleaned');
     });
+    it('should not call scrubCustomApp with fastReset, but no bundleid and app', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        noReset: false, fullReset: false
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      should.equal(result, undefined);
+    });
   });
 });

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -131,5 +131,35 @@ describe('simulator management', function () {
       await runSimulatorReset(stoppedDeviceDummy, opts);
       result.should.eql('cleaned');
     });
+    it('should call scrubCustomApp with fastReset and app', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        app: 'path/to/app.app',
+        noReset: false, fullReset: false
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      should.equal(result, undefined);
+    });
+    it('should return immediately with noReset and app', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        app: 'path/to/app.app',
+        noReset: true, fullReset: false
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      should.equal(result, undefined);
+    });
+    it('should call clean with fullRest and app', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        app: 'path/to/app.app',
+        noReset: false, fullReset: true
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      result.should.eql('cleaned');
+    });
   });
 });

--- a/test/unit/simulator-management-specs.js
+++ b/test/unit/simulator-management-specs.js
@@ -1,8 +1,8 @@
-import { createSim, getExistingSim } from '../../lib/simulator-management.js';
+import { createSim, getExistingSim, runSimulatorReset } from '../../lib/simulator-management.js';
 import sinon from 'sinon';
 import chai from 'chai';
 
-chai.should();
+const should = chai.should();
 
 const caps = {platformName: 'iOS', deviceName: 'iPhone 6', platformVersion: '10.1', app: '/foo.app'};
 const simctlModule = require('node-simctl');
@@ -84,6 +84,52 @@ describe('simulator management', function () {
       createDeviceStub.calledOnce.should.be.true;
       createDeviceStub.firstCall.args[0].should.eql('10.1');
       getSimulatorStub.notCalled.should.be.true;
+    });
+  });
+  describe('runSimulatorReset', function () {
+    let result;
+    const stoppedDeviceDummy = {
+      isRunning: () => false,
+      scrubCustomApp: (path, bundleId) => {
+        result = {path, bundleId};
+      },
+      clean: () => {
+        result = 'cleaned';
+      },
+      shutdown: () => {}
+    };
+
+    beforeEach(function () {
+      result = undefined;
+    });
+
+    it('should call scrubCustomApp with fastReset', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        noReset: false, fullReset: false
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      result.path.should.eql('');
+      result.bundleId.should.eql('io.appium.example');
+    });
+    it('should return immediately with noReset', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        noReset: true, fullReset: false
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      should.equal(result, undefined);
+    });
+    it('should call clean with fullRest', async function () {
+      const opts = {
+        udid: '301CD634-00A9-4042-B463-BD4E755167EA',
+        bundleId: 'io.appium.example',
+        noReset: false, fullReset: true
+      };
+      await runSimulatorReset(stoppedDeviceDummy, opts);
+      result.should.eql('cleaned');
     });
   });
 });


### PR DESCRIPTION
**[update]**

We implemented this way, uninstall everytime without noReset, because of untrusted clearing local data in simulator.
We'd like to avoid reminding unexpected previous data even if Appium called scrub method.

So, I changed to just adding test cases here.

---

related to https://github.com/appium/appium/issues/12873 

According to the issue, we previously did not require `app` as fastReset (default).
(Simulator scope. Not for real devices)

Current logic to clear local data is:

1. check `opts.app` => if it exists, return (not clean the simulator data)
2. If the app does not exist => `path.basename(opts.app)` raises an error => not clean the simulator data

So, in this PR, I changed to call `scrubCustomApp` instead of uninstalling the app every time (except for noReset is true) for fast reset.

reset strategy will be (simulator):
(fastReset is the default behaviour)

- current:
    - fastReset:
        - no app/only bundle id => stop the app
            - In safari case, `cleanSafari` is called
        - app / bundle id => stop the app, uninstall/install the app
    - noRest: nothing
    - fullReset: clear simulator every time
- will be
    - fastReset:
        - no app/only bundle id => stop the app, clean local data
        - app / bundle id => stop the app, clean local data, install the app(without uninstall it)
    - noRest: Does not 
    - fullReset: clear simulator every time


----


# This PR

- with `app`
```
[debug] [iOS] Getting bundle ID from app '/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/2019611-34297-1wo7yom.yi1v/UICatalog.app': 'com.example.apple-samplecode.UICatalog'
[debug] [BaseDriver] Event 'resetStarted' logged at 1562813146678 (11:45:46 GMT+0900 (Japan Standard Time))
[debug] [iOSSim] Cleaning app data files for 'UICatalog.app', 'com.example.apple-samplecode.UICatalog'
[debug] [iOSSim] Checking whether simulator has been run before: yes
[debug] [iOSSim] Building bundle path map
[debug] [iOSSim] Deleting directory: '/Users/kazu/Library/Developer/CoreSimulator/Devices/301CD634-00A9-4042-B463-BD4E755167EA/data/Containers/Data/Application/907BD309-DCDF-4D63-BD59-7C6C2B68578C'
[debug] [iOSSim] Deleting file: '/Users/kazu/Library/Developer/CoreSimulator/Devices/Library/Preferences/com.example.apple-samplecode.UICatalog.plist'
[debug] [BaseDriver] Event 'resetComplete' logged at 1562813147282 (11:45:47 GMT+0900 (Japan Standard Time))
```

- without `app`
```
[debug] [BaseDriver] Event 'resetStarted' logged at 1562814077305 (12:01:17 GMT+0900 (Japan Standard Time))
[debug] [iOSSim] Cleaning app data files for '', 'com.example.apple-samplecode.UICatalog'
[debug] [iOSSim] Checking whether simulator has been run before: yes
[debug] [iOSSim] Building bundle path map
[debug] [iOSSim] Deleting directory: '/Users/kazu/Library/Developer/CoreSimulator/Devices/301CD634-00A9-4042-B463-BD4E755167EA/data/Containers/Data/Application/D6B4B93E-229E-435B-A6E2-97701E037E82'
[debug] [iOSSim] Deleting file: '/Users/kazu/Library/Developer/CoreSimulator/Devices/Library/Preferences/com.example.apple-samplecode.UICatalog.plist'
[debug] [BaseDriver] Event 'resetComplete' logged at 1562814077954 (12:01:17 GMT+0900 (Japan Standard Time))
```

# Current

- with `app`
```
[debug] [BaseDriver] Event 'resetStarted' logged at 1562754988756 (19:36:28 GMT+0900 (Japan Standard Time))
[XCUITest] Not scrubbing third party app in anticipation of uninstall
[debug] [BaseDriver] Event 'resetComplete' logged at 1562754989194 (19:36:29 GMT+0900 (Japan Standard Time))
```

- without `ap`
```
[debug] [BaseDriver] Event 'resetStarted' logged at 1562812653284 (11:37:33 GMT+0900 (Japan Standard Time))
[XCUITest] path is not defined
[XCUITest] Reset: could not scrub application with id "com.example.apple-samplecode.UICatalog". Leaving as is.
[debug] [BaseDriver] Event 'resetComplete' logged at 1562812653494 (11:37:33 GMT+0900 (Japan Standard Time))
[XCUITest] Continuing without capturing device logs: iOS Simulator with udid 301CD634-00A9-4042-B463-BD4E755167EA is not running
```