### PR TITLE
feat: Use xctrace tool for performance stats recording if possible

### DIFF
--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -1,14 +1,13 @@
 import _ from 'lodash';
 import path from 'path';
 import { fs, zip, logger, util } from 'appium-support';
-import { SubProcess } from 'teen_process';
+import { SubProcess, exec } from 'teen_process';
 import log from '../logger';
 import { encodeBase64OrUpload } from '../utils';
 import { waitForCondition } from 'asyncbox';
 import os from 'os';
 
-
-let commands = {};
+const commands = {};
 
 const PERF_RECORD_FEAT_NAME = 'perf_record';
 const PERF_RECORD_SECURITY_MESSAGE = 'Performance measurement requires relaxing security for simulator. ' +
@@ -20,15 +19,34 @@ const STARTUP_TIMEOUT_MS = 15 * 1000;
 const DEFAULT_PROFILE_NAME = 'Activity Monitor';
 const DEFAULT_EXT = 'trace';
 const DEFAULT_PID = 'current';
-const INSTRUMENTS_BINARY = 'instruments';
+const INSTRUMENTS = 'instruments';
+const XCRUN = 'xcrun';
+const XCTRACE = 'xctrace';
 
+
+async function requireXctrace () {
+  let xcrunPath;
+  try {
+    xcrunPath = await fs.which(XCRUN);
+  } catch (e) {
+    log.errorAndThrow(`${XCRUN} has not been found in PATH. ` +
+      `Please make sure XCode development tools are installed`);
+  }
+  try {
+    await exec(xcrunPath, [XCTRACE, 'help']);
+  } catch (e) {
+    log.errorAndThrow(`${XCTRACE} is not available for the active Xcode version. ` +
+      `Please make sure XCode is up to date. Original error: ${e.stderr || e.message}`);
+  }
+  return xcrunPath;
+}
 
 async function requireInstruments () {
   try {
-    return await fs.which(INSTRUMENTS_BINARY);
+    return await fs.which(INSTRUMENTS);
   } catch (e) {
-    log.errorAndThrow(`${INSTRUMENTS_BINARY} has not been found in PATH. ` +
-      `Please make sure Xcode development tools are installed`);
+    log.errorAndThrow(`${INSTRUMENTS} has not been found in PATH. ` +
+      `Please make sure XCode development tools are installed`);
   }
 }
 
