### PR TITLE
feat: use idb instead of xcodebuild

### DIFF
--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -13,6 +13,7 @@ jobs:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
       MOCHA_FILE: '${{ parameters.name }}-tests.xml'
+      USE_IDB: ${{ parameters.useIDB }}
       CI: true
     pool:
       vmImage: 'macOS-10.14'

--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -13,7 +13,7 @@ jobs:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
       MOCHA_FILE: '${{ parameters.name }}-tests.xml'
-      USE_IDB: ${{ parameters.useIDB }}
+      LAUNCH_WITH_IDB: ${{ parameters.launchWithIDB }}
       CI: true
     pool:
       vmImage: 'macOS-10.14'

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -5,7 +5,7 @@ parameters:
   deviceName: 'iphone simulator'
   tvosName: ''
   tvosDeviceName: ''
-  useIDB: false
+  launchWithIDB: false
 jobs:
   - template: ./ios-e2e-template.yml
     parameters:
@@ -68,7 +68,7 @@ jobs:
 #      iosVersion: ${{ parameters.iosVersion }}
 #      xcodeVersion: ${{ parameters.xcodeVersion }}
 #      deviceName: ${{ parameters.deviceName }}
-#      useIDB: true
+#      launchWithIDB: true
 #      script: |
 #        brew tap facebook/fb
 #        brew install idb-companion

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -5,6 +5,7 @@ parameters:
   deviceName: 'iphone simulator'
   tvosName: ''
   tvosDeviceName: ''
+  useIDB: false
 jobs:
   - template: ./ios-e2e-template.yml
     parameters:
