### PR TITLE
fix: 'null' replace error when the context changes from web to null (native)

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -98,7 +98,7 @@ commands.setContext = async function setContext (name, callback, skipReadyCheck)
   }
 
   log.debug(`Attempting to set context to '${name}' from '${this.curContext ? this.curContext : NATIVE_WIN}'`);
-  if (alreadyInContext(name, this.curContext) || alreadyInContext(name.replace(WEBVIEW_BASE, ''), this.curContext)) {
+  if (alreadyInContext(name, this.curContext) || (name !== null && alreadyInContext(name.replace(WEBVIEW_BASE, ''), this.curContext))) {
     // already in the named context, no need to do anything
     log.debug(`Already in '${name}' context. Doing nothing.`);
     return;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -87,6 +87,13 @@ extensions.getNewRemoteDebugger = async function getNewRemoteDebugger () {
   }, this.isRealDevice());
 };
 
+/**
+ * Set context
+ *
+ * @param {?string} name - The name of context to set. It could be 'null' as NATIVE_WIN.
+ * @param {callback} callback The callback. (It is not called in this method)
+ * @param {boolean} skipReadyCheck - Whether it waits for the new context is ready
+ */
 commands.setContext = async function setContext (name, callback, skipReadyCheck) {
   function alreadyInContext (desired, current) {
     return (desired === current ||
@@ -98,7 +105,8 @@ commands.setContext = async function setContext (name, callback, skipReadyCheck)
   }
 
   log.debug(`Attempting to set context to '${name}' from '${this.curContext ? this.curContext : NATIVE_WIN}'`);
-  if (alreadyInContext(name, this.curContext) || (name !== null && alreadyInContext(name.replace(WEBVIEW_BASE, ''), this.curContext))) {
+
+  if (alreadyInContext(name, this.curContext) || alreadyInContext(_.replace(name, WEBVIEW_BASE, ''), this.curContext)) {
     // already in the named context, no need to do anything
     log.debug(`Already in '${name}' context. Doing nothing.`);
     return;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -104,11 +104,11 @@ commands.setContext = async function setContext (name, callback, skipReadyCheck)
     return context === NATIVE_WIN || context === null;
   }
 
-  log.debug(`Attempting to set context to '${name}' from '${this.curContext ? this.curContext : NATIVE_WIN}'`);
+  log.debug(`Attempting to set context to '${name || NATIVE_WIN}' from '${this.curContext ? this.curContext : NATIVE_WIN}'`);
 
   if (alreadyInContext(name, this.curContext) || alreadyInContext(_.replace(name, WEBVIEW_BASE, ''), this.curContext)) {
     // already in the named context, no need to do anything
-    log.debug(`Already in '${name}' context. Doing nothing.`);
+    log.debug(`Already in '${name || NATIVE_WIN}' context. Doing nothing.`);
     return;
   }
   if (isNativeContext(name)) {
@@ -124,7 +124,7 @@ commands.setContext = async function setContext (name, callback, skipReadyCheck)
     await this.getContexts();
   }
 
-  let contextId = name.replace(WEBVIEW_BASE, '');
+  let contextId = _.replace(name, WEBVIEW_BASE, '');
   if (contextId === '') {
     // allow user to pass in "WEBVIEW" without an index
     // the second context will be the first webview as


### PR DESCRIPTION
I found an error in ruby lib core's nightly test.
The scenario was:

1. Set web-context
2. Set context as `null` (Then, Appium should set the context as native)

Then, the `name` was `null` and `replace` failed.
Previous implementation (before https://github.com/appium/appium-xcuitest-driver/pull/1105) avoided this error by `if (isNativeContext(name)) {` in the next line.


https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=1425&view=logs&j=b357693d-6cc3-5f61-d7af-e4ebe11dce24&t=25c282ea-11ac-5a8c-6a63-157c06b57748

```
[HTTP] --> POST /wd/hub/session/0f2307fb-bfb5-49c0-a168-5e72e545fbc5/context
[HTTP] {"name":null}
[debug] [W3C (0f2307fb)] Calling AppiumDriver.setContext() with args: [null,"0f2307fb-bfb5-49c0-a168-5e72e545fbc5"]
[debug] [XCUITest] Executing command 'setContext'
[debug] [XCUITest] Attempting to set context to 'null' from '84266.1'
[debug] [W3C (0f2307fb)] Encountered internal error running command: TypeError: Cannot read property 'replace' of null
[debug] [W3C (0f2307fb)]     at XCUITestDriver.setContext (/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/lib/commands/context.js:101:72)
[debug] [W3C (0f2307fb)]     at commandExecutor (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:328:23)
[debug] [W3C (0f2307fb)]     at /Users/kazu/GitHub/appium/node_modules/async-lock/lib/index.js:125:12
[debug] [W3C (0f2307fb)]     at AsyncLock._promiseTry (/Users/kazu/GitHub/appium/node_modules/async-lock/lib/index.js:249:31)
[debug] [W3C (0f2307fb)]     at exec (/Users/kazu/GitHub/appium/node_modules/async-lock/lib/index.js:124:9)
[debug] [W3C (0f2307fb)]     at AsyncLock.acquire (/Users/kazu/GitHub/appium/node_modules/async-lock/lib/index.js:140:3)
[debug] [W3C (0f2307fb)]     at XCUITestDriver.executeCommand (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:330:39)
[debug] [W3C (0f2307fb)]     at XCUITestDriver.executeCommand (/Users/kazu/GitHub/appium/node_modules/appium-xcuitest-driver/lib/driver.js:704:24)
[debug] [W3C (0f2307fb)]     at AppiumDriver.executeCommand (/Users/kazu/GitHub/appium/lib/appium.js:496:36)
[debug] [W3C (0f2307fb)]     at process._tickCallback (internal/process/next_tick.js:68:7)
[HTTP] <-- POST /wd/hub/session/0f2307fb-bfb5-49c0-a168-5e72e545fbc5/context 500 31 ms - 555
```