### PR TITLE
feat: Add mobile commands for audio recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ These can be enabled when running this driver through Appium, via the `--allow-i
 |------------|-----------|
 |shutdown_other_sims|Allow any session to use a capability to shutdown any running simulators on the host|
 |perf_record|Allow recording the system performance and other metrics of the simulator|
+|audio_record|Allow recording of host audio input(s)|
 
 
 ### Watch

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -106,6 +106,9 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     deleteFile: 'mobileDeleteFile',
     deleteFolder: 'mobileDeleteFolder',
+
+    startAudioRecording: 'startAudioRecording',
+    stopAudioRecording: 'stopAudioRecording',
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -15,6 +15,7 @@ import fileMovementExtensions from './file-movement';
 import screenshotExtensions from './screenshots';
 import pasteboardExtensions from './pasteboard';
 import locationExtensions from './location';
+import recordAudioExtensions from './record-audio';
 import recordScreenExtensions from './recordscreen';
 import lockExtensions from './lock';
 import appManagementExtensions from './app-management';
@@ -39,7 +40,7 @@ Object.assign(commands, contextCommands, executeExtensions,
   lockExtensions, recordScreenExtensions, appManagementExtensions, performanceExtensions,
   clipboardExtensions, certificateExtensions, batteryExtensions, cookiesExtensions,
   biometricExtensions, keychainsExtensions, permissionsExtensions, deviceInfoExtensions,
-  activeAppnfoExtensions
+  activeAppnfoExtensions, recordAudioExtensions,
 );
 
 export default commands;

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -105,7 +105,7 @@ class AudioRecorder {
       this.timeoutHandler = null;
     }
 
-    if (this.mainProcess && this.mainProcess.isRunning) {
+    if (this.isRecording()) {
       const interruptPromise = this.mainProcess.stop(force ? 'SIGTERM' : 'SIGINT');
       this.mainProcess = null;
       try {

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -1,0 +1,260 @@
+import { fs, tempDir, logger, util } from 'appium-support';
+import { SubProcess } from 'teen_process';
+import log from '../logger';
+import { encodeBase64OrUpload } from '../utils';
+import { waitForCondition } from 'asyncbox';
+
+
+const commands = {};
+
+const AUDIO_RECORD_FEAT_NAME = 'audio_record';
+const MAX_RECORDING_TIME_SEC = 60 * 60 * 24;
+const DEFAULT_RECORDING_TIME_SEC = 60 * 3;
+const PROCESS_STARTUP_TIMEOUT_MS = 5000;
+const DEFAULT_BITRATE = '128k';
+const DEFAULT_CODEC = 'aac';
+const DEFAULT_CHANNELS = 2;
+const DEFAULT_RATE = 44100;
+const DEFAULT_EXT = '.mp4';
+const FFMPEG_BINARY = 'ffmpeg';
+const ffmpegLogger = logger.getLogger(FFMPEG_BINARY);
+
+
+class AudioRecorder {
+  constructor (input, audioPath, opts = {}) {
+    this.audioPath = audioPath;
+    this.opts = opts;
+    this.input = input;
+    this.mainProcess = null;
+    this.timeoutHandler = null;
+  }
+
+  async start (timeoutMs) {
+    try {
+      await fs.which(FFMPEG_BINARY);
+    } catch (err) {
+      throw new Error(`'${FFMPEG_BINARY}' binary is not found in PATH. Install it using 'brew install ffmpeg'. ` +
+        `Check https://www.ffmpeg.org/download.html for more details.`);
+    }
+
+    const {
+      audioCodec,
+      audioBitrate,
+      audioChannels,
+      audioRate,
+    } = this.opts;
+
+    const args = [
+      '-f', 'avfoundation',
+      '-i', this.input,
+      '-c:a', audioCodec,
+      '-b:a', audioBitrate,
+      '-ac', `${audioChannels}`,
+      '-ar', `${audioRate}`,
+      this.audioPath,
+    ];
+
+    this.mainProcess = new SubProcess(FFMPEG_BINARY, args);
+    let isCaptureStarted = false;
+    this.mainProcess.on('output', (stdout, stderr) => {
+      if (stderr) {
+        if (stderr.trim().startsWith('size=')) {
+          if (!isCaptureStarted) {
+            isCaptureStarted = true;
+          }
+        } else {
+          ffmpegLogger.info(`${stderr}`);
+        }
+      }
+    });
+    await this.mainProcess.start(0);
+    try {
+      await waitForCondition(() => isCaptureStarted, {
+        waitMs: PROCESS_STARTUP_TIMEOUT_MS,
+        intervalMs: 300,
+      });
+    } catch (e) {
+      log.warn(`Audio capture process did not start within ${PROCESS_STARTUP_TIMEOUT_MS}ms. Continuing anyway`);
+    }
+    if (!this.mainProcess.isRunning) {
+      this.mainProcess = null;
+      throw new Error(`The audio capture process '${FFMPEG_BINARY}' died unexpectedly. ` +
+        `Check server logs for more details`);
+    }
+    log.info(`Starting capture on audio input '${this.input}' with command: '${util.quote([FFMPEG_BINARY, ...args])}'. ` +
+      `Will timeout in ${timeoutMs}ms`);
+
+    this.timeoutHandler = setTimeout(async () => {
+      if (await this.interrupt()) {
+        log.info(`Audio capture on channel '${this.input}' has been finished after ${timeoutMs}ms timeout`);
+      } else {
+        log.warn(`Cannot finish the active recording on audio input '${this.input}' after ${timeoutMs}ms timeout`);
+      }
+    }, timeoutMs);
+  }
+
+  isRecording () {
+    return !!(this.mainProcess?.isRunning);
+  }
+
+  async interrupt (force = false) {
+    let result = true;
+
+    if (this.timeoutHandler) {
+      clearTimeout(this.timeoutHandler);
+      this.timeoutHandler = null;
+    }
+
+    if (this.mainProcess && this.mainProcess.isRunning) {
+      const interruptPromise = this.mainProcess.stop(force ? 'SIGTERM' : 'SIGINT');
+      this.mainProcess = null;
+      try {
+        await interruptPromise;
+      } catch (e) {
+        log.warn(`Cannot ${force ? 'terminate' : 'interrupt'} ${FFMPEG_BINARY}. ` +
+          `Original error: ${e.message}`);
+        result = false;
+      }
+    }
+
+    return result;
+  }
+
+  async finish () {
+    await this.interrupt();
+    return this.audioPath;
+  }
+
+  async cleanup () {
+    if (await fs.exists(this.audioPath)) {
+      await fs.rimraf(this.audioPath);
+    }
+  }
+}
+
+
+/**
+ * @typedef {Object} StartRecordingOptions
+ *
+ * @property {!string} audioInput - The name of the corresponding audio input device to use for the
+ * capture. The full list of capture devices could be shown using `ffmpeg -f avfoundation -list_devices true -i ""`
+ * Terminal command.
+ * @property {?string} audioCodec [aac] - The name of the audio codec. The Advanced Audio Codec is used by default.
+ * @property {?string} audioBitrate [128k] - The bitrate of the resulting audio stream. 128k by default.
+ * @property {?string|number} audioChannels [2] - The count of audio channels in the resulting stream. Setting it to `1`
+ * will create a single channel (mono) audio stream.
+ * @property {?string|number} audioRate [44100] - The sampling rate of the resulting audio stream.
+ * @property {?string|number} timeLimit [180] - The maximum recording time, in seconds.
+ * The default value is 180, the maximum value is 86400 (1 day).
+ * @property {?boolean} forceRestart [false] - Whether to restart audio capture process forcefully when
+ * startRecordingAudio is called (`true`) or ignore the call until the current audio recording is completed.
+ */
+
+/**
+ * Records the given hardware audio input into an .mp4 file.
+ *
+ * @param {?StartRecordingOptions} options - The available options.
+ * @throws {Error} If audio recording has failed to start.
+ */
+commands.startRecordingAudio = async function startRecordingAudio (options = {}) {
+  if (!this.isFeatureEnabled(AUDIO_RECORD_FEAT_NAME)) {
+    log.errorAndThrow(`Audio capture feature must be enabled on the server side. ` +
+      `Please set '--relaxed-security' or '--allow-insecure' with '${AUDIO_RECORD_FEAT_NAME}' option. ` +
+      `Read https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.`);
+  }
+
+  const {
+    timeLimit = DEFAULT_RECORDING_TIME_SEC,
+    audioInput,
+    audioCodec = DEFAULT_CODEC,
+    audioBitrate = DEFAULT_BITRATE,
+    audioChannels = DEFAULT_CHANNELS,
+    audioRate = DEFAULT_RATE,
+    forceRestart,
+  } = options;
+
+  if (!audioInput) {
+    log.errorAndThrow(`The mandatory audioInput option is not provided. Please set it ` +
+      `to a correct value (e. g. ':1'). Use 'ffmpeg -f avfoundation -list_devices true -i ""' ` +
+      `command to list available input sources`);
+  }
+
+  if (this._audioRecorder?.isRecording()) {
+    log.info(`There is an active audio capture process`);
+    if (forceRestart) {
+      log.info(`Stopping it because 'forceRestart' option is set to true`);
+      await this._audioRecorder.interrupt(true);
+    } else {
+      log.info(`Doing nothing. ` +
+        `Set 'forceRestart' option to true if you'd like to start a new audio capture session`);
+      return;
+    }
+  }
+  if (this._audioRecorder) {
+    await this._audioRecorder.cleanup();
+    this._audioRecorder = null;
+  }
+
+  const audioPath = await tempDir.path({
+    prefix: `appium_${util.uuidV4().substring(0, 8)}`,
+    suffix: DEFAULT_EXT,
+  });
+
+  const audioRecorder = new AudioRecorder(audioInput, audioPath, {
+    audioCodec,
+    audioBitrate,
+    audioChannels,
+    audioRate,
+  });
+
+  const timeoutSeconds = parseFloat(timeLimit);
+  if (isNaN(timeoutSeconds) || timeoutSeconds > MAX_RECORDING_TIME_SEC || timeoutSeconds <= 0) {
+    log.errorAndThrow(`The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC}] seconds. ` +
+      `The value of '${timeLimit}' has been passed instead.`);
+  }
+
+  try {
+    await audioRecorder.start(timeoutSeconds * 1000);
+  } catch (e) {
+    await audioRecorder.interrupt(true);
+    await audioRecorder.cleanup();
+    throw e;
+  }
+  this._audioRecorder = audioRecorder;
+};
+
+/**
+ * Stop recording of the audio input. If no audio recording process is running then
+ * the endpoint will try to get the recently recorded file.
+ * If no previously recorded file is found and no active audio recording
+ * processes are running then the method returns an empty string.
+ *
+ * @returns {string} Base64-encoded content of the recorded media file or an
+ * empty string if no audio recording has been started before.
+ * @throws {Error} If there was an error while getting the recorded file.
+ */
+commands.stopRecordingAudio = async function stopRecordingAudio () {
+  if (!this._audioRecorder) {
+    log.info('Audio capture has not been started. There is nothing to stop');
+    return '';
+  }
+
+  let resultPath;
+  try {
+    resultPath = await this._audioRecorder.finish();
+    if (!await fs.exists(resultPath)) {
+      log.errorAndThrow(`The audio capture utility has failed ` +
+        `to store the actual audio recording at '${resultPath}'`);
+    }
+  } catch (e) {
+    await this._audioRecorder.interrupt(true);
+    await this._audioRecorder.cleanup();
+    this._audioRecorder = null;
+    throw e;
+  }
+  return await encodeBase64OrUpload(resultPath);
+};
+
+
+export { commands };
+export default commands;

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -8,7 +8,7 @@ import { waitForCondition } from 'asyncbox';
 const commands = {};
 
 const AUDIO_RECORD_FEAT_NAME = 'audio_record';
