### PR TITLE
feat: switch reduce motion via settings API

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -370,7 +370,7 @@ class XCUITestDriver extends BaseDriver {
 
       // set reduceMotion if capability is set
       if (util.hasValue(this.opts.reduceMotion)) {
-        await this.opts.device.setReduceMotion(this.opts.reduceMotion);
+        await this.updateSettings({reduceMotion: this.opts.reduceMotion});
       }
 
       this.localConfig = await iosSettings.setLocaleAndPreferences(this.opts.device, this.opts, this.isSafari(), async (sim) => {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -368,11 +368,6 @@ class XCUITestDriver extends BaseDriver {
         }
       }
 
-      // set reduceMotion if capability is set
-      if (util.hasValue(this.opts.reduceMotion)) {
-        await this.updateSettings({reduceMotion: this.opts.reduceMotion});
-      }
-
       this.localConfig = await iosSettings.setLocaleAndPreferences(this.opts.device, this.opts, this.isSafari(), async (sim) => {
         await shutdownSimulator(sim);
 
@@ -437,6 +432,8 @@ class XCUITestDriver extends BaseDriver {
     }
 
     await this.startWda(this.opts.sessionId, realDevice);
+
+    await this.setReduceMotion(this.opts.reduceMotion);
 
     await this.setInitialOrientation(this.opts.orientation);
     this.logEvent('orientationSet');
@@ -1143,6 +1140,19 @@ class XCUITestDriver extends BaseDriver {
     }
     for (const otherApp of otherApps) {
       await installToSimulator(this.opts.device, otherApp, undefined, this.opts.noReset);
+    }
+  }
+
+  /**
+   * Set reduceMotion as 'motion' or set false if no 'reduceMotion' in capabilities.
+   * It works only on simulator.
+   * @param {?boolean} motion Wether enable reduceMotion
+   */
+  async setReduceMotion (motion) {
+    if (this.isSimulator()) {
+      const setValue = util.hasValue(motion) ? motion : false;
+      this.logEvent(`set reduceMotion to ${setValue}`);
+      await this.updateSettings({reduceMotion: setValue});
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1144,11 +1144,11 @@ class XCUITestDriver extends BaseDriver {
   }
 
   /**
-   * Set reduceMotion as 'isEnabled' or set false if no 'reduceMotion' in capabilities.
+   * Set reduceMotion as 'isEnabled' only when the capabilities has 'reduceMotion'
    * The call is ignored for real devices.
    * @param {?boolean} isEnabled Wether enable reduceMotion
    */
-  async setReduceMotion (isEnabled = false) {
+  async setReduceMotion (isEnabled) {
     if (this.isRealDevice() || !_.isBoolean(isEnabled)) {
       return;
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1144,16 +1144,17 @@ class XCUITestDriver extends BaseDriver {
   }
 
   /**
-   * Set reduceMotion as 'motion' or set false if no 'reduceMotion' in capabilities.
-   * It works only on simulator.
-   * @param {?boolean} motion Wether enable reduceMotion
+   * Set reduceMotion as 'isEnabled' or set false if no 'reduceMotion' in capabilities.
+   * The call is ignored for real devices.
+   * @param {?boolean} isEnabled Wether enable reduceMotion
    */
-  async setReduceMotion (motion) {
-    if (this.isSimulator()) {
-      const setValue = util.hasValue(motion) ? motion : false;
-      this.logEvent(`set reduceMotion to ${setValue}`);
-      await this.updateSettings({reduceMotion: setValue});
+  async setReduceMotion (isEnabled = false) {
+    if (this.isRealDevice() || !_.isBoolean(isEnabled)) {
+      return;
     }
+
+    log.info(`set reduceMotion to ${isEnabled}`);
+    await this.updateSettings({reduceMotion: isEnabled});
   }
 
   async setInitialOrientation (orientation) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1153,7 +1153,7 @@ class XCUITestDriver extends BaseDriver {
       return;
     }
 
-    log.info(`set reduceMotion to ${isEnabled}`);
+    log.info(`Setting reduceMotion to ${isEnabled}`);
     await this.updateSettings({reduceMotion: isEnabled});
   }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "appium-ios-simulator": "^3.14.0",
     "appium-remote-debugger": "^5.6.0",
     "appium-support": "^2.32.0",
-    "appium-webdriveragent": "^1.1.0",
+    "appium-webdriveragent": "^1.2.0",
     "appium-xcode": "^3.8.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -84,6 +84,7 @@ describe('driver commands', function () {
       sandbox.stub(driver, 'startSim').callsFake(_.noop);
       sandbox.stub(driver, 'startWdaSession').callsFake(_.noop);
       sandbox.stub(driver, 'startWda').callsFake(_.noop);
+      sandbox.stub(driver, 'setReduceMotion').callsFake(_.noop);
       sandbox.stub(driver, 'installAUT').callsFake(_.noop);
       sandbox.stub(iosDriver.settings, 'setLocale').callsFake(_.noop);
       sandbox.stub(iosDriver.settings, 'setPreferences').callsFake(_.noop);


### PR DESCRIPTION
related to https://github.com/appium/WebDriverAgent/pull/202


Before:
- Can configure the setting only when before launching simulators (It requires to reset simulator)

After:
- Can change the setting without closing simulator