### PR TITLE
feat: add activeAppInfo

### DIFF
--- a/lib/commands/activeAppInfo.js
+++ b/lib/commands/activeAppInfo.js
@@ -1,4 +1,4 @@
-let extensions = {}, commands = {};
+const extensions = {}, commands = {};
 
 /**
  * Returns ActiveApp info.

--- a/lib/commands/activeAppInfo.js
+++ b/lib/commands/activeAppInfo.js
@@ -1,0 +1,15 @@
+let extensions = {}, commands = {};
+
+/**
+ * Returns ActiveApp info.
+ *
+ * @returns {Object} The response of `/wda/activeAppInfo'`
+ * @throws {Error} if an error raised by command
+ */
+commands.mobileGetActiveAppInfo = async function mobileGetActiveAppInfo () {
+  return await this.proxyCommand('/wda/activeAppInfo', 'GET');
+};
+
+Object.assign(extensions, commands);
+export { commands };
+export default extensions;

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -1,4 +1,4 @@
-let extensions = {}, commands = {};
+const extensions = {}, commands = {};
 
 /**
  * Returns device info.

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -70,6 +70,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     batteryInfo: 'mobileGetBatteryInfo',
     deviceInfo: 'mobileGetDeviceInfo',
+    activeAppInfo: 'mobileGetActiveAppInfo',
 
     pressButton: 'mobilePressButton',
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -23,6 +23,7 @@ import clipboardExtensions from './clipboard';
 import certificateExtensions from './certificate';
 import batteryExtensions from './battery';
 import deviceInfoExtensions from './deviceInfo';
+import activeAppnfoExtensions from './activeAppInfo';
 import cookiesExtensions from './cookies';
 import biometricExtensions from './biometric';
 import keychainsExtensions from './keychains';
@@ -37,7 +38,8 @@ Object.assign(commands, contextCommands, executeExtensions,
   alertExtensions, screenshotExtensions, pasteboardExtensions, locationExtensions,
   lockExtensions, recordScreenExtensions, appManagementExtensions, performanceExtensions,
   clipboardExtensions, certificateExtensions, batteryExtensions, cookiesExtensions,
-  biometricExtensions, keychainsExtensions, permissionsExtensions, deviceInfoExtensions
+  biometricExtensions, keychainsExtensions, permissionsExtensions, deviceInfoExtensions,
+  activeAppnfoExtensions
 );
 
 export default commands;

--- a/test/unit/commands/activeAppInfo-specs.js
+++ b/test/unit/commands/activeAppInfo-specs.js
@@ -1,0 +1,44 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import XCUITestDriver from '../../../';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('get activeapp commands', function () {
+  const driver = new XCUITestDriver();
+  // give the driver a spy-able proxy object
+  driver.wda = {jwproxy: {command: () => {}}};
+  let proxyStub;
+
+  this.beforeEach(function () {
+    proxyStub = sinon.stub(driver.wda.jwproxy, 'command');
+  });
+
+  afterEach(function () {
+    proxyStub.restore();
+  });
+
+  it('get active app info', async function () {
+    proxyStub.returns({
+      pid: 15438,
+      name: '',
+      bundleId: 'com.apple.DocumentsApp',
+      processArguments: { env: { HAPPY: 'testing' }, args: ['happy', 'testing'] }
+    });
+
+    const out = await driver.mobileGetActiveAppInfo();
+    out.pid.should.eq(15438);
+    out.name.should.eq('');
+    out.bundleId.should.eq('com.apple.DocumentsApp');
+    out.processArguments.env.HAPPY.should.eq('testing');
+    out.processArguments.args[0].should.eq('happy');
+    out.processArguments.args[1].should.eq('testing');
+  });
+
+  it('get active app info raise an error if the endpoint raises error', async function () {
+    proxyStub.throws();
+    await driver.mobileGetActiveAppInfo().should.eventually.be.rejected;
+  });
+});


### PR DESCRIPTION
https://github.com/appium/WebDriverAgent/pull/194/files

```
> @@driver.execute_script('mobile: activeAppInfo', {})
=> {"processArguments"=>{"env"=>{"HAPPY"=>"testing"}, "args"=>["happy", "tseting"]}, "name"=>"", "pid"=>505, "bundleId"=>"com.apple.mobilesafari"}
```

`/wda/activeAppInfo` isn't new endpoint