### PR TITLE
refactor: Change web elements caching logic

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -9,7 +9,7 @@ const commands = {}, extensions = {};
 commands.elementDisplayed = async function elementDisplayed (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     return await this.executeAtom('is_displayed', [atomsElement]);
   }
 
@@ -19,7 +19,7 @@ commands.elementDisplayed = async function elementDisplayed (el) {
 commands.elementEnabled = async function elementEnabled (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     return await this.executeAtom('is_enabled', [atomsElement]);
   }
 
@@ -29,7 +29,7 @@ commands.elementEnabled = async function elementEnabled (el) {
 commands.elementSelected = async function elementSelected (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     return await this.executeAtom('is_selected', [atomsElement]);
   }
 
@@ -39,7 +39,7 @@ commands.elementSelected = async function elementSelected (el) {
 commands.getName = async function getName (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     const script = 'return arguments[0].tagName.toLowerCase()';
     return await this.executeAtom('execute_script', [script, [atomsElement]]);
   }
@@ -71,9 +71,6 @@ commands.getAttribute = async function getAttribute (attribute, el) {
     return await this.getNativeAttribute(attribute, el);
   }
   const atomsElement = this.getAtomsElement(el);
-  if (_.isNull(atomsElement)) {
-    throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}`);
-  }
   return await this.executeAtom('get_attribute_value', [atomsElement, attribute]);
 };
 
@@ -83,9 +80,6 @@ commands.getProperty = async function getProperty (property, el) {
     return await this.getNativeAttribute(property, el);
   }
   const atomsElement = this.getAtomsElement(el);
-  if (_.isNull(atomsElement)) {
-    throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}`);
-  }
   return await this.executeAtom('get_attribute_value', [atomsElement, property]);
 };
 
@@ -94,7 +88,7 @@ commands.getText = async function getText (el) {
   if (!this.isWebContext()) {
     return await this.proxyCommand(`/element/${el}/text`, 'GET');
   }
-  let atomsElement = this.useAtomsElement(el);
+  let atomsElement = this.getAtomsElement(el);
   return await this.executeAtom('get_text', [atomsElement]);
 };
 
