### PR TITLE
fix: move remote debugger initialization to when it is used

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -205,11 +205,10 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
     // already connected
     pageArray = await getWebviewPages();
   } else {
-    if (this.remote) {
-      await this.remote.setConnectionKey();
-    } else {
+    if (!this.remote) {
       await this.connectToRemoteDebugger();
     }
+    await this.remote.setConnectionKey();
 
     pageArray = await getWebviewPages();
 


### PR DESCRIPTION
Early initialization and connection was a holdover from an earlier version of `appium-remote-debugger` that had some problems. 

This will fix the native portion of https://github.com/appium/appium/issues/13692, though the problem with the `EPIPE` error will remain on that person's machine, in a hybrid/web test.