### PR TITLE
refactor: Remove the obsolete stuff from input handlers

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -102,17 +102,25 @@ commands.getSize = async function getSize (el) {
   return {width: rect.width, height: rect.height};
 };
 
+/**
+ * Prepares the input value to be passed as an argument to WDA.
+ *
+ * @param {string|Array<string>} inp The actual text to type.
+ * Acceptable values of `inp`:
+ *   ['some text']
+ *   ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
+ *   'some text'
+ * @throws {Error} If the value is not acceptable for input
+ * @returns {Array<string>} The preprocessed value
+ */
 function prepareInputValue (inp) {
   if (!_.isArray(inp) && !_.isString(inp)) {
     throw new Error(`Only strings and arrays are supported as input arguments. ` +
       `Received: ${JSON.stringify(inp)}`);
   }
 
-  // possible values of `inp`:
-  //   ['some text']
-  //   ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
-  //   'some text'
-  // make it into an array of single characters
+  // make it into a string, so then we assure
+  // the array items are single characters
   if (_.isArray(inp)) {
     inp = inp.join('');
   }

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import { iosCommands } from 'appium-ios-driver';
 import { util } from 'appium-support';
-import { retryInterval, retry } from 'asyncbox';
 import log from '../logger';
 
 
@@ -103,56 +102,32 @@ commands.getSize = async function getSize (el) {
   return {width: rect.width, height: rect.height};
 };
 
-function hasSpecialKeys (keys) {
-  for (let char of keys) {
-    if (isSpecialKey(char)) {
-      return true;
+function prepareInputValue (inp) {
+  if (!_.isArray(inp) && !_.isString(inp)) {
+    throw new Error(`Only strings and arrays are supported as input arguments. ` +
+      `Received: ${JSON.stringify(inp)}`);
+  }
+
+  // possible values of `inp`:
+  //   ['some text']
+  //   ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
+  //   'some text'
+  // make it into an array of single characters
+  if (_.isArray(inp)) {
+    inp = inp.join('');
+  }
+  // The `split` method must not be used on the string
+  // to properly handle all Unicode code points
+  return [...inp].map((k) => {
+    if (['\uE006', '\uE007'].includes(k)) { // RETURN or ENTER
+      return '\n';
     }
-  }
-  return false;
+    if (['\uE003', '\ue017'].includes(k)) { // BACKSPACE or DELETE
+      return '\b';
+    }
+    return k;
+  });
 }
-
-function isSpecialKey (k) {
-  if (k === '\uE003' || k === '\ue017') { // BACKSPACE or DELETE
-    return true;
-  } else if (k === '\uE006' || k === '\uE007') { // RETURN or ENTER
-    return true;
-  }
-  return false;
-}
-
-function translateKey (k) {
-  if (k === '\uE006' || k === '\uE007') { // RETURN or ENTER
-    return '\n';
-  } else if (k === '\uE003' || k === '\ue017') { // BACKSPACE or DELETE
-    return '\b';
-  }
-  return k;
-}
-
-extensions.bringUpKeyboard = async function bringUpKeyboard (element) {
-  // sometimes input is attempted before we have a keyboard. Try to bring one up
-  // but we want to handle the retries on find
-  let implicitWaitMs = this.implicitWaitMs;
-  await this.setImplicitWait(0);
-  try {
-    await retryInterval(10, 10, async () => {
-      try {
-        await this.findNativeElementOrElements('class name', 'XCUIElementTypeKeyboard', false);
-        log.debug('Keyboard found. Continuing with text input.');
-      } catch (err) {
-        // no keyboard found
-        log.debug('No keyboard found. Clicking element to open it.');
-        await this.nativeClick(element);
-
-        await this.findNativeElementOrElements('class name', 'XCUIElementTypeKeyboard', false);
-      }
-    });
-  } finally {
-    // no matter what we do, make sure we have the implicit wait set up correctly
-    await this.setImplicitWait(implicitWaitMs);
-  }
-};
 
 commands.setValueImmediate = async function setValueImmediate (value, el) {
   // WDA does not provide no way to set the value directly
@@ -162,105 +137,32 @@ commands.setValueImmediate = async function setValueImmediate (value, el) {
 
 commands.setValue = async function setValue (value, el) {
   el = util.unwrapElement(el);
-  if (this.isWebContext()) {
-    let atomsElement = this.useAtomsElement(el);
-    await this.executeAtom('click', [atomsElement]);
-    await this.executeAtom('type', [atomsElement, value]);
-  } else {
-    const setFormattedValue = async (input, isKeyboardPresenceCheckEnabled) => {
-      if (typeof input !== 'string' && !(input instanceof Array)) {
-        input = input.toString().split('');
-      }
-      try {
-        await this.proxyCommand(`/element/${el}/value`, 'POST', {value: input});
-      } catch (err) {
-        // make sure there is a keyboard if this is a text field
-        if (isKeyboardPresenceCheckEnabled && await this.getAttribute('type', el) === 'XCUIElementTypeTextField') {
-          log.info(`Cannot type in the text field because of ${err}.\nTrying to apply a workaround...`);
-          await this.bringUpKeyboard(el);
-          await this.proxyCommand(`/element/${el}/value`, 'POST', {value: input});
-        } else {
-          throw err;
-        }
-      }
-    };
-
-    // possible values of `value`:
-    //   ['some text']
-    //   ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
-    //   'some text'
-    if (_.isNull(value) || _.isUndefined(value) || _.isPlainObject(value)) {
-      throw new Error(`Only strings and arrays of strings are supported as input arguments. Received: '${JSON.stringify(value)}'`);
-    }
-    if (_.isArray(value)) {
-      // make sure that all the strings inside are a single character long
-      value = _.flatMap(value, (v) => (_.isString(v) ? v : JSON.stringify(v)).split(''));
-    } else {
-      // make it into an array of characters
-      value = (value || '').toString().split('');
-    }
-
-    if (!hasSpecialKeys(value)) {
-      // nothing special, so just send it in
-      await setFormattedValue(value, true);
-      return;
-    }
-
-    // if there are special characters, go through the value until we get to one,
-    // and then print it individually
-    // currently only supporting return, enter, backspace, and delete
-    let buffer = [];
-    let isFirstChar = true;
-    for (let k of value) {
-      let char = translateKey(k);
-
-      if (char === k) {
-        buffer.push(char);
-        continue;
-      }
-
-      // write and clear the buffer
-      await setFormattedValue(buffer, isFirstChar);
-      isFirstChar = false;
-      buffer = [];
-
-      // write the character
-      await setFormattedValue([char], isFirstChar);
-    }
-    // finally, send anything that might be left
-    if (buffer.length) {
-      await setFormattedValue(buffer, false);
-    }
+  if (!this.isWebContext()) {
+    await this.proxyCommand(`/element/${el}/value`, 'POST', {
+      value: prepareInputValue(value),
+    });
+    return;
   }
+
+  const atomsElement = this.useAtomsElement(el);
+  await this.executeAtom('click', [atomsElement]);
+  await this.executeAtom('type', [atomsElement, value]);
 };
 
 commands.keys = async function keys (value) {
-  if (_.isArray(value)) {
-    // concatenate any individual strings
-    value = value.join('');
-  }
-  if (_.isString(value)) {
-    // split into component characters
-    value = value.split('');
-  }
-
-  let buffer = [];
-  for (let k of value) {
-    let char = translateKey(k);
-
-    buffer.push(char);
-  }
-  await this.proxyCommand('/wda/keys', 'POST', {value: buffer});
+  await this.proxyCommand('/wda/keys', 'POST', {
+    value: prepareInputValue(value),
+  });
 };
 
 commands.clear = async function clear (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    let atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.useAtomsElement(el);
     await this.executeAtom('clear', [atomsElement]);
     return;
   }
-  await retry(5, this.proxyCommand.bind(this), `/element/${el}/clear`, 'POST');
+  await this.proxyCommand(`/element/${el}/clear`, 'POST');
 };
 
 commands.getContentSize = async function getContentSize (el) {


### PR DESCRIPTION
Currently WDA is much more advanced than when the previous code was written, so it handles the keyboard presence and retries on its own. Also, there was a bug in the code related to strings split. the issue was that the standard `String.split` method does not properly handle complex Unicode characters, like smiles.