### PR TITLE
fix: handle safari alerts during atom execution

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -27,7 +27,7 @@ commands.click = async function click (el) {
     log.debug('Using native web tap');
     await this.nativeWebTap(el);
   } else {
-    let atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.useAtomsElement(el);
     return await this.executeAtom('click', [atomsElement]);
   }
 };

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -266,7 +266,13 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   }
 };
 
-extensions.checkForAlert = async function checkForAlert () { // eslint-disable-line require-await
+extensions.checkForAlert = async function checkForAlert () {
+  try {
+    await this.getAlert();
+    return true;
+  } catch (ign) {
+    // no alert found, so pass through and return false
+  }
   return false;
 };
 

--- a/test/functional/web/safari-alerts-e2e-specs.js
+++ b/test/functional/web/safari-alerts-e2e-specs.js
@@ -27,7 +27,7 @@ describe('safari - alerts', function () {
     let caps = _.defaults({
       safariInitialUrl: GUINEA_PIG_PAGE,
       safariAllowPopups: true,
-      nativeWebTap: true,
+      nativeWebTap: false,
     }, SAFARI_CAPS);
     driver = await initSession(caps);
   });


### PR DESCRIPTION
Actually do the check for an alert. The atom will not actually complete until the alert is closed in the native layer, so returning is a must.

The tests were passing because all our alert tests use `nativeWebTap`, which works.

Fixes https://github.com/appium/appium/issues/13979 and https://github.com/appium/appium/issues/13549