### PR TITLE
Fix Azure nightly builds [1 of n]

### DIFF
--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -14,15 +14,14 @@ jobs:
   # Run the E2E tests on local simulators across different ios and xcode versions
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhoneXS_13
+      name: iphone_13_0
       iosVersion: 13.0
       xcodeVersion: 11
-      deviceName: "iPhone XS"
       tvosName: AppleTV_13
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhoneXR_12_2
+      name: iphone_12_2
       iosVersion: 12.2
       xcodeVersion: 10.2
       deviceName: "iPhone XR"
@@ -30,25 +29,22 @@ jobs:
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhoneXSMax_12_1
+      name: iphone_12_1
       iosVersion: 12.1
       xcodeVersion: 10.1
-      deviceName: "iPhone XS Max"
       tvosName: AppleTV_12_1
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhone7_12
+      name: iphone_12_0
       iosVersion: 12.0
       xcodeVersion: 10
-      deviceName: "iPhone 7"
       tvosName: AppleTV_12
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhone7_11_4
+      name: iphone_11_4
       iosVersion: 11.4
       xcodeVersion: "9.4.1"
-      deviceName: "iPhone 7"
       tvosName: AppleTV_11_4
       tvosDeviceName: "Apple TV"

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -4,32 +4,12 @@ jobs:
   # Run node tests on past node versions
   - template: ./templates/node-build-template.yml
     parameters:
-      nodeVersion: 10.x
-      name: Node10_Tests
+      nodeVersion: 12.x
+      name: Node12_Tests
   - template: ./templates/node-build-template.yml
     parameters:
-      nodeVersion: 8.x
-      name: Node8_Tests
-
-  # TODO: Real device tests go here
-
-  # Run E2E tests on grid of Sauce simulators
-  - template: ./templates/sauce-e2e-template.yml
-    parameters:
-      matrix:
-        # TODO: Add iOS 13 once it is released on Sauce Labs
-        iPhone_X_12_2:
-          CLOUD_PLATFORM_VERSION: 12.2
-          DEVICE_NAME: "iPhone 7 Simulator"
-        iPhone_X_Max_12_0:
-          CLOUD_PLATFORM_VERSION: 12.0
-          DEVICE_NAME: "iPhone 7 Simulator"
-        iPhone_7_12_0:
-          CLOUD_PLATFORM_VERSION: 11.3
-          DEVICE_NAME: "iPhone 7 Simulator"
-        iPhone7_11_3:
-          CLOUD_PLATFORM_VERSION: 11.3
-          DEVICE_NAME: "iPhone 7 Simulator"
+      nodeVersion: 10.x
+      name: Node10_Tests
 
   # Run the E2E tests on local simulators across different ios and xcode versions
   - template: ./templates/xcuitest-e2e-template.yml

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -24,7 +24,6 @@ jobs:
       name: iphone_12_2
       iosVersion: 12.2
       xcodeVersion: 10.2
-      deviceName: "iPhone XR"
       tvosName: AppleTV_12_2
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml

--- a/ci-jobs/sauce-build.yml
+++ b/ci-jobs/sauce-build.yml
@@ -1,0 +1,21 @@
+# https://docs.microsoft.com/azure/devops/pipelines/languages/android
+jobs:
+  # TODO: Real device tests go here
+
+  # Run E2E tests on grid of Sauce simulators
+  - template: ./templates/sauce-e2e-template.yml
+    parameters:
+      matrix:
+        # TODO: Add iOS 13 once it is released on Sauce Labs
+        iPhone_X_12_2:
+          CLOUD_PLATFORM_VERSION: 12.2
+          DEVICE_NAME: "iPhone 7 Simulator"
+        iPhone_X_Max_12_0:
+          CLOUD_PLATFORM_VERSION: 12.0
+          DEVICE_NAME: "iPhone 7 Simulator"
+        iPhone_7_12_0:
+          CLOUD_PLATFORM_VERSION: 11.3
+          DEVICE_NAME: "iPhone 7 Simulator"
+        iPhone7_11_3:
+          CLOUD_PLATFORM_VERSION: 11.3
+          DEVICE_NAME: "iPhone 7 Simulator"

