### PR TITLE
fix: make remoteSocketPromise func call

### DIFF
--- a/lib/device-connections-factory.js
+++ b/lib/device-connections-factory.js
@@ -23,10 +23,10 @@ class iProxy {
       return;
     }
 
-    const remoteSocketPromise = utilities.connectPort(this.udid, this.deviceport)
+    const remoteSocketPromise = () => utilities.connectPort(this.udid, this.deviceport)
       .catch((e) => void this.log.debug(e.message));
     this.localServer = net.createServer(async (localSocket) => {
-      const remoteSocket = await remoteSocketPromise;
+      const remoteSocket = await remoteSocketPromise();
       if (!remoteSocket) {
         localSocket.destroy();
         return;


### PR DESCRIPTION
The call should happen inside `net.createServer`. Before this change, never the session established. (Continue to show the error message)