### PR TITLE
feat: Add disableAutomaticScreenshots capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Capability | Description
 |`appium:screenshotQuality`| Changes the quality of phone display screenshots following [xctest/xctimagequality](https://developer.apple.com/documentation/xctest/xctimagequality?language=objc)  Default value is `1`. `0` is the highest and `2` is the lowest quality. You can also change it via [settings](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md) command. `0` might cause OutOfMemory crash on high-resolution devices like iPad Pro. | e.g. `0`, `1`, `2` |
 |`appium:autoAcceptAlerts`| Accept all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
 |`appium:autoDismissAlerts`| Dismiss all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
+|`appium:disableAutomaticScreenshots`| Disable automatic screenshots taken by XCTest at every interaction. Default is up to `WebDriverAgent`'s config to decide, which currently defaults to `true`. |`true` or `false`|
 
 ### Simulator
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -241,6 +241,9 @@ let desiredCapConstraints = _.defaults({
   },
   includeDeviceCapsToSessionInfo: {
     isBoolean: true,
+  },
+  disableAutomaticScreenshots: {
+    isBoolean: true,
   }
 }, iosDesiredCapConstraints);
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -956,6 +956,7 @@ class XCUITestDriver extends BaseDriver {
       waitForIdleTimeout: this.opts.waitForIdleTimeout,
       shouldUseCompactResponses: this.opts.shouldUseCompactResponses,
       elementResponseFields: this.opts.elementResponseFields,
+      disableAutomaticScreenshots: this.opts.disableAutomaticScreenshots,
     };
     if (this.opts.autoAcceptAlerts) {
       wdaCaps.defaultAlertAction = 'accept';

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "appium-ios-simulator": "^3.25.1",
     "appium-remote-debugger": "^8.13.2",
     "appium-support": "^2.47.1",
-    "appium-webdriveragent": "^3.4.0",
+    "appium-webdriveragent": "^3.6.0",
     "appium-xcode": "^3.8.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -10,6 +10,7 @@ describe('language and locale', function () {
   const BUNDLE_ID = 'com.test.app';
   const DEFAULT_CAPS = {
     elementResponseFields: undefined,
+    disableAutomaticScreenshots: undefined,
     shouldUseCompactResponses: undefined,
     waitForIdleTimeout: undefined,
     shouldWaitForQuiescence: true,

--- a/test/unit/processargs-specs.js
+++ b/test/unit/processargs-specs.js
@@ -11,6 +11,7 @@ describe('process args', function () {
   let proxySpy = sinon.stub(driver, 'proxyCommand');
   const DEFAULT_CAPS = {
     elementResponseFields: undefined,
+    disableAutomaticScreenshots: undefined,
     shouldUseCompactResponses: undefined,
     waitForIdleTimeout: undefined,
     shouldWaitForQuiescence: true,


### PR DESCRIPTION
The value of this will override WDA's default config for disabling XCTest automatic screenshot taking.

Depends on this change on WDA: https://github.com/appium/WebDriverAgent/pull/483