--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -20,7 +20,9 @@ jobs:
     - checkout: self
     - script: |
         echo "Mocha output file: $MOCHA_FILE"
-        echo 
+        echo "Platform Version: $PLATFORM_VERSION"
+        echo "Device Name: $DEVICE_NAME"
+      displayName: Print Environment Variables
     - script: ls /Applications/
       displayName: List Installed Applications
     - script: sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer

--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -12,12 +12,15 @@ jobs:
     variables:
       PLATFORM_VERSION: ${{ parameters.iosVersion }}
       DEVICE_NAME: ${{ parameters.deviceName }}
-      MOCHA_FILE: '$(DEVICE_NAME)-$(PLATFORM_VERSION)-tests.xml'
+      MOCHA_FILE: '${{ parameters.name }}-tests.xml'
       CI: true
     pool:
       vmImage: 'macOS-10.14'
     steps:
     - checkout: self
+    - script: |
+        echo "Mocha output file: $MOCHA_FILE"
+        echo 
     - script: ls /Applications/
       displayName: List Installed Applications
     - script: sudo xcode-select -s /Applications/Xcode_${{ parameters.xcodeVersion }}.app/Contents/Developer
@@ -29,6 +32,7 @@ jobs:
     - task: NodeTool@0
       inputs:
         versionSpec: 10.x
+    # TODO: Toss this
     - script: |
         sed -i '' 's/git@github.com:/https:\/\/github.com\//' /Users/travis/build/appium/appium-xcuitest-driver/.gitmodules;
         git submodule update --init --recursive;

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -2,7 +2,7 @@ parameters:
   name: ''
   iosVersion: ''
   xcodeVersion: ''
