### PR TITLE
fix: parsing SSL output from OpenSSL output

### DIFF
--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -67,7 +67,7 @@ async function extractCommonName (certBuffer) {
   try {
     await fs.writeFile(tempCert.path, certBuffer);
     const {stdout} = await exec('openssl', ['x509', '-noout', '-subject', '-in', tempCert.path]);
-    const cnMatch = /\/CN=([^\/]+)/.exec(stdout); // eslint-disable-line no-useless-escape
+    const cnMatch = /(\/CN=([^\/]+))|(,\sCN\s=\s([^,]+))/.exec(stdout); // eslint-disable-line no-useless-escape
     if (cnMatch) {
       return cnMatch[1].trim();
     }

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -67,17 +67,30 @@ async function extractCommonName (certBuffer) {
   try {
     await fs.writeFile(tempCert.path, certBuffer);
     const {stdout} = await exec('openssl', ['x509', '-noout', '-subject', '-in', tempCert.path]);
-    const cnMatch = /(\/CN=([^\/]+))|(,\sCN\s=\s([^,]+))/.exec(stdout); // eslint-disable-line no-useless-escape
-    if (cnMatch) {
-      return cnMatch[1].trim();
-    }
-    throw new Error(`There is no common name value in '${stdout}' output`);
+    return parseCommonName(stdout);
   } catch (err) {
     throw new Error(`Cannot parse common name value from the certificate. Is it valid and base64-encoded? ` +
                     `Original error: ${err.message}`);
   } finally {
     await fs.rimraf(tempCert.path);
   }
+}
+
+const LIBRE_SSL_PATTERN = /\/CN=([^\/]+)/; // eslint-disable-line no-useless-escape
+const OPEN_SSL_PATTERN = /,\sCN\s=\s([^,]+)/;
+
+function parseCommonName (stringCertificate) {
+  const result = [LIBRE_SSL_PATTERN, OPEN_SSL_PATTERN].reduce((acc, r) => {
+    if (acc) {
+      return acc;
+    }
+    const match = r.exec(stringCertificate);
+    return match && match[1];
+  }, null);
+  if (!result) {
+    throw new Error(`There is no common name value in '${stringCertificate}' output`);
+  }
+  return result;
 }
 
 /**
@@ -386,5 +399,5 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
 };
 
 Object.assign(extensions, commands);
-export { commands };
+export { commands, parseCommonName };
 export default extensions;

--- a/test/unit/commands/ssl-certificate-specs.js
+++ b/test/unit/commands/ssl-certificate-specs.js
@@ -1,0 +1,18 @@
+import chai from 'chai';
+import { parseCommonName } from '../../../lib/commands/certificate';
+
+chai.should();
+
+describe('ssl certificate parser command', function () {
+  const sslOutputLibreSSL = 'subject= /C=US/ST=California/L=San Francisco/O=BadSSL/CN=*.badssl.com';
+  const sslOutputOpenSSL = 'subject=C = US, ST = California, L = San Francisco, O = BadSSL, CN = *.badssl.com';
+  const expectedString = '*.badssl.com';
+
+  it('try to parse LibreSSL command output', function () {
+    parseCommonName(sslOutputLibreSSL).should.eql(expectedString);
+  });
+
+  it('try to parse OpenSSL command output', function () {
+    parseCommonName(sslOutputOpenSSL).should.eql(expectedString);
+  });
+});


### PR DESCRIPTION
The separator (`/`) for the values of the output in LibreSSL (OpenSSL in MacOS/OpenBSD) is different from the separator ` , ` in OpenSSL in Linux.

**appium-xcuitest-driver** is expecting to run on macOS so the regex which parses the output from LibreSSL (OpenSSL in MacOS/OpenBSD) doesn't work when using OpenSSL.

This patch adds the fallback to parse the OpenSSL output in case it fails to parse the LibreSSL output.

