### PR TITLE
Fix handling of attribute when hiding keyboard

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -18,6 +18,8 @@ commands.getNativeAttribute = async function getNativeAttribute (attribute, el) 
     return await this.getContentSize(el);
   }
 
+  el = util.unwrapElement(el);
+
   // otherwise let WDA handle attribute requests
   let value = await this.proxyCommand(`/element/${el}/attribute/${attribute}`, 'GET');
   // Transform the result for the case when WDA returns an integer representation for a boolean value

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -114,10 +114,10 @@ commands.hideKeyboard = async function hideKeyboard (strategy, ...possibleKeys) 
     try {
       await this.proxyCommand('/wda/keyboard/dismiss', 'POST');
       return;
-    } catch (err) {
-      log.debug('Cannot dismiss the keyboard using the native call. Trying to apply a workaround...');
-    }
+    } catch (ign) {}
   }
+
+  log.debug('Cannot dismiss the keyboard using the native call. Trying to apply a workaround...');
 
   let keyboard;
   try {
@@ -130,7 +130,7 @@ commands.hideKeyboard = async function hideKeyboard (strategy, ...possibleKeys) 
   possibleKeys.pop(); // last parameter is the session id
   possibleKeys = possibleKeys.filter((element) => !!element); // get rid of undefined elements
   if (possibleKeys.length) {
-    for (let key of possibleKeys) {
+    for (const key of possibleKeys) {
       let el = _.last(await this.findNativeElementOrElements('accessibility id', key, true, keyboard));
       if (el) {
         log.debug(`Attempting to hide keyboard by pressing '${key}' key.`);
@@ -146,6 +146,10 @@ commands.hideKeyboard = async function hideKeyboard (strategy, ...possibleKeys) 
       return;
     }
     let buttons = await this.findNativeElementOrElements('class name', 'XCUIElementTypeButton', true, keyboard);
+    if (_.isEmpty(buttons)) {
+      log.warn(`No button elements found. Unable to hide.`);
+      return;
+    }
     await this.nativeClick(_.last(buttons));
   }
 };


### PR DESCRIPTION
Before:
```
info HTTP --> POST /wd/hub/session/2e5c2452-7e6b-46c0-96e7-3e31a58dce81/appium/device/hide_keyboard
info HTTP {}
dbug MJSONWP (2e5c2452) Calling XCUITestDriver.hideKeyboard() with args: [null,null,null,null,"2e5c2452-7e6b-46c0-96e7-3e31a58dce81"]
dbug XCUITest Executing command 'hideKeyboard'
dbug BaseDriver Waiting up to 0 ms for condition
dbug WD Proxy Matched '/element' to command name 'findElement'
dbug WD Proxy Proxying [POST /element] to [POST http://localhost:8100/session/FD20A0A8-EDAD-42DD-824B-A09301810C9B/element] with body: {"using":"class name","value":"XCUIElementTypeKeyboard"}
dbug WD Proxy Got response with status 200: {"value":{"ELEMENT":"D0000000-0000-0000-FA5E-000000000000"},"sessionId":"FD20A0A8-EDAD-42DD-824B-A09301810C9B","status":0}
dbug XCUITest Finding keyboard and clicking final button to close
dbug WD Proxy Matched '/element/[object Object]/attribute/visible' to command name 'getAttribute'
dbug WD Proxy Proxying [GET /element/[object Object]/attribute/visible] to [GET http://localhost:8100/session/FD20A0A8-EDAD-42DD-824B-A09301810C9B/element/[object Object]/attribute/visible] with no body
dbug WD Proxy Got response with status 200: {
dbug WD Proxy   "value" : null,
dbug WD Proxy   "sessionId" : "FD20A0A8-EDAD-42DD-824B-A09301810C9B",
dbug WD Proxy   "status" : 0
dbug WD Proxy }
dbug BaseDriver Waiting up to 0 ms for condition
dbug WD Proxy Matched '/element/D0000000-0000-0000-FA5E-000000000000/elements' to command name 'findElementsFromElement'
dbug WD Proxy Proxying [POST /element/D0000000-0000-0000-FA5E-000000000000/elements] to [POST http://localhost:8100/session/FD20A0A8-EDAD-42DD-824B-A09301810C9B/element/D0000000-0000-0000-FA5E-000000000000/elements] with body: {"using":"class name","value":"XCUIElementTypeButton"}
dbug WD Proxy Got response with status 200: {"value":[],"sessionId":"FD20A0A8-EDAD-42DD-824B-A09301810C9B","status":0}
dbug WD Proxy Matched '/element/undefined/click' to command name 'click'
dbug WD Proxy Proxying [POST /element/undefined/click] to [POST http://localhost:8100/session/FD20A0A8-EDAD-42DD-824B-A09301810C9B/element/undefined/click] with body: {}
dbug WD Proxy Got response with status 200: {"value":{},"sessionId":"FD20A0A8-EDAD-42DD-824B-A09301810C9B","status":13}
WARN WD Proxy Got an unexpected response: {"value":{},"sessionId":"FD20A0A8-EDAD-42DD-824B-A09301810C9B","status":13}
here
The request to /element/undefined/click has failed t: The request to /element/undefined/click has failed
dbug MJSONWP Matched JSONWP error code 13 to UnknownError
dbug MJSONWP (2e5c2452) Encountered internal error running command: UnknownError: An unknown server-side error occurred while processing the command. Original error: [object Object]
dbug MJSONWP (2e5c2452)     at errorFromMJSONWPStatusCode (/Users/isaac/code/appium-base-driver/lib/protocol/errors.js:789:10)
dbug MJSONWP (2e5c2452)     at ProxyRequestError.errorFromMJSONWPStatusCode [as getActualError] (/Users/isaac/code/appium-base-driver/lib/protocol/errors.js:683:14)
dbug MJSONWP (2e5c2452)     at JWProxy.getActualError [as command] (/Users/isaac/code/appium-base-driver/lib/jsonwp-proxy/proxy.js:264:19)
info HTTP <-- POST /wd/hub/session/2e5c2452-7e6b-46c0-96e7-3e31a58dce81/appium/device/hide_keyboard 500 486 ms - 186
```

After:
```
info HTTP --> POST /wd/hub/session/4d5ff990-eefa-4d10-997c-fc1c681c043d/appium/device/hide_keyboard
info HTTP {}
dbug MJSONWP (4d5ff990) Calling XCUITestDriver.hideKeyboard() with args: [null,null,null,null,"4d5ff990-eefa-4d10-997c-fc1c681c043d"]
dbug XCUITest Executing command 'hideKeyboard'
dbug XCUITest Cannot dismiss the keyboard using the native call. Trying to apply a workaround...
dbug BaseDriver Waiting up to 0 ms for condition
dbug WD Proxy Matched '/element' to command name 'findElement'
dbug WD Proxy Proxying [POST /element] to [POST http://localhost:8100/session/513A8DAA-0552-4451-9211-176124700809/element] with body: {"using":"class name","value":"XCUIElementTypeKeyboard"}
dbug WD Proxy Got response with status 200: {"value":{"ELEMENT":"D0000000-0000-0000-A261-000000000000"},"sessionId":"513A8DAA-0552-4451-9211-176124700809","status":0}
dbug XCUITest Finding keyboard and clicking final button to close
dbug WD Proxy Matched '/element/D0000000-0000-0000-A261-000000000000/attribute/visible' to command name 'getAttribute'
dbug WD Proxy Proxying [GET /element/D0000000-0000-0000-A261-000000000000/attribute/visible] to [GET http://localhost:8100/session/513A8DAA-0552-4451-9211-176124700809/element/D0000000-0000-0000-A261-000000000000/attribute/visible] with no body
dbug WD Proxy Got response with status 200: {
dbug WD Proxy   "value" : true,
dbug WD Proxy   "sessionId" : "513A8DAA-0552-4451-9211-176124700809",
dbug WD Proxy   "status" : 0
dbug WD Proxy }
dbug BaseDriver Waiting up to 0 ms for condition
dbug WD Proxy Matched '/element/D0000000-0000-0000-A261-000000000000/elements' to command name 'findElementsFromElement'
dbug WD Proxy Proxying [POST /element/D0000000-0000-0000-A261-000000000000/elements] to [POST http://localhost:8100/session/513A8DAA-0552-4451-9211-176124700809/element/D0000000-0000-0000-A261-000000000000/elements] with body: {"using":"class name","value":"XCUIElementTypeButton"}
dbug WD Proxy Got response with status 200: {"value":[],"sessionId":"513A8DAA-0552-4451-9211-176124700809","status":0}
WARN XCUITest No button elements found. Unable to hide.
dbug MJSONWP (4d5ff990) Responding to client with driver.hideKeyboard() result: null
info HTTP <-- POST /wd/hub/session/4d5ff990-eefa-4d10-997c-fc1c681c043d/appium/device/hide_keyboard 200 650 ms - 76
```