### PR TITLE
docs: Run WDA bootstrap only for new releases 

### DIFF
--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -126,10 +126,14 @@ is updated, and is _not_ recommended):
     `appium/node_modules/appium-xcuitest-driver/node_modules`) and, if it is not present there, under `appium/node_modules`.
     You could also see the full path to WebDriverAgent's folder in Appium server logs
     after a session has been started.
-    Open a terminal and go to that location, then run the following in order to
+    Open a terminal and go to that location, then run the following to
     set the project up:
 ```
     mkdir -p Resources/WebDriverAgent.bundle
+```
+    If you build an WebDriverAgent with a version before 2.32.0 (e.g. as part of
+    an Appium release before 1.20.0) you also have to run
+```
     ./Scripts/bootstrap.sh -d
 ```
 *   Open `WebDriverAgent.xcodeproj` in Xcode. For **both** the `WebDriverAgentLib`


### PR DESCRIPTION
WebDriverAgent's bootstrap.sh script is redundant since version 2.32.0
of WebDriverAgent. It only prints to the command-line that everything is
ok. Therefore we can simplify the setup instructions by not calling this
script anymore. In addition this is a preparation for removing the
bootstrap.sh script from WebDriverAgent.