### PR TITLE
fix: add bundleid to full context list

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -241,6 +241,23 @@ extensions.listWebFrames = async function listWebFrames (useUrl = true) {
   return pageArray;
 };
 
+commands.getContexts = async function getContexts () {
+  log.debug('Getting list of available contexts');
+  const contexts = await this.getContextsAndViews(false);
+
+  const mapFn = this.opts.fullContextList
+    ? (context) => {
+      return {
+        id: context.id.toString(),
+        title: context.view.title,
+        url: context.view.url,
+        bundleId: context.view.bundleId,
+      };
+    }
+    : (context) => context.id.toString();
+  return contexts.map(mapFn);
+};
+
 /**
  * @typedef {Object} Context
  *


### PR DESCRIPTION
The latest `appium-remote-debugger` exposes the bundle id for webview apps. Add that to the data in the full context list, so clients have more information to choose the correct webview for their situation.