### PR TITLE
chore: add Appium 2.0 compatible metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,14 @@
   "engines": [
     "node"
   ],
+  "appium": {
+    "driverName": "xcuitest",
+    "automationName": "XCUITest",
+    "platformNames": [
+      "iOS"
+    ],
+    "mainClass": "XCUITestDriver"
+  },
   "main": "./build/index.js",
   "bin": {},
   "directories": {


### PR DESCRIPTION
@mykola-mokhnach this is the kind of thing all the drivers will need to do in order to advertise their details to the appium 2 server.