### PR TITLE
fix: catching error when no available web pages

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -156,13 +156,18 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
 
   const currentUrl = useUrl ? this.getCurrentUrl() : undefined;
   let pageArray = [];
+  const getWebviewPages = async () => {
+    try {
+      return await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
+    } catch (err) {
+      log.debug(`No available web pages: ${err.message}`);
+      return [];
+    }
+  };
+
   if (this.remote && this.remote.appIdKey) {
     // already connected
-    try {
-      pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
-    } catch (err) {
-      log.debug(`No available web pages: ${err}`);
-    }
+    pageArray = await getWebviewPages();
   } else {
     // not connected
     this.remote = await this.getNewRemoteDebugger();
@@ -172,11 +177,7 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
       log.debug('Unable to connect to the remote debugger.');
       return [];
     }
-    try {
-      pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
-    } catch (err) {
-      log.debug(`No available web pages: ${err}`);
-    }
+    pageArray = await getWebviewPages();
     this.remote.on(RemoteDebugger.EVENT_PAGE_CHANGE, this.onPageChange.bind(this));
     this.remote.on(RemoteDebugger.EVENT_FRAMES_DETACHED, () => {
       if (!_.isEmpty(this.curWebFrames)) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -155,14 +155,13 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
   log.debug(`Selecting by url: ${useUrl} ${useUrl ? `(expected url: '${this.getCurrentUrl()}')` : ''}`);
 
   const currentUrl = useUrl ? this.getCurrentUrl() : undefined;
-  let pageArray;
+  let pageArray = [];
   if (this.remote && this.remote.appIdKey) {
     // already connected
     try {
       pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
     } catch (err) {
       log.debug(`No available web pages: ${err}`);
-      pageArray = [];
     }
   } else {
     // not connected
@@ -177,7 +176,6 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
       pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
     } catch (err) {
       log.debug(`No available web pages: ${err}`);
-      pageArray = [];
     }
     this.remote.on(RemoteDebugger.EVENT_PAGE_CHANGE, this.onPageChange.bind(this));
     this.remote.on(RemoteDebugger.EVENT_FRAMES_DETACHED, () => {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -158,7 +158,12 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
   let pageArray;
   if (this.remote && this.remote.appIdKey) {
     // already connected
-    pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
+    try {
+      pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
+    } catch (err) {
+      log.debug(`No available web pages: ${err}`);
+      pageArray = [];
+    }
   } else {
     // not connected
     this.remote = await this.getNewRemoteDebugger();
@@ -168,7 +173,12 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
       log.debug('Unable to connect to the remote debugger.');
       return [];
     }
-    pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
+    try {
+      pageArray = await this.remote.selectApp(currentUrl, this.opts.webviewConnectRetries, this.opts.ignoreAboutBlankUrl);
+    } catch (err) {
+      log.debug(`No available web pages: ${err}`);
+      pageArray = [];
+    }
     this.remote.on(RemoteDebugger.EVENT_PAGE_CHANGE, this.onPageChange.bind(this));
     this.remote.on(RemoteDebugger.EVENT_FRAMES_DETACHED, () => {
       if (!_.isEmpty(this.curWebFrames)) {


### PR DESCRIPTION
Currently, https://github.com/appium/appium-remote-debugger/blob/b8f5be6bd0fe9577c0f3ca54eac595a049e7aaaa/lib/remote-debugger.js#L324 is rased when we run below scenario.

1. Open an ios-uicatalog app
2. Call `available contexts` command
    - Get `NATIVE_APP` 🆗 
3. Open `Web View` cell
    - open webview
4. call `available contexts` command
    - Get `NATIVE_APP` and `WEBVIEW_xxxx` 🆗 
5. Back
    - No webview page
6. call `available contexts` command
    - https://github.com/appium/appium-remote-debugger/blob/b8f5be6bd0fe9577c0f3ca54eac595a049e7aaaa/lib/remote-debugger.js#L324 is raised

This is because we do not handle the error in xcuitest layer.
The error means we have no available webview. So, I think we can make the result `[]`

In this PR, I handle the error as try/catch in xcuitest layer, but I also wonder we can return `[]` in https://github.com/appium/appium-remote-debugger/blob/b8f5be6bd0fe9577c0f3ca54eac595a049e7aaaa/lib/remote-debugger.js#L324

@imurchie 
Do you have any good idea how to handle the issue?
try/catch in xcuitest layer like this PR, return `[]` in the remote debugger or other good ideas...