### PR TITLE
chore: Refactor the background endpoint implementation

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -21,56 +21,42 @@ commands.active = async function active () {
  * Close app (simulate device home button). It is possible to restore
  * the app after the timeout or keep it minimized based on the parameter value.
  *
- * Possible values for `duration`:
- * - any positive number of seconds: come back after X seconds, show deprecation warning
- * - any negative number of seconds: never come back, show deprecation warning
- * - undefined: come back after the default timeout (defined by WDA), show deprecation warning. After deprecation: never come back
+ * @param {?number|Object} seconds
+ * - any positive number of seconds: come back after X seconds
+ * - any negative number of seconds or zero: never come back
+ * - undefined/null: never come back
  * - {timeout: 5000}: come back after 5 seconds
  * - {timeout: null}, {timeout: -2}: never come back
  */
-commands.background = async function background (duration) {
-  const homescreenEndpoint = '/wda/homescreen';
-  const deactivateAppEndpoint = '/wda/deactivateApp';
+commands.background = async function background (seconds) {
+  const homescreen = '/wda/homescreen';
+  const deactivateApp = '/wda/deactivateApp';
+
   let endpoint;
-  let params;
-  if (_.isUndefined(duration)) {
-    // TODO: Replace the block after deprecated stuff is removed
-    // endpoint = homescreenEndpoint;
-    log.warn('commands.background: Application under test will never be restored in the future if no duration is provided. ' +
-             'See https://github.com/appium/appium/issues/7741');
-    endpoint = deactivateAppEndpoint;
-    params = {};
-  } else if (_.isNumber(duration)) {
-    // TODO: deprecate this case
-    log.warn('commands.background: Passing numbers to \'duration\' argument is deprecated. ' +
-             'See https://github.com/appium/appium/issues/7741');
-    if (duration >= 0) {
-      params = {duration};
-      endpoint = deactivateAppEndpoint;
-    } else {
-      endpoint = homescreenEndpoint;
-    }
-  } else if (_.isPlainObject(duration)) {
-    if (_.has(duration, 'timeout')) {
-      if (duration.timeout === null) {
-        endpoint = homescreenEndpoint;
-      } else if (_.isNumber(duration.timeout)) {
-        if (duration.timeout >= 0) {
-          params = {duration: duration.timeout / 1000.0};
-          endpoint = deactivateAppEndpoint;
-        } else {
-          endpoint = homescreenEndpoint;
-        }
+  let params = {};
+  const selectEndpoint = (timeoutSeconds) => {
+    if (!util.hasValue(timeoutSeconds)) {
+      endpoint = homescreen;
+    } if (!isNaN(timeoutSeconds)) {
+      if (timeoutSeconds >= 0) {
+        params = {duration: parseFloat(timeoutSeconds)};
+        endpoint = deactivateApp;
+      } else {
+        endpoint = homescreen;
       }
     }
+  };
+  if (_.has(seconds, 'timeout')) {
+    const {timeout} = seconds;
+    selectEndpoint(isNaN(timeout) ? timeout : parseFloat(timeout) / 1000.0);
+  } else {
+    selectEndpoint(seconds);
   }
-  if (_.isUndefined(endpoint)) {
-    log.errorAndThrow(`commands.background: Argument value is expected to be an object or 'undefined'. ` +
-                      `'${duration}' value has been provided instead. ` +
-                      `The 'timeout' attribute can be 'null' or any negative number to put the app under test ` +
-                      'into background and never come back or a positive number of milliseconds to wait until the app is restored.');
+  if (!endpoint) {
+    log.errorAndThrow(`Argument value is expected to be a valid number. ` +
+      `${JSON.stringify(seconds)} has been provided instead`);
   }
-  return await this.proxyCommand(endpoint, 'POST', params, endpoint !== homescreenEndpoint);
+  return await this.proxyCommand(endpoint, 'POST', params, endpoint !== homescreen);
 };
 
 commands.touchId = async function touchId (match = true) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -38,8 +38,9 @@ commands.background = async function background (seconds) {
     if (!util.hasValue(timeoutSeconds)) {
       endpoint = homescreen;
     } else if (!isNaN(timeoutSeconds)) {
-      if (timeoutSeconds >= 0) {
-        params = {duration: parseFloat(timeoutSeconds)};
+      const duration = parseFloat(timeoutSeconds);
+      if (duration >= 0) {
+        params = {duration};
         endpoint = deactivateApp;
       } else {
         endpoint = homescreen;

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -37,7 +37,7 @@ commands.background = async function background (seconds) {
   const selectEndpoint = (timeoutSeconds) => {
     if (!util.hasValue(timeoutSeconds)) {
       endpoint = homescreen;
-    } if (!isNaN(timeoutSeconds)) {
+    } else if (!isNaN(timeoutSeconds)) {
       if (timeoutSeconds >= 0) {
         params = {duration: parseFloat(timeoutSeconds)};
         endpoint = deactivateApp;

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -11,7 +11,7 @@ describe('general commands', function () {
   });
 
   describe('background', function () {
-    it('should deactivate app for the given time if seconds if zero or greater', async function () {
+    it('should deactivate app for the given time if seconds is zero or greater', async function () {
       await driver.background(0.5);
       proxyStub.calledOnce.should.be.true;
       proxyStub.firstCall.args[0].should.eql('/wda/deactivateApp');

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -11,10 +11,24 @@ describe('general commands', function () {
   });
 
   describe('background', function () {
-    it('should send translated POST request to WDA', async function () {
-      await driver.background();
+    it('should deactivate app for the given time if seconds if zero or greater', async function () {
+      await driver.background(0.5);
       proxyStub.calledOnce.should.be.true;
       proxyStub.firstCall.args[0].should.eql('/wda/deactivateApp');
+      proxyStub.firstCall.args[1].should.eql('POST');
+    });
+
+    it('should switch to home screen if seconds less than zero', async function () {
+      await driver.background(-1);
+      proxyStub.calledOnce.should.be.true;
+      proxyStub.firstCall.args[0].should.eql('/wda/homescreen');
+      proxyStub.firstCall.args[1].should.eql('POST');
+    });
+
+    it('should switch to home screen if seconds is null', async function () {
+      await driver.background(null);
+      proxyStub.calledOnce.should.be.true;
+      proxyStub.firstCall.args[0].should.eql('/wda/homescreen');
       proxyStub.firstCall.args[1].should.eql('POST');
     });
   });


### PR DESCRIPTION
I would like to keep the approach where `seconds` argument is passed to this endpoint like in Android to avoid unnecessary confusion for different clients.

The final rules will be:
- seconds value can be float
- if seconds value is greater or equal to zero then the app is minimized and restored after the timeout
- if seconds less than zero or null then home screen is shown