### PR TITLE
chore: Disable IDB-related e2e tests

### DIFF
--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -72,13 +72,14 @@ jobs:
       script: |
         npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/tv -g @skip-ci -i --exit
 
-  - template: ./ios-e2e-template.yml
-    parameters:
-      name: e2e_basic_idb_${{ parameters.name }}
-      iosVersion: ${{ parameters.iosVersion }}
-      xcodeVersion: ${{ parameters.xcodeVersion }}
-      deviceName: ${{ parameters.deviceName }}
-      launchWithIDB: true
-      script: |
-        npm install --no-save mjpeg-consumer
-        npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/basic -g @skip-ci -i --exit
+  # FIXME: these tests always fail with a timeout
+  # - template: ./ios-e2e-template.yml
+  #   parameters:
+  #     name: e2e_basic_idb_${{ parameters.name }}
+  #     iosVersion: ${{ parameters.iosVersion }}
+  #     xcodeVersion: ${{ parameters.xcodeVersion }}
+  #     deviceName: ${{ parameters.deviceName }}
+  #     launchWithIDB: true
+  #     script: |
+  #       npm install --no-save mjpeg-consumer
+  #       npx mocha --timeout 480000 --reporter mocha-multi-reporters --reporter-options configFile=$(Build.SourcesDirectory)/ci-jobs/mocha-config.json --recursive build/test/functional/basic -g @skip-ci -i --exit


### PR DESCRIPTION
These tests are always failing because of timeouts. I don't see any value in them unless they could be fixed.