### PR TITLE
chore: Do not perform simulator cache cleanup for Xcode 10+

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -1,15 +1,10 @@
-import path from 'path';
 import { getSimulator } from 'appium-ios-simulator';
 import { createDevice, getDevices, terminate, shutdown } from 'node-simctl';
 import { resetXCTestProcesses } from './utils';
 import _ from 'lodash';
 import log from './logger';
-import { tempDir, fs, mkdirp } from 'appium-support';
 import UUID from 'uuid-js';
 import { PLATFORM_NAME_IOS } from './desired-caps';
-
-
-const INSTALL_DAEMON_CACHE = 'com.apple.mobile.installd.staging';
 
 
 /**
@@ -148,53 +143,25 @@ async function installToSimulator (device, app, bundleId, noReset = true) {
     return;
   }
 
-  if (bundleId) {
-    if (await device.isAppInstalled(bundleId)) {
-      if (noReset) {
-        log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
-        return;
-      }
-      log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
-      await device.removeApp(bundleId);
+  if (bundleId && await device.isAppInstalled(bundleId)) {
+    if (noReset) {
+      log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
+      return;
     }
-  }
-
-  const installdCacheRoot = path.resolve(device.getDir(), 'Library', 'Caches', INSTALL_DAEMON_CACHE);
-  let tmpRoot = null;
-  if (await fs.exists(installdCacheRoot)) {
-    // Cleanup of installd cache helps to save disk space while running multiple tests
-    // without restarting the Simulator: https://github.com/appium/appium/issues/9410
-    tmpRoot = await tempDir.openDir();
-    log.debug('Cleaning installd cache to save the disk space');
-    await fs.mv(installdCacheRoot, path.resolve(tmpRoot, INSTALL_DAEMON_CACHE), {mkdirp: true});
-    await mkdirp(installdCacheRoot);
+    log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);
+    await device.removeApp(bundleId);
   }
 
   log.debug(`Installing '${app}' on Simulator with UUID '${device.udid}'...`);
   try {
-    try {
-      await device.installApp(app);
-    } catch (e) {
-      // it sometimes fails on Xcode 10 because of a race condition
-      log.info(`Got an error on '${app}' install: ${e.message}`);
-      // https://github.com/appium/appium/issues/11350
-      if (e.message.includes('MIInstallerErrorDomain') && tmpRoot) {
-        log.info(`installd requires the cache to be available in order to install '${app}'. ` +
-          `Restoring the cache`);
-        await fs.rimraf(installdCacheRoot);
-        await fs.mv(path.resolve(tmpRoot, INSTALL_DAEMON_CACHE), installdCacheRoot, {
-          mkdirp: true
-        });
-      }
-      log.info('Retrying application install');
-      await device.installApp(app);
-    }
-    log.debug('The app has been installed successfully.');
-  } finally {
-    if (tmpRoot && await fs.exists(tmpRoot)) {
-      await fs.rimraf(tmpRoot);
-    }
+    await device.installApp(app);
+  } catch (e) {
+    // it sometimes fails on Xcode 10 because of a race condition
+    log.info(`Got an error on '${app}' install: ${e.message}`);
+    log.info('Retrying application install');
+    await device.installApp(app);
   }
+  log.debug('The app has been installed successfully.');
 }
 
 async function shutdownOtherSimulators (currentDevice) {


### PR DESCRIPTION
It looks like after Xcode 9 Apple has fixed the cache overgrow issue after multiple apps install, so we can now remove the workaround.