### PR TITLE
fix: get active element should proxy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -78,6 +78,7 @@ const NO_PROXY_NATIVE_LIST = [
   ['POST', /clear/],
   ['POST', /context/],
   ['POST', /dismiss_alert/],
+  ['POST', /element\/active/], // MJSONWP get active element should proxy
   ['POST', /element$/],
   ['POST', /elements$/],
   ['POST', /execute/],


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/12968

WDA handles get active element as "GET" which is W3C spec. MJSONWP case the method is "POST".
xcuitest-driver has the proxy so MJSONWP case the request should be handled by xcuitest-driver.

https://github.com/appium/appium-xcuitest-driver/blob/master/lib/commands/general.js#L9-L14

e2e test exists, but it can work since it is W3C. (and it works fine)

fixed:

```
[HTTP] --> POST /wd/hub/session/18c36a40-d1ee-448f-a0d0-8c969b45698d/element/active
[HTTP] {}
[debug] [MJSONWP (18c36a40)] Calling AppiumDriver.active() with args: ["18c36a40-d1ee-448f-a0d0-8c969b45698d"]
[debug] [XCUITest] Executing command 'active'
[debug] [WD Proxy] Matched '/element/active' to command name 'active'
[debug] [WD Proxy] Proxying [GET /element/active] to [GET http://localhost:8100/session/D7785321-1D19-45A4-8850-F1612D73C0F1/element/active] with no body
[debug] [WD Proxy] Got response with status 200: {
[debug] [WD Proxy]   "value" : {
[debug] [WD Proxy]     "ELEMENT" : "1A000000-0000-0000-71EC-000000000000"
[debug] [WD Proxy]   },
[debug] [WD Proxy]   "sessionId" : "D7785321-1D19-45A4-8850-F1612D73C0F1",
[debug] [WD Proxy]   "status" : 0
[debug] [WD Proxy] }
[debug] [MJSONWP (18c36a40)] Responding to client with driver.active() result: {"element-6066-11e4-a52e-4f735466cecf":"1A000000-0000-0000-71EC-000000000000","ELEMENT":"1A000000-0000-0000-71EC-000000000000"}
[HTTP] <-- POST /wd/hub/session/18c36a40-d1ee-448f-a0d0-8c969b45698d/element/active 200 98 ms - 199
[HTTP]
```