### PR TITLE
feat: Add "iosSimulatorLogsPredicate" capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Differences are noted here:
 |`keychainsExcludePatterns`|This capability accepts comma-separated path patterns, which are going to be excluded from keychains restore while full reset is being performed on Simulator. It might be useful if you want to exclude only particular keychain types from being restored, like the applications keychain. This feature has no effect on real devices.|e.g. `*keychain*.db*` to exclude applications keychain from being restored|
 |`reduceMotion`| It allows to turn on/off reduce motion accessibility preference. Setting reduceMotion `on` helps to reduce flakiness during tests. Only on simulators | e.g `true` |
 |`permissions`| Allows to set permissions for the specified application bundle on Simulator only. The capability value is expected to be a valid JSON string with `{"<bundleId1>": {"<serviceName1>": "<serviceStatus1>", ...}, ...}` format. It is required that `applesimutils` package is installed and available in PATH. The list of available service names and statuses can be found at https://github.com/wix/AppleSimulatorUtils. | e. g. `{"com.apple.mobilecal": {"calendar": "YES"}}` |
+|`iosSimulatorLogsPredicate`|Set the `--predicate` flag in the ios simulator logs|e.g.: `'process != "locationd" AND process != "DTServiceHub"' AND process != "mobileassetd"`|
 
 
 ### General capabilities:

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -47,7 +47,7 @@ extensions.startLogCapture = async function startLogCapture () {
       this.logs.syslog = new IOSSimulatorLog({
         sim: this.opts.device,
         showLogs: this.opts.showIOSLog,
-        xcodeVersion: this.opts.xcodeVersion,
+        xcodeVersion: this.xcodeVersion,
         iosSimulatorLogsPredicate: this.opts.iosSimulatorLogsPredicate,
       });
     }

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -47,7 +47,7 @@ extensions.startLogCapture = async function startLogCapture () {
       this.logs.syslog = new IOSSimulatorLog({
         sim: this.opts.device,
         showLogs: this.opts.showIOSLog,
-        xcodeVersion: this.xcodeVersion,
+        iosSimulatorLogsPredicate: this.opts.iosSimulatorLogsPredicate,
       });
     }
     this.logs.safariConsole = new SafariConsoleLog(!!this.opts.showSafariConsoleLog);

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -47,6 +47,7 @@ extensions.startLogCapture = async function startLogCapture () {
       this.logs.syslog = new IOSSimulatorLog({
         sim: this.opts.device,
         showLogs: this.opts.showIOSLog,
+        xcodeVersion: this.opts.xcodeVersion,
         iosSimulatorLogsPredicate: this.opts.iosSimulatorLogsPredicate,
       });
     }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -183,6 +183,9 @@ let desiredCapConstraints = _.defaults({
   includeSafariInWebviews: {
     isBoolean: true
   },
+  iosSimulatorLogsPredicate: {
+    isString: true,
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS };

--- a/lib/device-log/ios-simulator-log.js
+++ b/lib/device-log/ios-simulator-log.js
@@ -8,11 +8,11 @@ const log = logger.getLogger('IOSSimulatorLog');
 const START_TIMEOUT = 10000;
 
 class IOSSimulatorLog extends IOSLog {
-  constructor (opts) {
+  constructor ({sim, showLogs, iosSimulatorLogsPredicate}) {
     super();
-    this.sim = opts.sim;
-    this.showLogs = !!opts.showLogs;
-    this.xcodeVersion = opts.xcodeVersion;
+    this.sim = sim;
+    this.showLogs = !!showLogs;
+    this.predicate = iosSimulatorLogsPredicate;
     this.proc = null;
   }
 
@@ -25,7 +25,14 @@ class IOSSimulatorLog extends IOSLog {
       throw new Error(`iOS Simulator with udid ${this.sim.udid} is not running`);
     }
     const tool = 'xcrun';
-    const args = ['simctl', 'spawn', this.sim.udid, 'log', 'stream', '--style', 'compact'];
+    let args = [
+      'simctl',
+      'spawn', this.sim.udid,
+      'log',
+      'stream',
+      '--style', 'compact',
+      ...this.predicate ? ['--predicate', this.predicate] : [],
+    ];
     log.debug(`Starting log capture for iOS Simulator with udid '${this.sim.udid}', ` +
                 `using '${tool} ${args.join(' ')}'`);
     try {

--- a/lib/device-log/ios-simulator-log.js
+++ b/lib/device-log/ios-simulator-log.js
@@ -8,10 +8,11 @@ const log = logger.getLogger('IOSSimulatorLog');
 const START_TIMEOUT = 10000;
 
 class IOSSimulatorLog extends IOSLog {
-  constructor ({sim, showLogs, iosSimulatorLogsPredicate}) {
+  constructor ({sim, showLogs, xcodeVersion, iosSimulatorLogsPredicate}) {
     super();
     this.sim = sim;
     this.showLogs = !!showLogs;
+    this.xcodeVersion = xcodeVersion;
     this.predicate = iosSimulatorLogsPredicate;
     this.proc = null;
   }
@@ -31,8 +32,10 @@ class IOSSimulatorLog extends IOSLog {
       'log',
       'stream',
       '--style', 'compact',
-      ...this.predicate ? ['--predicate', this.predicate] : [],
     ];
+    if (this.predicate) {
+      args.push('--predicate', this.predicate);
+    }
     log.debug(`Starting log capture for iOS Simulator with udid '${this.sim.udid}', ` +
                 `using '${tool} ${args.join(' ')}'`);
     try {

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -260,7 +260,7 @@ describe('XCUITestDriver - gestures', function () {
             }
             const { platformVersion, deviceName } = await driver.sessionCapabilities();
             const generic = getGenericSimulatorForIosVersion(platformVersion, deviceName);
-            if (generic && generic.toLowerCase() === 'iphone x') {
+            if (_.lowerCase(generic).includes('iphone x')) {
               return true;
             }
             return false;

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -260,7 +260,7 @@ describe('XCUITestDriver - gestures', function () {
             }
             const { platformVersion, deviceName } = await driver.sessionCapabilities();
             const generic = getGenericSimulatorForIosVersion(platformVersion, deviceName);
-            if (_.toLower(generic).includes('iphone x')) {
+            if (_.includes(_.toLower(generic), ('iphone x'))) {
               return true;
             }
             return false;

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -260,7 +260,7 @@ describe('XCUITestDriver - gestures', function () {
             }
             const { platformVersion, deviceName } = await driver.sessionCapabilities();
             const generic = getGenericSimulatorForIosVersion(platformVersion, deviceName);
-            if (generic.toLowerCase() === 'iphone x') {
+            if (generic && generic.toLowerCase() === 'iphone x') {
               return true;
             }
             return false;

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -260,7 +260,7 @@ describe('XCUITestDriver - gestures', function () {
             }
             const { platformVersion, deviceName } = await driver.sessionCapabilities();
             const generic = getGenericSimulatorForIosVersion(platformVersion, deviceName);
-            if (_.lowerCase(generic).includes('iphone x')) {
+            if (_.toLower(generic).includes('iphone x')) {
               return true;
             }
             return false;

--- a/test/unit/log-specs.js
+++ b/test/unit/log-specs.js
@@ -5,46 +5,76 @@ import sinon from 'sinon';
 import * as Logs from '../../lib/device-log/ios-simulator-log';
 import * as CrashLogs from '../../lib/device-log/ios-crash-log';
 import log from '../../lib/commands/log';
+import * as TeenProcess from 'teen_process';
 
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('XCUITestDriver - startLogCapture', function () {
-  let startCaptureSpy, crashLogStub, iosLogStub;
-
-  before(function () {
-    const spy = {
-      startCapture: _.noop,
-    };
-    startCaptureSpy = sinon.spy(spy, 'startCapture');
-    crashLogStub = sinon.stub(CrashLogs, 'IOSCrashLog').callsFake(function () {
-      this.startCapture = _.noop;
+describe('logs', function () {
+  describe('startLogCapture', function () {
+    let startCaptureSpy, crashLogStub, iosLogStub;
+    before(function () {
+      const spy = {
+        startCapture: _.noop,
+      };
+      startCaptureSpy = sinon.spy(spy, 'startCapture');
+      crashLogStub = sinon.stub(CrashLogs, 'IOSCrashLog').callsFake(function () {
+        this.startCapture = _.noop;
+      });
+      iosLogStub = sinon.stub(Logs, 'IOSSimulatorLog').callsFake(function () {
+        this.startCapture = spy.startCapture;
+      });
     });
-    iosLogStub = sinon.stub(Logs, 'IOSSimulatorLog').callsFake(function () {
-      this.startCapture = spy.startCapture;
+
+    after(function () {
+      startCaptureSpy.restore();
+      crashLogStub.restore();
+      iosLogStub.restore();
+    });
+
+    // establish that the basic things work as we imagine
+    it('should not spawn more than one instance of idevicesyslog', async function () {
+      const fakeInstance = {
+        logs: undefined,
+        opts: {},
+        isRealDevice: _.noop,
+      };
+      startCaptureSpy.callCount.should.equal(0);
+      await log.startLogCapture.call(fakeInstance);
+      startCaptureSpy.callCount.should.equal(1);
+      fakeInstance.logs.syslog.isCapturing = true;
+
+      await log.startLogCapture.call(fakeInstance);
+      startCaptureSpy.callCount.should.equal(1);
     });
   });
 
-  after(function () {
-    startCaptureSpy.restore();
-    crashLogStub.restore();
-    iosLogStub.restore();
-  });
-
-  // establish that the basic things work as we imagine
-  it('should not spawn more than one instance of idevicesyslog', async function () {
-    const fakeInstance = {
-      logs: undefined,
-      opts: {},
-      isRealDevice: _.noop,
-    };
-    startCaptureSpy.callCount.should.equal(0);
-    await log.startLogCapture.call(fakeInstance);
-    startCaptureSpy.callCount.should.equal(1);
-    fakeInstance.logs.syslog.isCapturing = true;
-
-    await log.startLogCapture.call(fakeInstance);
-    startCaptureSpy.callCount.should.equal(1);
+  describe('IosSimulatorLog', function () {
+    let subprocessStub;
+    beforeEach(function () {
+      subprocessStub = sinon.stub(TeenProcess, 'SubProcess').callsFake(() => {
+        return {on: _.noop, start: _.noop};
+      });
+    });
+    afterEach(function () {
+      subprocessStub.restore();
+    });
+    it('should call xcrun log stream process', async function () {
+      const predicate = 'process != "locationd" AND process != "DTServiceHub"';
+      const udid = 'fake-udid';
+      const fakeSim = {udid, isRunning: () => true};
+      const iosSimulatorLog = new Logs.IOSSimulatorLog({
+        iosSimulatorLogsPredicate: predicate,
+        sim: fakeSim,
+        showLogs: true,
+      });
+      await iosSimulatorLog.startCapture();
+      subprocessStub.callCount.should.equal(1);
+      subprocessStub.getCall(0).args.should.eql([
+        'xcrun',
+        ['simctl', 'spawn', udid, 'log', 'stream', '--style', 'compact', '--predicate', predicate]
+      ]);
+    });
   });
 });


### PR DESCRIPTION
* Add capability `iosSimulatorLogsPredicate` which is a string that gets added on as a flag to the `xcrun simctl spawn <udid> log...` sub-process as `--predicate <predicate>`
* Updated IosSimulatorLog class to include this as an option
* Added a unit test for IosSimulatorLog

Reasoning:
Logging when upgrading to Xcode 11 has become extemely verbose and we need a way to reduce the verbosity so that 1. logs are easier to make sense of 2. we don't deal with memory issues due to huge log files

Other:
* Removed xcodeVersion property because it wasn't being used

Note:
* The `XCUITestDriver - startLogCapture` tests weren't changed, they were just moved into another nested describe block and that's why the diff is so noisy

Related issues:
* https://github.com/appium/appium/issues/13366
* https://github.com/appium/appium/issues/13245