### PR TITLE
feat: Fallback to ios-deploy usage if ios-device lib fails to install the app bundle

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -34,14 +34,9 @@ class IOSDeploy {
 
   async install (app) {
     const start = process.hrtime();
-    const printSuccessMessage = () => {
-      const [seconds, nanos] = process.hrtime(start);
-      log.info(`Installation is successful after ${(seconds + nanos / 1e9).toFixed(3)}s`);
-    };
     try {
       const bundlePathOnPhone = await this.pushAppBundle(app);
       await this.installApplication(bundlePathOnPhone);
-      printSuccessMessage();
     } catch (e) {
       log.warn('An error was thrown during the installation process. ' +
         `Falling back to ${IOS_DEPLOY}`, e);
@@ -59,8 +54,9 @@ class IOSDeploy {
       } catch (e1) {
         throw new Error(`Could not install '${app}': ${e1.stderr || e1.message}`);
       }
-      printSuccessMessage();
     }
+    const [seconds, nanos] = process.hrtime(start);
+    log.info(`Installation is successful after ${(seconds + nanos / 1e9).toFixed(3)}s`);
   }
 
   async installApplication (bundlePathOnPhone) {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -47,14 +47,19 @@ class IOSDeploy {
         `Falling back to ${IOS_DEPLOY}`, e);
       try {
         await fs.which(IOS_DEPLOY);
+      } catch (e1) {
+        throw new Error(`Could not install '${app}': ` +
+          `${IOS_DEPLOY} utility has not been found in PATH. Is it installed?`);
+      }
+      try {
         await exec(IOS_DEPLOY, [
           '--id', this.udid,
           '--bundle', app
         ]);
-        printSuccessMessage();
       } catch (e1) {
-        throw new Error(`Could not install app: '${e1.message}'`);
+        throw new Error(`Could not install '${app}': ${e1.stderr || e1.message}`);
       }
+      printSuccessMessage();
     }
   }
 

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -5,11 +5,13 @@ import { services, utilities } from 'appium-ios-device';
 import B from 'bluebird';
 import log from './logger';
 import _ from 'lodash';
+import { exec } from 'teen_process';
 
 const APPLICATION_INSTALLED_NOTIFICATION = 'com.apple.mobile.application_installed';
 const INSTALLATION_STAGING_DIR = 'PublicStaging';
 const ITEM_PUSH_TIMEOUT = 30 * 1000;
 const APPLICATION_NOTIFICATION_TIMEOUT = 30 * 1000;
+const IOS_DEPLOY = 'ios-deploy';
 
 class IOSDeploy {
 
@@ -31,14 +33,28 @@ class IOSDeploy {
   }
 
   async install (app) {
-    const start = new Date();
+    const start = process.hrtime();
+    const printSuccessMessage = () => {
+      const [seconds, nanos] = process.hrtime(start);
+      log.info(`Installation is successful after ${(seconds + nanos / 1e9).toFixed(3)}s`);
+    };
     try {
       const bundlePathOnPhone = await this.pushAppBundle(app);
       await this.installApplication(bundlePathOnPhone);
-      log.info(`Installation is successful after ${new Date() - start}ms`);
+      printSuccessMessage();
     } catch (e) {
-      log.error('Error was thrown during the installation process', e);
-      throw new Error(`Could not install app: '${e.message}'`);
+      log.warn('An error was thrown during the installation process. ' +
+        `Falling back to ${IOS_DEPLOY}`, e);
+      try {
+        await fs.which(IOS_DEPLOY);
+        await exec(IOS_DEPLOY, [
+          '--id', this.udid,
+          '--bundle', app
+        ]);
+        printSuccessMessage();
+      } catch (e1) {
+        throw new Error(`Could not install app: '${e1.message}'`);
+      }
     }
   }
 

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -49,10 +49,10 @@ class IOSDeploy {
       try {
         await exec(IOS_DEPLOY, [
           '--id', this.udid,
-          '--bundle', app
+          '--bundle', app,
         ]);
       } catch (e1) {
-        throw new Error(`Could not install '${app}': ${e1.stderr || e1.message}`);
+        throw new Error(`Could not install '${app}': ${e1.stderr || e1.stdout || e1.message}`);
       }
     }
     const [seconds, nanos] = process.hrtime(start);


### PR DESCRIPTION
It seems like there are still some cases where `ios-device` caanot handle app installation properly but `ios-deploy` can. So, we can make the flow more flexible