### PR TITLE
fix: Avoid deleting an app after installation is completed

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -20,18 +20,12 @@ commands.mobileInstallApp = async function mobileInstallApp (opts = {}) {
   const {app} = extractMandatoryOptions(opts, ['app']);
   const dstPath = await this.helpers.configureApp(app, '.app');
   log.info(`Installing '${dstPath}' to the ${this.isRealDevice() ? 'real device' : 'Simulator'} ` +
-           `with UDID ${this.opts.device.udid}`);
+    `with UDID ${this.opts.device.udid}`);
   if (!await fs.exists(dstPath)) {
     log.errorAndThrow(`The application at '${dstPath}' does not exist or is not accessible`);
   }
-  try {
-    await this.opts.device.installApp(dstPath);
-    log.info(`Installation of '${dstPath}' succeeded`);
-  } finally {
-    if (dstPath !== app) {
-      await fs.rimraf(dstPath);
-    }
-  }
+  await this.opts.device.installApp(dstPath);
+  log.info(`Installation of '${dstPath}' succeeded`);
 };
 
 commands.mobileIsAppInstalled = async function mobileIsAppInstalled (opts = {}) {


### PR DESCRIPTION
`confifureApp` manages the applications cache on its own. Deletion of the app on the client side might cause cache damage.
Addresses https://github.com/appium/appium/issues/13412#issuecomment-564042217