### PR TITLE
chore: add message for a real device

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -479,8 +479,7 @@ class XCUITestDriver extends BaseDriver {
       try {
         await this.navToInitialWebview();
       } catch (e) {
-        throw Error(`${e.message} Please check the device configuration and troubleshoot in ` +
-          `http://appium.io/docs/en/writing-running-appium/web/mobile-web`);
+        throw Error(`${e.message} Please check the troubleshoot in http://appium.io/docs/en/writing-running-appium/web/mobile-web`);
       }
       this.logEvent('initialWebviewNavigated');
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -479,10 +479,10 @@ class XCUITestDriver extends BaseDriver {
       try {
         await this.navToInitialWebview();
       } catch (e) {
-        if (this.isRealDevice()) {
-          log.warn("Please ensure 'Web Inspector' is enabled in the device, http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device");
-        }
-        throw e;
+        if (!this.isRealDevice()) { throw e; }
+
+        throw Error(`${e.message} Please ensure 'Web Inspector' is enabled on the device, ` +
+          `http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device`);
       }
       this.logEvent('initialWebviewNavigated');
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -479,7 +479,10 @@ class XCUITestDriver extends BaseDriver {
       try {
         await this.navToInitialWebview();
       } catch (e) {
-        throw Error(`${e.message} Please check the troubleshoot in http://appium.io/docs/en/writing-running-appium/web/mobile-web`);
+        if (this.isSafari()) {
+          throw Error(`${e.message} Please check the troubleshoot in http://appium.io/docs/en/writing-running-appium/web/mobile-web`);
+        }
+        throw e;
       }
       this.logEvent('initialWebviewNavigated');
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -476,7 +476,14 @@ class XCUITestDriver extends BaseDriver {
 
     if (this.isSafari() || this.opts.autoWebview) {
       log.debug('Waiting for initial webview');
-      await this.navToInitialWebview();
+      try {
+        await this.navToInitialWebview();
+      } catch (e) {
+        if (this.isRealDevice()) {
+          log.warn("Please ensure 'Web Inspector' is enabled in the device, http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device");
+        }
+        throw e;
+      }
       this.logEvent('initialWebviewNavigated');
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -479,10 +479,8 @@ class XCUITestDriver extends BaseDriver {
       try {
         await this.navToInitialWebview();
       } catch (e) {
-        if (!this.isRealDevice()) { throw e; }
-
-        throw Error(`${e.message} Please ensure 'Web Inspector' is enabled on the device, ` +
-          `http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device`);
+        throw Error(`${e.message} Please check the device configuration and troubleshoot in ` +
+          `http://appium.io/docs/en/writing-running-appium/web/mobile-web`);
       }
       this.logEvent('initialWebviewNavigated');
     }


### PR DESCRIPTION
It is helpful to add a quick guide to ensure Web Inspector for `browserName: safari` when a new session failed because of no Web Inspector disabled.
(Ideally, I'd have liked to check Web Inspector value via WDA, but no proper value was there. `inspectorEnabled` in AXSettings.h returns always false, for example.)

Client log
- before
```ruby
> @core.start_driver
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Could not navigate to webview; there are none!
from UnknownError: An unknown server-side error occurred while processing the command. Original error: Could not navigate to webview; there are none!
```

- after
```ruby
> @core.start_driver
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Could not navigate to webview; there are none! Please ensure 'Web Inspector' is enabled in the device, http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device
from UnknownError: An unknown server-side error occurred while processing the command. Original error: Could not navigate to webview; there are none! Please ensure 'Web Inspector' is enabled in the device, http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device
```

---

server log

- before
```
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1609119240279 (17:34:00 GMT-0800 (Pacific Standard Time))
[debug] [W3C] Encountered internal error running command: Error: Could not navigate to webview; there are none!
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:539:13)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
[debug] [W3C]     at spinHandles (/Users/kazuaki/GitHub/appium-xcuitest-driver/node_modules/appium-ios-driver/lib/commands/context.js:546:14)
...
```

- after
```
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1609119628095 (17:40:28 GMT-0800 (Pacific Standard Time))
[debug] [W3C] Encountered internal error running command: Error: Could not navigate to webview; there are none! Please ensure 'Web Inspector' is enabled in the device, http://appium.io/docs/en/writing-running-appium/web/mobile-web/#mobile-safari-on-a-real-ios-device
[debug] [W3C]     at XCUITestDriver.start (/Users/kazuaki/GitHub/appium-xcuitest-driver/lib/driver.js:484:15)
[debug] [W3C]     at XCUITestDriver.createSession (/Users/kazuaki/GitHub/appium-xcuitest-driver/lib/driver.js:215:7)
[debug] [W3C]     at AppiumDriver.createSession (/Users/kazuaki/GitHub/appium/lib/appium.js:371:35)
[HTTP] <-- POST /wd/hub/session 500 99298 ms - 887
[HTTP]
```