### PR TITLE
chore: update appium-remote-debugger

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -283,4 +283,14 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   }
 };
 
+extensions.mobileWebNav = async function mobileWebNav (navType) {
+  this.remote.allowNavigationWithoutReload = true;
+  try {
+    await this.executeAtom('execute_script', [`history.${navType}();`, null]);
+  } finally {
+    this.remote.allowNavigationWithoutReload = false;
+  }
+};
+
+
 export default extensions;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "appium-ios-device": "^1.2.1",
     "appium-ios-driver": "^4.0.0",
     "appium-ios-simulator": "^3.14.0",
-    "appium-remote-debugger": "^6.7.0",
+    "appium-remote-debugger": "^7.0.0",
     "appium-support": "^2.32.0",
     "appium-webdriveragent": "^2.3.2",
     "appium-xcode": "^3.8.0",

--- a/test/functional/web/helpers.js
+++ b/test/functional/web/helpers.js
@@ -32,7 +32,7 @@ async function spinTitleEquals (driver, expectedTitle, tries = 10, interval = 50
   await retryInterval(tries, interval, async function () {
     const title = await spinTitle(driver);
     if (title !== expectedTitle) {
-      throw new Error(`Could not find expected title. Found: '${title}'`);
+      throw new Error(`Could not find expected title: '${expectedTitle}'. Found: '${title}'`);
     }
   });
 }


### PR DESCRIPTION
Small change needed to handle the new `appium-remote-debugger` release, over and above what Greenkeeper is proposing.