### PR TITLE
fix: add getPlatformVersion to ios-deploy object

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -22,7 +22,7 @@ import {
   normalizePlatformVersion, isLocalHost } from './utils';
 import {
   getConnectedDevices, runRealDeviceReset, installToRealDevice,
-  getRealDeviceObj, getOSVersion } from './real-device-management';
+  getRealDeviceObj } from './real-device-management';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import path from 'path';
@@ -277,6 +277,12 @@ class XCUITestDriver extends BaseDriver {
     this.opts.udid = udid;
     this.opts.realDevice = realDevice;
 
+    // at this point if there is no platformVersion, get it from the device
+    if (!this.opts.platformVersion && this.opts.device) {
+      this.opts.platformVersion = await this.opts.device.getPlatformVersion();
+      log.info(`No platformVersion specified. Using device version: '${this.opts.platformVersion}'`);
+    }
+
     const normalizedVersion = normalizePlatformVersion(this.opts.platformVersion);
     if (this.opts.platformVersion !== normalizedVersion) {
       log.info(`Normalized platformVersion capability value '${this.opts.platformVersion}' to '${normalizedVersion}'`);
@@ -291,12 +297,6 @@ class XCUITestDriver extends BaseDriver {
       this.xcodeVersion = await getAndCheckXcodeVersion();
     }
     this.logEvent('xcodeDetailsRetrieved');
-
-    // at this point if there is no platformVersion, get it from the device
-    if (!this.opts.platformVersion && this.opts.device) {
-      this.opts.platformVersion = await this.opts.device.getPlatformVersion();
-      log.info(`No platformVersion specified. Using device version: '${this.opts.platformVersion}'`);
-    }
 
     if ((this.opts.browserName || '').toLowerCase() === 'safari') {
       log.info('Safari test requested');
@@ -794,15 +794,6 @@ class XCUITestDriver extends BaseDriver {
       }
 
       const device = await getRealDeviceObj(this.opts.udid);
-      if (_.isEmpty(this.opts.platformVersion)) {
-        log.info('Getting the platformVersion from the phone since it was not specified in the capabilities');
-        try {
-          const osVersion = await getOSVersion(this.opts.udid);
-          this.opts.platformVersion = util.coerceVersion(osVersion);
-        } catch (e) {
-          log.warn(`Cannot determine real device platform version. Original error: ${e.message}`);
-        }
-      }
       return {device, realDevice: true, udid: this.opts.udid};
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -293,13 +293,9 @@ class XCUITestDriver extends BaseDriver {
     this.logEvent('xcodeDetailsRetrieved');
 
     // at this point if there is no platformVersion, get it from the device
-    if (!this.opts.platformVersion) {
-      if (this.opts.device && _.isFunction(this.opts.device.getPlatformVersion)) {
-        this.opts.platformVersion = await this.opts.device.getPlatformVersion();
-        log.info(`No platformVersion specified. Using device version: '${this.opts.platformVersion}'`);
-      } else {
-        // TODO: this is when it is a real device. when we have a real object wire it in
-      }
+    if (!this.opts.platformVersion && this.opts.device) {
+      this.opts.platformVersion = await this.opts.device.getPlatformVersion();
+      log.info(`No platformVersion specified. Using device version: '${this.opts.platformVersion}'`);
     }
 
     if ((this.opts.browserName || '').toLowerCase() === 'safari') {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -1,7 +1,7 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 import { fs } from 'appium-support';
 import path from 'path';
-import { services } from 'appium-ios-device';
+import { services, utilities } from 'appium-ios-device';
 import B from 'bluebird';
 import log from './logger';
 import _ from 'lodash';
@@ -145,6 +145,10 @@ class IOSDeploy {
     } finally {
       service.close();
     }
+  }
+
+  async getPlatformVersion () {
+    return await utilities.getOSVersion(this.udid);
   }
 }
 


### PR DESCRIPTION
Easy enough to get the platform version from the device using `appium-ios-device`.