### PR TITLE
fix: Add GET /timeouts to the list of non-proxied urls

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -64,6 +64,7 @@ const NO_PROXY_NATIVE_LIST = [
   ['GET', /screenshot/],
   ['GET', /size/],
   ['GET', /source/],
+  ['GET', /timeouts$/],
   ['GET', /url/],
   ['GET', /window/],
   ['POST', /accept_alert/],


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/13233