### PR TITLE
feat: bump generic iPhone for iOS 13.0

### DIFF
--- a/lib/ios-generic-simulators.js
+++ b/lib/ios-generic-simulators.js
@@ -1,0 +1,10 @@
+export default {
+  'ipad simulator': [
+    ['0.0', 'iPad Retina'],
+    ['10.3', 'iPad Air'],
+  ],
+  'iphone simulator': [
+    ['0.0', 'iPhone 6'],
+    ['13.0', 'iPhone X'],
+  ]
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ import { SubProcess, exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from './logger';
+import iosGenericSimulators from './ios-generic-simulators';
 import _fs from 'fs';
 import url from 'url';
 import v8 from 'v8';
@@ -57,21 +58,37 @@ async function getAndCheckIosSdkVersion () {
   }
 }
 
-function translateDeviceName (platformVersion, devName = '') {
-  let deviceName = devName;
-  switch (devName.toLowerCase().trim()) {
-    case 'iphone simulator':
-      deviceName = 'iPhone 6';
-      break;
-    case 'ipad simulator':
-      // iPad Retina is no longer available for ios 10.3
-      //   so we pick another iPad to use as default
-      deviceName = platformVersion && util.compareVersions(platformVersion, '<', '10.3') ? 'iPad Retina' : 'iPad Air';
-      break;
-  }
+/**
+ * Get the generic simulator for a given IOS version and device type (iPhone, iPad)
+ *
+ * @param {string|number} platformVersion IOS version. e.g.) 13.0
+ * @param {string} deviceName Type of IOS device. Can be iPhone, iPad (possibly more in the future)
+ *
+ * @returns {string} Generic iPhone or iPad simulator (if applicable)
+ */
+function getGenericSimulatorForIosVersion (platformVersion, deviceName) {
+  let genericSimulators = iosGenericSimulators[deviceName];
 
-  if (deviceName !== devName) {
-    log.debug(`Changing deviceName from '${devName}' to '${deviceName}'`);
+  if (genericSimulators) {
+    genericSimulators = genericSimulators.sort(([simOne], [simTwo]) => util.compareVersions(simOne, '<', simTwo) ? -1 : 1);
+
+    // Find the highest iOS version in the list that is below the provided version
+    let genericIosSimulator;
+    for (const [platformVersionFromList, iosSimulator] of genericSimulators) {
+      if (util.compareVersions(platformVersionFromList, '>', platformVersion)) {
+        break;
+      }
+      genericIosSimulator = iosSimulator;
+    }
+    return genericIosSimulator;
+  }
+}
+
+function translateDeviceName (platformVersion, deviceName = '') {
+  const deviceNameTranslated = getGenericSimulatorForIosVersion(platformVersion, deviceName.toLowerCase().trim());
+  if (deviceNameTranslated) {
+    log.debug(`Changing deviceName from '${deviceName}' to '${deviceNameTranslated}'`);
+    return deviceNameTranslated;
   }
   return deviceName;
 }

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -66,11 +66,16 @@ describe('utils', function () {
   }));
 
   describe('determineDevice', function () {
+    const ipadDeviceName = 'iPad Simulator';
+    const iphoneDeviceName = 'iPhone Simulator';
+    const outrageouslyHighIosVersion = '999999.999999';
+
     it('should set the correct iPad simulator generic device', function () {
-      const ipadDeviceName = 'iPad Simulator';
       let deviceName = translateDeviceName('10.1.2', ipadDeviceName);
       deviceName.should.equal('iPad Retina');
-      deviceName = translateDeviceName(10.103, ipadDeviceName);
+    });
+    it('should set the correct iPad simulator generic device for iOS >= 10.3', function () {
+      let deviceName = translateDeviceName(10.103, ipadDeviceName);
       deviceName.should.equal('iPad Air');
       deviceName = translateDeviceName('10.3', ipadDeviceName);
       deviceName.should.equal('iPad Air');
@@ -78,8 +83,21 @@ describe('utils', function () {
       deviceName.should.equal('iPad Air');
     });
     it('should set the correct iPhone simulator generic device', function () {
-      let deviceName = translateDeviceName(10.3, 'iPhone Simulator');
-      deviceName.should.equal('iPhone 6');
+      translateDeviceName('0.0', iphoneDeviceName).should.equal('iPhone 6');
+      translateDeviceName('10.3', iphoneDeviceName).should.equal('iPhone 6');
+    });
+    it('should set the correct iPhone simulator generic device for simulators gte iOS 13.0', function () {
+      translateDeviceName('13.0', iphoneDeviceName).should.equal('iPhone X');
+    });
+    it('should set the default iPhone simulator to the highest generic device that is defined in ios-generic-simulators.js', function () {
+      // The highest iOS version we define for iPhone in ios-generic-simulators.js is currently iOS 13.0
+      // If this changes, update this test
+      translateDeviceName(outrageouslyHighIosVersion, iphoneDeviceName).should.equal('iPhone X');
+    });
+    it('should set the default iPad simulator to the highest generic device that is defined in ios-generic-simulators.js', function () {
+      // The highest iOS version for iPad we define in ios-generic-simulators.js is currently iOS 10.3
+      // If this changes, update this test
+      translateDeviceName(outrageouslyHighIosVersion, ipadDeviceName).should.equal('iPad Air');
     });
   });
 


### PR DESCRIPTION
What this pull request does

* Bumps up the default device for the generic `iphone simulator` for iOS 13+ from `iPhone 6` to `iPhone X`

_WHY?_: `iOS 13` does not support `iPhone 6` so this needs to be changed. Chose `iPhone X` over `iPhone 11` because it's not quite the latest and not bleeding edge.

* Refactored logic so that the default generic versions are specified in a plain Javascript object in `ios-generic-simulators.js`

_WHY?_: So we're not hardcoding this in code. We just need to keep this file (and the tests) up-to-date