### PR TITLE
fix: whoops! did not remove the early remote debugger start

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -408,9 +408,6 @@ class XCUITestDriver extends BaseDriver {
       this.logEvent('appInstalled');
     }
 
-    // start the remote debugger, so it is ready whenever it is needed
-    await this.connectToRemoteDebugger();
-
     // if we only have bundle identifier and no app, fail if it is not already installed
     if (!this.opts.app && this.opts.bundleId && !this.safari) {
       if (!await this.opts.device.isAppInstalled(this.opts.bundleId)) {


### PR DESCRIPTION
I did the work to initialize later but missed the important step of removing the early initialization. This goes, again, toward https://github.com/appium/appium/issues/13692