### PR TITLE
fix: Look for temporary logs in the specific root folder instead of the whole tempdir

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,9 @@ async function clearSystemFiles (wda) {
   // Cleaning up big temporary files created by XCTest: https://github.com/appium/appium/issues/9410
   const globPattern = `${os.tmpdir()}/${XCTEST_LOGS_CACHE_FOLDER_PREFIX}*/`;
   const dstFolders = await fs.glob(globPattern);
-  if (!_.isEmpty(dstFolders)) {
+  if (_.isEmpty(dstFolders)) {
+    log.debug(`Did not find the temporary XCTest logs root at '${globPattern}'`);
+  } else {
     // perform the cleanup asynchronously
     for (const dstFolder of dstFolders) {
       let cleanedFilesCount = 0;
@@ -166,8 +168,6 @@ async function clearSystemFiles (wda) {
       }).catch(() => {});
     }
     log.debug(`Started background XCTest logs cleanup in '${dstFolders}'`);
-  } else {
-    log.debug(`Did not find the temporary XCTest logs root at '${globPattern}'`);
   }
 
   if (await fs.exists(logsRoot)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,8 @@ const XCTEST_LOG_FILES_PATTERNS = [
   /^Session-WebDriverAgentRunner.*\.log$/i,
   /^StandardOutputAndStandardError\.txt$/i,
 ];
+const XCTEST_LOGS_CACHE = 'com.apple.dt.XCTest';
+
 
 async function detectUdid () {
   log.debug('Auto-detecting real device udid...');
@@ -135,31 +137,35 @@ async function clearSystemFiles (wda) {
   derivedDataCleanupMarkers.set(logsRoot, 0);
 
   // Cleaning up big temporary files created by XCTest: https://github.com/appium/appium/issues/9410
-  const tmpDir = os.tmpdir();
-  let cleanedFilesCount = 0;
-  // perform the cleanup asynchronously
-  B.resolve(fs.walkDir(tmpDir, true, (itemPath, isDir) => {
-    if (isDir) {
-      return;
-    }
-    const fileName = path.basename(itemPath);
-    if (!XCTEST_LOG_FILES_PATTERNS.some((p) => p.test(fileName))) {
-      return;
-    }
+  const xctestTmpLogsRoot = path.resolve(os.tmpdir(), XCTEST_LOGS_CACHE);
+  if (await fs.exists(xctestTmpLogsRoot)) {
+    let cleanedFilesCount = 0;
+    // perform the cleanup asynchronously
+    B.resolve(fs.walkDir(xctestTmpLogsRoot, true, (itemPath, isDir) => {
+      if (isDir) {
+        return;
+      }
+      const fileName = path.basename(itemPath);
+      if (!XCTEST_LOG_FILES_PATTERNS.some((p) => p.test(fileName))) {
+        return;
+      }
 
-    // delete the file asynchronously
-    fs.unlink(itemPath)
-      // eslint-disable-next-line promise/prefer-await-to-then
-      .then(() => {
-        cleanedFilesCount++;
-      }).catch(() => {});
-  })).finally(() => {
-    if (cleanedFilesCount > 0) {
-      log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
-        `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'}`);
-    }
-  }).catch(() => {});
-  log.debug(`Started background XCTest logs cleanup in '${tmpDir}'`);
+      // delete the file asynchronously
+      fs.unlink(itemPath)
+        // eslint-disable-next-line promise/prefer-await-to-then
+        .then(() => {
+          cleanedFilesCount++;
+        }).catch(() => {});
+    })).finally(() => {
+      if (cleanedFilesCount > 0) {
+        log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
+          `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'}`);
+      }
+    }).catch(() => {});
+    log.debug(`Started background XCTest logs cleanup in '${xctestTmpLogsRoot}'`);
+  } else {
+    log.debug(`Did not find the temporary XCTest logs root at '${xctestTmpLogsRoot}'`);
+  }
 
   if (await fs.exists(logsRoot)) {
     log.info(`Cleaning test logs in '${logsRoot}' folder`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,7 +144,7 @@ async function clearSystemFiles (wda) {
   } else {
     // perform the cleanup asynchronously
     for (const dstFolder of dstFolders) {
-      let cleanedFilesCount = 0;
+      let scheduledFilesCount = 0;
       B.resolve(fs.walkDir(dstFolder, true, (itemPath, isDir) => {
         if (isDir) {
           return;
@@ -155,15 +155,14 @@ async function clearSystemFiles (wda) {
         }
 
         // delete the file asynchronously
-        fs.unlink(itemPath)
-          // eslint-disable-next-line promise/prefer-await-to-then
-          .then(() => {
-            cleanedFilesCount++;
-          }).catch(() => {});
+        fs.unlink(itemPath).catch((e) => {
+          log.debug(e.message);
+        });
+        scheduledFilesCount++;
       })).finally(() => {
-        if (cleanedFilesCount > 0) {
-          log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
-            `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'} in '${dstFolder}'`);
+        if (scheduledFilesCount > 0) {
+          log.info(`Scheduled ${scheduledFilesCount} temporary XCTest log ` +
+            `file${scheduledFilesCount === 1 ? '' : 's'} for cleanup in '${dstFolder}'`);
         }
       }).catch(() => {});
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,7 @@ const XCTEST_LOG_FILES_PATTERNS = [
   /^Session-WebDriverAgentRunner.*\.log$/i,
   /^StandardOutputAndStandardError\.txt$/i,
 ];
-const XCTEST_LOGS_CACHE = 'com.apple.dt.XCTest';
+const XCTEST_LOGS_CACHE_FOLDER_PREFIX = 'com.apple.dt.XCTest';
 
 
 async function detectUdid () {
@@ -137,34 +137,37 @@ async function clearSystemFiles (wda) {
   derivedDataCleanupMarkers.set(logsRoot, 0);
 
   // Cleaning up big temporary files created by XCTest: https://github.com/appium/appium/issues/9410
-  const xctestTmpLogsRoot = path.resolve(os.tmpdir(), XCTEST_LOGS_CACHE);
-  if (await fs.exists(xctestTmpLogsRoot)) {
-    let cleanedFilesCount = 0;
+  const globPattern = `${os.tmpdir()}/${XCTEST_LOGS_CACHE_FOLDER_PREFIX}*/`;
+  const dstFolders = await fs.glob(globPattern);
+  if (!_.isEmpty(dstFolders)) {
     // perform the cleanup asynchronously
-    B.resolve(fs.walkDir(xctestTmpLogsRoot, true, (itemPath, isDir) => {
-      if (isDir) {
-        return;
-      }
-      const fileName = path.basename(itemPath);
-      if (!XCTEST_LOG_FILES_PATTERNS.some((p) => p.test(fileName))) {
-        return;
-      }
+    for (const dstFolder of dstFolders) {
+      let cleanedFilesCount = 0;
+      B.resolve(fs.walkDir(dstFolder, true, (itemPath, isDir) => {
+        if (isDir) {
+          return;
+        }
+        const fileName = path.basename(itemPath);
+        if (!XCTEST_LOG_FILES_PATTERNS.some((p) => p.test(fileName))) {
+          return;
+        }
 
-      // delete the file asynchronously
-      fs.unlink(itemPath)
-        // eslint-disable-next-line promise/prefer-await-to-then
-        .then(() => {
-          cleanedFilesCount++;
-        }).catch(() => {});
-    })).finally(() => {
-      if (cleanedFilesCount > 0) {
-        log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
-          `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'}`);
-      }
-    }).catch(() => {});
-    log.debug(`Started background XCTest logs cleanup in '${xctestTmpLogsRoot}'`);
+        // delete the file asynchronously
+        fs.unlink(itemPath)
+          // eslint-disable-next-line promise/prefer-await-to-then
+          .then(() => {
+            cleanedFilesCount++;
+          }).catch(() => {});
+      })).finally(() => {
+        if (cleanedFilesCount > 0) {
+          log.info(`Successfully cleaned up ${cleanedFilesCount} ` +
+            `temporary XCTest log file${cleanedFilesCount === 1 ? '' : 's'} in '${dstFolder}'`);
+        }
+      }).catch(() => {});
+    }
+    log.debug(`Started background XCTest logs cleanup in '${dstFolders}'`);
   } else {
-    log.debug(`Did not find the temporary XCTest logs root at '${xctestTmpLogsRoot}'`);
+    log.debug(`Did not find the temporary XCTest logs root at '${globPattern}'`);
   }
 
   if (await fs.exists(logsRoot)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,7 +156,7 @@ async function clearSystemFiles (wda) {
 
         // delete the file asynchronously
         fs.unlink(itemPath).catch((e) => {
-          log.debug(e.message);
+          log.info(e.message);
         });
         scheduledFilesCount++;
       })).finally(() => {
@@ -164,7 +164,9 @@ async function clearSystemFiles (wda) {
           log.info(`Scheduled ${scheduledFilesCount} temporary XCTest log ` +
             `file${scheduledFilesCount === 1 ? '' : 's'} for cleanup in '${dstFolder}'`);
         }
-      }).catch(() => {});
+      }).catch((e) => {
+        log.info(e.message);
+      });
     }
     log.debug(`Started background XCTest logs cleanup in '${dstFolders}'`);
   }

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -28,8 +28,7 @@ describe('utils', function () {
         .once()
         .returns();
       mocks.fs.expects('exists')
-        .once()
-        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
+        .atLeast(1)
         .returns(true);
       mocks.iosUtils.expects('clearLogs')
         .once()
@@ -48,7 +47,7 @@ describe('utils', function () {
         .once()
         .returns();
       mocks.fs.expects('exists')
-        .withExactArgs(`${DERIVED_DATA_ROOT}/Logs`)
+        .atLeast(1)
         .returns(true);
       mocks.iosUtils.expects('clearLogs')
         .once()

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -24,6 +24,9 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      mocks.fs.expects('glob')
+        .once()
+        .returns([]);
       mocks.fs.expects('walkDir')
         .once()
         .returns();
@@ -43,6 +46,9 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      mocks.fs.expects('glob')
+        .once()
+        .returns([]);
       mocks.fs.expects('walkDir')
         .once()
         .returns();


### PR DESCRIPTION
This should speed up the cleanup process