### PR TITLE
fix mjpegstream logic for returning screenshots

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -17,7 +17,8 @@ commands.getScreenshot = async function getScreenshot () {
   };
 
   // if we've specified an mjpeg server, use that
-  if (this.mjpegStrem) {
+  if (this.mjpegStream) {
+    log.info(`mjpeg video stream provided, returning latest frame as screenshot`);
     const data = await this.mjpegStream.lastChunkPNGBase64();
     if (data) {
       return data;


### PR DESCRIPTION
So, a typo here prevented screenshots from being returned from the mjpegstream.

Here's something interesting though, fixing this caused screenshots on my machine to go from taking ~172ms each to taking ~436ms. So by fixing this, screenshots are actually _less_ performant on iOS.