### PR TITLE
refactor: simplify wait for atoms

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -24,7 +24,6 @@ const NOTCHED_DEVICE_SIZES = [
 ];
 
 const ATOM_WAIT_TIMEOUT = 2 * 60000;
-const ATOM_WAIT_INITIAL_TIMEOUT = 1000;
 const ATOM_WAIT_ALERT_WAIT = 400;
 
 let extensions = {};
@@ -263,18 +262,12 @@ extensions.checkForAlert = async function checkForAlert () {
   } catch (err) {
     // no alert found, so pass through and return false
     log.debug(`No alert found: ${err.message}`);
+    throw err;
   }
-  return false;
 };
 
 extensions.waitForAtom = async function waitForAtom (promise) {
   const timer = new timing.Timer().start();
-
-  // make sure the promise is cancellable, so when an alert is found it can
-  // be removed
-  B.config({
-    cancellation: true,
-  });
 
   // need to check for alert while the atom is being executed.
   // so notify ourselves when it happens
@@ -294,31 +287,34 @@ extensions.waitForAtom = async function waitForAtom (promise) {
       done = true;
     });
 
-  // before checking for an alert,
-  // try for a second to just allow the atom to return
-  try {
-    await waitForCondition(() => done, {
-      waitMs: ATOM_WAIT_INITIAL_TIMEOUT,
-      intervalMs: 0, // just for the pause in execution
-    });
-  } catch (err) {
-    // there has been adequate time for the atom to return,
-    // so try ten times to check alert
-    for (let i = 0; i < 10; i++) {
-      // check if the promise has been resolved
-      if (done) break; // eslint-disable-line curly
-      // check if there is an alert
-      if (await this.checkForAlert()) {
-        // we found an alert, and should just return control
-        promise.cancel();
-        return '';
+  // try ten times to check alert
+  for (let i = 0; i < 10; i++) {
+    // pause, or the atom promise is resolved
+    try {
+      await waitForCondition(() => done, {
+        waitMs: ATOM_WAIT_ALERT_WAIT,
+        intervalMs: 0, // just for the pause in execution
+      });
+      // `done` became true, so atom promise is resolved
+      break;
+    } catch (ign) {
+      // `done` never became true, so move on to trying to find an alert
+    }
+
+    // check if there is an alert, or the atom promise is resolved
+    try {
+      const res = await B.any([this.checkForAlert(), promise]);
+      if (error) {
+        throw error;
       }
-      // check again, and pause if not done
-      if (done) break; // eslint-disable-line curly
-      await B.delay(ATOM_WAIT_ALERT_WAIT);
+      return this.parseExecuteResponse(res);
+    } catch (err) {
+      // no alert found, so pass through
     }
   }
 
+  // at this point, all that can be done is wait for the atom promise to be
+  // resolved
   const res = await promise;
   if (error) {
     throw error;

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -257,13 +257,7 @@ extensions.translateWebCoords = async function translateWebCoords (coords) {
 };
 
 extensions.checkForAlert = async function checkForAlert () {
-  try {
-    return _.isString(await this.getAlertText());
-  } catch (err) {
-    // no alert found, so pass through and return false
-    log.debug(`No alert found: ${err.message}`);
-    throw err;
-  }
+  return _.isString(await this.getAlertText());
 };
 
 extensions.waitForAtom = async function waitForAtom (promise) {
@@ -310,6 +304,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
       return this.parseExecuteResponse(res);
     } catch (err) {
       // no alert found, so pass through
+      log.debug(`No alert found: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
Change to wait for the atom promise at the same time as checking for the alert. This also makes it so there are no dead waits... it is always short-circuited if the atom promise resolves.