### PR TITLE
chore: Improve the logic for the alert checking in web context

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -27,8 +27,8 @@ const NOTCHED_DEVICE_SIZES = [
 const ELEMENT_OFFSET = 5000;
 const { W3C_WEB_ELEMENT_IDENTIFIER } = util;
 
-const ATOM_WAIT_TIMEOUT = 2 * 60000;
-const ATOM_WAIT_ALERT_WAIT = 400;
+const ATOM_WAIT_TIMEOUT_MS = 2 * 60000;
+const ATOM_INITIAL_WAIT_MS = 400;
 
 const commands = {}, helpers = {}, extensions = {};
 
@@ -565,56 +565,57 @@ extensions.waitForAtom = async function waitForAtom (promise) {
 
   // need to check for alert while the atom is being executed.
   // so notify ourselves when it happens
-  let done = false;
-  let error = null;
-  promise = B.resolve(promise) // eslint-disable-line promise/catch-or-return
-    .timeout(ATOM_WAIT_TIMEOUT)
-    .catch(function (err) { // eslint-disable-line promise/prefer-await-to-callbacks
-      log.debug(`Error received while executing atom: ${err.message}`);
-      if (err instanceof B.TimeoutError) {
-        err = new Error(`Did not get any response for atom execution after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
-      }
-      // save and check later, or an Unhandled rejection will be reported
-      error = err;
-    })
-    .finally(function () {
-      done = true;
-    });
-
-  // try ten times to check alert
-  for (let i = 0; i < 10; i++) {
-    // pause, or the atom promise is resolved
-    try {
-      await waitForCondition(() => done, {
-        waitMs: ATOM_WAIT_ALERT_WAIT,
-        intervalMs: 0, // just for the pause in execution
-      });
-      // `done` became true, so atom promise is resolved
-      break;
-    } catch (ign) {
-      // `done` never became true, so move on to trying to find an alert
+  const timedAtomPromise = B.resolve(promise).timeout(ATOM_WAIT_TIMEOUT_MS);
+  const handleAtomPromiseError = (err) => {
+    log.debug(`Error received while executing atom: ${err.message}`);
+    if (err instanceof B.TimeoutError) {
+      return new Error(`Did not get any response for atom execution after ` +
+        `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
     }
+    return err;
+  };
 
-    // check if there is an alert, or the atom promise is resolved
+  // pause, or the atom promise is resolved
+  try {
+    await waitForCondition(() => !timedAtomPromise.isPending(), {
+      waitMs: ATOM_INITIAL_WAIT_MS,
+      intervalMs: 0, // just for the pause in execution
+    });
+  } catch (ign) {
+    // move on to trying to find an alert
+  }
+
+  if (timedAtomPromise.isPending()) {
+    if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
+      this._webAlertChecker = async () => {
+        while (timedAtomPromise.isPending()) {
+          try {
+            if (await this.checkForAlert()) {
+              return true;
+            }
+          } catch (ign) {}
+        }
+        return false;
+      };
+    }
     try {
-      const res = await B.any([this.checkForAlert(), promise]);
-      if (error) {
-        throw error;
-      }
-      return this.parseExecuteResponse(res);
+      // check if there is an alert, or the atom promise is resolved
+      await B.any([this._webAlertChecker, timedAtomPromise]);
     } catch (err) {
-      // no alert found, so pass through
-      log.debug(`No alert found: ${err.message}`);
+      throw new handleAtomPromiseError(err);
+    }
+    if (timedAtomPromise.isPending() && await this._webAlertChecker) {
+      throw new errors.UnexpectedAlertOpenError();
     }
   }
 
   // at this point, all that can be done is wait for the atom promise to be
   // resolved
-  const res = await promise;
-  if (error) {
-    throw error;
+  try {
+    return this.parseExecuteResponse(await timedAtomPromise);
+  } catch (err) {
+    throw handleAtomPromiseError(err);
   }
-  return this.parseExecuteResponse(res);
 };
 
 extensions.mobileWebNav = async function mobileWebNav (navType) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -567,12 +567,13 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   // so notify ourselves when it happens
   const timedAtomPromise = B.resolve(promise).timeout(ATOM_WAIT_TIMEOUT_MS);
   const handleAtomPromiseError = (err) => {
-    log.debug(`Error received while executing atom: ${err.message}`);
-    if (err instanceof B.TimeoutError) {
+    const originalError = (err instanceof B.AggregateError) ? err[0] : err;
+    log.debug(`Error received while executing atom: ${originalError.message}`);
+    if (originalError instanceof B.TimeoutError) {
       return new Error(`Did not get any response for atom execution after ` +
         `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
     }
-    return err;
+    return originalError;
   };
 
   // pause, or the atom promise is resolved

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -586,9 +586,10 @@ extensions.waitForAtom = async function waitForAtom (promise) {
 
   // otherwise make sure there is no unexpected alert covering the element
   if (timedAtomPromise.isPending()) {
+    let shouldCheckForAlert = true;
     if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
       this._webAlertChecker = B.resolve(async () => {
-        while (timedAtomPromise.isPending()) {
+        while (shouldCheckForAlert && timedAtomPromise.isPending()) {
           try {
             if (await this.checkForAlert()) {
               return true;
@@ -600,6 +601,9 @@ extensions.waitForAtom = async function waitForAtom (promise) {
     }
     await handlePromiseError(B.any([this._webAlertChecker, timedAtomPromise]));
     if (timedAtomPromise.isPending() && await this._webAlertChecker) {
+      shouldCheckForAlert = false;
+      // To avoid unhandled exception error
+      timedAtomPromise.catch(() => {});
       throw new errors.UnexpectedAlertOpenError();
     }
   }

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -1,4 +1,4 @@
-import { retryInterval, waitForCondition } from 'asyncbox';
+import { retryInterval } from 'asyncbox';
 import { util, timing } from 'appium-support';
 import log from '../logger';
 import _ from 'lodash';
@@ -28,7 +28,7 @@ const ELEMENT_OFFSET = 5000;
 const { W3C_WEB_ELEMENT_IDENTIFIER } = util;
 
 const ATOM_WAIT_TIMEOUT_MS = 2 * 60000;
-const ATOM_INITIAL_WAIT_MS = 400;
+const ATOM_INITIAL_WAIT_MS = 1000;
 
 const commands = {}, helpers = {}, extensions = {};
 
@@ -566,26 +566,25 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   // need to check for alert while the atom is being executed.
   // so notify ourselves when it happens
   const timedAtomPromise = B.resolve(promise).timeout(ATOM_WAIT_TIMEOUT_MS);
-  const handleAtomPromiseError = (err) => {
-    const originalError = (err instanceof B.AggregateError) ? err[0] : err;
-    log.debug(`Error received while executing atom: ${originalError.message}`);
-    if (originalError instanceof B.TimeoutError) {
-      return new Error(`Did not get any response for atom execution after ` +
-        `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+  const handlePromiseError = async (p) => {
+    try {
+      return await p;
+    } catch (err) {
+      const originalError = (err instanceof B.AggregateError) ? err[0] : err;
+      log.debug(`Error received while executing atom: ${originalError.message}`);
+      if (originalError instanceof B.TimeoutError) {
+        throw new Error(`Did not get any response for atom execution after ` +
+          `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+      }
+      throw originalError;
     }
-    return originalError;
   };
 
-  // pause, or the atom promise is resolved
-  try {
-    await waitForCondition(() => !timedAtomPromise.isPending(), {
-      waitMs: ATOM_INITIAL_WAIT_MS,
-      intervalMs: 0, // just for the pause in execution
-    });
-  } catch (ign) {
-    // move on to trying to find an alert
-  }
+  // if the atom promise is fulfilled within ATOM_INITIAL_WAIT_MS
+  // then we don't need to check for an alert presence
+  await handlePromiseError(B.any([B.delay(ATOM_INITIAL_WAIT_MS), timedAtomPromise]));
 
+  // otherwise make sure there is no unexpected alert covering the element
   if (timedAtomPromise.isPending()) {
     if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
       this._webAlertChecker = B.resolve(async () => {
@@ -599,24 +598,15 @@ extensions.waitForAtom = async function waitForAtom (promise) {
         return false;
       });
     }
-    try {
-      // check if there is an alert, or the atom promise is resolved
-      await B.any([this._webAlertChecker, timedAtomPromise]);
-    } catch (err) {
-      throw new handleAtomPromiseError(err);
-    }
+    await handlePromiseError(B.any([this._webAlertChecker, timedAtomPromise]));
     if (timedAtomPromise.isPending() && await this._webAlertChecker) {
       throw new errors.UnexpectedAlertOpenError();
     }
   }
 
-  // at this point, all that can be done is wait for the atom promise to be
-  // resolved
-  try {
-    return this.parseExecuteResponse(await timedAtomPromise);
-  } catch (err) {
-    throw handleAtomPromiseError(err);
-  }
+  // at this point, all that can be done is wait for the atom promise
+  // to be fulfilled
+  return await handlePromiseError(timedAtomPromise);
 };
 
 extensions.mobileWebNav = async function mobileWebNav (navType) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -587,7 +587,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   // otherwise make sure there is no unexpected alert covering the element
   if (timedAtomPromise.isPending()) {
     if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
-      this._webAlertChecker = B.resolve(async () => {
+      this._webAlertChecker = B.resolve((async () => {
         while (timedAtomPromise.isPending()) {
           try {
             if (await this.checkForAlert()) {
@@ -596,7 +596,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
           } catch (ign) {}
         }
         return false;
-      });
+      })());
     }
     await handlePromiseError(B.any([this._webAlertChecker, timedAtomPromise]));
     if (timedAtomPromise.isPending() && await this._webAlertChecker) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -586,10 +586,9 @@ extensions.waitForAtom = async function waitForAtom (promise) {
 
   // otherwise make sure there is no unexpected alert covering the element
   if (timedAtomPromise.isPending()) {
-    let shouldCheckForAlert = true;
     if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
       this._webAlertChecker = B.resolve(async () => {
-        while (shouldCheckForAlert && timedAtomPromise.isPending()) {
+        while (timedAtomPromise.isPending()) {
           try {
             if (await this.checkForAlert()) {
               return true;
@@ -601,7 +600,6 @@ extensions.waitForAtom = async function waitForAtom (promise) {
     }
     await handlePromiseError(B.any([this._webAlertChecker, timedAtomPromise]));
     if (timedAtomPromise.isPending() && await this._webAlertChecker) {
-      shouldCheckForAlert = false;
       // To avoid unhandled exception error
       timedAtomPromise.catch(() => {});
       throw new errors.UnexpectedAlertOpenError();

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -587,7 +587,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
 
   if (timedAtomPromise.isPending()) {
     if (!this._webAlertChecker || !this._webAlertChecker.isPending()) {
-      this._webAlertChecker = async () => {
+      this._webAlertChecker = B.resolve(async () => {
         while (timedAtomPromise.isPending()) {
           try {
             if (await this.checkForAlert()) {
@@ -596,7 +596,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
           } catch (ign) {}
         }
         return false;
-      };
+      });
     }
     try {
       // check if there is an alert, or the atom promise is resolved


### PR DESCRIPTION
The previous implementation was creating multiple getAlertRequests requests, which were unnecessarily stacked to the WDA queue and eventually killing the server. This fix prevents that from happening and makes sure we only have single alert detection request at a time. 