### PR TITLE
refactor: Perform temporary files cleanup using Node promises

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -154,9 +154,9 @@ async function clearSystemFiles (wda) {
         cleanedFilesCount++;
       }).catch(() => {});
   })).finally(() => {
-    if (cleanedFilesCount) {
+    if (cleanedFilesCount > 0) {
       log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
-        `temporary XCTest log file${cleanedFilesCount > 1 ? 's' : ''}`);
+        `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'}`);
     }
   }).catch(() => {});
   log.debug(`Started background XCTest logs cleanup in '${tmpDir}'`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -138,7 +138,7 @@ async function clearSystemFiles (wda) {
   const tmpDir = os.tmpdir();
   let cleanedFilesCount = 0;
   // perform the cleanup asynchronously
-  B.resolve(fs.walkDir(tmpDir, true, async (itemPath, isDir) => {
+  B.resolve(fs.walkDir(tmpDir, true, (itemPath, isDir) => {
     if (isDir) {
       return;
     }
@@ -147,10 +147,12 @@ async function clearSystemFiles (wda) {
       return;
     }
 
-    try {
-      await fs.unlink(itemPath);
-      cleanedFilesCount++;
-    } catch (ign) {}
+    // delete the file asynchronously
+    fs.unlink(itemPath)
+      // eslint-disable-next-line promise/prefer-await-to-then
+      .then(() => {
+        cleanedFilesCount++;
+      }).catch(() => {});
   })).finally(() => {
     if (cleanedFilesCount) {
       log.info(`Successfully cleaned up ${cleanedFilesCount} ` +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,19 +3,23 @@ import { utilities } from 'appium-ios-device';
 import { fs, util, net, plist } from 'appium-support';
 import path from 'path';
 import { utils as iosUtils } from 'appium-ios-driver';
-import { SubProcess, exec } from 'teen_process';
+import { exec } from 'teen_process';
 import xcode from 'appium-xcode';
 import _ from 'lodash';
 import log from './logger';
 import iosGenericSimulators from './ios-generic-simulators';
 import _fs from 'fs';
 import url from 'url';
+import os from 'os';
 import v8 from 'v8';
 import { PLATFORM_NAME_TVOS } from './desired-caps';
 import semver from 'semver';
 
 const DEFAULT_TIMEOUT_KEY = 'default';
-
+const XCTEST_LOG_FILES_PATTERNS = [
+  /^Session-WebDriverAgentRunner.*\.log$/i,
+  /^StandardOutputAndStandardError\.txt$/i,
+];
 
 async function detectUdid () {
   log.debug('Auto-detecting real device udid...');
@@ -131,17 +135,29 @@ async function clearSystemFiles (wda) {
   derivedDataCleanupMarkers.set(logsRoot, 0);
 
   // Cleaning up big temporary files created by XCTest: https://github.com/appium/appium/issues/9410
-  const cleanupCmd = `find -E /private/var/folders ` +
-    `-regex '.*/Session-WebDriverAgentRunner.*\\.log$|.*/StandardOutputAndStandardError\\.txt$' ` +
-    `-type f -exec sh -c 'echo "" > "{}"' \\;`;
-  const cleanupTask = new SubProcess('bash', ['-c', cleanupCmd], {
-    detached: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  // Do not wait for the task to be completed, since it might take a lot of time
-  // We keep it running after Appium process is killed
-  await cleanupTask.start(0, true);
-  log.debug(`Started background XCTest logs cleanup: ${cleanupCmd}`);
+  const tmpDir = os.tmpdir();
+  let cleanedFilesCount = 0;
+  // perform the cleanup asynchronously
+  B.resolve(fs.walkDir(tmpDir, true, async (itemPath, isDir) => {
+    if (isDir) {
+      return;
+    }
+    const fileName = path.basename(itemPath);
+    if (!XCTEST_LOG_FILES_PATTERNS.some((p) => p.test(fileName))) {
+      return;
+    }
+
+    try {
+      await fs.unlink(itemPath);
+      cleanedFilesCount++;
+    } catch (ign) {}
+  })).finally(() => {
+    if (cleanedFilesCount) {
+      log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
+        `temporary XCTest log file${cleanedFilesCount > 1 ? 's' : ''}`);
+    }
+  }).catch(() => {});
+  log.debug(`Started background XCTest logs cleanup in '${tmpDir}'`);
 
   if (await fs.exists(logsRoot)) {
     log.info(`Cleaning test logs in '${logsRoot}' folder`);

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -24,6 +24,9 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      mocks.fs.expects('walkDir')
+        .once()
+        .returns();
       mocks.fs.expects('exists')
         .once()
         .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
@@ -41,6 +44,9 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      mocks.fs.expects('walkDir')
+        .once()
+        .returns();
       mocks.fs.expects('exists')
         .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
         .returns(true);


### PR DESCRIPTION
I think this is more appropriate way of doing the cleanup. We cannot rely on the command line tools