### PR TITLE
chore: bump ios driver to 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "appium-base-driver": "^5.1.0",
     "appium-idb": "^0",
     "appium-ios-device": "^1.4.1",
-    "appium-ios-driver": "^4.0.0",
+    "appium-ios-driver": "^4.6.0",
     "appium-ios-simulator": "^3.20.0",
     "appium-remote-debugger": "^8.2.0",
     "appium-support": "^2.39.0",


### PR DESCRIPTION
https://github.com/appium/appium-ios-driver/pull/415