### PR TITLE
feat: make this.wdaRemotePort configuarable

### DIFF
--- a/lib/wda/webdriveragent.js
+++ b/lib/wda/webdriveragent.js
@@ -37,6 +37,7 @@ class WebDriverAgent {
     this.setWDAPaths(args.bootstrapPath, args.agentPath);
 
     this.wdaLocalPort = args.wdaLocalPort;
+    this.wdaRemotePort = args.wdaLocalPort || WDA_AGENT_PORT;
     this.wdaBaseUrl = args.wdaBaseUrl || WDA_BASE_URL;
 
     this.prebuildWDA = args.prebuildWDA;
@@ -70,7 +71,7 @@ class WebDriverAgent {
       usePrebuiltWDA: args.usePrebuiltWDA,
       updatedWDABundleId: args.updatedWDABundleId,
       launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
-      wdaRemotePort: this.realDevice ? WDA_AGENT_PORT : (this.wdaLocalPort || WDA_AGENT_PORT),
+      wdaRemotePort: this.wdaRemotePort,
       useXctestrunFile: this.useXctestrunFile,
       derivedDataPath: args.derivedDataPath,
       mjpegServerPort: args.mjpegServerPort,
@@ -238,13 +239,13 @@ class WebDriverAgent {
     if (this.iproxy) {
       return this.iproxy;
     }
-    const iproxy = new iProxy(this.device.udid, this.url.port, WDA_AGENT_PORT);
+    const iproxy = new iProxy(this.device.udid, this.url.port, this.wdaRemotePort);
     try {
       await iproxy.start();
       return iproxy;
     } catch (e) {
       iproxy.quit();
-      throw new Error(`Couldn't start port forwarding on port ${WDA_AGENT_PORT}. Please provide a different port using 'wdaLocalPort' capability`);
+      throw new Error(`Couldn't start port forwarding on port ${this.wdaRemotePort}. Please provide a different port using 'wdaLocalPort' capability`);
     }
   }
 


### PR DESCRIPTION
Currently, we can port forward only to 8100 on a real device. Here can be `this.wdaLocalPort` as same as simulators. (I could not remember why `wdaRemotePort` was only `WDA_AGENT_PORT` for real device though...)



If a user set both `wdaLocalPort` and `wdaBaseUrl`, appium can send WDA via xcodebuild port forwarding to `wdaLocalPort` and it can communicate with WDA via `wdaBaseUrl:wdaLocalPort`. Then, Appium can re-use running WDA on the device regardless of xcodebuild's port condition since Appium communicate with WDA via `wdaBaseUrl:wdaLocalPort`.
The combination can avoid https://github.com/appium/appium/issues/13127 port issue.


I tested on a real device and a simulator with below configurations. Ran `driver.start_driver` twice and `driver.start_driver => driver.quite => driver.start_driver` scenarios. Test target app was `app` capability and `bundleId` capability (instaled app) cases.

- changed only `wdaLocalPort`
- changed only `wdaBaseUrl`
- changed both `wdaLocalPort` and `wdaBaseUrl`
