### PR TITLE
chore: fix ssl test by adding altNames

### DIFF
--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -37,7 +37,12 @@ if (!process.env.REAL_DEVICE && !process.env.CLOUD) {
 
       // Create a random pem certificate
       let privateKey = await pem.createPrivateKeyAsync();
-      let keys = await pem.createCertificateAsync({days: 1, selfSigned: true, serviceKey: privateKey.key});
+      let keys = await pem.createCertificateAsync({
+        days: 1,
+        selfSigned: true,
+        serviceKey: privateKey.key,
+        altNames: ['localhost'],
+      });
       pemCertificate = keys.certificate;
 
       // Host an SSL server that uses that certificate


### PR DESCRIPTION
Add "Subject Alternative Name" to SSL certificate so that it complies with new Mac 10.15/iOS 13 standards (see https://support.apple.com/en-us/HT210176 for reference... `TLS server certificates must present the DNS name of the server in the Subject Alternative Name extension of the certificate. DNS names in the CommonName of a certificate are no longer trusted`)