@@ -117,7 +111,7 @@ extensions.getNativeRect = async function getNativeRect (el) {
 commands.getLocation = async function getLocation (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = await this.useAtomsElement(el);
+    const atomsElement = await this.getAtomsElement(el);
     let loc = await this.executeAtom('get_top_left_coordinates', [atomsElement]);
     if (this.opts.absoluteWebLocations) {
       const script = 'return [' +
@@ -141,11 +135,7 @@ commands.getLocationInView = async function getLocationInView (el) {
 commands.getSize = async function getSize (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    let atomsElement = this.getAtomsElement(el);
-    if (atomsElement === null) {
-      throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}'`);
-    }
-    return await this.executeAtom('get_size', [atomsElement]);
+    return await this.executeAtom('get_size', [this.getAtomsElement(el)]);
   }
 
   const rect = await this.getElementRect(el);
@@ -205,7 +195,7 @@ commands.setValue = async function setValue (value, el) {
     return;
   }
 
-  const atomsElement = this.useAtomsElement(el);
+  const atomsElement = this.getAtomsElement(el);
   await this.executeAtom('click', [atomsElement]);
   await this.executeAtom('type', [atomsElement, value]);
 };
@@ -219,7 +209,7 @@ commands.keys = async function keys (value) {
 commands.clear = async function clear (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     await this.executeAtom('clear', [atomsElement]);
     return;
   }

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -14,7 +14,7 @@ const MOMENT_FORMAT_ISO8601 = 'YYYY-MM-DDTHH:mm:ssZ';
 
 commands.active = async function active () {
   if (this.isWebContext()) {
-    return await this.executeAtom('active_element', []);
+    return this.cacheWebElements(await this.executeAtom('active_element', []));
   }
   return await this.proxyCommand(`/element/active`, 'GET');
 };

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -29,7 +29,7 @@ commands.moveTo = async function moveTo (el, xoffset = 0, yoffset = 0) {
       y: y + yoffset
     };
     this.curWebCoords = coords;
-    let atomsElement = this.useAtomsElement(el);
+    let atomsElement = this.getAtomsElement(el);
     let relCoords = {x: xoffset, y: yoffset};
     await this.executeAtom('move_mouse', [atomsElement, relCoords]);
   } else {
@@ -92,7 +92,7 @@ commands.click = async function click (el) {
     log.debug('Using native web tap');
     await this.nativeWebTap(el);
   } else {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     return await this.executeAtom('click', [atomsElement]);
   }
 };

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -45,7 +45,7 @@ commands.getScreenshot = async function getScreenshot () {
 commands.getElementScreenshot = async function getElementScreenshot (el) {
   el = util.unwrapElement(el);
   if (this.isWebContext()) {
-    const atomsElement = this.useAtomsElement(el);
+    const atomsElement = this.getAtomsElement(el);
     return await this.executeAtom('getElementScreenshot', [atomsElement]);
   }
 

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -24,13 +24,25 @@ const NOTCHED_DEVICE_SIZES = [
   {w: 1242, h: 2688}, // 11 Pro Max, Xs Max
 ];
 
-const ELEMENT_OFFSET = 5000;
 const { W3C_WEB_ELEMENT_IDENTIFIER } = util;
 
 const ATOM_WAIT_TIMEOUT_MS = 2 * 60000;
 const ATOM_INITIAL_WAIT_MS = 1000;
 
 const commands = {}, helpers = {}, extensions = {};
+
+function isValidElementIdentifier (id) {
+  if (!_.isString(id) && !_.isNumber(id)) {
+    return false;
+  }
+  if (_.isString(id) && _.isEmpty(id)) {
+    return false;
+  }
+  if (_.isNumber(id) && isNaN(id)) {
+    return false;
+  }
+  return true;
+}
 
 commands.setFrame = async function setFrame (frame) {
   if (!this.isWebContext()) {
@@ -44,13 +56,13 @@ commands.setFrame = async function setFrame (frame) {
   }
 
   if (helpers.hasElementId(frame)) {
-    let atomsElement = this.useAtomsElement(helpers.getElementId(frame));
-    let value = await this.executeAtom('get_frame_window', [atomsElement]);
+    const atomsElement = this.getAtomsElement(frame);
+    const value = await this.executeAtom('get_frame_window', [atomsElement]);
     log.debug(`Entering new web frame: '${value.WINDOW}'`);
     this.curWebFrames.unshift(value.WINDOW);
   } else {
     const atom = _.isNumber(frame) ? 'frame_by_index' : 'frame_by_id_or_name';
-    let value = await this.executeAtom(atom, [frame]);
+    const value = await this.executeAtom(atom, [frame]);
     if (_.isNull(value) || _.isUndefined(value.WINDOW)) {
       throw new errors.NoSuchFrameError();
     }
@@ -64,7 +76,7 @@ commands.getCssProperty = async function getCssProperty (propertyName, el) {
     throw new errors.NotImplementedError();
   }
 
-  const atomsElement = this.useAtomsElement(el);
+  const atomsElement = this.getAtomsElement(el);
   return await this.executeAtom('get_value_of_css_property', [atomsElement, propertyName]);
 };
 
@@ -73,7 +85,7 @@ commands.submit = async function submit (el) {
     throw new errors.NotImplementedError();
   }
 
-  const atomsElement = this.useAtomsElement(el);
+  const atomsElement = this.getAtomsElement(el);
   await this.executeAtom('submit', [atomsElement]);
 };
 
@@ -183,11 +195,30 @@ helpers._deleteCookie = async function _deleteCookie (cookieName) {
   await this.executeAtom('execute_script', [script, []]);
 };
 
+helpers.cacheWebElements = function cacheWebElements (rawElements) {
+  if (!(_.isArray(rawElements) || _.isPlainObject(rawElements))) {
+    throw new errors.UnknownError(`Web element identifiers cannot be parsed from ` +
+      JSON.stringify(rawElements));
+  }
+
+  const cacheElement = (el) => {
+    const elId = util.unwrapElement(el);
+    if (!isValidElementIdentifier(elId)) {
+      throw new errors.UnknownError(`The web element identifier ${JSON.stringify(elId)} cannot be parsed`);
+    }
+    const localId = util.uuidV4();
+    this.webElementsCache.set(localId, elId);
+    return util.wrapElement(localId);
+  };
+
+  return _.isArray(rawElements) ? rawElements.map(cacheElement) : cacheElement(rawElements);
+};
+
 extensions.findWebElementOrElements = async function findWebElementOrElements (strategy, selector, many, ctx) {
-  let atomsElement = this.getAtomsElement(ctx);
+  const contextElement = _.isNil(ctx) ? null : this.getAtomsElement(ctx);
   let element;
   let doFind = async () => {
-    element = await this.executeAtom(`find_element${many ? 's' : ''}`, [strategy, selector, atomsElement]);
+    element = await this.executeAtom(`find_element${many ? 's' : ''}`, [strategy, selector, contextElement]);
     return !_.isNull(element);
   };
   try {
@@ -202,13 +233,12 @@ extensions.findWebElementOrElements = async function findWebElementOrElements (s
   }
 
   if (many) {
-    return element;
-  } else {
-    if (!element || _.size(element) === 0) {
-      throw new errors.NoSuchElementError();
-    }
-    return element;
+    return this.cacheWebElements(element);
   }
+  if (!element || _.size(element) === 0) {
+    throw new errors.NoSuchElementError();
+  }
+  return this.cacheWebElements(element);
 };
 
 extensions.clickWebCoords = async function clickWebCoords () {
@@ -231,43 +261,19 @@ helpers.executeAtomAsync = async function executeAtomAsync (atom, args, response
   return await this.waitForAtom(promise);
 };
 
-helpers.getAtomsElement = function getAtomsElement (wdId) {
-  let atomsId;
-  try {
-    atomsId = this.webElementIds[parseInt(wdId, 10) - ELEMENT_OFFSET];
-  } catch (e) {
-    return null;
+helpers.getAtomsElement = function getAtomsElement (elOrId) {
+  const elId = util.unwrapElement(elOrId);
+  if (!this.webElementsCache.has(elId)) {
+    throw new errors.StaleElementReferenceError();
   }
-  if (_.isUndefined(atomsId)) {
-    return null;
-  }
-  return {ELEMENT: atomsId};
-};
-
-helpers.useAtomsElement = function useAtomsElement (el) {
-  if (parseInt(el, 10) < ELEMENT_OFFSET) {
-    log.debug(`Element with id '${el}' passed in for use with ` +
-      `atoms, but it's out of our internal scope. Adding ${ELEMENT_OFFSET}.`);
-    el = (parseInt(el, 10) + ELEMENT_OFFSET).toString();
-  }
-  let atomsElement = this.getAtomsElement(el);
-  if (atomsElement === null) {
-    throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${el}'`);
-  }
-  return atomsElement;
+  return {ELEMENT: this.webElementsCache.get(elId)};
 };
 
 helpers.convertElementsForAtoms = function convertElementsForAtoms (args = []) {
   const resultArgs = [];
   for (const arg of args) {
     if (helpers.hasElementId(arg)) {
-      // Get the element key from W3C or MJSONWP key
-      const elementId = helpers.getElementId(arg);
-      const atomsElement = this.getAtomsElement(elementId);
-      if (atomsElement === null) {
-        throw new errors.UnknownError(`Error converting element ID for using in WD atoms: '${elementId}'`);
-      }
-      resultArgs.push(atomsElement);
+      resultArgs.push(this.getAtomsElement(arg));
     } else if (_.isArray(arg)) {
       resultArgs.push(this.convertElementsForAtoms(arg));
     } else {
@@ -275,45 +281,6 @@ helpers.convertElementsForAtoms = function convertElementsForAtoms (args = []) {
     }
   }
   return resultArgs;
-};
-
-helpers.parseExecuteResponse = function parseExecuteResponse (res) {
-  if (_.isNull(res) || _.isUndefined(res)) return null; // eslint-disable-line curly
-
-  let wdElement = null;
-  if (!_.isArray(res)) {
-    if (helpers.hasElementId(res)) {
-      wdElement = this.parseElementResponse(res);
-      if (wdElement === null) {
-        throw new errors.UnknownError(`Error converting element ID atom for using in WD: '${helpers.getElementId(res)}'`);
-      }
-      res = wdElement;
-    }
-  } else {
-    // value is an array, so go through and convert each
-    let args = [];
-    for (let arg of res) {
-      wdElement = arg;
-      if (helpers.hasElementId(arg)) {
-        wdElement = this.parseElementResponse(arg);
-        if (wdElement === null) {
-          throw new errors.UnknownError(`Error converting element ID atom for using in WD: '${helpers.getElementId(arg)}'`);
-        }
-        args.push(wdElement);
-      } else {
-        args.push(arg);
-      }
-    }
-    res = args;
-  }
-  return res;
-};
-
-helpers.parseElementResponse = function parseElementResponse (element) {
-  let objId = helpers.getElementId(element);
-  let clientId = (ELEMENT_OFFSET + this.webElementIds.length).toString();
-  this.webElementIds.push(objId);
-  return {ELEMENT: clientId};
 };
 
 helpers.getElementId = function getElementId (element) {
@@ -471,7 +438,7 @@ async function tapWebElementNatively (driver, atomsElement) {
 }
 
 extensions.nativeWebTap = async function nativeWebTap (el) {
-  const atomsElement = this.useAtomsElement(el);
+  const atomsElement = this.getAtomsElement(el);
 
   // if strict native tap, do not try to do it with WDA directly
   if (!(await this.settings.getSettings()).nativeWebTapStrict && await tapWebElementNatively(this, atomsElement)) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -272,25 +272,19 @@ helpers.getAtomsElement = function getAtomsElement (elOrId) {
 };
 
 helpers.convertElementsForAtoms = function convertElementsForAtoms (args = []) {
-  const resultArgs = [];
-  for (const arg of args) {
+  return args.map((arg) => {
     if (helpers.hasElementId(arg)) {
-      let convertedElement = arg;
       try {
-        convertedElement = this.getAtomsElement(arg);
+        return this.getAtomsElement(arg);
       } catch (err) {
         if (!isErrorType(err, errors.StaleElementReferenceError)) {
           throw err;
         }
       }
-      resultArgs.push(convertedElement);
-    } else if (_.isArray(arg)) {
-      resultArgs.push(this.convertElementsForAtoms(arg));
-    } else {
-      resultArgs.push(arg);
+      return arg;
     }
-  }
-  return resultArgs;
+    return _.isArray(arg) ? this.convertElementsForAtoms(arg) : arg;
+  });
 };
 
 helpers.getElementId = function getElementId (element) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -206,9 +206,11 @@ helpers.cacheWebElements = function cacheWebElements (rawElements) {
     if (!isValidElementIdentifier(elId)) {
       throw new errors.UnknownError(`The web element identifier ${JSON.stringify(elId)} cannot be parsed`);
     }
-    const localId = util.uuidV4();
-    this.webElementsCache.set(localId, elId);
-    return util.wrapElement(localId);
+    // In newer debugger releases element identifiers look like `:wdc:1628151649325`
+    // We assume it is safe to use these to identify cached elements
+    const cacheId = _.includes(elId, ':') ? elId : util.uuidV4();
+    this.webElementsCache.set(cacheId, elId);
+    return util.wrapElement(cacheId);
   };
 
   return _.isArray(rawElements) ? rawElements.map(cacheElement) : cacheElement(rawElements);

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -3,7 +3,7 @@ import { util, timing } from 'appium-support';
 import log from '../logger';
 import _ from 'lodash';
 import B from 'bluebird';
-import { errors } from 'appium-base-driver';
+import { errors, isErrorType } from 'appium-base-driver';
 import cookieUtils from '../cookies';
 
 const IPHONE_TOP_BAR_HEIGHT = 71;
@@ -275,7 +275,15 @@ helpers.convertElementsForAtoms = function convertElementsForAtoms (args = []) {
   const resultArgs = [];
   for (const arg of args) {
     if (helpers.hasElementId(arg)) {
-      resultArgs.push(this.getAtomsElement(arg));
+      let convertedElement = arg;
+      try {
+        convertedElement = this.getAtomsElement(arg);
+      } catch (err) {
+        if (!isErrorType(err, errors.StaleElementReferenceError)) {
+          throw err;
+        }
+      }
+      resultArgs.push(convertedElement);
     } else if (_.isArray(arg)) {
       resultArgs.push(this.convertElementsForAtoms(arg));
     } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import url from 'url';
 import { WebDriverAgent } from 'appium-webdriveragent';
 import log from './logger';
+import LRU from 'lru-cache';
 import {
   createSim, getExistingSim, runSimulatorReset, installToSimulator,
   shutdownOtherSimulators, shutdownSimulator, setLocaleAndPreferences
@@ -67,6 +68,7 @@ const DEFAULT_SETTINGS = {
 // This lock assures, that each driver session does not
 // affect shared resources of the other parallel sessions
 const SHARED_RESOURCES_GUARD = new AsyncLock();
+const WEB_ELEMENTS_CACHE_SIZE = 500;
 
 /* eslint-disable no-useless-escape */
 const NO_PROXY_NATIVE_LIST = [
@@ -190,7 +192,6 @@ class XCUITestDriver extends BaseDriver {
     this.cachedWdaStatus = null;
 
     this.curWebFrames = [];
-    this.webElementIds = [];
     this._currentUrl = null;
     this.curContext = null;
     this.xcodeVersion = {};
@@ -200,6 +201,10 @@ class XCUITestDriver extends BaseDriver {
     this.pageLoadMs = 6000;
     this.landscapeWebCoordsOffset = 0;
     this.remote = null;
+
+    this.webElementsCache = new LRU({
+      max: WEB_ELEMENTS_CACHE_SIZE,
+    });
   }
 
   get driverData () {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "css-selector-parser": "^1.4.1",
     "js2xmlparser2": "^0.2.0",
     "lodash": "^4.17.10",
+    "lru-cache": "^6.0.0",
     "moment": "^2.24.0",
     "moment-timezone": "^0.x",
     "node-simctl": "^6.4.0",

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -269,7 +269,7 @@ describe('element commands', function () {
 
     before(function () {
       executeStub = sinon.stub(driver, 'execute').returns([fixtureXOffset, fixtureYOffset]);
-      atomsElStub = sinon.stub(driver, 'useAtomsElement').callsFake((el) => el);
+      atomsElStub = sinon.stub(driver, 'getAtomsElement').callsFake((el) => el);
       atomStub = sinon.stub(driver, 'executeAtom').returns({x: 0, y: 0});
       proxyStub = sinon.stub(driver, 'proxyCommand');
     });


### PR DESCRIPTION
The current logic is not very flexible and does not allow elements whose ids contain non-digit chars. Also it might potentially create a memory leak, because `this.webElementIds` array never gets shifted. 