### PR TITLE
chore: Do not enforce trace pointer setting

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -859,7 +859,7 @@ class XCUITestDriver extends BaseDriver {
       connectHardwareKeyboard: !!this.opts.connectHardwareKeyboard,
       pasteboardAutomaticSync: this.opts.simulatorPasteboardAutomaticSync || 'off',
       isHeadless: !!this.opts.isHeadless,
-      tracePointer: !!this.opts.simulatorTracePointer,
+      tracePointer: this.opts.simulatorTracePointer,
       devicePreferences: {},
     };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -857,7 +857,7 @@ class XCUITestDriver extends BaseDriver {
     const runOpts = {
       scaleFactor: this.opts.scaleFactor,
       connectHardwareKeyboard: !!this.opts.connectHardwareKeyboard,
-      pasteboardAutomaticSync: this.opts.simulatorPasteboardAutomaticSync || 'off',
+      pasteboardAutomaticSync: this.opts.simulatorPasteboardAutomaticSync ?? 'off',
       isHeadless: !!this.opts.isHeadless,
       tracePointer: this.opts.simulatorTracePointer,
       devicePreferences: {},


### PR DESCRIPTION
Setting it to false enforces the corresponding simulator setting to be changed every time it is started