### PR TITLE
feat: add includeSafariInWebviews cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Differences are noted here:
 |`screenshotQuality`| Changes the quality of phone display screenshots following [xctest/xctimagequality](https://developer.apple.com/documentation/xctest/xctimagequality?language=objc)  Default value is `1`. `0` is the highest and `2` is the lowest quality. You can also change it via [settings](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md) command. `0` might cause OutOfMemory crash on high-resolution devices like iPad Pro. | e.g. `0`, `1`, `2` |
 |`skipLogCapture`|Skips to start capturing logs such as crash, system, safari console and safari network. It might improve performance such as network. Log related commands will not work. Defaults to `false`. |`true` or `false`|
 |`safariGarbageCollect`|Turns on/off Web Inspector garbage collection when executing scripts on Safari. Turning on may improve performance. Defaults to `false`.|`true` or `false`|
+|`includeSafariInWebviews`|Add Safari web contexts to the list of contexts available during a native/webview app test. This is useful if the
+test opens Safari and needs to be able to interact with it. Defaults to `false`.|`true` or `false`|
 
 ## Opt-in Features (With Security Risk)
 

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -71,6 +71,7 @@ extensions.getNewRemoteDebugger = async function getNewRemoteDebugger () {
   return createRemoteDebugger({
     bundleId: this.opts.bundleId,
     isSafari: this.isSafari(),
+    includeSafari: this.opts.includeSafariInWebviews,
     useNewSafari: this.useNewSafari(),
     pageLoadMs: this.pageLoadMs,
     platformVersion: this.opts.platformVersion,

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -177,6 +177,9 @@ let desiredCapConstraints = _.defaults({
   otherApps: {
     isString: true
   },
+  includeSafariInWebviews: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "appium-ios-device": "^0.10.2",
     "appium-ios-driver": "^4.0.0",
     "appium-ios-simulator": "^3.14.0",
-    "appium-remote-debugger": "^5.1.0",
+    "appium-remote-debugger": "^5.3.0",
     "appium-support": "^2.32.0",
     "appium-webdriveragent": "^1.1.0",
     "appium-xcode": "^3.8.0",


### PR DESCRIPTION
Add a cap `includeSafariInWebviews` which signals to the remote debugger to add safari apps to the available list.

I would go for making this default to `true` but that would be a breaking change.