### PR TITLE
chore: fix broken control center test

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -415,7 +415,7 @@ function normalizePlatformVersion (originalVersion) {
 }
 
 
-export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion, getGenericSimulatorForIosVersion,
+export { detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
   checkAppPresent, getDriverInfo,
   clearSystemFiles, translateDeviceName, normalizeCommandTimeouts,
   DEFAULT_TIMEOUT_KEY, markSystemFilesForCleanup, printUser,

--- a/test/functional/basic/gesture-e2e-specs.js
+++ b/test/functional/basic/gesture-e2e-specs.js
@@ -7,7 +7,7 @@ import { retryInterval } from 'asyncbox';
 import { UICATALOG_CAPS } from '../desired';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APPIUM_IMAGE } from '../web/helpers';
-import { getGenericSimulatorForIosVersion } from '../../../lib/utils';
+import { translateDeviceName } from '../../../lib/utils';
 import { util } from 'appium-support';
 import xcode from 'appium-xcode';
 
@@ -255,11 +255,8 @@ describe('XCUITestDriver - gestures', function () {
               return true;
             }
             const { platformVersion, deviceName } = await driver.sessionCapabilities();
-            const generic = getGenericSimulatorForIosVersion(platformVersion, deviceName);
-            if (_.includes(_.toLower(generic), ('iphone x'))) {
-              return true;
-            }
-            return false;
+            const translatedDeviceName = translateDeviceName(platformVersion, deviceName).toLowerCase();
+            return _.includes(translatedDeviceName, 'iphone x');
           })();
 
           x = width / 2;


### PR DESCRIPTION
The test in gestures-e2e was using `getGenericSimulatorForIosVersion` method in `utils`; a method that is only used by `translateDeviceName` and does not have any unit tests. The test was failing because it expects lowercase deviceName which it wasn't getting so it wasn't returning the correct result.

The fix is to just use `translateDeviceName` method directly, and then make `getGenericSimulatorForIosVersion` unexported (ie: a private method).