### PR TITLE
feat: allow safari alert with block/allow buttons to be handled

### DIFF
--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -113,18 +113,21 @@ helpers.getAlert = async function getAlert () {
   }
 
   // determine that the name of the button is what is expected
-  const assertButtonName = async (button, expectedName = '') => {
+  const assertButtonName = async (button, expectedNames = []) => {
     button = util.unwrapElement(button);
     const name = await this.proxyCommand(`/element/${button}/attribute/name`, 'GET');
-    if (name?.toLowerCase() !== expectedName.toLowerCase()) {
-      throw new errors.NoAlertOpenError();
+    if (_.some(expectedNames, (expectedName) => expectedName === name?.toLowerCase())) {
+      return name;
     }
+    // the name was not found in the list expected
+    throw new errors.NoAlertOpenError();
   };
+
 
   if (possibleAlertButtons.length === 1) {
     // make sure the button is 'Close'
     const closeButton = possibleAlertButtons[0];
-    await assertButtonName(closeButton, 'close');
+    await assertButtonName(closeButton, ['close']);
 
     // add a function on the alert to close by clicking the 'Close' button
     alert.close = async () => {
@@ -133,15 +136,15 @@ helpers.getAlert = async function getAlert () {
   } else {
     // ensure the buttons are 'Cancel' and 'OK'
     const firstButton = possibleAlertButtons[0];
-    await assertButtonName(firstButton, 'cancel');
+    await assertButtonName(firstButton, ['cancel', 'block']);
     const secondButton = possibleAlertButtons[1];
-    await assertButtonName(secondButton, 'ok');
+    await assertButtonName(secondButton, ['ok', 'allow']);
 
-    // add cancel function to the alert, clicking the 'Cancel' button
+    // add cancel function to the alert, clicking the 'Cancel'/'Block' button
     alert.cancel = async () => {
       await this.proxyCommand(`/element/${util.unwrapElement(firstButton)}/click`, 'POST');
     };
-    // add ok function to the alert, clicking the 'OK' button
+    // add ok function to the alert, clicking the 'OK'/'Allow' button
     alert.ok = async () => {
       await this.proxyCommand(`/element/${util.unwrapElement(secondButton)}/click`, 'POST');
     };

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -65,6 +65,10 @@ describe('safari - windows and frames', function () {
       await driver.setImplicitWaitTimeout(1000);
     });
 
+    beforeEach(async function () {
+      await openPage(driver, GUINEA_PIG_PAGE);
+    });
+
 
     it('should be able to open js popup windows', async function () {
       await driver.execute(`window.open('/test/guinea-pig2.html', null)`);

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -65,6 +65,14 @@ describe('safari - windows and frames', function () {
       await driver.setImplicitWaitTimeout(1000);
     });
 
+
+    it('should be able to open js popup windows', async function () {
+      await driver.execute(`window.open('/test/guinea-pig2.html', null)`);
+      await driver.acceptAlert();
+      await spinTitleEquals(driver, 'I am another page title', 5)
+        .should.eventually.not.be.rejected;
+    });
+
     it('should throw nosuchwindow if there is not one', async function () {
       await driver.window('noexistman')
         .should.eventually.be.rejectedWith(/window could not be found/);


### PR DESCRIPTION
Add "Block"/"Allow" alerts to those recognized.
![Simulator Screen Shot - appiumTest-C33F9E2A-D126-499E-B7EA-7EB124163596-iPhone X - 2020-03-24 at 09 08 28](https://user-images.githubusercontent.com/2614354/77429020-633f0400-6daf-11ea-9061-cab1a6cdbb24.png)
![Simulator Screen Shot - appiumTest-C33F9E2A-D126-499E-B7EA-7EB124163596-iPhone X - 2020-03-24 at 09 10 30](https://user-images.githubusercontent.com/2614354/77429030-6639f480-6daf-11ea-9847-206eced1fd53.png)
![Simulator Screen Shot - appiumTest-C33F9E2A-D126-499E-B7EA-7EB124163596-iPhone X - 2020-03-24 at 09 09 49](https://user-images.githubusercontent.com/2614354/77429033-689c4e80-6daf-11ea-96a7-f50030f63777.png)

This should fix https://github.com/appium/appium/issues/8582 and https://github.com/appium/appium/issues/14091