### PR TITLE
fix: Pass velocity to `mobile: swipe` call

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -3,6 +3,7 @@ import { util } from 'appium-support';
 import _ from 'lodash';
 import log from '../logger';
 
+const SUPPORTED_GESTURE_DIRECTIONS = ['up', 'down', 'left', 'right'];
 
 const helpers = {}, extensions = {}, commands = {};
 
@@ -180,42 +181,56 @@ commands.nativeClick = async function nativeClick (el) {
  * all XCTest gestures
 */
 
-helpers.mobileScroll = async function mobileScroll (opts = {}, swipe = false) {
+helpers.mobileScroll = async function mobileScroll (opts = {}) {
   // WDA supports four scrolling strategies: predication based on name, direction,
-  // predicateString, and toVisible, in that order. Swiping requires direction.
+  // predicateString, and toVisible, in that order
+  const {
+    name,
+    direction,
+    predicateString,
+    toVisible,
+    distance,
+  } = opts;
   const params = {};
-  if (opts.name && !swipe) {
-    params.name = opts.name;
-  } else if (opts.direction) {
-    if (!['up', 'down', 'left', 'right'].includes(opts.direction.toLowerCase())) {
-      let msg = 'Direction must be up, down, left or right';
-      log.errorAndThrow(msg);
+  if (name) {
+    params.name = name;
+  } else if (direction) {
+    if (!SUPPORTED_GESTURE_DIRECTIONS.includes(_.toLower(direction))) {
+      throw new errors.InvalidArgumentError(`'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`);
     }
-    params.direction = opts.direction;
-  } else if (opts.predicateString && !swipe) {
-    params.predicateString = opts.predicateString;
-  } else if (opts.toVisible && !swipe) {
-    params.toVisible = opts.toVisible;
+    params.direction = direction;
+  } else if (predicateString) {
+    params.predicateString = predicateString;
+  } else if (toVisible) {
+    params.toVisible = toVisible;
   } else {
-    const msg = swipe
-      ? 'Mobile swipe requires direction'
-      : 'Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. Specify one of these';
-    throw new errors.InvalidArgumentError(msg);
+    throw new errors.InvalidArgumentError(
+      'Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. ' +
+      'Specify one of these');
   }
-
   // we can also optionally pass a distance which appears to be a ratio of
   // screen height, so 1.0 means a full screen's worth of scrolling
-  if (!swipe && opts.distance) {
-    params.distance = opts.distance;
+  if (!_.isNil(distance)) {
+    params.distance = distance;
   }
-
   const elementId = await toElementOrApplicationId(this, opts);
-  const endpoint = `/wda/element/${elementId}/${swipe ? 'swipe' : 'scroll'}`;
-  return await this.proxyCommand(endpoint, 'POST', params);
+  return await this.proxyCommand(`/wda/element/${elementId}/scroll`, 'POST', params);
 };
 
 helpers.mobileSwipe = async function mobileSwipe (opts = {}) {
-  return await this.mobileScroll(opts, true);
+  const {
+    direction,
+    velocity,
+  } = opts;
+  if (!SUPPORTED_GESTURE_DIRECTIONS.includes(_.toLower(direction))) {
+    throw new errors.InvalidArgumentError(`'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`);
+  }
+  const params = {direction};
+  if (!_.isNil(velocity)) {
+    params.velocity = velocity;
+  }
+  const elementId = await toElementOrApplicationId(this, opts);
+  return await this.proxyCommand(`/wda/element/${elementId}/swipe`, 'POST', params);
 };
 
 helpers.mobilePinch = async function mobilePinch (opts = {}) {

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -116,12 +116,12 @@ describe('gesture commands', function () {
 
       it('should throw an error if no direction is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4})
-          .should.eventually.be.rejectedWith(/Mobile swipe requires direction/);
+          .should.eventually.be.rejected;
       });
 
       it('should throw an error if invalid direction', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, direction: 'foo'})
-          .should.eventually.be.rejectedWith(/Direction must be up, down, left or right/);
+          .should.eventually.be.rejected;
       });
 
       it('should proxy a swipe up request through to WDA', async function () {


### PR DESCRIPTION
Addresses https://discuss.appium.io/t/cannot-use-velocity-in-ios-specific-gestures/34468