### PR TITLE
fix: Update capabilities verification logic to allow WDA execution without app under test

### DIFF
--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -348,10 +348,12 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
         log.info(`It looks like the '${cn}' certificate has been already added to the CA root`);
       }
     } finally {
-      try {
-        await this.activateApp(this.opts.bundleId);
-      } catch (e) {
-        log.warn(`Cannot restore the application '${this.opts.bundleId}'. Original error: ${e.message}`);
+      if (this.opts.bundleId) {
+        try {
+          await this.activateApp(this.opts.bundleId);
+        } catch (e) {
+          log.warn(`Cannot restore the application '${this.opts.bundleId}'. Original error: ${e.message}`);
+        }
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -298,7 +298,7 @@ class XCUITestDriver extends BaseDriver {
     }
     this.logEvent('xcodeDetailsRetrieved');
 
-    if ((this.opts.browserName || '').toLowerCase() === 'safari') {
+    if (_.toLower(this.opts.browserName) === 'safari') {
       log.info('Safari test requested');
       this.safari = true;
       this.opts.app = undefined;
@@ -313,7 +313,7 @@ class XCUITestDriver extends BaseDriver {
         // this option does not work on 12.2 and above
         this.opts.processArguments.args = ['-u', this._currentUrl];
       }
-    } else {
+    } else if (this.opts.app || this.opts.bundleId) {
       await this.configureApp();
     }
     this.logEvent('appConfigured');
@@ -322,10 +322,10 @@ class XCUITestDriver extends BaseDriver {
     // or if bundle id doesn't point to an installed app
     if (this.opts.app) {
       await checkAppPresent(this.opts.app);
-    }
 
-    if (!this.opts.bundleId) {
-      this.opts.bundleId = await appUtils.extractBundleId(this.opts.app);
+      if (!this.opts.bundleId) {
+        this.opts.bundleId = await appUtils.extractBundleId(this.opts.app);
+      }
     }
 
     await this.runReset();
@@ -716,14 +716,15 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // check for supported build-in apps
-    if (this.opts.app && this.opts.app.toLowerCase() === 'settings') {
-      this.opts.bundleId = 'com.apple.Preferences';
-      this.opts.app = null;
-      return;
-    } else if (this.opts.app && this.opts.app.toLowerCase() === 'calendar') {
-      this.opts.bundleId = 'com.apple.mobilecal';
-      this.opts.app = null;
-      return;
+    switch (_.toLower(this.opts.app)) {
+      case 'settings':
+        this.opts.bundleId = 'com.apple.Preferences';
+        this.opts.app = null;
+        return;
+      case 'calendar':
+        this.opts.bundleId = 'com.apple.mobilecal';
+        this.opts.app = null;
+        return;
     }
 
     const originalAppPath = this.opts.app;
@@ -732,7 +733,8 @@ class XCUITestDriver extends BaseDriver {
       this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
     } catch (err) {
       log.error(err);
-      throw new Error(`Bad app: ${this.opts.app}. App paths need to be absolute or an URL to a compressed app file${err && err.message ? `: ${err.message}` : ''}`);
+      throw new Error(`Bad app: ${this.opts.app}. ` +
+        `App paths need to be absolute or an URL to a compressed app file: ${err.message}`);
     }
     this.isAppTemporary = this.opts.app && await fs.exists(this.opts.app)
       && !await util.isSameDestination(originalAppPath, this.opts.app);
@@ -988,9 +990,9 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // make sure that the capabilities have one of `app` or `bundleId`
-    if ((caps.browserName || '').toLowerCase() !== 'safari' && !caps.app && !caps.bundleId) {
-      let msg = 'The desired capabilities must include either an app or a bundleId for iOS';
-      log.errorAndThrow(msg);
+    if (_.toLower(caps.browserName) !== 'safari' && !caps.app && !caps.bundleId) {
+      log.info('The desired capabilities include neither an app nor a bundleId. ' +
+        'WebDriverAgent will be started without the default app');
     }
 
     if (!util.coerceVersion(caps.platformVersion, false)) {


### PR DESCRIPTION
This feature has been already added to WDA. Now it's driver's turn