### PR TITLE
refactor: clean up app install error handling

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -37,24 +37,25 @@ class IOSDeploy {
     try {
       const bundlePathOnPhone = await this.pushAppBundle(app, timeout);
       await this.installApplication(bundlePathOnPhone);
-    } catch (e) {
-      log.warn(`Falling back to ${IOS_DEPLOY} usage`, e);
+    } catch (err) {
+      log.warn(`Error installing app: ${err.message}`);
+      log.warn(`Falling back to '${IOS_DEPLOY}' usage`);
       try {
         await fs.which(IOS_DEPLOY);
-      } catch (e1) {
+      } catch (err1) {
         throw new Error(`Could not install '${app}':\n` +
-          `  - ${e.message}\n` +
-          `  - ${IOS_DEPLOY} utility has not been found in PATH. Is it installed?`);
+          `  - ${err.message}\n` +
+          `  - '${IOS_DEPLOY}' utility has not been found in PATH. Is it installed?`);
       }
       try {
         await exec(IOS_DEPLOY, [
           '--id', this.udid,
           '--bundle', app,
         ]);
-      } catch (e1) {
+      } catch (err1) {
         throw new Error(`Could not install '${app}':\n` +
-          `  - ${e.message}\n` +
-          `  - ${e1.stderr || e1.stdout || e1.message}`);
+          `  - ${err.message}\n` +
+          `  - ${err1.stderr || err1.stdout || err1.message}`);
       }
     }
     const [seconds, nanos] = process.hrtime(start);
@@ -65,12 +66,12 @@ class IOSDeploy {
     const notificationService = await services.startNotificationProxyService(this.udid);
     const installationService = await services.startInstallationProxyService(this.udid);
     const appInstalledNotification = new B((resolve) => {
-      notificationService.observeNotification(APPLICATION_INSTALLED_NOTIFICATION, { notification: resolve });
+      notificationService.observeNotification(APPLICATION_INSTALLED_NOTIFICATION, {notification: resolve});
     });
     try {
-      await installationService.installApplication(bundlePathOnPhone, { PackageType: 'Developer'});
+      await installationService.installApplication(bundlePathOnPhone, {PackageType: 'Developer'});
       try {
-        await appInstalledNotification.timeout(APPLICATION_NOTIFICATION_TIMEOUT, `Couldn't get the application installed notification within ${APPLICATION_NOTIFICATION_TIMEOUT}ms but we will continue`);
+        await appInstalledNotification.timeout(APPLICATION_NOTIFICATION_TIMEOUT, `Could not get the application installed notification within ${APPLICATION_NOTIFICATION_TIMEOUT}ms but we will continue`);
       } catch (e) {
         log.warn(`Failed to receive the notification. Error: ${e.message}`);
       }
@@ -92,7 +93,7 @@ class IOSDeploy {
           await afcService.createDirectory(pathOnPhone);
         } else {
           const readStream = fs.createReadStream(itemPath, {autoClose: true});
-          const writeStream = await afcService.createWriteStream(pathOnPhone, {autoDestroy: true });
+          const writeStream = await afcService.createWriteStream(pathOnPhone, {autoDestroy: true});
           writeStream.on('finish', writeStream.destroy);
           const itemPushWait = new B((resolve, reject) => {
             writeStream.on('close', resolve);
@@ -100,7 +101,7 @@ class IOSDeploy {
           });
           readStream.pipe(writeStream);
           await itemPushWait.timeout(timeout,
-            `Couldn't push '${itemPath}' within the timeout of ${timeout}ms. ` +
+            `Could not push '${itemPath}' within the timeout of ${timeout}ms. ` +
             `Consider increasing the value of 'appPushTimeout' capability.`);
         }
       });

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "glob": "^7.1.0",
     "gulp": "^4.0.0",
     "ios-test-app": "^3.0.0",
-    "ios-uicatalog": "^3.0.0",
+    "ios-uicatalog": "^3.5.0",
     "mocha": "^6.0.0",
     "mocha-junit-reporter": "^1.23.1",
     "mocha-multi-reporters": "^1.1.7",


### PR DESCRIPTION
While looking at the logs for a failure in this code (https://github.com/appium/appium/issues/13716) I found the output confusing. This PR rearranges some of the error output, as well as normalizes some of the style.