### PR TITLE
refactor: do not check for app install status on new simulator

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1098,9 +1098,9 @@ class XCUITestDriver extends BaseDriver {
       // TODO: Let it throw after we confirm the architecture verification algorithm is stable
       log.warn(`*********************************`);
       log.warn(`${this.isSimulator() ? 'Simulator' : 'Real device'} architecture appears to be unsupported ` +
-               `by the '${this.opts.app}' application. ` +
-               `Make sure the correct deployment target has been selected for its compilation in Xcode.`);
-      log.warn('Don\'t be surprised if the application fails to launch.');
+               `by the '${this.opts.app}' application. `);
+      log.warn(`Make sure the correct deployment target has been selected for its compilation in Xcode.`);
+      log.warn('Do not be surprised if the application fails to launch.');
       log.warn(`*********************************`);
     }
 
@@ -1112,6 +1112,7 @@ class XCUITestDriver extends BaseDriver {
     } else {
       await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, {
         noReset: this.opts.noReset,
+        newSimulator: this.lifecycleData.createSim,
       });
     }
     if (this.opts.otherApps) {
@@ -1138,7 +1139,8 @@ class XCUITestDriver extends BaseDriver {
     }
     for (const otherApp of otherApps) {
       await installToSimulator(this.opts.device, otherApp, undefined, {
-        noReset: this.opts.noReset
+        noReset: this.opts.noReset,
+        newSimulator: this.lifecycleData.createSim,
       });
     }
   }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -134,6 +134,7 @@ async function runSimulatorReset (device, opts) {
  * @typedef {Object} InstallOptions
  *
  * @property {?boolean} noReset [false] Whether to disable reset
+ * @property {?boolean} newSimulator [false] Whether the simulator is brand new
  */
 
 /**
@@ -151,9 +152,10 @@ async function installToSimulator (device, app, bundleId, opts = {}) {
 
   const {
     noReset = true,
+    newSimulator = false,
   } = opts;
 
-  if (bundleId && await device.isAppInstalled(bundleId)) {
+  if (!newSimulator && bundleId && await device.isAppInstalled(bundleId)) {
     if (noReset) {
       log.debug(`App '${bundleId}' is already installed. No need to reinstall.`);
       return;

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -154,13 +154,14 @@ describe('installOtherApps', function () {
     driver.isRealDevice.returns(false);
     driver.opts.noReset = false;
     driver.opts.device = 'some-device';
+    driver.lifecycleData = {createSim: false};
     await driver.installOtherApps('/path/to/iosApp.app');
     driver.isRealDevice.calledOnce.should.be.true;
     SimulatorManagementModule.installToSimulator.calledOnce.should.be.true;
     SimulatorManagementModule.installToSimulator.calledWith(
       'some-device',
       '/path/to/iosApp.app',
-      undefined, {noReset: false}
+      undefined, {noReset: false, newSimulator: false}
     ).should.be.true;
   });
 
@@ -171,17 +172,18 @@ describe('installOtherApps', function () {
     driver.isRealDevice.returns(false);
     driver.opts.noReset = false;
     driver.opts.device = 'some-device';
+    driver.lifecycleData = {createSim: false};
     await driver.installOtherApps('["/path/to/iosApp1.app","/path/to/iosApp2.app"]');
     driver.isRealDevice.calledOnce.should.be.true;
     SimulatorManagementModule.installToSimulator.calledWith(
       'some-device',
       '/path/to/iosApp1.app',
-      undefined, {noReset: false}
+      undefined, {noReset: false, newSimulator: false}
     ).should.be.true;
     SimulatorManagementModule.installToSimulator.calledWith(
       'some-device',
       '/path/to/iosApp2.app',
-      undefined, {noReset: false}
+      undefined, {noReset: false, newSimulator: false}
     ).should.be.true;
   });
 });


### PR DESCRIPTION
There are times when we _know_ that a simulator is new. And so we do not really need to check if our app is on it.