### PR TITLE
chore: Add iOS 13.2 and 13.3 to tests

### DIFF
--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -14,8 +14,8 @@ jobs:
   # Run the E2E tests on local simulators across different ios and xcode versions
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iphone_13_2
-      iosVersion: 13.2
+      name: iphone_13_3
+      iosVersion: 13.3
       xcodeVersion: 11.3.1
       # skipTvOs: True
       tvosName: AppleTV_13_1

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -14,6 +14,14 @@ jobs:
   # Run the E2E tests on local simulators across different ios and xcode versions
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
+      name: iphone_13_2
+      iosVersion: 13.2
+      xcodeVersion: 11.3.1
+      # skipTvOs: True
+      tvosName: AppleTV_13_1
+      tvosDeviceName: "Apple TV"
+  - template: ./templates/xcuitest-e2e-template.yml
+    parameters:
       name: iphone_13_1
       iosVersion: 13.1
       xcodeVersion: 11.1

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -18,7 +18,7 @@ jobs:
       iosVersion: 13.3
       xcodeVersion: 11.3.1
       # skipTvOs: True
-      tvosName: AppleTV_13_1
+      tvosName: AppleTV_13_3
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -20,6 +20,14 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_1
       tvosDeviceName: "Apple TV"
+    - template: ./templates/xcuitest-e2e-template.yml
+    parameters:
+      name: iphone_13_3
+      iosVersion: 13.3
+      xcodeVersion: 11.3.1
+      # skipTvOs: True
+      tvosName: AppleTV_13_1
+      tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_1

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -20,13 +20,13 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_1
       tvosDeviceName: "Apple TV"
-    - template: ./templates/xcuitest-e2e-template.yml
+  - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iphone_13_3
-      iosVersion: 13.3
-      xcodeVersion: 11.3.1
+      name: iphone_13_2
+      iosVersion: 13.2
+      xcodeVersion: 11.2.1
       # skipTvOs: True
-      tvosName: AppleTV_13_1
+      tvosName: AppleTV_13_2
       tvosDeviceName: "Apple TV"
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -20,7 +20,6 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_3
       tvosDeviceName: "Apple TV"
-      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_2
@@ -29,7 +28,6 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_2
       tvosDeviceName: "Apple TV"
-      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_1

--- a/ci-jobs/nightly-build.yml
+++ b/ci-jobs/nightly-build.yml
@@ -20,6 +20,7 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_3
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_2
@@ -28,6 +29,7 @@ jobs:
       # skipTvOs: True
       tvosName: AppleTV_13_2
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_1
@@ -36,6 +38,7 @@ jobs:
       skipTvOs: True # There is no TvOS 13.1 for Xcode 11.1
       tvosName: AppleTV_13_1
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_13_0
@@ -43,6 +46,7 @@ jobs:
       xcodeVersion: 11
       tvosName: AppleTV_13
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_12_2
@@ -50,6 +54,7 @@ jobs:
       xcodeVersion: 10.2
       tvosName: AppleTV_12_2
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_12_1
@@ -57,6 +62,7 @@ jobs:
       xcodeVersion: 10.1
       tvosName: AppleTV_12_1
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iphone_12_0
@@ -64,3 +70,4 @@ jobs:
       xcodeVersion: 10
       tvosName: AppleTV_12
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.14'

--- a/ci-jobs/pr-validation-build.yml
+++ b/ci-jobs/pr-validation-build.yml
@@ -8,3 +8,4 @@ jobs:
       deviceName: "iPhone X"
       tvosName: AppleTV_13_3
       tvosDeviceName: "Apple TV"
+      vmImage: 'macOS-10.15'

--- a/ci-jobs/pr-validation-build.yml
+++ b/ci-jobs/pr-validation-build.yml
@@ -3,8 +3,8 @@ jobs:
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
       name: iPhoneX_13
-      iosVersion: 13.0
-      xcodeVersion: 11
+      iosVersion: 13.2
+      xcodeVersion: 11.3.1
       deviceName: "iPhone X"
-      tvosName: AppleTV_13
+      tvosName: AppleTV_13_2
       tvosDeviceName: "Apple TV"

