### PR TITLE
fix: Perform validation of retrieved derived data path

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -483,11 +483,15 @@ class XCUITestDriver extends BaseDriver {
     }
     // Let multiple WDA binaries with different derived data folders be built in parallel
     // Concurrent WDA builds from the same source will cause xcodebuild synchronization errors
-    const synchronizationKey = !this.opts.useXctestrunFile && await this.wda.isSourceFresh()
+    let synchronizationKey = XCUITestDriver.name;
+    if (this.opts.useXctestrunFile || !(await this.wda.isSourceFresh())) {
       // First-time compilation is an expensive operation, which is done faster if executed
       // sequentially. Xcodebuild spreads the load caused by the clang compiler to all available CPU cores
-      ? XCUITestDriver.name
-      : path.normalize(await this.wda.retrieveDerivedDataPath());
+      const derivedDataPath = await this.wda.retrieveDerivedDataPath();
+      if (derivedDataPath) {
+        synchronizationKey = path.normalize(derivedDataPath);
+      }
+    }
     log.debug(`Starting WebDriverAgent initialization with the synchronization key '${synchronizationKey}'`);
     if (SHARED_RESOURCES_GUARD.isBusy() && !this.opts.derivedDataPath && !this.opts.bootstrapPath) {
       log.debug(`Consider setting a unique 'derivedDataPath' capability value for each parallel driver instance ` +
@@ -613,14 +617,18 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this.wda && !this.opts.webDriverAgentUrl) {
-      const synchronizationKey = path.normalize(await this.wda.retrieveDerivedDataPath());
-      await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
-        if (this.opts.clearSystemFiles) {
-          await clearSystemFiles(this.wda);
-        } else {
-          log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+      if (this.opts.clearSystemFiles) {
+        let synchronizationKey = XCUITestDriver.name;
+        const derivedDataPath = await this.wda.retrieveDerivedDataPath();
+        if (derivedDataPath) {
+          synchronizationKey = path.normalize(derivedDataPath);
         }
-      });
+        await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+          await clearSystemFiles(this.wda);
+        });
+      } else {
+        log.debug('Not clearing log files. Use `clearSystemFiles` capability to turn on.');
+      }
     }
 
     if (this.isWebContext()) {


### PR DESCRIPTION
The returned result might be undefined, so we need to make sure first that it can be passed to `path.normalize`