### PR TITLE
fix: only print message from real device proxy connect error

### DIFF
--- a/lib/device-connections-factory.js
+++ b/lib/device-connections-factory.js
@@ -32,7 +32,7 @@ class iProxy {
         localSocket.pipe(remoteSocket);
         remoteSocket.pipe(localSocket);
       } catch (e) {
-        this.log.error(e);
+        this.log.error(e.message);
         localSocket.end();
       }
     });


### PR DESCRIPTION
There is nothing particularly instructive in the full stack trace, and it makes the WDA startup process _very_ verbose:
```
dbug [11-47-26:657] WD Proxy Matched '/status' to command name 'getStatus'
dbug [11-47-26:658] WD Proxy Proxying [GET /status] to [GET http://127.0.0.1:8100/status] with no body
ERR! [11-47-26:661] iProxy@c54f3306 Error: Connection was refused to port 8100
ERR! [11-47-26:661] iProxy@c54f3306     at responseCallback (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/usbmux/index.js:212:15)
ERR! [11-47-26:661] iProxy@c54f3306     at cb (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/usbmux/index.js:133:19)
ERR! [11-47-26:661] iProxy@c54f3306     at Usbmux._handleData (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/usbmux/index.js:66:5)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.emit (events.js:198:13)
ERR! [11-47-26:661] iProxy@c54f3306     at addChunk (_stream_readable.js:287:12)
ERR! [11-47-26:661] iProxy@c54f3306     at readableAddChunk (_stream_readable.js:268:11)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.Readable.push (_stream_readable.js:223:10)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.push (_stream_transform.js:151:32)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder._decode (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/usbmux/transformer/usbmux-decoder.js:26:10)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder._transform (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/usbmux/transformer/usbmux-decoder.js:13:10)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.Transform._read (_stream_transform.js:190:10)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.Transform._write (_stream_transform.js:178:12)
ERR! [11-47-26:661] iProxy@c54f3306     at doWrite (_stream_writable.js:415:12)
ERR! [11-47-26:661] iProxy@c54f3306     at writeOrBuffer (_stream_writable.js:399:5)
ERR! [11-47-26:661] iProxy@c54f3306     at UsbmuxDecoder.Writable.write (_stream_writable.js:299:11)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.ondata (_stream_readable.js:708:20)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.emit (events.js:198:13)
ERR! [11-47-26:661] iProxy@c54f3306     at addChunk (_stream_readable.js:287:12)
ERR! [11-47-26:661] iProxy@c54f3306     at readableAddChunk (_stream_readable.js:268:11)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.Readable.push (_stream_readable.js:223:10)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.push (_stream_transform.js:151:32)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter._decode (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/util/transformer/length-based-splitter.js:69:10)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter._transform (/Users/isaacmurchie/code/appium-xcuitest-driver/node_modules/appium-ios-device/lib/util/transformer/length-based-splitter.js:30:47)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.Transform._read (_stream_transform.js:190:10)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.Transform._write (_stream_transform.js:178:12)
ERR! [11-47-26:661] iProxy@c54f3306     at doWrite (_stream_writable.js:415:12)
ERR! [11-47-26:661] iProxy@c54f3306     at writeOrBuffer (_stream_writable.js:399:5)
ERR! [11-47-26:661] iProxy@c54f3306     at LengthBasedSplitter.Writable.write (_stream_writable.js:299:11)
ERR! [11-47-26:661] iProxy@c54f3306     at Socket.ondata (_stream_readable.js:708:20)
ERR! [11-47-26:661] iProxy@c54f3306     at Socket.emit (events.js:198:13)
ERR! [11-47-26:661] iProxy@c54f3306     at addChunk (_stream_readable.js:287:12)
ERR! [11-47-26:661] iProxy@c54f3306     at readableAddChunk (_stream_readable.js:268:11)
ERR! [11-47-26:661] iProxy@c54f3306     at Socket.Readable.push (_stream_readable.js:223:10)
ERR! [11-47-26:661] iProxy@c54f3306     at Pipe.onStreamRead [as onread] (internal/stream_base_commons.js:94:17)
info [11-47-26:663] WD Proxy Got an unexpected response with status undefined: {"code":"ECONNRESET"}
```

Cc @KazuCocoa re: https://github.com/appium/appium-ios-device/commit/695da4cfef29c199cc681d77207e63a1b1025f2e#commitcomment-37127278