### PR TITLE
chore: remove shrinkwrap from package

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -22,6 +22,9 @@ jobs:
       name: Install prod dependencies
     - run: rm -rf package-lock.json
       name: Delete package-lock (if it exists)
+    # Below shrinkwrap will be needed in Appium 2.0
+    # - run: npm shrinkwrap 
+    #   name: Create shrinkwrap 
     - run: npm install --no-package-lock
       name: Install dev dependencies
     - run: npm test

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -22,8 +22,6 @@ jobs:
       name: Install prod dependencies
     - run: rm -rf package-lock.json
       name: Delete package-lock (if it exists)
-    - run: npm shrinkwrap
-      name: Create shrinkwrap
     - run: npm install --no-package-lock
       name: Install dev dependencies
     - run: npm test


### PR DESCRIPTION
fixes https://github.com/appium/appium/issues/14732

shrinkwrap is necessary in our `appium` package regular release, but not in each separate modules, I think.
e.g. Appium 1.18.1 has shrinkwrap in the package, but not in the node_modules/appium-xcuitest-driver package

Is this removal enough?