### PR TITLE
chore: Deprecate `element` in favour of `elementId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ one to select or value selection suing `sendKeys` API does not work because of a
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | yes | PickerWheel's internal element id (as hexadecimal hash string) to perform value selection on. The element must be of type XCUIElementTypePickerWheel | abcdef12-1111-2222-3333-444444
+elementId (`element` before version 1.22) | string | yes | PickerWheel's internal element id (as hexadecimal hash string) to perform value selection on. The element must be of type XCUIElementTypePickerWheel | abcdef12-1111-2222-3333-444444
 order | string | yes | Either `next` to select the value next to the current one from the target picker wheel or `previous` to select the previous one. | next
 offset | number | no | The value in range [0.01, 0.5]. It defines how far from picker wheel's center the click should happen. The actual distance is calculated by multiplying this value to the actual picker wheel height. Too small offset value may not change the picker wheel value and too high value may cause the wheel to switch two or more values at once. Usually the optimal value is located in range [0.15, 0.3]. `0.2` by default | 0.15
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -6,6 +6,16 @@ import log from '../logger';
 
 const helpers = {}, extensions = {}, commands = {};
 
+function toElementId (opts = {}) {
+  const el = opts.elementId || opts.element;
+  return el ? util.unwrapElement(el) : null;
+}
+
+async function toElementOrApplicationId (driver, opts = {}) {
+  return toElementId(opts)
+    || util.unwrapElement(await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false));
+}
+
 commands.moveTo = async function moveTo (el, xoffset = 0, yoffset = 0) {
   el = util.unwrapElement(el);
 
@@ -20,7 +30,7 @@ commands.moveTo = async function moveTo (el, xoffset = 0, yoffset = 0) {
     let relCoords = {x: xoffset, y: yoffset};
     await this.executeAtom('move_mouse', [atomsElement, relCoords]);
   } else {
-    if (_.isNull(el) || _.isUndefined(el)) {
+    if (_.isNil(el)) {
       if (!this.curCoords) {
         throw new errors.UnknownException(
           'Current cursor position unknown, please use moveTo with an element the first time.');
@@ -41,22 +51,22 @@ commands.moveTo = async function moveTo (el, xoffset = 0, yoffset = 0) {
 
 function requireFloatParameter (paramName, paramValue, methodName) {
   if (_.isUndefined(paramValue)) {
-    log.errorAndThrow(`"${paramName}" parameter is mandatory for "${methodName}" call`);
+    throw new errors.InvalidArgumentError(`"${paramName}" parameter is mandatory for "${methodName}" call`);
   }
   const result = parseFloat(paramValue);
   if (isNaN(result)) {
-    log.errorAndThrow(`"${paramName}" parameter should be a valid number. "${paramValue}" is given instead`);
+    throw new errors.InvalidArgumentError(`"${paramName}" parameter should be a valid number. "${paramValue}" is given instead`);
   }
   return result;
 }
 
 function requireIntParameter (paramName, paramValue, methodName) {
   if (_.isUndefined(paramValue)) {
-    log.errorAndThrow(`"${paramName}" parameter is mandatory for "${methodName}" call`);
+    throw new errors.InvalidArgumentError(`"${paramName}" parameter is mandatory for "${methodName}" call`);
   }
   const result = parseInt(paramValue, 10);
   if (isNaN(result)) {
-    log.errorAndThrow(`"${paramName}" parameter should be a valid integer. "${paramValue}" is given instead`);
+    throw new errors.InvalidArgumentError(`"${paramName}" parameter should be a valid integer. "${paramValue}" is given instead`);
   }
   return result;
 }
@@ -164,12 +174,9 @@ commands.nativeClick = async function nativeClick (el) {
 */
 
 helpers.mobileScroll = async function mobileScroll (opts = {}, swipe = false) {
-  if (!opts.element) {
-    opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
-  }
   // WDA supports four scrolling strategies: predication based on name, direction,
   // predicateString, and toVisible, in that order. Swiping requires direction.
-  let params = {};
+  const params = {};
   if (opts.name && !swipe) {
     params.name = opts.name;
   } else if (opts.direction) {
@@ -183,10 +190,10 @@ helpers.mobileScroll = async function mobileScroll (opts = {}, swipe = false) {
   } else if (opts.toVisible && !swipe) {
     params.toVisible = opts.toVisible;
   } else {
-    let msg = swipe
+    const msg = swipe
       ? 'Mobile swipe requires direction'
       : 'Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. Specify one of these';
-    log.errorAndThrow(msg);
+    throw new errors.InvalidArgumentError(msg);
   }
 
   // we can also optionally pass a distance which appears to be a ratio of
@@ -195,8 +202,8 @@ helpers.mobileScroll = async function mobileScroll (opts = {}, swipe = false) {
     params.distance = opts.distance;
   }
 
-  let element = util.unwrapElement(opts.element);
-  let endpoint = `/wda/element/${element}/${swipe ? 'swipe' : 'scroll'}`;
+  const elementId = await toElementOrApplicationId(this, opts);
+  const endpoint = `/wda/element/${elementId}/${swipe ? 'swipe' : 'scroll'}`;
   return await this.proxyCommand(endpoint, 'POST', params);
 };
 
@@ -205,22 +212,19 @@ helpers.mobileSwipe = async function mobileSwipe (opts = {}) {
 };
 
 helpers.mobilePinch = async function mobilePinch (opts = {}) {
-  if (!opts.element) {
-    opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
-  }
   const params = {
     scale: requireFloatParameter('scale', opts.scale, 'pinch'),
     velocity: requireFloatParameter('velocity', opts.velocity, 'pinch')
   };
-  const el = util.unwrapElement(opts.element);
-  return await this.proxyCommand(`/wda/element/${el}/pinch`, 'POST', params);
+  const elementId = await toElementOrApplicationId(this, opts);
+  return await this.proxyCommand(`/wda/element/${elementId}/pinch`, 'POST', params);
 };
 
 helpers.mobileDoubleTap = async function mobileDoubleTap (opts = {}) {
-  if (opts.element) {
+  const elementId = toElementId(opts);
+  if (elementId) {
     // Double tap element
-    const el = util.unwrapElement(opts.element);
-    return await this.proxyCommand(`/wda/element/${el}/doubleTap`, 'POST');
+    return await this.proxyCommand(`/wda/element/${elementId}/doubleTap`, 'POST');
   }
   // Double tap coordinates
   const params = {
@@ -231,21 +235,18 @@ helpers.mobileDoubleTap = async function mobileDoubleTap (opts = {}) {
 };
 
 helpers.mobileTwoFingerTap = async function mobileTwoFingerTap (opts = {}) {
-  if (!opts.element) {
-    opts.element = await this.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false);
-  }
-  const el = util.unwrapElement(opts.element);
-  return await this.proxyCommand(`/wda/element/${el}/twoFingerTap`, 'POST');
+  const elementId = await toElementOrApplicationId(this, opts);
+  return await this.proxyCommand(`/wda/element/${elementId}/twoFingerTap`, 'POST');
 };
 
 helpers.mobileTouchAndHold = async function mobileTouchAndHold (opts = {}) {
-  let params = {
+  const params = {
     duration: requireFloatParameter('duration', opts.duration, 'touchAndHold')
   };
-  if (opts.element) {
+  const elementId = toElementId(opts);
+  if (elementId) {
     // Long tap element
-    const el = util.unwrapElement(opts.element);
-    return await this.proxyCommand(`/wda/element/${el}/touchAndHold`, 'POST', params);
+    return await this.proxyCommand(`/wda/element/${elementId}/touchAndHold`, 'POST', params);
   }
   // Long tap coordinates
   params.x = requireFloatParameter('x', opts.x, 'touchAndHold');
@@ -258,8 +259,8 @@ helpers.mobileTap = async function mobileTap (opts = {}) {
     x: requireFloatParameter('x', opts.x, 'tap'),
     y: requireFloatParameter('y', opts.y, 'tap')
   };
-  const el = opts.element ? (util.unwrapElement(opts.element)) : '0';
-  return await this.proxyCommand(`/wda/tap/${el}`, 'POST', params);
+  const elementId = toElementId(opts) || '0';
+  return await this.proxyCommand(`/wda/tap/${elementId}`, 'POST', params);
 };
 
 helpers.mobileDragFromToForDuration = async function mobileDragFromToForDuration (opts = {}) {
@@ -270,58 +271,56 @@ helpers.mobileDragFromToForDuration = async function mobileDragFromToForDuration
     toX: requireFloatParameter('toX', opts.toX, 'dragFromToForDuration'),
     toY: requireFloatParameter('toY', opts.toY, 'dragFromToForDuration')
   };
-  if (opts.element) {
+  const elementId = toElementId(opts);
+  if (elementId) {
     // Drag element
-    const el = util.unwrapElement(opts.element);
-    return await this.proxyCommand(`/wda/element/${el}/dragfromtoforduration`, 'POST', params);
+    return await this.proxyCommand(`/wda/element/${elementId}/dragfromtoforduration`, 'POST', params);
   }
   // Drag coordinates
   return await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
 };
 
 helpers.mobileTapWithNumberOfTaps = async function mobileTapWithNumberOfTaps (opts = {}) {
-  if (!opts.element) {
-    log.errorAndThrow('Element id is expected to be set for tapWithNumberOfTaps method');
+  const elementId = toElementId(opts);
+  if (!elementId) {
+    throw new errors.InvalidArgumentError('Element id is expected to be set for tapWithNumberOfTaps method');
   }
   const params = {
     numberOfTaps: requireIntParameter('numberOfTaps', opts.numberOfTaps, 'tapWithNumberOfTaps'),
     numberOfTouches: requireIntParameter('numberOfTouches', opts.numberOfTouches, 'tapWithNumberOfTaps'),
   };
-  const el = util.unwrapElement(opts.element);
-  return await this.proxyCommand(`/wda/element/${el}/tapWithNumberOfTaps`, 'POST', params);
+  return await this.proxyCommand(`/wda/element/${elementId}/tapWithNumberOfTaps`, 'POST', params);
 };
 
 helpers.mobileSelectPickerWheelValue = async function mobileSelectPickerWheelValue (opts = {}) {
-  if (!opts.element) {
-    log.errorAndThrow('Element id is expected to be set for selectPickerWheelValue method');
+  const elementId = toElementId(opts);
+  if (elementId) {
+    throw new errors.InvalidArgumentError('Element id is expected to be set for selectPickerWheelValue method');
   }
   if (!_.isString(opts.order) || !['next', 'previous'].includes(opts.order.toLowerCase())) {
-    log.errorAndThrow(`The mandatory 'order' parameter is expected to be equal either to 'next' or 'previous'. ` +
-                      `'${opts.order}' is given instead`);
+    throw new errors.InvalidArgumentError(`The mandatory 'order' parameter is expected to be equal either to 'next' or 'previous'. ` +
+      `'${opts.order}' is given instead`);
   }
-  const el = util.unwrapElement(opts.element);
   const params = {order: opts.order};
   if (opts.offset) {
     params.offset = requireFloatParameter('offset', opts.offset, 'selectPickerWheelValue');
   }
-  return await this.proxyCommand(`/wda/pickerwheel/${el}/select`, 'POST', params);
+  return await this.proxyCommand(`/wda/pickerwheel/${elementId}/select`, 'POST', params);
 };
 
 helpers.mobileRotateElement = async function mobileRotateElement (opts = {}) {
-  if (!opts.element) {
-    log.errorAndThrow('Element id is expected to be set for rotateElement method');
+  const elementId = toElementId(opts);
+  if (elementId) {
+    throw new errors.InvalidArgumentError('Element id is expected to be set for rotateElement method');
   }
-  const el = util.unwrapElement(opts.element);
   const params = {
     rotation: requireFloatParameter('rotation', opts.rotation, 'rotateElement'),
     velocity: requireFloatParameter('velocity', opts.velocity, 'rotateElement'),
   };
-  return await this.proxyCommand(`/wda/element/${el}/rotate`, 'POST', params);
+  return await this.proxyCommand(`/wda/element/${elementId}/rotate`, 'POST', params);
 };
 
 helpers.getCoordinates = async function getCoordinates (gesture) {
-  let el = gesture.options.element;
-
   // defaults
   let coordinates = {x: 0, y: 0, areOffsets: false};
 
@@ -335,8 +334,9 @@ helpers.getCoordinates = async function getCoordinates (gesture) {
   }
 
   // figure out the element coordinates.
-  if (el) {
-    let rect = await this.getElementRect(el);
+  const elementId = toElementId(gesture.options);
+  if (elementId) {
+    let rect = await this.getElementRect(elementId);
     let pos = {x: rect.x, y: rect.y};
     let size = {w: rect.width, h: rect.height};
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -7,6 +7,9 @@ import log from '../logger';
 const helpers = {}, extensions = {}, commands = {};
 
 function toElementId (opts = {}) {
+  if (opts.element) {
+    log.info(`The 'element' argument name is deprecated. Consider using 'elementId' instead`);
+  }
   const el = opts.elementId || opts.element;
   return el ? util.unwrapElement(el) : null;
 }

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -272,12 +272,11 @@ helpers.mobileDragFromToForDuration = async function mobileDragFromToForDuration
     toY: requireFloatParameter('toY', opts.toY, 'dragFromToForDuration')
   };
   const elementId = toElementId(opts);
-  if (elementId) {
+  return elementId
     // Drag element
-    return await this.proxyCommand(`/wda/element/${elementId}/dragfromtoforduration`, 'POST', params);
-  }
-  // Drag coordinates
-  return await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
+    ? await this.proxyCommand(`/wda/element/${elementId}/dragfromtoforduration`, 'POST', params)
+    // Drag coordinates
+    : await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
 };
 
 helpers.mobileTapWithNumberOfTaps = async function mobileTapWithNumberOfTaps (opts = {}) {
@@ -294,7 +293,7 @@ helpers.mobileTapWithNumberOfTaps = async function mobileTapWithNumberOfTaps (op
 
 helpers.mobileSelectPickerWheelValue = async function mobileSelectPickerWheelValue (opts = {}) {
   const elementId = toElementId(opts);
-  if (elementId) {
+  if (!elementId) {
     throw new errors.InvalidArgumentError('Element id is expected to be set for selectPickerWheelValue method');
   }
   if (!_.isString(opts.order) || !['next', 'previous'].includes(opts.order.toLowerCase())) {
@@ -310,7 +309,7 @@ helpers.mobileSelectPickerWheelValue = async function mobileSelectPickerWheelVal
 
 helpers.mobileRotateElement = async function mobileRotateElement (opts = {}) {
   const elementId = toElementId(opts);
-  if (elementId) {
+  if (!elementId) {
     throw new errors.InvalidArgumentError('Element id is expected to be set for rotateElement method');
   }
   const params = {


### PR DESCRIPTION
Related to https://github.com/appium/appium-uiautomator2-driver/pull/458 and https://github.com/appium/appium/issues/15392#issuecomment-844785946