-  deviceName: ''
+  deviceName: 'iphone simulator'
   tvosName: ''
   tvosDeviceName: ''
 jobs:

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -55,6 +55,10 @@ describe('XCUITestDriver - basics -', function () {
 
   describe('session -', function () {
     it('should get session details with our caps merged with WDA response', async function () {
+      if (process.env.SAUCE_EMUSIM) {
+        // Sauce adds extraneous caps that are hard to test
+        this.skip();
+      }
       const extraWdaCaps = {
         CFBundleIdentifier: 'com.example.apple-samplecode.UICatalog',
         device: 'iphone',

--- a/test/functional/device/otherApps-e2e-specs.js
+++ b/test/functional/device/otherApps-e2e-specs.js
@@ -2,12 +2,12 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { MULTIPLE_APPS } from '../desired';
-
+import { translateDeviceName } from '../../../lib/utils';
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('XCUITestDriver', function () {
+describe('OtherApps', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let caps;
@@ -18,6 +18,7 @@ describe('XCUITestDriver', function () {
       usePrebuiltWDA: true,
       wdaStartupRetries: 0,
     }, MULTIPLE_APPS);
+    caps.deviceName = translateDeviceName(caps.platformVersion, caps.deviceName);
   });
 
   afterEach(async function () {

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -18,8 +18,11 @@ const should = chai.should();
 chai.use(chaiAsPromised);
 
 async function createDevice () {
-  return await createDeviceNodeSimctl(SIM_DEVICE_NAME,
-    translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName), UICATALOG_SIM_CAPS.platformVersion);
+  return await createDeviceNodeSimctl(
+    SIM_DEVICE_NAME,
+    translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName),
+    UICATALOG_SIM_CAPS.platformVersion
+  );
 }
 
 async function getNumSims () {

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -4,7 +4,7 @@ import { retryInterval } from 'asyncbox';
 import { getSimulator } from 'appium-ios-simulator';
 import request from 'request-promise';
 import { killAllSimulators, shutdownSimulator, deleteDeviceWithRetry } from '../helpers/simulator';
-import { getDevices, createDevice } from 'node-simctl';
+import { getDevices, createDevice as createDeviceNodeSimctl } from 'node-simctl';
 import _ from 'lodash';
 import B from 'bluebird';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
@@ -16,6 +16,11 @@ const SIM_DEVICE_NAME = 'xcuitestDriverTest';
 
 const should = chai.should();
 chai.use(chaiAsPromised);
+
+async function createDevice () {
+  return await createDeviceNodeSimctl(SIM_DEVICE_NAME,
+    translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName), UICATALOG_SIM_CAPS.platformVersion);
+}
 
 async function getNumSims () {
   return (await getDevices())[UICATALOG_SIM_CAPS.platformVersion].length;
@@ -29,8 +34,7 @@ describe('XCUITestDriver', function () {
 
   let driver;
   before(async function () {
-    const udid = await createDevice(SIM_DEVICE_NAME,
-      translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName), UICATALOG_SIM_CAPS.platformVersion);
+    const udid = await createDevice();
     baseCaps = Object.assign({}, UICATALOG_SIM_CAPS, {udid});
     caps = Object.assign({
       usePrebuiltWDA: true,
@@ -165,10 +169,9 @@ describe('XCUITestDriver', function () {
         simsAfter.should.equal(simsBefore);
       });
 
-      it('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async function () {
+      it.only('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async function () {
         // before
-        const udid = await createDevice(SIM_DEVICE_NAME,
-          UICATALOG_SIM_CAPS.deviceName, UICATALOG_SIM_CAPS.platformVersion);
+        const udid = await createDevice();
         let sim = await getSimulator(udid);
         await sim.run();
 
@@ -197,8 +200,7 @@ describe('XCUITestDriver', function () {
 
       it('with udid booted: uses sim and leaves it afterwards', async function () {
         // before
-        const udid = await createDevice(SIM_DEVICE_NAME,
-          UICATALOG_SIM_CAPS.deviceName, UICATALOG_SIM_CAPS.platformVersion);
+        const udid = await createDevice();
         let sim = await getSimulator(udid);
         await sim.run();
 
@@ -247,8 +249,7 @@ describe('XCUITestDriver', function () {
         this.timeout(MOCHA_TIMEOUT);
 
         // before
-        const udid = await createDevice(SIM_DEVICE_NAME,
-          UICATALOG_SIM_CAPS.deviceName, UICATALOG_SIM_CAPS.platformVersion);
+        const udid = await createDevice();
         let sim = await getSimulator(udid);
 
         // some systems require a pause before initializing.

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import B from 'bluebird';
 import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { UICATALOG_CAPS, UICATALOG_SIM_CAPS } from '../desired';
+import { translateDeviceName } from '../../../lib/utils';
 
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
@@ -29,7 +30,7 @@ describe('XCUITestDriver', function () {
   let driver;
   before(async function () {
     const udid = await createDevice(SIM_DEVICE_NAME,
-      UICATALOG_SIM_CAPS.deviceName, UICATALOG_SIM_CAPS.platformVersion);
+      translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName), UICATALOG_SIM_CAPS.platformVersion);
     baseCaps = Object.assign({}, UICATALOG_SIM_CAPS, {udid});
     caps = Object.assign({
       usePrebuiltWDA: true,

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -169,7 +169,7 @@ describe('XCUITestDriver', function () {
         simsAfter.should.equal(simsBefore);
       });
 
-      it.only('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async function () {
+      it('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async function () {
         // before
         const udid = await createDevice();
         let sim = await getSimulator(udid);

--- a/test/functional/driver/protocol-e2e-specs.js
+++ b/test/functional/driver/protocol-e2e-specs.js
@@ -11,7 +11,7 @@ import { W3C_CAPS } from '../desired';
 const should = chai.should();
 chai.use(chaiAsPromised);
 
-describe('XCUITestDriver', function () {
+describe('Protocol', function () {
   this.timeout(MOCHA_TIMEOUT);
   if (!process.env.REAL_DEVICE) {
     describe('w3c compliance', function () {

--- a/test/functional/driver/webdriveragent-derived-data-path-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-derived-data-path-e2e-specs.js
@@ -7,6 +7,7 @@ import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
 import { UICATALOG_SIM_CAPS } from '../desired';
 import path from 'path';
 import fs from 'fs';
+import { translateDeviceName } from '../../../lib/utils';
 
 
 const SIM_DEVICE_NAME = 'xcuitestDriverTest';
@@ -15,7 +16,7 @@ const TEMP_FOLDER = '/tmp/WebDriverAgent';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('XCUITestDriver', function () {
+describe('WebDriverAgent Derived Data Path', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let baseCaps;
@@ -23,8 +24,11 @@ describe('XCUITestDriver', function () {
 
   let driver;
   before(async function () {
-    const udid = await createDevice(SIM_DEVICE_NAME,
-      UICATALOG_SIM_CAPS.deviceName, UICATALOG_SIM_CAPS.platformVersion);
+    const udid = await createDevice(
+      SIM_DEVICE_NAME,
+      translateDeviceName(UICATALOG_SIM_CAPS.platformVersion, UICATALOG_SIM_CAPS.deviceName),
+      UICATALOG_SIM_CAPS.platformVersion
+    );
     baseCaps = Object.assign({}, UICATALOG_SIM_CAPS, {udid});
     caps = Object.assign({
       usePrebuiltWDA: true,

--- a/test/functional/driver/webdriveragent-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-e2e-specs.js
@@ -9,6 +9,7 @@ import { SubProcess } from 'teen_process';
 import { PLATFORM_VERSION, DEVICE_NAME } from '../desired';
 import { MOCHA_TIMEOUT } from '../helpers/session';
 import { retryInterval } from 'asyncbox';
+import { translateDeviceName } from '../../../lib/utils';
 
 let WebDriverAgent;
 if (!process.env.CLOUD) {
@@ -46,10 +47,14 @@ describe('WebDriverAgent', function () {
 
     xcodeVersion = await getVersion(true);
   });
-  describe('with fresh sim', function () {
+  describe.only('with fresh sim', function () {
     let device;
     before(async function () {
-      let simUdid = await createDevice(SIM_DEVICE_NAME, DEVICE_NAME, PLATFORM_VERSION);
+      let simUdid = await createDevice(
+        DEVICE_NAME,
+        translateDeviceName(PLATFORM_VERSION, DEVICE_NAME),
+        PLATFORM_VERSION
+      );
       device = await getSimulator(simUdid);
     });
 

--- a/test/functional/driver/webdriveragent-e2e-specs.js
+++ b/test/functional/driver/webdriveragent-e2e-specs.js
@@ -47,11 +47,11 @@ describe('WebDriverAgent', function () {
 
     xcodeVersion = await getVersion(true);
   });
-  describe.only('with fresh sim', function () {
+  describe('with fresh sim', function () {
     let device;
     before(async function () {
       let simUdid = await createDevice(
-        DEVICE_NAME,
+        SIM_DEVICE_NAME,
         translateDeviceName(PLATFORM_VERSION, DEVICE_NAME),
         PLATFORM_VERSION
       );


### PR DESCRIPTION
* Separate Sauce and Nightly into separate YML because Sauce is flakey and requires the uploaded  Appium bundle which limits its use-cases to only nightly
* Update the trigger (from the Azure interface, not reflected here) to run both `nightly` and on `refs/tags/*`... whenever a new Appium XCUITest Driver tag is published, these tests will run.

Next steps:
* [ ] Run the Sauce tests again, make them less flakey though
* [ ] Make these tests more reliable
* [ ] Publish the results of these tests to Slack