### PR TITLE
fix: update build-wda script to a regular file

### DIFF
--- a/lib/build-wda.js
+++ b/lib/build-wda.js
@@ -1,0 +1,30 @@
+import { WebDriverAgent } from 'appium-webdriveragent';
+import { translateDeviceName, getAndCheckXcodeVersion, getAndCheckIosSdkVersion } from './utils';
+import { getExistingSim } from './simulator-management';
+import { asyncify } from 'asyncbox';
+
+const DEFAULT_SIM_NAME = 'iPhone 12';
+
+// TODO: allow passing in all the various build params as CLI args
+async function build () {
+  const xcodeVersion = await getAndCheckXcodeVersion();
+  const iosVersion = await getAndCheckIosSdkVersion();
+  const deviceName = translateDeviceName(iosVersion, DEFAULT_SIM_NAME);
+  const device = await getExistingSim({
+    platformVersion: iosVersion,
+    deviceName
+  });
+  const wda = new WebDriverAgent(xcodeVersion, {
+    iosSdkVersion: iosVersion,
+    platformVersion: iosVersion,
+    showXcodeLog: true,
+    device,
+  });
+  await wda.xcodebuild.start(true);
+}
+
+if (require.main === module) {
+  asyncify(build);
+}
+
+export default build;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ],
     "mainClass": "XCUITestDriver",
     "scripts": {
-      "build-wda": "./node_modules/appium-webdriveragent/Scripts/build-webdriveragent.js"
+      "build-wda": "./build/lib/build-wda.js"
     }
   },
   "main": "./build/index.js",


### PR DESCRIPTION
We can't rely on directory hierarchies to find the script within WDA.
Also, it turns out that what we wanted out of this script was different anyway.