### PR TITLE
build: get coverage in azure

### DIFF
--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -45,17 +45,9 @@ jobs:
         versionSpec: 10.x
     - script: npm install
       displayName: Install node dependencies
-    - script: npm run build
-      displayName: Build
     - script: ${{ parameters.script }}
       displayName: Run functional tests
     - task: PublishTestResults@2
       condition: always()
       inputs:
         testResultsFiles: $(MOCHA_FILE)
-    - task: PublishCodeCoverageResults@1
-      condition: always()
-      inputs:
-        codeCoverageTool: cobertura
-        summaryFileLocation: coverage/cobertura-coverage.xml
-        reporterDirectory: coverage/

--- a/ci-jobs/templates/node-build-template.yml
+++ b/ci-jobs/templates/node-build-template.yml
@@ -16,3 +16,10 @@ jobs:
       displayName: Install node dependencies
     - script: npm test
       displayName: npm test
+    - script: npx gulp coverage
+      displayName: Generate coverage
+    - task: PublishCodeCoverageResults@1
+      condition: always()
+      inputs:
+        codeCoverageTool: cobertura
+        summaryFileLocation: coverage/cobertura-coverage.xml

--- a/ci-jobs/templates/node-build-template.yml
+++ b/ci-jobs/templates/node-build-template.yml
@@ -14,7 +14,5 @@ jobs:
       displayName: Install Node ${{ parameters.nodeVersion }}
     - script: npm install
       displayName: Install node dependencies
-    - script: npm run build
-      displayName: Build
     - script: npm test
       displayName: npm test

--- a/ci-jobs/templates/node-build-template.yml
+++ b/ci-jobs/templates/node-build-template.yml
@@ -1,6 +1,6 @@
 parameters:
-  nodeVersion: 11.x
-  name: UnitTest
+  nodeVersion: 10.x
+  name: UnitTests
 jobs:
   # Run unit tests on different Node versions
   - job: ${{ parameters.name }}

--- a/ci-jobs/templates/sauce-e2e-template.yml
+++ b/ci-jobs/templates/sauce-e2e-template.yml
@@ -23,8 +23,6 @@ jobs:
         npm install mocha@5 # Fix until mocha-parallel-tests supports Mocha 6
         npm install mocha-parallel-tests
       displayName: Install node dependencies
-    - script: npm run build
-      displayName: Build
     - script: npx mocha-parallel-tests --timeout 400000 --max-parallel 0  --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --require build/test/env/env --recursive 'build/test/functional/basic/' 'build/test/functional/web/' 'build/test/functional/long/'
       displayName: Mocha E2E Tests for $(DEVICE_NAME) $(CLOUD_PLATFORM_VERSION)
       env:

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -8,6 +8,7 @@ parameters:
   tvosDeviceName: ''
   launchWithIDB: false
 jobs:
+  - template: ./node-build-template.yml
   - template: ./ios-e2e-template.yml
     parameters:
       name: e2e_basic_${{ parameters.name }}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "devDependencies": {
     "ajv": "^6.5.3",
     "appium-event-parser": "^1.0.0",
-    "appium-gulp-plugins": "^5.1.1",
+    "appium-gulp-plugins": "^5.2.0",
     "appium-test-support": "^1.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Remove step from _each_ functional test job, since the e2e coverage isn't collected. Add coverage generation to the unit test section. And remove superfluous build tasks, since `npm install` runs the transpilation.

Makes for a coverage pane in Azure: https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=9013&view=codecoverage-tab