@@ -104,28 +122,49 @@ class PerfRecorder {
   }
 
   async start () {
-    const instruments = await requireInstruments();
-
-    // https://help.apple.com/instruments/mac/current/#/devb14ffaa5
-    const args = [
-      '-w', this._udid,
-      '-t', this._profileName,
-      '-D', this._reportPath,
-      '-l', `${this._timeout}`,
-    ];
-    if (this._pid) {
-      args.push('-p', `${this._pid}`);
+    let binaryPath;
+    try {
+      binaryPath = await requireXctrace();
+    } catch (e) {
+      log.debug(e.message);
+      log.info(`Defaulting to ${INSTRUMENTS} usage`);
+      binaryPath = await requireInstruments();
     }
-    const fullCmd = [
-      instruments,
-      ...args,
-    ];
+
+    const args = [];
+    const toolName = path.basename(binaryPath) === XCRUN ? XCTRACE : INSTRUMENTS;
+    if (toolName === XCTRACE) {
+      args.push(
+        XCTRACE, 'record',
+        '--device', this._udid,
+        '--template', this._profileName,
+        '--output', this._reportPath,
+        '--time-limit', `${this._timeout}ms`,
+      );
+      if (this._pid) {
+        args.push('--attach', `${this._pid}`);
+      } else {
+        args.push('--all-processes');
+      }
+    } else {
+      // https://help.apple.com/instruments/mac/current/#/devb14ffaa5
+      args.push(
+        '-w', this._udid,
+        '-t', this._profileName,
+        '-D', this._reportPath,
+        '-l', `${this._timeout}`,
+      );
+      if (this._pid) {
+        args.push('-p', `${this._pid}`);
+      }
+    }
+    const fullCmd = [binaryPath, ...args];
     this._process = new SubProcess(fullCmd[0], fullCmd.slice(1));
     this._archivePromise = null;
-    this._logger.debug(`Starting ${INSTRUMENTS_BINARY}: ${util.quote(fullCmd)}`);
+    this._logger.debug(`Starting performance recording: ${util.quote(fullCmd)}`);
     this._process.on('output', (stdout, stderr) => {
       if (_.trim(stdout || stderr)) {
-        this._logger.debug(`[${INSTRUMENTS_BINARY}] ${stdout || stderr}`);
+        this._logger.debug(`[${toolName}] ${stdout || stderr}`);
       }
     });
     this._process.once('exit', async (code, signal) => {
@@ -150,7 +189,7 @@ class PerfRecorder {
           return true;
         }
         if (!this._process) {
-          throw new Error(`${INSTRUMENTS_BINARY} process died unexpectedly`);
+          throw new Error(`${toolName} process died unexpectedly`);
         }
         return false;
       }, {
@@ -159,9 +198,12 @@ class PerfRecorder {
       });
     } catch (e) {
       await this._enforceTermination();
+      const listProfilesCommand = toolName === XCTRACE
+        ? `${XCRUN} ${XCTRACE} list templates`
+        : `${INSTRUMENTS} s`;
       this._logger.errorAndThrow(`There is no .${DEFAULT_EXT} file found for performance profile ` +
         `'${this._profileName}'. Make sure the profile is supported on this device. ` +
-        `You could use 'instruments -s' command to see the list of all available profiles. ` +
+        `You could use '${listProfilesCommand}' command to see the list of all available profiles. ` +
         `Check the server log for more details`);
     }
     this._logger.info(`The performance recording has started. Will timeout in ${this._timeout}ms`);
@@ -192,7 +234,6 @@ class PerfRecorder {
  *
  * @property {?number|string} timeout [300000] - The maximum count of milliseconds to record the profiling information.
  * @property {?string} profileName [Activity Monitor] - The name of existing performance profile to apply.
- *                                                      Execute `instruments -s` to show the list of available profiles.
  *                                                      Can also contain the full path to the chosen template on the server file system.
  *                                                      Note, that not all profiles are supported on mobile devices.
  * @property {?string|number} pid - The ID of the process to measure the performance for.
@@ -206,7 +247,9 @@ class PerfRecorder {
  * Starts performance profiling for the device under test.
  * Relaxing security is mandatory for simulators. It can always work for real devices.
  *
- * The `instruments` developer utility is used for this purpose under the hood.
+ * Since XCode 14 the method tries to use `xctrace` tool to record performance stats.
+ * The `instruments` developer utility is used as a fallback for this purpose if `xctrace`
+ * is not available.
  * It is possible to record multiple profiles at the same time.
  * Read https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html
  * for more details.
@@ -304,10 +347,10 @@ commands.mobileStopPerfRecord = async function mobileStopPerfRecord (opts = {}) 
 
   const {
     profileName = DEFAULT_PROFILE_NAME,
+    remotePath,
   } = opts;
 
-  const recorders = this._perfRecorders
-    .filter((x) => x.profileName === profileName);
+  const recorders = this._perfRecorders.filter((x) => x.profileName === profileName);
   if (_.isEmpty(recorders)) {
     log.errorAndThrow(`There are no records for performance profile '${profileName}' ` +
       `and device ${this.opts.device.udid}. Have you started the profiling before?`);
@@ -315,11 +358,10 @@ commands.mobileStopPerfRecord = async function mobileStopPerfRecord (opts = {}) 
   const resultPath = await recorders[0].stop();
   if (!await fs.exists(resultPath)) {
     log.errorAndThrow(`There is no .${DEFAULT_EXT} file found for performance profile '${profileName}' ` +
-      `and device ${this.opts.device.udid}. Make sure the profile is supported on this device. ` +
-      `You could use 'instruments -s' command to see the list of all available profiles.`);
+      `and device ${this.opts.device.udid}. Make sure the selected profile is supported on this device`);
   }
 
-  return await encodeBase64OrUpload(resultPath, opts.remotePath, opts);
+  return await encodeBase64OrUpload(resultPath, remotePath, opts);
 };
 
 

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -15,7 +15,7 @@ const PERF_RECORD_SECURITY_MESSAGE = 'Performance measurement requires relaxing 
   'referencing https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md for more details.';
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const STOP_TIMEOUT_MS = 3 * 60 * 1000;
-const STARTUP_TIMEOUT_MS = 15 * 1000;
+const STARTUP_TIMEOUT_MS = 60 * 1000;
 const DEFAULT_PROFILE_NAME = 'Activity Monitor';
 const DEFAULT_EXT = 'trace';
 const DEFAULT_PID = 'current';

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -200,7 +200,7 @@ class PerfRecorder {
       await this._enforceTermination();
       const listProfilesCommand = toolName === XCTRACE
         ? `${XCRUN} ${XCTRACE} list templates`
-        : `${INSTRUMENTS} s`;
+        : `${INSTRUMENTS} -s`;
       this._logger.errorAndThrow(`There is no .${DEFAULT_EXT} file found for performance profile ` +
         `'${this._profileName}'. Make sure the profile is supported on this device. ` +
         `You could use '${listProfilesCommand}' command to see the list of all available profiles. ` +


### PR DESCRIPTION
Since XCode the `instruments` tool is going to be deprecated and removed from developer tools. The `xctrace` is proposed as a drop-in replacement. This PR adds support of this tool and still keeps a fallback to instruments for older Xcode versions.