### PR TITLE
feat: add option for wait duration for mobile context list

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -259,9 +259,17 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
  * @returns {Array} List of Context objects
  */
 extensions.mobileGetContexts = async function mobileGetContexts (opts = {}) {
-  const {
+  let {
     waitForWebviewMs = 0,
   } = opts;
+
+  // make sure it is a number, so the duration check works properly
+  if (!_.isNumber(waitForWebviewMs)) {
+    waitForWebviewMs = parseInt(waitForWebviewMs, 10);
+    if (isNaN(waitForWebviewMs)) {
+      waitForWebviewMs = 0;
+    }
+  }
 
   const curOpt = this.opts.fullContextList;
   // `appium-ios-driver#getContexts` returns the full list of contexts
@@ -270,20 +278,17 @@ extensions.mobileGetContexts = async function mobileGetContexts (opts = {}) {
 
   const timer = new timing.Timer().start();
   try {
-    if (waitForWebviewMs === 0) {
-      return await this.getContexts();
-    }
+    let contexts;
+    do {
+      contexts = await this.getContexts();
 
-    while (timer.getDuration().asMilliSeconds < waitForWebviewMs) {
-      log.debug('Retrieving contexts');
-      const contexts = await this.getContexts();
       if (contexts.length >= 2) {
         log.debug(`Found webview context after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
         return contexts;
       }
       log.debug(`No webviews found in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
-    }
-    return [NATIVE_WIN];
+    } while (timer.getDuration().asMilliSeconds < waitForWebviewMs);
+    return contexts;
   } finally {
     // reset the option so there are no side effects
     this.opts.fullContextList = curOpt;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -283,7 +283,7 @@ extensions.mobileGetContexts = async function mobileGetContexts (opts = {}) {
       }
       log.debug(`No webviews found in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
     }
-    return NATIVE_WIN;
+    return [NATIVE_WIN];
   } finally {
     // reset the option so there are no side effects
     this.opts.fullContextList = curOpt;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -1,7 +1,7 @@
 import { iosCommands, IOSPerformanceLog, NATIVE_WIN, WEBVIEW_WIN } from 'appium-ios-driver';
 import { createRemoteDebugger, RemoteDebugger } from 'appium-remote-debugger';
 import { errors, isErrorType } from 'appium-base-driver';
-import { util } from 'appium-support';
+import { util, timing } from 'appium-support';
 import log from '../logger';
 import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
@@ -103,6 +103,11 @@ commands.setContext = async function setContext (name, callback, skipReadyCheck)
   }
   function isNativeContext (context) {
     return context === NATIVE_WIN || context === null;
+  }
+
+  // allow the full context list to be passed in
+  if (name && name.id) {
+    name = name.id;
   }
 
   log.debug(`Attempting to set context to '${name || NATIVE_WIN}' from '${this.curContext ? this.curContext : NATIVE_WIN}'`);
@@ -248,15 +253,37 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
 /**
  * Get the contexts available, with information about the url and title of each
  * webview
+ *
+ * @param {Object} opts - Options set, which can include `waitForWebviewMs` to
+ *                        specify the period to poll for available webviews
  * @returns {Array} List of Context objects
  */
-extensions.mobileGetContexts = async function mobileGetContexts () {
+extensions.mobileGetContexts = async function mobileGetContexts (opts = {}) {
+  const {
+    waitForWebviewMs = 0,
+  } = opts;
+
   const curOpt = this.opts.fullContextList;
+  // `appium-ios-driver#getContexts` returns the full list of contexts
+  // if this option is on
+  this.opts.fullContextList = true;
+
+  const timer = new timing.Timer().start();
   try {
-    // `appium-ios-driver#getContexts` returns the full list of contexts
-    // if this option is on
-    this.opts.fullContextList = true;
-    return await this.getContexts();
+    if (waitForWebviewMs === 0) {
+      return await this.getContexts();
+    }
+
+    while (timer.getDuration().asMilliSeconds < waitForWebviewMs) {
+      log.debug('Retrieving contexts');
+      const contexts = await this.getContexts();
+      if (contexts.length >= 2) {
+        log.debug(`Found webview context after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+        return contexts;
+      }
+      log.debug(`No webviews found in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+    }
+    return NATIVE_WIN;
   } finally {
     // reset the option so there are no side effects
     this.opts.fullContextList = curOpt;

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -299,9 +299,8 @@ describe('XCUITestDriver - basics -', function () {
 
   describe('contexts -', function () {
     before(async function () {
-      const el = await driver.elementByAccessibilityId('Web View');
-      await driver.execute('mobile: scroll', {element: el, toVisible: true});
-      await el.click();
+      await driver.execute('mobile: scroll', {direction: 'down'});
+      await driver.elementByAccessibilityId('Web View').click();
     });
     after(async function () {
       await driver.back();
@@ -309,12 +308,8 @@ describe('XCUITestDriver - basics -', function () {
     });
 
     it('should start a session, navigate to url, get title', async function () {
-      const contexts = await retryInterval(100, 1000, async function () {
-        // on some systems (like Travis) it takes a while to load the webview
-        const contexts = await driver.contexts();
-        contexts.length.should.be.at.least(2);
-        return contexts;
-      });
+      // on some systems (like Travis) it takes a while to load the webview
+      const contexts = await driver.execute('mobile: getContexts', {waitForWebviewMs: 30000});
 
       await driver.context(contexts[1]);
       await driver.get(GUINEA_PIG_PAGE);


### PR DESCRIPTION
Add an option, `waitForWebviewMs`, to the mobile execute version of `getContexts`, which will make it blocking for that period of time. Workaround for https://github.com/appium/appium/issues/13770