### PR TITLE
feat: add execute commands for removing files

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -86,6 +86,9 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     getPermission: 'mobileGetPermission',
 
     siriCommand: 'mobileSiriCommand',
+
+    deleteFile: 'mobileDeleteFile',
+    deleteFolder: 'mobileDeleteFolder',
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -348,13 +348,13 @@ async function deleteFromSimulator (device, remotePath) {
     const {bundleId, pathInContainer: dstPath} = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
-      `Will get the data from '${dstPath}'`);
+      `'${dstPath}' will be deleted`);
     pathOnServer = dstPath;
   } else {
     const simRoot = device.getDir();
     pathOnServer = path.posix.join(simRoot, remotePath);
     verifyIsSubPath(pathOnServer, simRoot);
-    log.info(`Got the full item path: ${pathOnServer}`);
+    log.info(`Got the full path: ${pathOnServer}`);
   }
   if (!await fs.exists(pathOnServer)) {
     log.errorAndThrow(`The remote path at '${pathOnServer}' does not exist`);

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -60,7 +60,7 @@ async function mkdirpDevice (service, dir) {
 
 async function createService (udid, remotePath) {
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const { bundleId, pathInContainer, containerType } = await parseContainerPath(remotePath);
+    const {bundleId, pathInContainer, containerType} = await parseContainerPath(remotePath);
     const service = await createAfcClient(udid, bundleId, containerType);
     const relativePath = isDocuments(containerType) ? path.join(CONTAINER_DOCUMENTS_PATH, pathInContainer) : pathInContainer;
     return {service, relativePath};
@@ -182,7 +182,7 @@ async function parseContainerPath (remotePath, containerRootSupplier) {
 async function pushFileToSimulator (device, remotePath, base64Data) {
   const buffer = Buffer.from(base64Data, 'base64');
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
+    const {bundleId, pathInContainer: dstPath} = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
       `Will put the data into '${dstPath}'`);
@@ -224,7 +224,7 @@ async function pushFileToSimulator (device, remotePath, base64Data) {
  * @param {string} base64Data - Base-64 encoded content of the file to be uploaded.
  */
 async function pushFileToRealDevice (device, remotePath, base64Data) {
-  const { service, relativePath } = await createService(device.udid, remotePath);
+  const {service, relativePath} = await createService(device.udid, remotePath);
   try {
     await mkdirpDevice(service, path.dirname(relativePath));
     const stream = await service.createWriteStream(relativePath, { autoClose: true });
@@ -234,7 +234,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
     try {
       await closeEvent;
     } catch (e) {
-      throw new Error(`Couldnt push the file within the given timeout ${IO_TIMEOUT}ms`);
+      throw new Error(`Could not push the file within the given timeout ${IO_TIMEOUT}ms`);
     }
   } finally {
     service.close();
@@ -260,7 +260,7 @@ async function pushFileToRealDevice (device, remotePath, base64Data) {
 async function pullFromSimulator (device, remotePath, isFile) {
   let pathOnServer;
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
+    const {bundleId, pathInContainer: dstPath} = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
       `Will get the data from '${dstPath}'`);
@@ -304,7 +304,7 @@ async function pullFromSimulator (device, remotePath, isFile) {
  * @return {string} Base-64 encoded content of the remote file
  */
 async function pullFromRealDevice (device, remotePath, isFile) {
-  const { service, relativePath } = await createService(device.udid, remotePath);
+  const {service, relativePath} = await createService(device.udid, remotePath);
   try {
     const fileInfo = await service.getFileInfo(relativePath);
     if (isFile && fileInfo.isDirectory()) {
@@ -345,7 +345,7 @@ async function pullFromRealDevice (device, remotePath, isFile) {
 async function deleteFromSimulator (device, remotePath) {
   let pathOnServer;
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
-    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
+    const {bundleId, pathInContainer: dstPath} = await parseContainerPath(remotePath,
       async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
     log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
       `Will get the data from '${dstPath}'`);
@@ -448,14 +448,18 @@ commands.pullFile = async function pullFile (remotePath) {
     : await pullFromRealDevice(this.opts.device, remotePath, true);
 };
 
+async function deleteFileOrFolder (device, remotePath, isSimulator) {
+  return isSimulator
+    ? await deleteFromSimulator(device, remotePath)
+    : await deleteFromRealDevice(device, remotePath);
+}
+
 commands.mobileDeleteFolder = async function mobileDeleteFolder (opts = {}) {
   let {remotePath} = opts;
   if (!remotePath.endsWith('/')) {
     remotePath = `${remotePath}/`;
   }
-  return this.isSimulator()
-    ? await deleteFromSimulator(this.opts.device, remotePath)
-    : await deleteFromRealDevice(this.opts.device, remotePath);
+  return await deleteFileOrFolder(this.opts.device, remotePath, this.isSimulator());
 };
 
 commands.mobileDeleteFile = async function mobileDeleteFile (opts = {}) {
@@ -464,9 +468,7 @@ commands.mobileDeleteFile = async function mobileDeleteFile (opts = {}) {
     log.errorAndThrow(`It is expected that remote path points to a file and not to a folder. ` +
                       `'${remotePath}' is given instead`);
   }
-  return this.isSimulator()
-    ? await deleteFromSimulator(this.opts.device, remotePath)
-    : await deleteFromRealDevice(this.opts.device, remotePath);
+  return await deleteFileOrFolder(this.opts.device, remotePath, this.isSimulator());
 };
 
 commands.getSimFileFullPath = async function getSimFileFullPath (remotePath) {

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -308,10 +308,10 @@ async function pullFromRealDevice (device, remotePath, isFile) {
   try {
     const fileInfo = await service.getFileInfo(relativePath);
     if (isFile && fileInfo.isDirectory()) {
-      throw new Error(`The requested path is not a file. Path: ${remotePath}`);
+      throw new Error(`The requested path is not a file. Path: '${remotePath}'`);
     }
     if (!isFile && !fileInfo.isDirectory()) {
-      throw new Error(`The requested path is not a folder. Path: ${remotePath}`);
+      throw new Error(`The requested path is not a folder. Path: '${remotePath}'`);
     }
 
     if (fileInfo.isFile()) {
@@ -321,7 +321,74 @@ async function pullFromRealDevice (device, remotePath, isFile) {
     }
   } catch (e) {
     if (e.message.includes(OBJECT_NOT_FOUND_ERROR_MESSAGE)) {
-      throw new Error(`Path '${remotePath}' doesn't exists on the device`);
+      throw new Error(`Path '${remotePath}' does not exist on the device`);
+    }
+    throw e;
+  } finally {
+    service.close();
+  }
+}
+
+/**
+ * Remove the file or folder from the device
+ *
+ * @param {Object} device - The device object, which represents the device under test.
+ *                          This object is expected to have the `udid` property containing the
+ *                          valid device ID.
+ * @param {string} remotePath - The path to a file or a folder, which exists in the corresponding application
+ *                              container on Simulator. Use
+ *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              format to pull a file or a folder from an application container of the given type.
+ *                              Possible container types are 'app', 'data', 'groups', '<A specific App Group container>'.
+ *                              The default type is 'app'.
+ */
+async function deleteFromSimulator (device, remotePath) {
+  let pathOnServer;
+  if (CONTAINER_PATH_PATTERN.test(remotePath)) {
+    const { bundleId, pathInContainer: dstPath } = await parseContainerPath(remotePath,
+      async (appBundle, containerType) => await getAppContainer(device.udid, appBundle, null, containerType));
+    log.info(`Parsed bundle identifier '${bundleId}' from '${remotePath}'. ` +
+      `Will get the data from '${dstPath}'`);
+    pathOnServer = dstPath;
+  } else {
+    const simRoot = device.getDir();
+    pathOnServer = path.posix.join(simRoot, remotePath);
+    verifyIsSubPath(pathOnServer, simRoot);
+    log.info(`Got the full item path: ${pathOnServer}`);
+  }
+  if (!await fs.exists(pathOnServer)) {
+    log.errorAndThrow(`The remote path at '${pathOnServer}' does not exist`);
+  }
+  await fs.rimraf(pathOnServer);
+}
+
+/**
+ * Remove the file or folder from the device
+ *
+ * @param {Object} device - The device object, which represents the device under test.
+ *                          This object is expected to have the `udid` property containing the
+ *                          valid device ID.
+ * @param {string} remotePath - The path to an existing remote file on the device. This variable can be prefixed with
+ *                              bundle id, so then the file will be downloaded from the corresponding
+ *                              application container instead of the default media folder. Use
+ *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              format to pull a file or a folder from an application container of the given type.
+ *                              The only supported container type is 'documents'. If the container type is not set
+ *                              explicitly for a bundle id, then the default application container is going to be mounted
+ *                              (aka --container ifuse argument)
+ *                              e.g. If `@com.myapp.bla:documents/111.png` is provided,
+ *                                   `On My iPhone/<app name>` in Files app will be mounted in the host machine.
+ *                                   `On My iPhone/<app name>/111.png` wil be pulled into the mounted host machine
+ *                                   and Appium returns the data as base64-encoded string to client.
+ *                                   `@com.myapp.bla:documents/` means `On My iPhone/<app name>`.
+ */
+async function deleteFromRealDevice (device, remotePath) {
+  const { service, relativePath } = await createService(device.udid, remotePath);
+  try {
+    await service.deleteDirectory(relativePath);
+  } catch (e) {
+    if (e.message.includes(OBJECT_NOT_FOUND_ERROR_MESSAGE)) {
+      throw new Error(`Path '${remotePath}' does not exist on the device`);
     }
     throw e;
   } finally {
@@ -379,6 +446,27 @@ commands.pullFile = async function pullFile (remotePath) {
   return this.isSimulator()
     ? await pullFromSimulator(this.opts.device, remotePath, true)
     : await pullFromRealDevice(this.opts.device, remotePath, true);
+};
+
+commands.mobileDeleteFolder = async function mobileDeleteFolder (opts = {}) {
+  let {remotePath} = opts;
+  if (!remotePath.endsWith('/')) {
+    remotePath = `${remotePath}/`;
+  }
+  return this.isSimulator()
+    ? await deleteFromSimulator(this.opts.device, remotePath)
+    : await deleteFromRealDevice(this.opts.device, remotePath);
+};
+
+commands.mobileDeleteFile = async function mobileDeleteFile (opts = {}) {
+  const {remotePath} = opts;
+  if (remotePath.endsWith('/')) {
+    log.errorAndThrow(`It is expected that remote path points to a file and not to a folder. ` +
+                      `'${remotePath}' is given instead`);
+  }
+  return this.isSimulator()
+    ? await deleteFromSimulator(this.opts.device, remotePath)
+    : await deleteFromRealDevice(this.opts.device, remotePath);
 };
 
 commands.getSimFileFullPath = async function getSimFileFullPath (remotePath) {


### PR DESCRIPTION
Adds functions (`mobile: deleteFile` and `mobile: deleteFolder`) to remove files/folders from the device or simulator.

Locally this has been tested with an iPhone 7 Plus running iOS 13.1 with
```js
describe('keynote', function () {
  const caps = {
    bundleId: 'com.apple.Keynote',
    platformName: 'iOS',
    platformVersion: '13.1',
    automationName: 'XCUITest',
    udid: 'auto',
    app: null,
    browserName: null,
  }
  let driver;
  before(async function () {
    driver = await initSession(caps);
  });
  after(async function () {
    await deleteSession();
  });

  it('should push a file', async function () {
    const stringData = `random string data ${Math.random()}`;
    const base64Data = Buffer.from(stringData).toString('base64');
    const remotePath = '@com.apple.Keynote:documents/higher.txt';

    await driver.pushFile(remotePath, base64Data);

    const remoteStringData = await pullFileAsString(driver, remotePath);
    remoteStringData.should.equal(stringData);

    await driver.execute('mobile: deleteFile', {remotePath});

    await pullFileAsString(driver, remotePath).should.eventually.be.rejectedWith(/does not exist on the device/);
  });
});
```