### PR TITLE
feat: add appium:includeDeviceCapsToSessionInfo to be able to ignore /screen call to WDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ appium:automationName | Must always be set to `xcuitest`. Values of `automationN
 `appium:fullReset` | Being set to `true` always enforces the application under test to be fully uninstalled before starting a new session. `false` by default
 `appium:printPageSourceOnFindFailure` | Enforces the server to dump the actual XML page source into the log if any error happens. `false` by default.
 `browserName` | The name of the browser to run the test on. If this capability is provided then the driver will try to start the test in Web context mode (Native mode is applied by default). Read [Automating hybrid apps](https://appium.io/docs/en/writing-running-appium/web/hybrid/) for more details. Usually equals to `safari`.
-`appium:includeScreenInfoInSession` | Whether to include screen information as the result of [Get Session Capabilities](http://appium.io/docs/en/commands/session/get/) result. It includes `pixelRatio`, `statBarHeight` and `viewportRect`, but it causes an extra API call to WDA which may increase the response time like [this issue](https://github.com/appium/appium/issues/15101). Defaults to `true`.
+`appium:includeDeviceCapsToSessionInfo` | Whether to include screen information as the result of [Get Session Capabilities](http://appium.io/docs/en/commands/session/get/). It includes `pixelRatio`, `statBarHeight` and `viewportRect`, but it causes an extra API call to WDA which may increase the response time like [this issue](https://github.com/appium/appium/issues/15101). Defaults to `true`.
 
 ### App
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ appium:automationName | Must always be set to `xcuitest`. Values of `automationN
 `appium:fullReset` | Being set to `true` always enforces the application under test to be fully uninstalled before starting a new session. `false` by default
 `appium:printPageSourceOnFindFailure` | Enforces the server to dump the actual XML page source into the log if any error happens. `false` by default.
 `browserName` | The name of the browser to run the test on. If this capability is provided then the driver will try to start the test in Web context mode (Native mode is applied by default). Read [Automating hybrid apps](https://appium.io/docs/en/writing-running-appium/web/hybrid/) for more details. Usually equals to `safari`.
+`appium:includeScreenInfoInSession` | Whether to include screen information as the result of [Get Session Capabilities](http://appium.io/docs/en/commands/session/get/) result. It includes `pixelRatio`, `statBarHeight` and `viewportRect`, but it causes an extra API call to WDA which may increase the response time like [this issue](https://github.com/appium/appium/issues/15101). Defaults to `true`.
 
 ### App
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -239,6 +239,9 @@ let desiredCapConstraints = _.defaults({
   safariIgnoreWebHostnames: {
     isString: true,
   },
+  includeScreenInfoInSession: {
+    isBoolean: true,
+  }
 }, iosDesiredCapConstraints);
 
 export { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -239,7 +239,7 @@ let desiredCapConstraints = _.defaults({
   safariIgnoreWebHostnames: {
     isString: true,
   },
-  includeScreenInfoInSession: {
+  includeDeviceCapsToSessionInfo: {
     isBoolean: true,
   }
 }, iosDesiredCapConstraints);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1223,7 +1223,11 @@ class XCUITestDriver extends BaseDriver {
     if (!this.wdaCaps) {
       this.wdaCaps = await this.proxyCommand('/', 'GET');
     }
-    if (!this.deviceCaps) {
+
+    const shouldGetScreenInfo = _.isBoolean(this.opts.includeScreenInfoInSession)
+      ? this.opts.includeScreenInfoInSession
+      : true; // Backward compatibility
+    if (shouldGetScreenInfo && !this.deviceCaps) {
       const {statusBarSize, scale} = await this.getScreenInfo();
       this.deviceCaps = {
         pixelRatio: scale,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1224,10 +1224,10 @@ class XCUITestDriver extends BaseDriver {
       this.wdaCaps = await this.proxyCommand('/', 'GET');
     }
 
-    const shouldGetScreenInfo = _.isBoolean(this.opts.includeScreenInfoInSession)
-      ? this.opts.includeScreenInfoInSession
+    const shouldGetDeviceCaps = _.isBoolean(this.opts.includeDeviceCapsToSessionInfo)
+      ? this.opts.includeDeviceCapsToSessionInfo
       : true; // Backward compatibility
-    if (shouldGetScreenInfo && !this.deviceCaps) {
+    if (shouldGetDeviceCaps && !this.deviceCaps) {
       const {statusBarSize, scale} = await this.getScreenInfo();
       this.deviceCaps = {
         pixelRatio: scale,
@@ -1237,7 +1237,7 @@ class XCUITestDriver extends BaseDriver {
     }
     log.info('Merging WDA caps over Appium caps for session detail response');
     return Object.assign({udid: this.opts.udid}, driverSession,
-      this.wdaCaps.capabilities, this.deviceCaps);
+      this.wdaCaps.capabilities, this.deviceCaps || {});
   }
 
   async reset () {

--- a/test/unit/commands/session-specs.js
+++ b/test/unit/commands/session-specs.js
@@ -42,6 +42,7 @@ describe('session commands', function () {
         javascript_enabled: true,
         app: 'NOTLOL.app',
       };
+      driver.deviceCaps = undefined;
       let res = await driver.getSession();
       proxySpy.calledOnce.should.be.true;
       res.should.eql({
@@ -53,6 +54,25 @@ describe('session commands', function () {
         statBarHeight: 20,
         viewportRect: {x: 1, y: 2, height: 3, width: 4},
         pixelRatio: 3,
+      });
+    });
+
+    it('should merge caps with WDA response without screen info', async function () {
+      driver.caps = {
+        platformName: 'iOS',
+        javascript_enabled: true,
+        app: 'NOTLOL.app',
+      };
+      driver.deviceCaps = undefined;
+      driver.opts.includeScreenInfoInSession = false;
+      let res = await driver.getSession();
+      proxySpy.calledOnce.should.be.false;
+      res.should.eql({
+        sillyCap: true,
+        app: 'LOL.app',
+        platformName: 'iOS',
+        javascript_enabled: true,
+        udid: 'cecinestpasuneudid'
       });
     });
   });

--- a/test/unit/commands/session-specs.js
+++ b/test/unit/commands/session-specs.js
@@ -64,7 +64,7 @@ describe('session commands', function () {
         app: 'NOTLOL.app',
       };
       driver.deviceCaps = undefined;
-      driver.opts.includeScreenInfoInSession = false;
+      driver.opts.includeDeviceCapsToSessionInfo = false;
       let res = await driver.getSession();
       proxySpy.calledOnce.should.be.false;
       res.should.eql({


### PR DESCRIPTION
For https://github.com/appium/appium/issues/15101

In some environments, it seems `/screen` endpoint takes long time to get the response in XCTest.
As a workaround for now, we can disable the call.

We can call them via an extension like `mobile:screenInfo` or existing `deviceInfo`?