### PR TITLE
fix: turn uninstall app logic in quitAndUninstall and setupCaching to respect updatedWDABundleId

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -486,7 +486,7 @@ class XCUITestDriver extends BaseDriver {
     return await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
       if (this.opts.useNewWDA) {
         log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
-        await this.wda.quitAndUninstall();
+        await this.wda.quitAndUninstall(this.opts.updatedWDABundleId);
         this.logEvent('wdaUninstalled');
       } else if (!util.hasValue(this.wda.webDriverAgentUrl)) {
         await this.wda.setupCaching(this.opts.updatedWDABundleId);

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -160,7 +160,8 @@ class WebDriverAgent {
    *
    * @param {?string} bundleId The bundle id which will be removed from test device.
    */
-  async uninstall (bundleId = null) {
+  async uninstall (bundleId = WDA_BUNDLE_ID) {
+    // in case null is given
     const removeBundleId = util.hasValue(bundleId) ? bundleId : WDA_BUNDLE_ID;
     log.debug(`Removing WDA application, '${removeBundleId}', from device`);
     try {
@@ -398,8 +399,9 @@ class WebDriverAgent {
    * Quit running WDA and uninstall it.
    * @param {?string} updatedWDABundleId
    */
-  async quitAndUninstall (updatedWDABundleId) {
-    let installedBundleIdentifier = updatedWDABundleId || WDA_BUNDLE_ID;
+  async quitAndUninstall (updatedWDABundleId = WDA_BUNDLE_ID) {
+    // In case null is given
+    let installedBundleIdentifier = util.hasValue(updatedWDABundleId) ? updatedWDABundleId : WDA_BUNDLE_ID;
     const status = await this.getStatus();
     if (status && status.build) {
       // Uninstall running WDA which can communicate with xcuitest-driver

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -155,10 +155,16 @@ class WebDriverAgent {
     }
   }
 
-  async uninstall () {
-    log.debug(`Removing WDA application from device`);
+  /**
+   * Remove WDA from the test device.
+   * Remove default WDA_BUNDLE_ID if no bundleId is given.
+   * @param {?string} bundleId
+   */
+  async uninstall (bundleId) {
+    const removeBundleId = util.hasValue(bundleId) ? bundleId : WDA_BUNDLE_ID;
+    log.debug(`Removing WDA application, '${removeBundleId}', from device`);
     try {
-      await this.device.removeApp(WDA_BUNDLE_ID);
+      await this.device.removeApp(removeBundleId);
     } catch (e) {
       log.warn(`WebDriverAgent uninstall failed. Perhaps, it is already uninstalled? Original error: ${JSON.stringify(e)}`);
     }
@@ -350,13 +356,15 @@ class WebDriverAgent {
       productBundleIdentifier,
       upgradedAt,
     } = status.build;
-    if (util.hasValue(productBundleIdentifier) && util.hasValue(updatedWDABundleId) && updatedWDABundleId !== productBundleIdentifier) {
-      log.info(`Will uninstall running WDA since it has different bundle id. The actual value is '${productBundleIdentifier}'.`);
-      return await this.uninstall();
-    }
-    if (util.hasValue(productBundleIdentifier) && !util.hasValue(updatedWDABundleId) && WDA_RUNNER_BUNDLE_ID !== productBundleIdentifier) {
-      log.info(`Will uninstall running WDA since its bundle id is not equal to the default value ${WDA_RUNNER_BUNDLE_ID}`);
-      return await this.uninstall();
+    if (util.hasValue(productBundleIdentifier)) {
+      if (util.hasValue(updatedWDABundleId) && updatedWDABundleId !== productBundleIdentifier) {
+        log.info(`Will uninstall running WDA, '${productBundleIdentifier}', in order to install '${updatedWDABundleId}'`);
+        return await this.uninstall(productBundleIdentifier);
+      }
+      if (!util.hasValue(updatedWDABundleId) && WDA_RUNNER_BUNDLE_ID !== productBundleIdentifier) {
+        log.info(`Will uninstall running WDA, '${productBundleIdentifier}', in order to install the default WDA '${WDA_RUNNER_BUNDLE_ID}'`);
+        return await this.uninstall(productBundleIdentifier);
+      }
     }
 
     const actualUpgradeTimestamp = await getWDAUpgradeTimestamp(this.bootstrapPath);
@@ -365,7 +373,8 @@ class WebDriverAgent {
     if (actualUpgradeTimestamp && upgradedAt && _.toLower(`${actualUpgradeTimestamp}`) !== _.toLower(`${upgradedAt}`)) {
       log.info('Will uninstall running WDA since it has different version in comparison to the one ' +
         `which is bundled with appium-xcuitest-driver module (${actualUpgradeTimestamp} != ${upgradedAt})`);
-      return await this.uninstall();
+      // Uninstall running WDA on the device
+      return await this.uninstall(productBundleIdentifier);
     }
 
     const message = util.hasValue(productBundleIdentifier)
@@ -375,9 +384,22 @@ class WebDriverAgent {
     this.webDriverAgentUrl = this.url.href;
   }
 
-  async quitAndUninstall () {
+  /**
+   * Quite and uninstall
+   * @param {?string} updatedWDABundleId
+   */
+  async quitAndUninstall (updatedWDABundleId) {
+    let installedBundleIdentifier = updatedWDABundleId || WDA_BUNDLE_ID;
+    const status = await this.getStatus();
+    if (status && status.build) {
+      const { productBundleIdentifier } = status.build;
+      if (util.hasValue(productBundleIdentifier)) {
+        installedBundleIdentifier = productBundleIdentifier;
+      }
+    }
+
     await this.quit();
-    await this.uninstall();
+    await this.uninstall(installedBundleIdentifier);
   }
 }
 

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -157,10 +157,14 @@ class WebDriverAgent {
 
   /**
    * Remove WDA from the test device.
-   * Remove default WDA_BUNDLE_ID if no bundleId is given.
+   *
+   * Remove default WDA_BUNDLE_ID if no bundleId is given or simulator
+   * since WDA runs as WDA_BUNDLE_ID on simlator even if we set 'updatedWDABundleId'
+   * as another name.
+   *
    * @param {?string} bundleId
    */
-  async uninstall (bundleId) {
+  async uninstall (bundleId = null) {
     const removeBundleId = util.hasValue(bundleId) ? bundleId : WDA_BUNDLE_ID;
     log.debug(`Removing WDA application, '${removeBundleId}', from device`);
     try {
@@ -357,12 +361,14 @@ class WebDriverAgent {
       upgradedAt,
     } = status.build;
     if (util.hasValue(productBundleIdentifier)) {
+      // For real device. updatedWDABundleId should be set, in general.
       if (util.hasValue(updatedWDABundleId) && updatedWDABundleId !== productBundleIdentifier) {
-        log.info(`Will uninstall running WDA, '${productBundleIdentifier}', in order to install '${updatedWDABundleId}'`);
+        log.info(`Will uninstall running WDA, '${productBundleIdentifier}' and install '${updatedWDABundleId}'`);
         return await this.uninstall(productBundleIdentifier);
       }
+      // For simulator. No updatedWDABundleId case.
       if (!util.hasValue(updatedWDABundleId) && WDA_RUNNER_BUNDLE_ID !== productBundleIdentifier) {
-        log.info(`Will uninstall running WDA, '${productBundleIdentifier}', in order to install the default WDA '${WDA_RUNNER_BUNDLE_ID}'`);
+        log.info(`Will uninstall running WDA, '${productBundleIdentifier}', and install the default WDA '${WDA_RUNNER_BUNDLE_ID}'`);
         return await this.uninstall(productBundleIdentifier);
       }
     }
@@ -373,8 +379,16 @@ class WebDriverAgent {
     if (actualUpgradeTimestamp && upgradedAt && _.toLower(`${actualUpgradeTimestamp}`) !== _.toLower(`${upgradedAt}`)) {
       log.info('Will uninstall running WDA since it has different version in comparison to the one ' +
         `which is bundled with appium-xcuitest-driver module (${actualUpgradeTimestamp} != ${upgradedAt})`);
+
+      // The default WDA_RUNNER_BUNDLE_ID can expect it is running with WDA_BUNDLE_ID
+      if (WDA_RUNNER_BUNDLE_ID === productBundleIdentifier) {
+        // Uninstall the default WDA
+        return await this.uninstall();
+      } else {
+        return await this.uninstall(productBundleIdentifier);
+      }
+
       // Uninstall running WDA on the device
-      return await this.uninstall(productBundleIdentifier);
     }
 
     const message = util.hasValue(productBundleIdentifier)
@@ -385,13 +399,15 @@ class WebDriverAgent {
   }
 
   /**
-   * Quite and uninstall
+   * Quit running WDA and uninstall it.
    * @param {?string} updatedWDABundleId
    */
   async quitAndUninstall (updatedWDABundleId) {
     let installedBundleIdentifier = updatedWDABundleId || WDA_BUNDLE_ID;
     const status = await this.getStatus();
     if (status && status.build) {
+      // Uninstall running WDA which can communicate with xcuitest-driver
+      // to release using port
       const { productBundleIdentifier } = status.build;
       if (util.hasValue(productBundleIdentifier)) {
         installedBundleIdentifier = productBundleIdentifier;

--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -158,11 +158,7 @@ class WebDriverAgent {
   /**
    * Remove WDA from the test device.
    *
-   * Remove default WDA_BUNDLE_ID if no bundleId is given or simulator
-   * since WDA runs as WDA_BUNDLE_ID on simlator even if we set 'updatedWDABundleId'
-   * as another name.
-   *
-   * @param {?string} bundleId
+   * @param {?string} bundleId The bundle id which will be removed from test device.
    */
   async uninstall (bundleId = null) {
     const removeBundleId = util.hasValue(bundleId) ? bundleId : WDA_BUNDLE_ID;


### PR DESCRIPTION
Current uninstalling WDA in quitAndUninstall and setupCaching does not respect `updatedWDABundleId`. They uninstall the default bundle id every time.

In this PR, I've tweaked them to be able to uninstall customised bundle id.

Base logic is trying to remove `productBundleIdentifier` which can get via `status` command by running WDA. If `productBundleIdentifier` was `WDA_RUNNER_BUNDLE_ID`, we can assume the bundle id is the default (`WDA_BUNDLE_ID`) value. Then, we must uninstall WDA_BUNDLE_ID instead of `productBundleIdentifier`(`WDA_RUNNER_BUNDLE_ID`).


---

Current the cache logic works, but WDA is overridden on real devices.