### PR TITLE
fix: lowercase in name command

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -40,7 +40,7 @@ commands.getName = async function getName (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
     const atomsElement = this.useAtomsElement(el);
-    const script = 'return arguments[0].tagName';
+    const script = 'return arguments[0].tagName.toLowerCase()';
     return await this.executeAtom('execute_script', [script, [atomsElement]]);
   }
 


### PR DESCRIPTION
As a part of decoupling appium ios driver in https://github.com/appium/appium-xcuitest-driver/pull/1297
When the getName method was moved, toLowerCase() was missing which was originally present in [appium-ios-driver](https://github.com/appium/appium-ios-driver/blob/9755e309af6f5cbd4a895ca3f157650a943eff5b/lib/commands/element.js#L124) thus causing a parity in the behavior of some of the test scripts.