### PR TITLE
chore: Make sure calendar access is assigned before app startup

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -441,6 +441,14 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
+    if (this.isSimulator()) {
+      if (this.opts.calendarAccessAuthorized) {
+        await this.opts.device.enableCalendarAccess(this.opts.bundleId);
+      } else if (this.opts.calendarAccessAuthorized === false) {
+        await this.opts.device.disableCalendarAccess(this.opts.bundleId);
+      }
+    }
+
     await this.startWda(this.opts.sessionId, realDevice);
 
     await this.setReduceMotion(this.opts.reduceMotion);
@@ -464,14 +472,6 @@ class XCUITestDriver extends BaseDriver {
     if (this.isSafari() && this.isRealDevice() && util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
       // on 12.2 the page is not opened in WDA
       await this.setUrl(this._currentUrl);
-    }
-
-    if (!this.isRealDevice()) {
-      if (this.opts.calendarAccessAuthorized) {
-        await this.opts.device.enableCalendarAccess(this.opts.bundleId);
-      } else if (this.opts.calendarAccessAuthorized === false) {
-        await this.opts.device.disableCalendarAccess(this.opts.bundleId);
-      }
     }
   }
 


### PR DESCRIPTION
Changing permissions via simctl terminates/backgrounds the app under test, so we need to make sure this is done after the app is installed, but before it is started.