### PR TITLE
feat: Add shouldTerminateApp capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Capability | Description
 |`appium:autoAcceptAlerts`| Accept all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
 |`appium:autoDismissAlerts`| Dismiss all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
 |`appium:disableAutomaticScreenshots`| Disable automatic screenshots taken by XCTest at every interaction. Default is up to `WebDriverAgent`'s config to decide, which currently defaults to `true`. |`true` or `false`|
+|`appium:shouldTerminateApp`| Specify if the app should be terminated on session end (when `bundleId` is provided). Default is `true`. |`true` or `false`|
 
 ### Simulator
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Capability | Description
 |`appium:autoAcceptAlerts`| Accept all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
 |`appium:autoDismissAlerts`| Dismiss all iOS alerts automatically if they pop up. This includes privacy access permission alerts (e.g., location, contacts, photos). Default is `false`. |`true` or `false`|
 |`appium:disableAutomaticScreenshots`| Disable automatic screenshots taken by XCTest at every interaction. Default is up to `WebDriverAgent`'s config to decide, which currently defaults to `true`. |`true` or `false`|
-|`appium:shouldTerminateApp`| Specify if the app should be terminated on session end (when `bundleId` is provided). Default is `true`. |`true` or `false`|
+|`appium:shouldTerminateApp`| Specify if the app should be terminated on session end. This capability only has an effect if an application identifier has been passed to the test session (either explicitly, by setting bundleId, or implicitly, by providing app). Default is `true`. |`true` or `false`|
 
 ### Simulator
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -244,6 +244,9 @@ let desiredCapConstraints = _.defaults({
   },
   disableAutomaticScreenshots: {
     isBoolean: true,
+  },
+  shouldTerminateApp: {
+    isBoolean: true,
   }
 }, iosDesiredCapConstraints);
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -957,6 +957,7 @@ class XCUITestDriver extends BaseDriver {
       shouldUseCompactResponses: this.opts.shouldUseCompactResponses,
       elementResponseFields: this.opts.elementResponseFields,
       disableAutomaticScreenshots: this.opts.disableAutomaticScreenshots,
+      shouldTerminateApp: this.opts.shouldTerminateApp ?? true
     };
     if (this.opts.autoAcceptAlerts) {
       wdaCaps.defaultAlertAction = 'accept';

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "appium-ios-simulator": "^3.25.1",
     "appium-remote-debugger": "^8.13.2",
     "appium-support": "^2.47.1",
-    "appium-webdriveragent": "^3.6.0",
+    "appium-webdriveragent": "^3.7.0",
     "appium-xcode": "^3.8.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -16,6 +16,7 @@ describe('language and locale', function () {
     shouldWaitForQuiescence: true,
     shouldUseTestManagerForVisibilityDetection: false,
     maxTypingFrequency: 60,
+    shouldTerminateApp: true,
     shouldUseSingletonTestManager: true,
     eventloopIdleDelaySec: 0,
     environment: {},

--- a/test/unit/processargs-specs.js
+++ b/test/unit/processargs-specs.js
@@ -17,6 +17,7 @@ describe('process args', function () {
     shouldWaitForQuiescence: true,
     shouldUseTestManagerForVisibilityDetection: false,
     maxTypingFrequency: 60,
+    shouldTerminateApp: true,
     shouldUseSingletonTestManager: true,
     eventloopIdleDelaySec: 0,
   };


### PR DESCRIPTION
To specify if the app should be terminated on session end (when `bundleId` is present). The default is `true` to be consistent with the existing behaviour.

Depends on: https://github.com/appium/WebDriverAgent/pull/486