### PR TITLE
refactor: clean up tests

### DIFF
--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -41,8 +41,8 @@ describe('XCUITestDriver - basics -', function () {
       }
 
       await driver.setImplicitWaitTimeout(10000);
-      let findElementPromise = B.resolve(driver.elementById('WrongLocator'));
-      let status = await driver.status();
+      const findElementPromise = driver.elementById('WrongLocator');
+      const status = await driver.status();
       status.wda.should.exist;
       findElementPromise.isPending().should.be.true;
       try {

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -182,7 +182,6 @@ describe('XCUITestDriver - find', function () {
         texts.should.include('X Button');
       });
       it.skip('should filter by indices', async function () {
-        await driver.setImplicitWaitTimeout(10000);
         let el = await driver.elementByXPath('//XCUIElementTypeTable[1]//XCUIElementTypeButton[4]');
         (await el.getAttribute('name')).should.equal('X Button');
       });
@@ -290,7 +289,6 @@ describe('XCUITestDriver - find', function () {
         let element = await driver.elementByAccessibilityId('Text Fields');
         await driver.execute('mobile: scroll', {element, toVisible: true});
       } catch (ign) {}
-      await driver.setImplicitWaitTimeout(5000);
     });
     afterEach(async function () {
       await driver.back();

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -2,8 +2,8 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { retryInterval } from 'asyncbox';
 import { getSimulator } from 'appium-ios-simulator';
-import { killAllSimulators, shutdownSimulator } from '../helpers/simulator';
-import { getDevices, createDevice, deleteDevice } from 'node-simctl';
+import { killAllSimulators, shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
+import { getDevices, createDevice } from 'node-simctl';
 import _ from 'lodash';
 import B from 'bluebird';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
@@ -17,12 +17,6 @@ chai.use(chaiAsPromised);
 
 async function getNumSims () {
   return (await getDevices())[UICATALOG_SIM_CAPS.platformVersion].length;
-}
-
-async function deleteDeviceWithRetry (udid) {
-  try {
-    await retryInterval(10, 1000, deleteDevice, udid);
-  } catch (ign) {}
 }
 
 describe('XCUITestDriver', function () {

--- a/test/functional/driver/motion-e2e-specs.js
+++ b/test/functional/driver/motion-e2e-specs.js
@@ -1,23 +1,17 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { getSimulator } from 'appium-ios-simulator';
-import { shutdownSimulator } from '../helpers/simulator';
-import { createDevice, deleteDevice } from 'node-simctl';
-import { retryInterval } from 'asyncbox';
+import { shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
+import { createDevice } from 'node-simctl';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { SETTINGS_CAPS } from '../desired';
+
 
 const SIM_DEVICE_NAME = 'xcuitestDriverMotionTest';
 const PREDICATE_SEARCH = '-ios predicate string';
 
 chai.should();
 chai.use(chaiAsPromised);
-
-const deleteDeviceWithRetry = async function (udid) {
-  try {
-    await retryInterval(10, 1000, deleteDevice, udid);
-  } catch (ign) {}
-};
 
 describe('ReduceMotion', function () {
   this.timeout(MOCHA_TIMEOUT);

--- a/test/functional/driver/otherApps-e2e-specs.js
+++ b/test/functional/driver/otherApps-e2e-specs.js
@@ -1,24 +1,16 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { retryInterval } from 'asyncbox';
 import { getSimulator } from 'appium-ios-simulator';
-import { shutdownSimulator } from '../helpers/simulator';
-import { createDevice, deleteDevice } from 'node-simctl';
+import { shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
+import { createDevice } from 'node-simctl';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { MULTIPLE_APPS } from '../desired';
 
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
 
-// eslint-disable-next-line no-unused-vars
-const should = chai.should();
+chai.should();
 chai.use(chaiAsPromised);
-
-async function deleteDeviceWithRetry (udid) {
-  try {
-    await retryInterval(10, 1000, deleteDevice, udid);
-  } catch (ign) {}
-}
 
 describe('XCUITestDriver', function () {
   this.timeout(MOCHA_TIMEOUT);

--- a/test/functional/driver/webdriveragent-derived-data-path-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-derived-data-path-e2e-specs.js
@@ -1,9 +1,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { retryInterval } from 'asyncbox';
 import { getSimulator } from 'appium-ios-simulator';
-import { shutdownSimulator } from '../helpers/simulator';
-import { createDevice, deleteDevice } from 'node-simctl';
+import { shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
+import { createDevice } from 'node-simctl';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { UICATALOG_SIM_CAPS } from '../desired';
 import path from 'path';
@@ -13,14 +12,8 @@ import fs from 'fs';
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
 const TEMP_FOLDER = '/tmp/WebDriverAgent';
 
-const should = chai.should(); // eslint-disable-line no-unused-vars
+chai.should();
 chai.use(chaiAsPromised);
-
-const deleteDeviceWithRetry = async function (udid) {
-  try {
-    await retryInterval(10, 1000, deleteDevice, udid);
-  } catch (ign) {}
-};
 
 describe('XCUITestDriver', function () {
   this.timeout(MOCHA_TIMEOUT);

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -142,8 +142,6 @@ async function initSession (caps) {
     caps.udid = serverRes[1].udid;
   }
 
-  await driver.setImplicitWaitTimeout(process.env.CI ? 30000 : 5000);
-
   return driver;
 }
 

--- a/test/functional/helpers/simulator.js
+++ b/test/functional/helpers/simulator.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import { getDevices, shutdown } from 'node-simctl';
+import { getDevices, shutdown, deleteDevice } from 'node-simctl';
+import { retryInterval } from 'asyncbox';
 import { resetXCTestProcesses } from '../../../lib/utils';
 import { shutdownSimulator } from '../../../lib/simulator-management';
 import { killAllSimulators as simKill } from 'appium-ios-simulator';
@@ -22,5 +23,11 @@ async function killAllSimulators () {
   await simKill();
 }
 
+async function deleteDeviceWithRetry (udid) {
+  try {
+    await retryInterval(10, 1000, deleteDevice, udid);
+  } catch (ign) {}
+}
 
-export { killAllSimulators, shutdownSimulator };
+
+export { killAllSimulators, shutdownSimulator, deleteDeviceWithRetry };

--- a/test/functional/tv/tvos-e2e-specs.js
+++ b/test/functional/tv/tvos-e2e-specs.js
@@ -1,22 +1,16 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { retryInterval } from 'asyncbox';
 import { getSimulator } from 'appium-ios-simulator';
-import { shutdownSimulator } from '../helpers/simulator';
-import { createDevice, deleteDevice } from 'node-simctl';
+import { shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
+import { createDevice } from 'node-simctl';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { TVOS_CAPS } from '../desired';
+
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
 
 chai.should();
 chai.use(chaiAsPromised);
-
-async function deleteDeviceWithRetry (udid) {
-  try {
-    await retryInterval(10, 1000, deleteDevice, udid);
-  } catch (ign) {}
-}
 
 describe('tvOS', function () {
   this.timeout(MOCHA_TIMEOUT);

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -99,7 +99,7 @@ describe('Safari - basics -', function () {
 
     describe('implicit wait', function () {
       it('should set the implicit wait for finding web elements', async function () {
-        await driver.setImplicitWaitTimeout(7 * 1000);
+        await driver.setImplicitWaitTimeout(5000);
 
         let before = new Date().getTime() / 1000;
         let hasThrown = false;
@@ -116,7 +116,7 @@ describe('Safari - basics -', function () {
         }
 
         let after = new Date().getTime() / 1000;
-        ((after - before) > 7).should.be.ok;
+        ((after - before) > 5).should.be.ok;
         await driver.setImplicitWaitTimeout(0);
       });
     });

--- a/test/functional/web/safari-nativewebtap-e2e-specs.js
+++ b/test/functional/web/safari-nativewebtap-e2e-specs.js
@@ -82,6 +82,9 @@ describe('Safari - coordinate conversion -', function () {
               fullReset: true,
               noReset: false,
             }, caps));
+            if (process.env.CI) {
+              await driver.setImplicitWaitTimeout(10000);
+            }
           } catch (err) {
             if (err.message.includes('Invalid device type') || err.message.includes('Incompatible device')) {
               skipped = true;


### PR DESCRIPTION
Two things:
- remove most of our implicit wait usage
- consolidate the five separate-but-identical definitions of `deleteDeviceWithRetry`.