--- a/ci-jobs/pr-validation-build.yml
+++ b/ci-jobs/pr-validation-build.yml
@@ -2,9 +2,9 @@
 jobs:
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhoneX_13_2
-      iosVersion: 13.2
+      name: iPhoneX_13_3
+      iosVersion: 13.3
       xcodeVersion: 11.3.1
       deviceName: "iPhone X"
-      tvosName: AppleTV_13_2
+      tvosName: AppleTV_13_3
       tvosDeviceName: "Apple TV"

--- a/ci-jobs/pr-validation-build.yml
+++ b/ci-jobs/pr-validation-build.yml
@@ -2,7 +2,7 @@
 jobs:
   - template: ./templates/xcuitest-e2e-template.yml
     parameters:
-      name: iPhoneX_13
+      name: iPhoneX_13_2
       iosVersion: 13.2
       xcodeVersion: 11.3.1
       deviceName: "iPhone X"

--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -1,12 +1,13 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
 parameters:
-    script: ''
-    name: ios-e2e-test
-    dependsOn: ''
-    iosVersion: 13.0
-    xcodeVersion: 11
-    deviceName: 'iPhone X'
-    skipTvOs: False
+  script: ''
+  name: ios-e2e-test
+  dependsOn: ''
+  iosVersion: 13.3
+  xcodeVersion: 11.3.1
+  deviceName: 'iPhone X'
+  skipTvOs: False
+  vmImage: 'macOS-10.14'
 
 jobs:
   - job: ${{ parameters.name }}
@@ -18,7 +19,7 @@ jobs:
       LAUNCH_WITH_IDB: ${{ parameters.launchWithIDB }}
       CI: true
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: ${{ parameters.vmImage }}
     steps:
     - checkout: self
     - script: |
@@ -36,7 +37,7 @@ jobs:
       displayName: List Installed Simulators
     - task: NodeTool@0
       inputs:
-        versionSpec: 10.x
+        versionSpec: 12.x
     - script: npm install
       displayName: Install node dependencies
     - script: npm run build

--- a/ci-jobs/templates/sauce-e2e-template.yml
+++ b/ci-jobs/templates/sauce-e2e-template.yml
@@ -17,7 +17,7 @@ jobs:
     - checkout: self
     - task: NodeTool@0
       inputs:
-        versionSpec: 10.x
+        versionSpec: 12.x
     - script: |
         npm install
         npm install mocha@5 # Fix until mocha-parallel-tests supports Mocha 6

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -7,6 +7,7 @@ parameters:
   tvosName: ''
   tvosDeviceName: ''
   launchWithIDB: false
+  vmImage: 'macOS-10.15'
 jobs:
   - template: ./ios-e2e-template.yml
     parameters:
@@ -14,6 +15,7 @@ jobs:
       iosVersion: ${{ parameters.iosVersion }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npm install --no-save mjpeg-consumer
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/basic -g @skip-ci -i --exit
@@ -24,6 +26,7 @@ jobs:
       iosVersion: ${{ parameters.iosVersion }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/device -g @skip-ci -i --exit
 
@@ -33,6 +36,7 @@ jobs:
       iosVersion: ${{ parameters.iosVersion }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/driver -g @skip-ci -i --exit
 
@@ -42,6 +46,7 @@ jobs:
       iosVersion: ${{ parameters.iosVersion }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/web -g @skip-ci -i --exit
 
@@ -51,6 +56,7 @@ jobs:
       iosVersion: ${{ parameters.iosVersion }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/long -g @skip-ci -i --exit
 
@@ -61,6 +67,7 @@ jobs:
       skipTvOs: ${{ parameters.skipTvOs }}
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.tvosDeviceName }}
+      vmImage: ${{ parameters.vmImage }}
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/tv -g @skip-ci -i --exit
 # IDB test is commented out at the moment since it is not working with xcode 11 and azure


### PR DESCRIPTION
* Add iOS 13.2 and 13.3 to nightly tests
* Make Node 12 the default, because it's LTS
* Make iOS 13.3 the test that is run on pull requests