@@ -60,3 +61,17 @@ jobs:
       deviceName: ${{ parameters.tvosDeviceName }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options config-file=./ci-jobs/mocha-config.json --recursive build/test/functional/tv -g @skip-ci -i --exit
+# IDB test is commented out at the moment since it is not working with xcode 11 and azure
+#  - template: ./ios-e2e-template.yml
+#    parameters:
+#      name: e2e_basic_idb_${{ parameters.name }}
+#      iosVersion: ${{ parameters.iosVersion }}
+#      xcodeVersion: ${{ parameters.xcodeVersion }}
+#      deviceName: ${{ parameters.deviceName }}
+#      useIDB: true
+#      script: |
+#        brew tap facebook/fb
+#        brew install idb-companion
+#        pip3.7 install fb-idb
+#        npm install --no-save mjpeg-consumer
+#        npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options config-file=./ci-jobs/mocha-config.json --recursive build/test/functional/basic -g @skip-ci -i --exit

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -62,7 +62,7 @@ let desiredCapConstraints = _.defaults({
   derivedDataPath: {
     isString: true
   },
-  useIDB: {
+  launchWithIDB: {
     isBoolean: true
   },
   useNewWDA: {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -62,6 +62,9 @@ let desiredCapConstraints = _.defaults({
   derivedDataPath: {
     isString: true
   },
+  useIDB: {
+    isBoolean: true
+  },
   useNewWDA: {
     isBoolean: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -395,7 +395,7 @@ class XCUITestDriver extends BaseDriver {
           this.logEvent('customCertInstalled');
         }
       }
-      if (this.opts.useIDB && this.isSimulator()) {
+      if (this.opts.launchWithIDB && this.isSimulator()) {
         try {
           const idb = new IDB({udid});
           await idb.connect();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -395,13 +395,14 @@ class XCUITestDriver extends BaseDriver {
           this.logEvent('customCertInstalled');
         }
       }
-
-      try {
-        const idb = new IDB({udid});
-        await idb.connect();
-        this.opts.device.idb = idb;
-      } catch (e) {
-        log.info(`idb will not be used for Simulator interaction. Original error: ${e.message}`);
+      if (this.opts.useIDB && this.isSimulator()) {
+        try {
+          const idb = new IDB({udid});
+          await idb.connect();
+          this.opts.device.idb = idb;
+        } catch (e) {
+          log.info(`idb will not be used for Simulator interaction. Original error: ${e.message}`);
+        }
       }
 
       this.logEvent('simStarted');
@@ -612,11 +613,6 @@ class XCUITestDriver extends BaseDriver {
 
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
-
-    if (this.isSimulator() && (this.opts.device || {}).idb) {
-      await this.opts.device.idb.disconnect();
-      this.opts.device.idb = null;
-    }
 
     await this.stop();
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -276,6 +276,8 @@ async function resetXCTestProcesses (udid, isSimulator) {
   const processPatterns = [`xcodebuild.*${udid}`];
   if (isSimulator) {
     processPatterns.push(`${udid}.*XCTRunner`);
+    // The pattern to find in case idb was used
+    processPatterns.push(`xctest.*${udid}`);
   }
   log.debug(`Killing running processes '${processPatterns.join(', ')}' for the device ${udid}...`);
   for (const pgrepPattern of processPatterns) {

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -240,7 +240,7 @@ class WebDriverAgent {
     await resetXCTestProcesses(this.device.udid, !this.isRealDevice);
 
     if (this.idb) {
-      return this.startWithIDB();
+      return await this.startWithIDB();
     }
 
     await this.xcodebuild.init(this.noSessionProxy);
@@ -253,7 +253,7 @@ class WebDriverAgent {
   }
 
   async startWithIDB () {
-    log.info('Will launch WDA with idb instead of xcodebuild since it is provided');
+    log.info('Will launch WDA with idb instead of xcodebuild since the corresponding flag is enabled');
     const {wdaBundleId, testBundleId} = await this.prepareWDA();
     const env = {
       USE_PORT: this.wdaRemotePort,

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import url from 'url';
 import { JWProxy } from 'appium-base-driver';
-import { fs, util } from 'appium-support';
+import { fs, util, plist } from 'appium-support';
 import log from '../logger';
 import { NoSessionProxy } from './no-session-proxy';
 import { getWDAUpgradeTimestamp, CARTHAGE_ROOT } from './utils';
@@ -10,9 +10,7 @@ import { resetXCTestProcesses, getPIDsListeningOnPort } from '../utils';
 import XcodeBuild from './xcodebuild';
 import { exec } from 'teen_process';
 import AsyncLock from 'async-lock';
-import {
-  BOOTSTRAP_PATH, WDA_BUNDLE_ID, WDA_RUNNER_BUNDLE_ID, checkForDependencies
-} from 'appium-webdriveragent';
+import { BOOTSTRAP_PATH, WDA_BUNDLE_ID, WDA_RUNNER_BUNDLE_ID, checkForDependencies, bundleWDASim } from 'appium-webdriveragent';
 
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
@@ -20,7 +18,6 @@ const WDA_BASE_URL = 'http://localhost';
 const WDA_CF_BUNDLE_NAME = 'WebDriverAgentRunner-Runner';
 
 const SHARED_RESOURCES_GUARD = new AsyncLock();
-
 
 class WebDriverAgent {
   constructor (xcodeVersion, args = {}) {
@@ -34,6 +31,7 @@ class WebDriverAgent {
     this.iosSdkVersion = args.iosSdkVersion;
     this.host = args.host;
     this.isRealDevice = !!args.realDevice;
+    this.idb = (args.device || {}).idb;
 
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
@@ -54,6 +52,7 @@ class WebDriverAgent {
     this.useXctestrunFile = args.useXctestrunFile;
     this.usePrebuiltWDA = args.usePrebuiltWDA;
     this.derivedDataPath = args.derivedDataPath;
+    this.mjpegServerPort = args.mjpegServerPort;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
 
@@ -77,7 +76,7 @@ class WebDriverAgent {
       wdaRemotePort: this.wdaRemotePort,
       useXctestrunFile: this.useXctestrunFile,
       derivedDataPath: args.derivedDataPath,
-      mjpegServerPort: args.mjpegServerPort,
+      mjpegServerPort: this.mjpegServerPort,
     });
   }
 
@@ -224,7 +223,7 @@ class WebDriverAgent {
 
     // useXctestrunFile and usePrebuiltWDA use existing dependencies
     // It depends on user side
-    if (this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
+    if (this.idb || this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
       log.info('Skipped WDA dependencies resolution according to the provided capabilities');
     } else {
       // make sure that the WDA dependencies have been built
@@ -240,6 +239,10 @@ class WebDriverAgent {
     // We need to provide WDA local port, because it might be occupied with
     await resetXCTestProcesses(this.device.udid, !this.isRealDevice);
 
+    if (this.idb) {
+      return this.startWithIDB();
+    }
+
     await this.xcodebuild.init(this.noSessionProxy);
 
     // Start the xcodebuild process
@@ -247,6 +250,50 @@ class WebDriverAgent {
       await this.xcodebuild.prebuild();
     }
     return await this.xcodebuild.start();
+  }
+
+  async startWithIDB () {
+    log.info('Will launch WDA with idb instead of xcodebuild since it is provided');
+    const {wdaBundleId, testBundleId} = await this.prepareWDA();
+    const env = {
+      USE_PORT: this.wdaRemotePort,
+      WDA_PRODUCT_BUNDLE_IDENTIFIER: this.updatedWDABundleId,
+    };
+    if (this.mjpegServerPort) {
+      env.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    }
+
+    return await this.idb.runXCUITest(wdaBundleId, wdaBundleId, testBundleId, {env});
+  }
+
+  async parseBundleId (wdaBundlePath) {
+    const infoPlistPath = path.join(wdaBundlePath, 'Info.plist');
+    const infoPlist = await plist.parsePlist(await fs.readFile(infoPlistPath));
+    if (!infoPlist.CFBundleIdentifier) {
+      throw new Error(`Couldn't find bundle id in ${infoPlistPath}`);
+    }
+    return infoPlist.CFBundleIdentifier;
+  }
+
+  async prepareWDA () {
+    const wdaBundlePath = await this.fetchWDABundle();
+    const wdaBundleId = await this.parseBundleId(wdaBundlePath);
+    if (!await this.device.isAppInstalled(wdaBundleId)) {
+      await this.device.installApp(wdaBundlePath);
+    }
+    const testBundleId = await this.idb.installXCTestBundle(path.join(wdaBundlePath, 'PlugIns', 'WebDriverAgentRunner.xctest'));
+    return {wdaBundleId, testBundleId, wdaBundlePath};
+  }
+
+  async fetchWDABundle () {
+    if (!this.derivedDataPath) {
+      return await bundleWDASim();
+    }
+    const wdaBundlePath = await fs.walkDir(this.derivedDataPath, true, (item) => item.endsWith('WebDriverAgentRunner-Runner.app'));
+    if (!wdaBundlePath) {
+      throw new Error(`Couldn't find the WDA bundle in the ${this.derivedDataPath}`);
+    }
+    return wdaBundlePath;
   }
 
   async isSourceFresh () {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -15,6 +15,7 @@ function checkFeatureInEnv (envArg) {
 }
 
 const PLATFORM_VERSION = process.env.PLATFORM_VERSION ? process.env.PLATFORM_VERSION : '11.3';
+const USE_IDB = process.env.USE_IDB;
 
 // If it's real device cloud, don't set a device name. Use dynamic device allocation.
 const DEVICE_NAME = process.env.DEVICE_NAME
@@ -85,6 +86,7 @@ let GENERIC_CAPS = {
   platformVersion: PLATFORM_VERSION,
   deviceName: DEVICE_NAME,
   automationName: 'XCUITest',
+  useIDB: !!USE_IDB,
   noReset: true,
   maxTypingFrequency: 30,
   clearSystemFiles: true,

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -15,7 +15,7 @@ function checkFeatureInEnv (envArg) {
 }
 
 const PLATFORM_VERSION = process.env.PLATFORM_VERSION ? process.env.PLATFORM_VERSION : '11.3';
-const USE_IDB = process.env.USE_IDB;
+const LAUNCH_WITH_IDB = process.env.LAUNCH_WITH_IDB;
 
 // If it's real device cloud, don't set a device name. Use dynamic device allocation.
 const DEVICE_NAME = process.env.DEVICE_NAME
@@ -86,7 +86,7 @@ let GENERIC_CAPS = {
   platformVersion: PLATFORM_VERSION,
   deviceName: DEVICE_NAME,
   automationName: 'XCUITest',
-  useIDB: !!USE_IDB,
+  launchWithIDB: !!LAUNCH_WITH_IDB,
   noReset: true,
   maxTypingFrequency: 30,
   clearSystemFiles: true,


### PR DESCRIPTION
Experimental idb support. idb currently doesn't work with xcode 11 and azure. It needs further investigation but it should be okay to merge it since it is just an alternative to xcodebuild and doesn't break the old logic