### PR TITLE
refactor: do not check for existence of simulator when it is known

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -11,6 +11,10 @@ let desiredCapConstraints = _.defaults({
     isString: true,
     inclusionCaseInsensitive: [PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS]
   },
+  deviceName: {
+    presence: true,
+    isString: true
+  },
   showXcodeLog: {
     isBoolean: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -8,7 +8,7 @@ import log from './logger';
 import {
   createSim, getExistingSim, runSimulatorReset, installToSimulator,
   shutdownOtherSimulators, shutdownSimulator } from './simulator-management';
-import { simExists, getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
+import { getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
 import { retryInterval, retry } from 'asyncbox';
 import { settings as iosSettings, defaultServerCaps, appUtils } from 'appium-ios-driver';
 import { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from './desired-caps';
@@ -782,12 +782,13 @@ class XCUITestDriver extends BaseDriver {
         log.debug(`Available devices: ${devices.join(', ')}`);
         if (!devices.includes(this.opts.udid)) {
           // check for a particular simulator
-          if (await simExists(this.opts.udid)) {
+          log.debug(`No real device with udid '${this.opts.udid}'. Looking for simulator`);
+          try {
             const device = await getSimulator(this.opts.udid);
             return {device, realDevice: false, udid: this.opts.udid};
+          } catch (ign) {
+            throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
           }
-
-          throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
         }
       }
 

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -7,6 +7,8 @@ import UUID from 'uuid-js';
 import { PLATFORM_NAME_IOS } from './desired-caps';
 
 
+const APPIUM_SIM_PREFIX = 'appiumTest';
+
 /**
  * Capability set by a user
  *
@@ -21,14 +23,16 @@ import { PLATFORM_NAME_IOS } from './desired-caps';
  * @returns {object} Simulator object associated with the udid passed in.
  */
 async function createSim (caps, platform = PLATFORM_NAME_IOS) {
-  const appiumTestDeviceName = `appiumTest-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`;
   const udid = await createDevice(
-    appiumTestDeviceName,
+    `${APPIUM_SIM_PREFIX}-${UUID.create().toString().toUpperCase()}-${caps.deviceName}`,
     caps.deviceName,
     caps.platformVersion,
-    { platform }
+    {platform},
   );
-  return await getSimulator(udid);
+  return await getSimulator(udid, {
+    platform,
+    checkExistence: false,
+  });
 }
 
 /**
@@ -40,24 +44,31 @@ async function createSim (caps, platform = PLATFORM_NAME_IOS) {
  * @returns {?object} Simulator object associated with the udid passed in. Or null if no device is running.
  */
 async function getExistingSim (opts) {
-  const devices = await getDevices(opts.platformVersion);
-  const appiumTestDeviceName = `appiumTest-${opts.deviceName}`;
-
   let appiumTestDevice;
 
-  for (const device of _.values(devices)) {
+  for (const device of _.values(await getDevices(opts.platformVersion))) {
     if (device.name === opts.deviceName) {
-      return await getSimulator(device.udid);
+      return await getSimulator(device.udid, {
+        platform: device.platform,
+        checkExistence: false,
+      });
     }
 
-    if (device.name === appiumTestDeviceName) {
+    if (device.name.startsWith(APPIUM_SIM_PREFIX) && device.name.endsWith(opts.deviceName)) {
       appiumTestDevice = device;
+      // choose the first booted simulator
+      if (device.state === 'Booted') {
+        break;
+      }
     }
   }
 
   if (appiumTestDevice) {
     log.warn(`Unable to find device '${opts.deviceName}'. Found '${appiumTestDevice.name}' (udid: '${appiumTestDevice.udid}') instead`);
-    return await getSimulator(appiumTestDevice.udid);
+    return await getSimulator(appiumTestDevice.udid, {
+      platform: appiumTestDevice.platform,
+      checkExistence: false,
+    });
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "appium-idb": "^0",
     "appium-ios-device": "^1.2.3",
     "appium-ios-driver": "^4.0.0",
-    "appium-ios-simulator": "^3.15.0",
+    "appium-ios-simulator": "^3.16.0",
     "appium-remote-debugger": "^7.3.0",
     "appium-support": "^2.37.0",
     "appium-webdriveragent": "^2.3.2",

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -45,7 +45,10 @@ describe('XCUITestDriver', function () {
     }, baseCaps);
   });
   after(async function () {
-    const sim = await getSimulator(caps.udid);
+    const sim = await getSimulator(caps.udid, {
+      platform: 'iOS',
+      checkExistence: false,
+    });
     await shutdownSimulator(sim);
     await deleteDeviceWithRetry(caps.udid);
   });
@@ -175,7 +178,10 @@ describe('XCUITestDriver', function () {
       it('with udid: uses sim and resets afterwards if resetOnSessionStartOnly is false', async function () {
         // before
         const udid = await createDevice();
-        let sim = await getSimulator(udid);
+        let sim = await getSimulator(udid, {
+          platform: 'iOS',
+          checkExistence: false,
+        });
         await sim.run();
 
         // test
@@ -204,7 +210,10 @@ describe('XCUITestDriver', function () {
       it('with udid booted: uses sim and leaves it afterwards', async function () {
         // before
         const udid = await createDevice();
-        let sim = await getSimulator(udid);
+        let sim = await getSimulator(udid, {
+          platform: 'iOS',
+          checkExistence: false,
+        });
         await sim.run();
 
         await B.delay(2000);
@@ -253,7 +262,10 @@ describe('XCUITestDriver', function () {
 
         // before
         const udid = await createDevice();
-        let sim = await getSimulator(udid);
+        let sim = await getSimulator(udid, {
+          platform: 'iOS',
+          checkExistence: false,
+        });
 
         // some systems require a pause before initializing.
         await B.delay(2000);

--- a/test/functional/tv/tvos-e2e-specs.js
+++ b/test/functional/tv/tvos-e2e-specs.js
@@ -27,7 +27,10 @@ describe('tvOS', function () {
     caps = Object.assign({usePrebuiltWDA: true}, baseCaps);
   });
   after(async function () {
-    const sim = await getSimulator(caps.udid);
+    const sim = await getSimulator(caps.udid, {
+      platform: 'tvOS',
+      checkExistence: false,
+    });
     await shutdownSimulator(sim);
     await deleteDeviceWithRetry(caps.udid);
   });


### PR DESCRIPTION
Use the new functionality in `appium-ios-simulator` to skip the check for a sim's existence when we have just created it.

Also, when getting the simulator in `determineDevice`, there is no need to check if it exists beforehand, since that is done in the `getSimulator` function.