### PR TITLE
feat: add nativeWebTapStrict cap

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -45,7 +45,7 @@ commands.click = async function click (el) {
     return await this.nativeClick(el);
   }
   el = util.unwrapElement(el);
-  if ((await this.settings.getSettings()).nativeWebTap) {
+  if ((await this.settings.getSettings()).nativeWebTap || (await this.settings.getSettings()).nativeWebTapStrict) {
     // atoms-based clicks don't always work in safari 7
     log.debug('Using native web tap');
     await this.nativeWebTap(el);

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -7,18 +7,22 @@ import B from 'bluebird';
 
 const IPHONE_TOP_BAR_HEIGHT = 71;
 const IPHONE_SCROLLED_TOP_BAR_HEIGHT = 41;
+const IPHONE_X_SCROLLED_OFFSET = 55;
 const IPHONE_X_NOTCH_OFFSET_IOS = 24;
 const IPHONE_X_NOTCH_OFFSET_IOS_13 = 20;
+
 const IPHONE_LANDSCAPE_TOP_BAR_HEIGHT = 51;
 const IPHONE_BOTTOM_BAR_OFFSET = 49;
 const TAB_BAR_OFFSET = 33;
 const IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET = 84;
 const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
-const IPHONE_X_WIDTH = 375;
-const IPHONE_X_HEIGHT = 812;
-const IPHONE_XR_WIDTH = 414;
-const IPHONE_XR_HEIGHT = 896;
+const IPHONE_X_WIDTH_PX = 1125; // 11 Pro, X, Xs
+const IPHONE_X_HEIGHT_PX = 2436;
+const IPHONE_11_WIDTH_PX = 828; // 11, Xr
+const IPHONE_11_HEIGHT_PX = 1792;
+const IPHONE_11_PRO_MAX_WIDTH_PX = 1242; // 11 Pro Max, Xs Max
+const IPHONE_11_PRO_MAX_HEIGHT_PX = 2688;
 
 const ATOM_WAIT_TIMEOUT = 5 * 60000;
 const ATOM_WAIT_INITIAL_TIMEOUT = 1000;
@@ -41,17 +45,44 @@ extensions.getSafariIsIphone = _.memoize(async function getSafariIsIphone () {
   return true;
 });
 
+extensions.getSafariDeviceSize = _.memoize(async function getSafariDeviceSize () {
+  const script = 'return {height: window.screen.availHeight * window.devicePixelRatio, width: window.screen.availWidth * window.devicePixelRatio};';
+  const {width, height} = await this.execute(script);
+  const [normHeight, normWidth] = height > width ? [height, width] : [width, height];
+  return {
+    width: normWidth,
+    height: normHeight,
+  };
+});
+
 extensions.getSafariIsIphoneX = _.memoize(async function getSafariIsIphone () {
   try {
-    const script = 'return {height: window.screen.availHeight, width: window.screen.availWidth};';
-    const {height, width} = await this.execute(script);
-    // check for the correct height and width
-    const [portraitHeight, portraitWidth] = height > width ? [height, width] : [width, height];
-    return (portraitHeight === IPHONE_X_HEIGHT && portraitWidth === IPHONE_X_WIDTH) ||
-           (portraitHeight === IPHONE_XR_HEIGHT && portraitWidth === IPHONE_XR_WIDTH);
-
+    const {width, height} = await this.getSafariDeviceSize();
+    return height === IPHONE_X_HEIGHT_PX && width === IPHONE_X_WIDTH_PX;
   } catch (err) {
     log.warn(`Unable to find device type from dimensions. Assuming not iPhone X`);
+    log.debug(`Error: ${err.message}`);
+  }
+  return false;
+});
+
+extensions.getSafariIsIphone11 = _.memoize(async function getSafariIsIphone () {
+  try {
+    const {width, height} = await this.getSafariDeviceSize();
+    return height === IPHONE_11_HEIGHT_PX && width === IPHONE_11_WIDTH_PX;
+  } catch (err) {
+    log.warn(`Unable to find device type from dimensions. Assuming not iPhone 11`);
+    log.debug(`Error: ${err.message}`);
+  }
+  return false;
+});
+
+extensions.getSafariIsIphone11ProMax = _.memoize(async function getSafariIsIphone11ProMax () {
+  try {
+    const {width, height} = await this.getSafariDeviceSize();
+    return height === IPHONE_11_PRO_MAX_HEIGHT_PX && width === IPHONE_11_PRO_MAX_WIDTH_PX;
+  } catch (err) {
+    log.warn(`Unable to find device type from dimensions. Assuming not iPhone 11`);
     log.debug(`Error: ${err.message}`);
   }
   return false;
@@ -61,28 +92,34 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
   let topOffset = 0;
   let bottomOffset = 0;
 
-  // keep track of implicit wait, and set locally to 0
-  const implicitWaitMs = this.implicitWaitMs;
-
   const isIphone = await this.getSafariIsIphone();
   const isIphoneX = isIphone && await this.getSafariIsIphoneX();
+  const isIphone11 = isIphone && await this.getSafariIsIphone11();
+  const isIphone11ProMax = isIphone && await this.getSafariIsIphone11ProMax();
 
   const orientation = realDims.h > realDims.w ? 'PORTRAIT' : 'LANDSCAPE';
 
-  const notchOffset = isIphoneX
+  const notchOffset = isIphoneX || isIphone11 || isIphone11ProMax
     ? util.compareVersions(this.opts.platformVersion, '=', '13.0')
       ? IPHONE_X_NOTCH_OFFSET_IOS_13
       : IPHONE_X_NOTCH_OFFSET_IOS
     : 0;
 
-  try {
-    this.setImplicitWait(0);
+  const isScrolled = await this.execute('return document.documentElement.scrollTop > 0');
+  if (isScrolled) {
+    topOffset = IPHONE_SCROLLED_TOP_BAR_HEIGHT + notchOffset;
 
-    // check if the full url bar is up
-    await this.findNativeElementOrElements('accessibility id', 'ReloadButton', false);
+    if (isIphoneX || isIphone11 || isIphone11ProMax) {
+      topOffset -= IPHONE_X_SCROLLED_OFFSET;
+    }
 
-    // reload button found, which means scrolling has not happened
+    // If the iPhone is landscape then there is no top bar
+    if (orientation === 'LANDSCAPE' && isIphone) {
+      topOffset = 0;
+    }
+  } else {
     topOffset = IPHONE_TOP_BAR_HEIGHT + notchOffset;
+
     if (isIphone) {
       if (orientation === 'PORTRAIT') {
         // The bottom bar is only visible when portrait
@@ -91,28 +128,14 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
         topOffset = IPHONE_LANDSCAPE_TOP_BAR_HEIGHT;
       }
     }
+
     if (orientation === 'LANDSCAPE' || !isIphone) {
       // Tabs only appear if the device is landscape or if it's an iPad so we only check visibility in this case
-      try {
-        await this.findNativeElementOrElements('-ios predicate string', `name LIKE '*, Tab' AND visible = 1`, false);
+      const tabs = await this.findNativeElementOrElements('-ios predicate string', `name LIKE '*, Tab' AND visible = 1`, true);
+      if (tabs.length > 0) {
         topOffset += TAB_BAR_OFFSET;
-      } catch (ign) {
-        // no element found, so no tabs and no need to deal with offset
       }
     }
-
-  } catch (err) {
-    // no reload button, which indicates scrolling has happened
-    topOffset = IPHONE_SCROLLED_TOP_BAR_HEIGHT + notchOffset;
-
-    // If the iPhone is landscape then there is not top bar
-    if (orientation === 'LANDSCAPE' && isIphone) {
-      topOffset = 0;
-    }
-
-  } finally {
-    // return implicit wait to what it was
-    this.setImplicitWait(implicitWaitMs);
   }
 
   topOffset += await this.getExtraNativeWebTapOffset();
@@ -124,23 +147,12 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
 extensions.getExtraNativeWebTapOffset = async function getExtraNativeWebTapOffset () {
   let offset = 0;
 
-  // keep track of implicit wait, and set locally to 0
-  const implicitWaitMs = this.implicitWaitMs;
-  try {
-    this.setImplicitWait(0);
-
-    // try to see if there is an Smart App Banner
-    try {
-      await this.findNativeElementOrElements('accessibility id', 'Close app download offer', false);
-      offset += await this.getSafariIsIphone() ?
-        IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET :
-        IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET;
-    } catch (ign) {
-      // no smart app banner found, so continue
-    }
-  } finally {
-    // return implicit wait to what it was
-    this.setImplicitWait(implicitWaitMs);
+  // try to see if there is an Smart App Banner
+  const banners = await this.findNativeElementOrElements('accessibility id', 'Close app download offer', true);
+  if (banners.length > 0) {
+    offset += await this.getSafariIsIphone() ?
+      IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET :
+      IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET;
   }
 
   log.debug(`Additional native web tap offset computed: ${offset}`);
@@ -223,17 +235,15 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
   log.debug(`Translating coordinates (${JSON.stringify(coords)}) to web coordinates`);
 
   // absolutize web coords
-  const implicitWaitMs = this.implicitWaitMs;
-  let webview;
-  try {
-    this.setImplicitWait(0);
-    webview = await retryInterval(5, 100,
-      async () => await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false));
-  } finally {
-    this.setImplicitWait(implicitWaitMs);
-  }
-
+  let webview = await retryInterval(5, 100, async () => {
+    const webviews = await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', true);
+    if (webviews.length === 0) {
+      throw new Error(`No webviews found. Unable to translate web coordinates for native web tap`);
+    }
+    return webviews[0];
+  });
   webview = util.unwrapElement(webview);
+
   const rect = await this.proxyCommand(`/element/${webview}/rect`, 'GET');
   const wvPos = {x: rect.x, y: rect.y};
   const realDims = {w: rect.width, h: rect.height};
@@ -271,8 +281,9 @@ extensions.checkForAlert = async function checkForAlert () {
   try {
     await this.getAlert();
     return true;
-  } catch (ign) {
+  } catch (err) {
     // no alert found, so pass through and return false
+    log.debug(`No alert found: ${err.message}`);
   }
   return false;
 };

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -17,12 +17,11 @@ const TAB_BAR_OFFSET = 33;
 const IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET = 84;
 const IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET = 95;
 
-const IPHONE_X_WIDTH_PX = 1125; // 11 Pro, X, Xs
-const IPHONE_X_HEIGHT_PX = 2436;
-const IPHONE_11_WIDTH_PX = 828; // 11, Xr
-const IPHONE_11_HEIGHT_PX = 1792;
-const IPHONE_11_PRO_MAX_WIDTH_PX = 1242; // 11 Pro Max, Xs Max
-const IPHONE_11_PRO_MAX_HEIGHT_PX = 2688;
+const NOTCHED_DEVICE_SIZES = [
+  {w: 1125, h: 2436}, // 11 Pro, X, Xs
+  {w: 828, h: 1792}, // 11, Xr
+  {w: 1242, h: 2688}, // 11 Pro Max, Xs Max
+];
 
 const ATOM_WAIT_TIMEOUT = 5 * 60000;
 const ATOM_WAIT_INITIAL_TIMEOUT = 1000;
@@ -55,34 +54,16 @@ extensions.getSafariDeviceSize = _.memoize(async function getSafariDeviceSize ()
   };
 });
 
-extensions.getSafariIsIphoneX = _.memoize(async function getSafariIsIphone () {
+extensions.getSafariIsNotched = _.memoize(async function getSafariIsNotched () {
   try {
     const {width, height} = await this.getSafariDeviceSize();
-    return height === IPHONE_X_HEIGHT_PX && width === IPHONE_X_WIDTH_PX;
+    for (const device of NOTCHED_DEVICE_SIZES) {
+      if (device.w === width && device.h === height) {
+        return true;
+      }
+    }
   } catch (err) {
-    log.warn(`Unable to find device type from dimensions. Assuming not iPhone X`);
-    log.debug(`Error: ${err.message}`);
-  }
-  return false;
-});
-
-extensions.getSafariIsIphone11 = _.memoize(async function getSafariIsIphone () {
-  try {
-    const {width, height} = await this.getSafariDeviceSize();
-    return height === IPHONE_11_HEIGHT_PX && width === IPHONE_11_WIDTH_PX;
-  } catch (err) {
-    log.warn(`Unable to find device type from dimensions. Assuming not iPhone 11`);
-    log.debug(`Error: ${err.message}`);
-  }
-  return false;
-});
-
-extensions.getSafariIsIphone11ProMax = _.memoize(async function getSafariIsIphone11ProMax () {
-  try {
-    const {width, height} = await this.getSafariDeviceSize();
-    return height === IPHONE_11_PRO_MAX_HEIGHT_PX && width === IPHONE_11_PRO_MAX_WIDTH_PX;
-  } catch (err) {
-    log.warn(`Unable to find device type from dimensions. Assuming not iPhone 11`);
+    log.warn(`Unable to find device type from dimensions. Assuming the device is not notched`);
     log.debug(`Error: ${err.message}`);
   }
   return false;
@@ -93,13 +74,11 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
   let bottomOffset = 0;
 
   const isIphone = await this.getSafariIsIphone();
-  const isIphoneX = isIphone && await this.getSafariIsIphoneX();
-  const isIphone11 = isIphone && await this.getSafariIsIphone11();
-  const isIphone11ProMax = isIphone && await this.getSafariIsIphone11ProMax();
+  const isNotched = isIphone && await this.getSafariIsNotched();
 
   const orientation = realDims.h > realDims.w ? 'PORTRAIT' : 'LANDSCAPE';
 
-  const notchOffset = isIphoneX || isIphone11 || isIphone11ProMax
+  const notchOffset = isNotched
     ? util.compareVersions(this.opts.platformVersion, '=', '13.0')
       ? IPHONE_X_NOTCH_OFFSET_IOS_13
       : IPHONE_X_NOTCH_OFFSET_IOS
@@ -109,7 +88,7 @@ extensions.getExtraTranslateWebCoordsOffset = async function getExtraTranslateWe
   if (isScrolled) {
     topOffset = IPHONE_SCROLLED_TOP_BAR_HEIGHT + notchOffset;
 
-    if (isIphoneX || isIphone11 || isIphone11ProMax) {
+    if (isNotched) {
       topOffset -= IPHONE_X_SCROLLED_OFFSET;
     }
 

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -182,7 +182,8 @@ async function tapWebElementNatively (driver, atomsElement) {
 extensions.nativeWebTap = async function nativeWebTap (el) {
   const atomsElement = this.useAtomsElement(el);
 
-  if (await tapWebElementNatively(this, atomsElement)) {
+  // if strict native tap, do not try to do it with WDA directly
+  if (!(await this.settings.getSettings()).nativeWebTapStrict && await tapWebElementNatively(this, atomsElement)) {
     return;
   }
   log.warn('Unable to do simple native web tap. Attempting to convert coordinates');

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -217,7 +217,10 @@ let desiredCapConstraints = _.defaults({
   },
   appPushTimeout: {
     isNumber: true
-  }
+  },
+  nativeWebTapStrict: {
+    isBoolean: true
+  },
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -37,6 +37,7 @@ const WDA_REAL_DEV_TUTORIAL_URL = 'https://github.com/appium/appium-xcuitest-dri
 const WDA_STARTUP_RETRY_INTERVAL = 10000;
 const DEFAULT_SETTINGS = {
   nativeWebTap: false,
+  nativeWebTapStrict: false,
   useJSONSource: false,
   shouldUseCompactResponses: true,
   elementResponseAttributes: 'type,label',
@@ -154,12 +155,12 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async onSettingsUpdate (key, value) {
-    if (key !== 'nativeWebTap') {
+    if (key !== 'nativeWebTap' && key !== 'nativeWebTapStrict') {
       return await this.proxyCommand('/appium/settings', 'POST', {
         settings: {[key]: value}
       });
     }
-    this.opts.nativeWebTap = !!value;
+    this.opts[key] = !!value;
   }
 
   resetIos () {
@@ -218,6 +219,10 @@ class XCUITestDriver extends BaseDriver {
       // ensure we track nativeWebTap capability as a setting as well
       if (_.has(this.opts, 'nativeWebTap')) {
         await this.updateSettings({nativeWebTap: this.opts.nativeWebTap});
+      }
+      // ensure we track nativeWebTapStrict capability as a setting as well
+      if (_.has(this.opts, 'nativeWebTapStrict')) {
+        await this.updateSettings({nativeWebTapStrict: this.opts.nativeWebTapStrict});
       }
       // ensure we track useJSONSource capability as a setting as well
       if (_.has(this.opts, 'useJSONSource')) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -119,8 +119,6 @@ const MEMOIZED_FUNCTIONS = [
   'getStatusBarHeight',
   'getDevicePixelRatio',
   'getScreenInfo',
-  'getSafariIsIphone',
-  'getSafariIsIphoneX',
 ];
 
 class XCUITestDriver extends BaseDriver {

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -19,251 +19,254 @@ const SUB_FRAME_1_TITLE = 'Sub frame 1';
 const SUB_FRAME_2_TITLE = 'Sub frame 2';
 const SUB_FRAME_3_TITLE = 'Sub frame 3';
 
-describe('safari - windows and frames - without safariAllowPopups', function () {
-  this.timeout(MOCHA_TIMEOUT);
-
-  let driver;
-  before(async function () {
-    const caps = _.defaults({
-      safariInitialUrl: GUINEA_PIG_PAGE,
-      safariAllowPopups: false,
-    }, SAFARI_CAPS);
-    driver = await initSession(caps);
-    await driver.setPageLoadTimeout(100);
-  });
-  after(async function () {
-    await deleteSession();
-  });
-
-  it('should not be able to open js popup windows', async function () {
-    await driver.execute("window.open('/test/guinea-pig2.html', null)");
-    await spinTitleEquals(driver, 'I am another page title', 5).should.eventually.be.rejected;
-  });
-});
-
 describe('safari - windows and frames', function () {
-  this.timeout(MOCHA_TIMEOUT);
+  describe('without safariAllowPopups', function () {
+    this.timeout(MOCHA_TIMEOUT);
 
-  let driver;
-  before(async function () {
-    const caps = _.defaults({
-      safariInitialUrl: GUINEA_PIG_PAGE,
-      safariAllowPopups: true,
-      // using JS atoms to open new window will, even if safari does not disable
-      // popups, open an alert asking if it is ok.
-      nativeWebTap: true,
-    }, SAFARI_CAPS);
-    driver = await initSession(caps);
-  });
-  after(async function () {
-    await deleteSession();
-  });
-
-  describe('windows', function () {
+    let driver;
     before(async function () {
-      // minimize waiting if something goes wrong
-      await driver.setImplicitWaitTimeout(1000);
+      const caps = _.defaults({
+        safariInitialUrl: GUINEA_PIG_PAGE,
+        safariAllowPopups: false,
+      }, SAFARI_CAPS);
+      driver = await initSession(caps);
+      await driver.setPageLoadTimeout(100);
+    });
+    after(async function () {
+      await deleteSession();
     });
 
-    beforeEach(async function () {
-      await openPage(driver, GUINEA_PIG_PAGE);
-    });
-
-
-    it('should be able to open js popup windows', async function () {
-      await driver.execute(`window.open('/test/guinea-pig2.html', null)`);
-      await driver.acceptAlert();
-      await spinTitleEquals(driver, 'I am another page title', 5)
-        .should.eventually.not.be.rejected;
-    });
-
-    it('should throw nosuchwindow if there is not one', async function () {
-      await driver.window('noexistman')
-        .should.eventually.be.rejectedWith(/window could not be found/);
-    });
-
-    it('should be able to open and close windows', async function () {
-      await driver.elementById('blanklink').click();
-      await spinTitleEquals(driver, 'I am another page title');
-
-      await driver.close();
-      await spinTitleEquals(driver, 'I am a page title');
-    });
-
-    it('should be able to use window handles', async function () {
-      const initialWindowHandle = await driver.windowHandle();
-
-      await driver.elementById('blanklink').click();
-      await spinTitleEquals(driver, 'I am another page title');
-
-      const newWindowHandle = await driver.windowHandle();
-
-      // should still have the first page
-      await driver.window(initialWindowHandle);
-      await spinTitleEquals(driver, 'I am a page title');
-
-      // should still have the second page
-      await driver.window(newWindowHandle);
-      await spinTitleEquals(driver, 'I am another page title');
-
-      // close and we should have the original page
-      await driver.close();
-      await spinTitleEquals(driver, 'I am a page title');
-    });
-
-    it('should be able to go back and forward', async function () {
-      await driver.elementByLinkText('i am a link').click();
-
-      await driver.elementById('only_on_page_2');
-      await driver.back();
-      await driver.elementById('i_am_a_textbox');
-      await driver.forward();
-      await driver.elementById('only_on_page_2');
-      await driver.back();
-    });
-
-    // broken on real devices, see https://github.com/appium/appium/issues/5167
-    it('should be able to open js popup windows with safariAllowPopups set to true @skip-real-device', async function () {
-      await driver.elementByLinkText('i am a new window link').click();
-      await spinTitleEquals(driver, 'I am another page title', 30);
+    it('should not be able to open js popup windows', async function () {
+      await driver.execute("window.open('/test/guinea-pig2.html', null)");
+      await spinTitleEquals(driver, 'I am another page title', 5).should.eventually.be.rejected;
     });
   });
 
-  describe('frames', function () {
-    beforeEach(async function () {
-      await openPage(driver, GUINEA_PIG_FRAME_PAGE);
+  describe('with safariAllowPopups', function () {
+    this.timeout(MOCHA_TIMEOUT);
+
+    let driver;
+    before(async function () {
+      const caps = _.defaults({
+        safariInitialUrl: GUINEA_PIG_PAGE,
+        safariAllowPopups: true,
+        // using JS atoms to open new window will, even if safari does not disable
+        // popups, open an alert asking if it is ok.
+        nativeWebTap: true,
+      }, SAFARI_CAPS);
+      driver = await initSession(caps);
+    });
+    after(async function () {
+      await deleteSession();
     });
 
-    it('should switch to frame by name', async function () {
-      await driver.frame('first');
-      await driver.title().should.eventually.equal(FRAMESET_TITLE);
+    describe('windows', function () {
+      before(async function () {
+        // minimize waiting if something goes wrong
+        await driver.setImplicitWaitTimeout(1000);
+      });
 
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
+      beforeEach(async function () {
+        await openPage(driver, GUINEA_PIG_PAGE);
+      });
+
+
+      it('should be able to open js popup windows', async function () {
+        await driver.execute(`window.open('/test/guinea-pig2.html', '_blank');`);
+        await driver.acceptAlert();
+        await spinTitleEquals(driver, 'I am another page title', 5)
+          .should.eventually.not.be.rejected;
+        await driver.close();
+      });
+
+      it('should throw nosuchwindow if there is not one', async function () {
+        await driver.window('noexistman')
+          .should.eventually.be.rejectedWith(/window could not be found/);
+      });
+
+      it('should be able to open and close windows', async function () {
+        await driver.elementById('blanklink').click();
+        await spinTitleEquals(driver, 'I am another page title');
+
+        await driver.close();
+        await spinTitleEquals(driver, 'I am a page title');
+      });
+
+      it('should be able to use window handles', async function () {
+        const initialWindowHandle = await driver.windowHandle();
+
+        await driver.elementById('blanklink').click();
+        await spinTitleEquals(driver, 'I am another page title');
+
+        const newWindowHandle = await driver.windowHandle();
+
+        // should still have the first page
+        await driver.window(initialWindowHandle);
+        await spinTitleEquals(driver, 'I am a page title');
+
+        // should still have the second page
+        await driver.window(newWindowHandle);
+        await spinTitleEquals(driver, 'I am another page title');
+
+        // close and we should have the original page
+        await driver.close();
+        await spinTitleEquals(driver, 'I am a page title');
+      });
+
+      it('should be able to go back and forward', async function () {
+        await driver.elementByLinkText('i am a link').click();
+
+        await driver.elementById('only_on_page_2');
+        await driver.back();
+        await driver.elementById('i_am_a_textbox');
+        await driver.forward();
+        await driver.elementById('only_on_page_2');
+        await driver.back();
+      });
+
+      // broken on real devices, see https://github.com/appium/appium/issues/5167
+      it('should be able to open js popup windows with safariAllowPopups set to true @skip-real-device', async function () {
+        await driver.elementByLinkText('i am a new window link').click();
+        await spinTitleEquals(driver, 'I am another page title', 30);
+      });
     });
 
-    it('should switch to frame by index', async function () {
-      await driver.frame(1);
-      await driver.title().should.eventually.equal(FRAMESET_TITLE);
+    describe('frames', function () {
+      beforeEach(async function () {
+        await openPage(driver, GUINEA_PIG_FRAME_PAGE);
+      });
 
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_2_TITLE);
+      it('should switch to frame by name', async function () {
+        await driver.frame('first');
+        await driver.title().should.eventually.equal(FRAMESET_TITLE);
+
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
+      });
+
+      it('should switch to frame by index', async function () {
+        await driver.frame(1);
+        await driver.title().should.eventually.equal(FRAMESET_TITLE);
+
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_2_TITLE);
+      });
+
+      it('should switch to frame by id', async function () {
+        await driver.frame('frame3');
+        await driver.title().should.eventually.equal(FRAMESET_TITLE);
+
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_3_TITLE);
+      });
+
+      it('should switch back to default content from frame', async function () {
+        await driver.frame('first');
+        await driver.title().should.eventually.equal(FRAMESET_TITLE);
+
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
+
+        await driver.frame(null);
+        await driver.elementByTagName('frameset').should.eventually.exist;
+      });
+
+      it('should switch to child frames', async function () {
+        await driver.frame('third');
+        await driver.title().should.eventually.equal(FRAMESET_TITLE);
+
+        await driver.frame('childframe');
+        await driver.elementById('only_on_page_2').should.eventually.exist;
+      });
+
+      it('should execute javascript in frame', async function () {
+        await driver.frame('first');
+        await driver.execute(GET_ELEM_SYNC)
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
+      });
+
+      it('should execute async javascript in frame', async function () {
+        await driver.setAsyncScriptTimeout(2000);
+        await driver.frame('first');
+        await driver.executeAsync(GET_ELEM_ASYNC)
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
+      });
+
+      it('should get source within a frame', async function () {
+        await driver.source().should.eventually.include(FRAMESET_TITLE);
+
+        await driver.frame('first');
+
+        const frameSource = await driver.source();
+        frameSource.should.include(SUB_FRAME_1_TITLE);
+        frameSource.should.not.include(FRAMESET_TITLE);
+      });
     });
 
-    it('should switch to frame by id', async function () {
-      await driver.frame('frame3');
-      await driver.title().should.eventually.equal(FRAMESET_TITLE);
+    describe('iframes', function () {
+      beforeEach(async function () {
+        await openPage(driver, GUINEA_PIG_IFRAME_PAGE);
+      });
 
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_3_TITLE);
-    });
+      it('should switch to iframe by name', async function () {
+        await driver.frame('iframe1');
+        await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
 
-    it('should switch back to default content from frame', async function () {
-      await driver.frame('first');
-      await driver.title().should.eventually.equal(FRAMESET_TITLE);
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
+      });
 
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
+      it('should switch to iframe by index', async function () {
+        await driver.frame(1);
+        await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
 
-      await driver.frame(null);
-      await driver.elementByTagName('frameset').should.eventually.exist;
-    });
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_2_TITLE);
+      });
 
-    it('should switch to child frames', async function () {
-      await driver.frame('third');
-      await driver.title().should.eventually.equal(FRAMESET_TITLE);
+      it('should switch to iframe by id', async function () {
+        await driver.frame('id-iframe3');
+        await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
 
-      await driver.frame('childframe');
-      await driver.elementById('only_on_page_2').should.eventually.exist;
-    });
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_3_TITLE);
+      });
 
-    it('should execute javascript in frame', async function () {
-      await driver.frame('first');
-      await driver.execute(GET_ELEM_SYNC)
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
-    });
+      it('should switch to iframe by element', async function () {
+        const frame = await driver.elementById('id-iframe3');
+        await driver.frame(frame);
+        await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
 
-    it('should execute async javascript in frame', async function () {
-      await driver.setAsyncScriptTimeout(2000);
-      await driver.frame('first');
-      await driver.executeAsync(GET_ELEM_ASYNC)
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
-    });
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_3_TITLE);
+      });
 
-    it('should get source within a frame', async function () {
-      await driver.source().should.eventually.include(FRAMESET_TITLE);
+      it('should not switch to iframe by element of wrong type', async function () {
+        const h1 = await driver.elementByTagName('h1');
+        await driver.frame(h1).should.eventually.be.rejected;
+      });
 
-      await driver.frame('first');
+      it('should switch back to default content from iframe', async function () {
+        await driver.frame('iframe1');
+        await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
 
-      const frameSource = await driver.source();
-      frameSource.should.include(SUB_FRAME_1_TITLE);
-      frameSource.should.not.include(FRAMESET_TITLE);
-    });
-  });
+        await driver.elementByTagName('h1').text()
+          .should.eventually.equal(SUB_FRAME_1_TITLE);
 
-  describe('iframes', function () {
-    beforeEach(async function () {
-      await openPage(driver, GUINEA_PIG_IFRAME_PAGE);
-    });
+        await driver.frame(null);
+        await driver.elementsByTagName('iframe').should.eventually.have.length(3);
+      });
 
-    it('should switch to iframe by name', async function () {
-      await driver.frame('iframe1');
-      await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
+      it('should get source within an iframe', async function () {
+        await driver.source()
+          .should.eventually.include(IFRAME_FRAMESET_TITLE);
 
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
-    });
+        await driver.frame('iframe1');
 
-    it('should switch to iframe by index', async function () {
-      await driver.frame(1);
-      await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
-
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_2_TITLE);
-    });
-
-    it('should switch to iframe by id', async function () {
-      await driver.frame('id-iframe3');
-      await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
-
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_3_TITLE);
-    });
-
-    it('should switch to iframe by element', async function () {
-      const frame = await driver.elementById('id-iframe3');
-      await driver.frame(frame);
-      await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
-
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_3_TITLE);
-    });
-
-    it('should not switch to iframe by element of wrong type', async function () {
-      const h1 = await driver.elementByTagName('h1');
-      await driver.frame(h1).should.eventually.be.rejected;
-    });
-
-    it('should switch back to default content from iframe', async function () {
-      await driver.frame('iframe1');
-      await driver.title().should.eventually.equal(IFRAME_FRAMESET_TITLE);
-
-      await driver.elementByTagName('h1').text()
-        .should.eventually.equal(SUB_FRAME_1_TITLE);
-
-      await driver.frame(null);
-      await driver.elementsByTagName('iframe').should.eventually.have.length(3);
-    });
-
-    it('should get source within an iframe', async function () {
-      await driver.source()
-        .should.eventually.include(IFRAME_FRAMESET_TITLE);
-
-      await driver.frame('iframe1');
-
-      const frameSource = await driver.source();
-      frameSource.should.include(SUB_FRAME_1_TITLE);
-      frameSource.should.not.include(IFRAME_FRAMESET_TITLE);
+        const frameSource = await driver.source();
+        frameSource.should.include(SUB_FRAME_1_TITLE);
+        frameSource.should.not.include(IFRAME_FRAMESET_TITLE);
+      });
     });
   });
 });


### PR DESCRIPTION
Add a capability, `nativeWebTapStrict`, which skips the attempt to not convert the web coordinates. See https://github.com/appium/appium/issues/14084

First, this makes sure the web coordinate conversion works for newer devices.