### PR TITLE
fix: Listen to socket server errors after its startup

### DIFF
--- a/lib/device-connections-factory.js
+++ b/lib/device-connections-factory.js
@@ -28,7 +28,7 @@ class iProxy {
         connection.pipe(socket);
         socket.pipe(connection);
       } catch (e) {
-        this.log.warn(e);
+        this.log.error(e);
         connection.end();
       }
     });
@@ -38,6 +38,7 @@ class iProxy {
     });
     this.serverSocket.listen(this.localport);
     await status;
+    this.serverSocket.on('error', (e) => this.log.error(e));
   }
 
   // eslint-disable-next-line require-await
@@ -52,10 +53,6 @@ class iProxy {
     // 30 seconds (see https://github.com/appium/appium-xcuitest-driver/pull/1094#issuecomment-546578765)
     this.serverSocket.once('close', () => {
       this.log.info('The connection has been closed');
-      this.serverSocket = null;
-    });
-    this.serverSocket.once('error', (e) => {
-      this.log.error('Failed to close the connection', e);
       this.serverSocket = null;
     });
     this.serverSocket.close();


### PR DESCRIPTION
We currently only listening to errors right after server startup or after we close it, although it makes sense to do that during the whole server life cycle.