-const MAX_RECORDING_TIME_SEC = 60 * 60 * 24;
+const MAX_RECORDING_TIME_SEC = 60 * 60 * 12;
 const DEFAULT_RECORDING_TIME_SEC = 60 * 3;
 const PROCESS_STARTUP_TIMEOUT_MS = 5000;
 const DEFAULT_BITRATE = '128k';
@@ -74,11 +74,11 @@ class AudioRecorder {
         intervalMs: 300,
       });
     } catch (e) {
-      log.warn(`Audio capture process did not start within ${PROCESS_STARTUP_TIMEOUT_MS}ms. Continuing anyway`);
+      log.warn(`Audio recording process did not start within ${PROCESS_STARTUP_TIMEOUT_MS}ms. Continuing anyway`);
     }
     if (!this.mainProcess.isRunning) {
       this.mainProcess = null;
-      throw new Error(`The audio capture process '${FFMPEG_BINARY}' died unexpectedly. ` +
+      throw new Error(`The audio recording process '${FFMPEG_BINARY}' died unexpectedly. ` +
         `Check server logs for more details`);
     }
     log.info(`Starting capture on audio input '${this.input}' with command: '${util.quote([FFMPEG_BINARY, ...args])}'. ` +
@@ -86,9 +86,9 @@ class AudioRecorder {
 
     this.timeoutHandler = setTimeout(async () => {
       if (await this.interrupt()) {
-        log.info(`Audio capture on channel '${this.input}' has been finished after ${timeoutMs}ms timeout`);
+        log.info(`The recording session on audio input '${this.input}' has been finished after ${timeoutMs}ms timeout`);
       } else {
-        log.warn(`Cannot finish the active recording on audio input '${this.input}' after ${timeoutMs}ms timeout`);
+        log.warn(`Cannot finish the recording session on audio input '${this.input}' after ${timeoutMs}ms timeout`);
       }
     }, timeoutMs);
   }
@@ -145,7 +145,7 @@ class AudioRecorder {
  * will create a single channel (mono) audio stream.
  * @property {?string|number} audioRate [44100] - The sampling rate of the resulting audio stream.
  * @property {?string|number} timeLimit [180] - The maximum recording time, in seconds.
- * The default value is 180, the maximum value is 86400 (1 day).
+ * The default value is 180, the maximum value is 43200 (12 hours).
  * @property {?boolean} forceRestart [false] - Whether to restart audio capture process forcefully when
  * startRecordingAudio is called (`true`) or ignore the call until the current audio recording is completed.
  */
@@ -180,13 +180,13 @@ commands.startRecordingAudio = async function startRecordingAudio (options = {})
   }
 
   if (this._audioRecorder?.isRecording()) {
-    log.info(`There is an active audio capture process`);
+    log.info(`There is an active audio recording process`);
     if (forceRestart) {
       log.info(`Stopping it because 'forceRestart' option is set to true`);
       await this._audioRecorder.interrupt(true);
     } else {
       log.info(`Doing nothing. ` +
-        `Set 'forceRestart' option to true if you'd like to start a new audio capture session`);
+        `Set 'forceRestart' option to true if you'd like to start a new audio recording session`);
       return;
     }
   }
@@ -235,7 +235,7 @@ commands.startRecordingAudio = async function startRecordingAudio (options = {})
  */
 commands.stopRecordingAudio = async function stopRecordingAudio () {
   if (!this._audioRecorder) {
-    log.info('Audio capture has not been started. There is nothing to stop');
+    log.info('Audio recording has not been started. There is nothing to stop');
     return '';
   }
 
@@ -243,7 +243,7 @@ commands.stopRecordingAudio = async function stopRecordingAudio () {
   try {
     resultPath = await this._audioRecorder.finish();
     if (!await fs.exists(resultPath)) {
-      log.errorAndThrow(`The audio capture utility has failed ` +
+      log.errorAndThrow(`${FFMPEG_BINARY} has failed ` +
         `to store the actual audio recording at '${resultPath}'`);
     }
   } catch (e) {

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -85,10 +85,13 @@ class AudioRecorder {
     }
     log.info(`Starting capture on audio input '${this.input}' with command: '${util.quote([FFMPEG_BINARY, ...args])}'. ` +
       `Will timeout in ${timeoutSeconds}s`);
-    this.mainProcess.once('exit', (code) => {
+    this.mainProcess.once('exit', (code, signal) => {
       // ffmpeg returns code 255 if SIGINT arrives
       if ([0, 255].includes(code)) {
         log.info(`The recording session on audio input '${this.input}' has been finished`);
+      } else {
+        log.debug(`The recording session on audio input '${this.input}' has exited ` +
+          `with code ${code}, signal ${signal}`);
       }
     });
   }

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -11,6 +11,7 @@ const AUDIO_RECORD_FEAT_NAME = 'audio_record';
 const MAX_RECORDING_TIME_SEC = 60 * 60 * 12;
 const DEFAULT_RECORDING_TIME_SEC = 60 * 3;
 const PROCESS_STARTUP_TIMEOUT_MS = 5000;
+const DEFAULT_SOURCE = 'avfoundation';
 const DEFAULT_BITRATE = '128k';
 const DEFAULT_CODEC = 'aac';
 const DEFAULT_CHANNELS = 2;
@@ -26,10 +27,9 @@ class AudioRecorder {
     this.opts = opts;
     this.input = input;
     this.mainProcess = null;
-    this.timeoutHandler = null;
   }
 
-  async start (timeoutMs) {
+  async start (timeoutSeconds) {
     try {
       await fs.which(FFMPEG_BINARY);
     } catch (err) {
@@ -38,6 +38,7 @@ class AudioRecorder {
     }
 
     const {
+      audioSource = DEFAULT_SOURCE,
       audioCodec,
       audioBitrate,
       audioChannels,
@@ -45,7 +46,8 @@ class AudioRecorder {
     } = this.opts;
 
     const args = [
-      '-f', 'avfoundation',
+      '-t', `${timeoutSeconds}`,
+      '-f', audioSource,
       '-i', this.input,
       '-c:a', audioCodec,
       '-b:a', audioBitrate,
@@ -82,15 +84,13 @@ class AudioRecorder {
         `Check server logs for more details`);
     }
     log.info(`Starting capture on audio input '${this.input}' with command: '${util.quote([FFMPEG_BINARY, ...args])}'. ` +
-      `Will timeout in ${timeoutMs}ms`);
-
-    this.timeoutHandler = setTimeout(async () => {
-      if (await this.interrupt()) {
-        log.info(`The recording session on audio input '${this.input}' has been finished after ${timeoutMs}ms timeout`);
-      } else {
-        log.warn(`Cannot finish the recording session on audio input '${this.input}' after ${timeoutMs}ms timeout`);
+      `Will timeout in ${timeoutSeconds}s`);
+    this.mainProcess.once('exit', (code) => {
+      // ffmpeg returns code 255 if SIGINT arrives
+      if ([0, 255].includes(code)) {
+        log.info(`The recording session on audio input '${this.input}' has been finished`);
       }
-    }, timeoutMs);
+    });
   }
 
   isRecording () {
@@ -98,13 +98,6 @@ class AudioRecorder {
   }
 
   async interrupt (force = false) {
-    let result = true;
-
-    if (this.timeoutHandler) {
-      clearTimeout(this.timeoutHandler);
-      this.timeoutHandler = null;
-    }
-
     if (this.isRecording()) {
       const interruptPromise = this.mainProcess.stop(force ? 'SIGTERM' : 'SIGINT');
       this.mainProcess = null;
@@ -113,11 +106,11 @@ class AudioRecorder {
       } catch (e) {
         log.warn(`Cannot ${force ? 'terminate' : 'interrupt'} ${FFMPEG_BINARY}. ` +
           `Original error: ${e.message}`);
-        result = false;
+        return false;
       }
     }
 
-    return result;
+    return true;
   }
 
   async finish () {
@@ -166,6 +159,8 @@ commands.startRecordingAudio = async function startRecordingAudio (options = {})
   const {
     timeLimit = DEFAULT_RECORDING_TIME_SEC,
     audioInput,
+    // Undocumented feature
+    audioSource,
     audioCodec = DEFAULT_CODEC,
     audioBitrate = DEFAULT_BITRATE,
     audioChannels = DEFAULT_CHANNELS,
@@ -201,20 +196,21 @@ commands.startRecordingAudio = async function startRecordingAudio (options = {})
   });
 
   const audioRecorder = new AudioRecorder(audioInput, audioPath, {
+    audioSource,
     audioCodec,
     audioBitrate,
     audioChannels,
     audioRate,
   });
 
-  const timeoutSeconds = parseFloat(timeLimit);
+  const timeoutSeconds = parseInt(timeLimit, 10);
   if (isNaN(timeoutSeconds) || timeoutSeconds > MAX_RECORDING_TIME_SEC || timeoutSeconds <= 0) {
     log.errorAndThrow(`The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC}] seconds. ` +
       `The value of '${timeLimit}' has been passed instead.`);
   }
 
   try {
-    await audioRecorder.start(timeoutSeconds * 1000);
+    await audioRecorder.start(timeoutSeconds);
   } catch (e) {
     await audioRecorder.interrupt(true);
     await audioRecorder.cleanup();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -614,10 +614,9 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
 
-    if (this._recentScreenRecorder) {
-      await this._recentScreenRecorder.interrupt(true);
-      await this._recentScreenRecorder.cleanup();
-      this._recentScreenRecorder = null;
+    for (const recorder in _.compact([this._recentScreenRecorder, this._audioRecorder])) {
+      await recorder.interrupt(true);
+      await recorder.cleanup();
     }
 
     if (!_.isEmpty(this._perfRecorders)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -614,7 +614,7 @@ class XCUITestDriver extends BaseDriver {
   async deleteSession () {
     await removeAllSessionWebSocketHandlers(this.server, this.sessionId);
 
-    for (const recorder in _.compact([this._recentScreenRecorder, this._audioRecorder])) {
+    for (const recorder of _.compact([this._recentScreenRecorder, this._audioRecorder])) {
       await recorder.interrupt(true);
       await recorder.cleanup();
     }


### PR DESCRIPTION
The idea of this PR is that we could record Simulator audio output using Soundflower like it is described in http://www.lorisware.com/blog/2012/04/28/recording-iphone-emulator-video-with-sound/

For real devices there is a possibility to connect a phone as an input device: https://www.makeuseof.com/tag/play-audio-iphone-mac/, although I've never tested that, since I don't have a real device :-P
In the worst case one could always use the classic audio jack connected to a microphone input of a mac machine.

The feature is insecure, because it allows to access system microphone, so it must be enabled explicitly on the server side.

I'll write a separate doc later on how to configure the Simulator for audio recording. It would be great if @KazuCocoa could help to check how audio capture works with real devices, so we have a complete documentation on the feature.

cc @dpgraham 