### PR TITLE
chore: Tune error messages and variable names for the connections factory

### DIFF
--- a/lib/device-connections-factory.js
+++ b/lib/device-connections-factory.js
@@ -18,18 +18,22 @@ class iProxy {
     if (this.serverSocket) {
       return;
     }
-    this.serverSocket = net.createServer(async (connection) => {
+    this.serverSocket = net.createServer(async (localSocket) => {
       try {
-        const socket = await utilities.connectPort(this.udid, this.deviceport);
-        socket.on('close', () => connection.end());
-        socket.on('error', (e) => this.log.error(e));
-        connection.on('close', () => socket.end());
-        connection.on('error', (e) => this.log.error(e));
-        connection.pipe(socket);
-        socket.pipe(connection);
+        const remoteSocket = await utilities.connectPort(this.udid, this.deviceport);
+        remoteSocket.on('close', () => localSocket.end());
+        remoteSocket.on('error', (e) => {
+          // not all remote socket errors are critical for the user
+          this.log.info(e.message);
+          this.log.debug(e);
+        });
+        localSocket.on('close', () => remoteSocket.end());
+        localSocket.on('error', (e) => this.log.warn(e.message));
+        localSocket.pipe(remoteSocket);
+        remoteSocket.pipe(localSocket);
       } catch (e) {
         this.log.error(e);
-        connection.end();
+        localSocket.end();
       }
     });
     const status = new B((resolve, reject) => {
@@ -38,7 +42,7 @@ class iProxy {
     });
     this.serverSocket.listen(this.localport);
     await status;
-    this.serverSocket.on('error', (e) => this.log.error(e));
+    this.serverSocket.on('error', (e) => this.log.warn(e.message));
   }
 
   // eslint-disable-next-line require-await


### PR DESCRIPTION
Not all errors thrown by remote socket are critical to us, it makes sense to print them at info level to not confuse users to much