### PR TITLE
fix: wait for atom finish before checking for alerts

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -1,5 +1,5 @@
 import { iosCommands } from 'appium-ios-driver';
-import { retryInterval } from 'asyncbox';
+import { retryInterval, waitForCondition } from 'asyncbox';
 import { util, timing } from 'appium-support';
 import log from '../logger';
 import _ from 'lodash';
@@ -21,6 +21,8 @@ const IPHONE_XR_WIDTH = 414;
 const IPHONE_XR_HEIGHT = 896;
 
 const ATOM_WAIT_TIMEOUT = 5 * 60000;
+const ATOM_WAIT_INITIAL_TIMEOUT = 1000;
+const ATOM_WAIT_ALERT_WAIT = 400;
 
 let extensions = {};
 
@@ -293,20 +295,31 @@ extensions.waitForAtom = async function waitForAtom (promise) {
       done = true;
     });
 
-  // try ten times to check alert, if we are not done yet
-  for (let i = 0; i < 10; i++) {
-    // check if the promise has been resolved
-    if (done) break; // eslint-disable-line curly
-    await B.delay(500);
-    if (done) break; // eslint-disable-line curly
-    // check if there is an alert
-    if (await this.checkForAlert()) {
-      // we found an alert, and should just return control
-      return '';
+  // before checking for an alert,
+  // try for a second to just allow the atom to return
+  try {
+    await waitForCondition(() => done, {
+      waitMs: ATOM_WAIT_INITIAL_TIMEOUT,
+      intervalMs: 0, // just for the pause in execution
+    });
+  } catch (err) {
+    // there has been adequate time for the atom to return,
+    // so try ten times to check alert
+    for (let i = 0; i < 10; i++) {
+      // check if the promise has been resolved
+      if (done) break; // eslint-disable-line curly
+      // check if there is an alert
+      if (await this.checkForAlert()) {
+        // we found an alert, and should just return control
+        return '';
+      }
+      // check again, and pause if not done
+      if (done) break; // eslint-disable-line curly
+      await B.delay(ATOM_WAIT_ALERT_WAIT);
     }
   }
 
-  let res = await promise;
+  const res = await promise;
   if (error instanceof B.TimeoutError) {
     throw new Error(`Did not get any response for atom execution after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
   }


### PR DESCRIPTION
Rather than going directly into checking for alerts, with a hardcoded wait, spend a second waiting for the promise to return. Then move on to checking for an alert.