### PR TITLE
fix: ensure unix timestamp is in utc

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -101,10 +101,13 @@ commands.getDeviceTime = async function getDeviceTime (format = MOMENT_FORMAT_IS
   log.info('Attempting to capture iOS device date and time');
   if (this.isRealDevice()) {
     const { timestamp, utcOffset } = await utilities.getDeviceTime(this.opts.udid);
-    return moment.unix(timestamp).utcOffset(utcOffset).format(format);
-  } else {
-    return await iosCommands.general.getDeviceTime.call(this, format);
+    log.debug(`timestamp: ${timestamp}, utcOffset: ${utcOffset}`);
+    return moment.unix(timestamp)
+      .utc().utcOffset(utcOffset)
+      .format(format);
   }
+
+  return await iosCommands.general.getDeviceTime.call(this, format);
 };
 
 // For W3C


### PR DESCRIPTION
Moment.js assumes that unix timestamps are given in local time zone by default (o_O): https://momentjs.com/docs/#/parsing/unix-timestamp/