### PR TITLE
fix: return offset properly in absoluteWebLocations

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -120,7 +120,9 @@ commands.getLocation = async function getLocation (el) {
     const atomsElement = await this.useAtomsElement(el);
     let loc = await this.executeAtom('get_top_left_coordinates', [atomsElement]);
     if (this.opts.absoluteWebLocations) {
-      const script = 'return [document.body.scrollLeft, document.body.scrollTop];';
+      const script = 'return [' +
+        'Math.max(window.pageXOffset,document.documentElement.scrollLeft,document.body.scrollLeft),' +
+        'Math.max(window.pageYOffset,document.documentElement.scrollTop,document.body.scrollTop)];';
       const [xOffset, yOffset] = await this.execute(script);
       loc.x += xOffset;
       loc.y += yOffset;


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/15675

I found `driver.execute_script 'return [document.body.scrollLeft, document.body.scrollTop];' ` was always zero while `driver.execute_script 'return [Math.max(window.pageXOffset, document.documentElement.scrollLeft, document.body.scrollLeft), Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop)];'` returns probably expected value.

On an iOS 15 real device,  pageXOffset and pageYOffset returned values but others were zero.