### PR TITLE
tests: Add noReset=true to driver bundleId tests

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -126,7 +126,7 @@ async function runSimulatorReset (device, opts) {
         await device.cleanSafari();
       } else {
         // iOS 8+ does not need basename
-        await device.scrubCustomApp(path.basename(opts.app || ''), opts.bundleId);
+        await device.scrubCustomApp('', opts.bundleId);
       }
     } catch (err) {
       log.warn(err.message);

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -73,14 +73,20 @@ describe('XCUITestDriver', function () {
     });
 
     it('should start and stop a session with only bundle id', async function () {
-      let localCaps = Object.assign({}, caps, {bundleId: 'com.example.apple-samplecode.UICatalog'});
+      let localCaps = Object.assign({}, caps, {
+        bundleId: 'com.example.apple-samplecode.UICatalog',
+        noReset: true,
+      });
       localCaps.app = null;
       await initSession(localCaps).should.not.eventually.be.rejected;
     });
 
     it('should start and stop a session with only bundle id when no sim is running', async function () {
       await killAllSimulators();
-      let localCaps = Object.assign({}, caps, {bundleId: 'com.example.apple-samplecode.UICatalog'});
+      let localCaps = Object.assign({}, caps, {
+        bundleId: 'com.example.apple-samplecode.UICatalog',
+        noReset: true,
+      });
       localCaps.app = null;
       await initSession(localCaps).should.not.eventually.be.rejected;
     });


### PR DESCRIPTION
Small change to the reset logic (given the check on line 119, there is no way that `opts.app` evaluates as truthy, so there is no need to recheck it).

With the change in https://github.com/appium/appium-xcuitest-driver/pull/1004 the driver tests when only bundleId is set continued to work, but with an added ~4 minutes to the run because of the error:
```
dbug WD Proxy Proxying [POST /session] to [POST http://localhost:8100/session] with body: {"desiredCapabilities":{"bundleId":"com.example.apple-samplecode.UICatalog","arguments":[],"environment":{},"eventloopIdleDelaySec":0,"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":30,"shouldUseSingletonTestManager":true}}
ERR! Xcode 2019-07-12 14:33:38.575419+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure to determine system application: Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000 "Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeSystemAppApplication' for Device system-wide element'." UserInfo={NSLocalizedDescription=Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeSystemAppApplication' for Device system-wide element'.} /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 
ERR! Xcode 2019-07-12 14:33:38.576061+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure to determine system application: (null) /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 
ERR! Xcode 2019-07-12 14:34:43.582407+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure getting list of active applications: Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000 "Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeFocusedApplications' for (null)'." UserInfo={NSLocalizedDescription=Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeFocusedApplications' for (null)'.} /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 2019-07-12 14:34:43.583800+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure getting list of active applications: (null) /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 
ERR! Xcode 2019-07-12 14:35:48.697932+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure to determine system application: Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000 "Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeSystemAppApplication' for Device system-wide element'." UserInfo={NSLocalizedDescription=Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeSystemAppApplication' for Device system-wide element'.} /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 2019-07-12 14:35:48.698633+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure to determine system application: (null) /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 
ERR! Xcode 2019-07-12 14:36:53.704784+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure getting list of active applications: Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000 "Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeFocusedApplications' for (null)'." UserInfo={NSLocalizedDescription=Timeout waiting for fulfillment of promise for 'Fetching attributes 'XC_kAXXCAttributeFocusedApplications' for (null)'.} /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 2019-07-12 14:36:53.705981+0000 WebDriverAgentRunner-Runner[5376:16979] Enqueue Failure: Failure getting list of active applications: (null) /Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 38 1
ERR! Xcode 
dbug WD Proxy Got response with status 200: {"value":{"sessionId":"9A26EF2F-AD66-4205-A437-759931250E17","capabilities":{"device":"iphone","browserName":null,"sdkVersion":"12.2","CFBundleIdentifier":null}},"sessionId":"9A26EF2F-AD66-4205-A437-759931250E17","status":0}
```
This is because resetting started to work, and we are no reinstalling the app.