### PR TITLE
Fix use of timeout in pushAppBundle

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -80,7 +80,7 @@ class IOSDeploy {
             writeStream.on('error', reject);
           });
           readStream.pipe(writeStream);
-          await itemPushWait.timeout(`Couldn't push '${itemPath}' within the timeout ${ITEM_PUSH_TIMEOUT}ms`, ITEM_PUSH_TIMEOUT);
+          await itemPushWait.timeout(ITEM_PUSH_TIMEOUT, `Couldn't push '${itemPath}' within the timeout ${ITEM_PUSH_TIMEOUT}ms`);
         }
       });
       log.debug(`Pushed the app files successfully after ${new Date() - start}ms`);


### PR DESCRIPTION
Fix timeout error when installing new app (wrong order of arguments for `.timeout()`)

Probably related to appium/appium#13180 and appium/appium#13218