### PR TITLE
feat: add reset location service call in mobile command, and capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ e = @driver.find_element :id, 'target element'
 ### mobile: resetLocationService
 
 Reset the location service on real device since Appium 1.22.0.
+It could delay a few seconds to reflect the lcoation by system.
 It raises an error if the device is simulator or an error occurred during the reset.
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,10 @@ e = @driver.find_element :id, 'target element'
 #### Reference
 [tapWithNumberOfTaps:numberOfTouches:](https://developer.apple.com/documentation/xctest/xcuielement/1618671-tapwithnumberoftaps)
 
+### mobile: resetLocationService
+
+Reset the location service on real device since Appium 1.22.0.
+It raises an error if the device is simulator or an error occurred during the reset.
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Capability | Description
 `appium:printPageSourceOnFindFailure` | Enforces the server to dump the actual XML page source into the log if any error happens. `false` by default.
 `browserName` | The name of the browser to run the test on. If this capability is provided then the driver will try to start the test in Web context mode (Native mode is applied by default). Read [Automating hybrid apps](https://appium.io/docs/en/writing-running-appium/web/hybrid/) for more details. Usually equals to `safari`.
 `appium:includeDeviceCapsToSessionInfo` | Whether to include screen information as the result of [Get Session Capabilities](http://appium.io/docs/en/commands/session/get/). It includes `pixelRatio`, `statBarHeight` and `viewportRect`, but it causes an extra API call to WDA which may increase the response time like [this issue](https://github.com/appium/appium/issues/15101). Defaults to `true`.
-`appium:resetLocationOnRealDevice` | Whether reset the location service in the session deletion on real device. Defaults to `false`.
+`appium:resetLocationService` | Whether reset the location service in the session deletion on real device. Defaults to `false`.
 
 ### App
 
@@ -1240,7 +1240,7 @@ e = @driver.find_element :id, 'target element'
 ### mobile: resetLocationService
 
 Reset the location service on real device since Appium 1.22.0.
-It could delay a few seconds to reflect the lcoation by system.
+It could delay a few seconds to reflect the location by the system.
 It raises an error if the device is simulator or an error occurred during the reset.
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Capability | Description
 `appium:printPageSourceOnFindFailure` | Enforces the server to dump the actual XML page source into the log if any error happens. `false` by default.
 `browserName` | The name of the browser to run the test on. If this capability is provided then the driver will try to start the test in Web context mode (Native mode is applied by default). Read [Automating hybrid apps](https://appium.io/docs/en/writing-running-appium/web/hybrid/) for more details. Usually equals to `safari`.
 `appium:includeDeviceCapsToSessionInfo` | Whether to include screen information as the result of [Get Session Capabilities](http://appium.io/docs/en/commands/session/get/). It includes `pixelRatio`, `statBarHeight` and `viewportRect`, but it causes an extra API call to WDA which may increase the response time like [this issue](https://github.com/appium/appium/issues/15101). Defaults to `true`.
+`appium:resetLocationOnRealDevice` | Whether reset the location service in the session deletion on real device. Defaults to `false`.
 
 ### App
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -146,6 +146,8 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     performIoHidEvent: 'mobilePerformIoHidEvent',
 
     configureLocalization: 'mobileConfigureLocalization',
+
+    resetLocationService: 'mobileResetLocationService',
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -1,3 +1,4 @@
+import { errors } from 'appium-base-driver';
 import { services } from 'appium-ios-device';
 import { util } from 'appium-support';
 import log from '../logger';
@@ -61,6 +62,27 @@ commands.setGeoLocation = async function setGeoLocation (location) {
     service.setLocation(latitude, longitude);
   } catch (e) {
     log.errorAndThrow(`Can't set the location on device '${this.opts.udid}'. Original error: ${e.message}`);
+  } finally {
+    service.close();
+  }
+};
+
+/**
+ * Reset the location service on real device.
+ * Raises not implemented error for simulator.
+ * @throws {Error} If the device is simulator, or 'resetLocation' raises an error.
+ */
+commands.mobileResetLocationService = async function mobileResetLocationService () {
+  if (this.isSimulator()) {
+    throw new errors.NotImplementedError();
+  }
+
+  const service = await services.startSimulateLocationService(this.opts.udid);
+  try {
+    service.resetLocation();
+  } catch (err) {
+    log.errorAndThrow(`Failed to reset the location on the device on device '${this.opts.udid}'. ` +
+      `Origianl error: ${err.message}`);
   } finally {
     service.close();
   }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -56,6 +56,9 @@ const desiredCapConstraints = {
   locationServicesAuthorized: {
     isBoolean: true
   },
+  resetLocationOnRealDevice: {
+    isBoolean: true
+  },
   localizableStringsDir: {
     isString: true
   },

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -56,7 +56,7 @@ const desiredCapConstraints = {
   locationServicesAuthorized: {
     isBoolean: true
   },
-  resetLocationOnRealDevice: {
+  resetLocationService: {
     isBoolean: true
   },
   localizableStringsDir: {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -733,7 +733,6 @@ class XCUITestDriver extends BaseDriver {
       } catch (err) {
         log.warn(`Failed to reset the location on the device on device '${this.opts.udid}'. ` +
           `Origianl error: ${err.message}`);
-        // ignore
       } finally {
         service.close();
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -724,12 +724,15 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    if (this.isRealDevice()) {
+    const shouldResetLocationServivce = this.isRealDevice() && !!this.opts.resetLocationOnRealDevice;
+    if (shouldResetLocationServivce) {
       const service = await services.startSimulateLocationService(this.opts.udid);
       try {
+        log.debug(`Reseting the lcoation service on device '${this.opts.udid}'`);
         service.resetLocation();
       } catch (err) {
-        log.warn(`Failed to reset the location on the device on device '${this.opts.udid}'`);
+        log.warn(`Failed to reset the location on the device on device '${this.opts.udid}'. ` +
+          `Origianl error: ${err.message}`);
         // ignore
       } finally {
         service.close();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -10,6 +10,7 @@ import {
   shutdownOtherSimulators, shutdownSimulator, setLocaleAndPreferences
 } from './simulator-management';
 import { getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
+import { services } from 'appium-ios-device';
 import { retryInterval, retry } from 'asyncbox';
 import { verifyApplicationPlatform, extractBundleId } from './app-utils';
 import { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from './desired-caps';
@@ -720,6 +721,18 @@ class XCUITestDriver extends BaseDriver {
         log.debug(`Deleting simulator created for this run (udid: '${this.opts.udid}')`);
         await shutdownSimulator(this.opts.device);
         await this.opts.device.delete();
+      }
+    }
+
+    if (this.isRealDevice()) {
+      const service = await services.startSimulateLocationService(this.opts.udid);
+      try {
+        service.resetLocation();
+      } catch (err) {
+        log.warn(`Failed to reset the location on the device on device '${this.opts.udid}'`);
+        // ignore
+      } finally {
+        service.close();
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -10,7 +10,6 @@ import {
   shutdownOtherSimulators, shutdownSimulator, setLocaleAndPreferences
 } from './simulator-management';
 import { getSimulator, installSSLCert, hasSSLCert } from 'appium-ios-simulator';
-import { services } from 'appium-ios-device';
 import { retryInterval, retry } from 'asyncbox';
 import { verifyApplicationPlatform, extractBundleId } from './app-utils';
 import { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from './desired-caps';
@@ -724,18 +723,11 @@ class XCUITestDriver extends BaseDriver {
       }
     }
 
-    const shouldResetLocationServivce = this.isRealDevice() && !!this.opts.resetLocationOnRealDevice;
+    const shouldResetLocationServivce = this.isRealDevice() && !!this.opts.resetLocationService;
     if (shouldResetLocationServivce) {
-      const service = await services.startSimulateLocationService(this.opts.udid);
       try {
-        log.debug(`Reseting the lcoation service on device '${this.opts.udid}'`);
-        service.resetLocation();
-      } catch (err) {
-        log.warn(`Failed to reset the location on the device on device '${this.opts.udid}'. ` +
-          `Origianl error: ${err.message}`);
-      } finally {
-        service.close();
-      }
+        await this.mobileResetLocationService();
+      } catch (ignore) { /* Ignore this error since mobileResetLocationService already logged the error */ }
     }
 
     if (!_.isEmpty(this.logs)) {


### PR DESCRIPTION
`service.resetLocation();` to reset the location service on a real device is available in our ios-device repo, but we do not implement it in XCUITest layer.

This PR adds:

1. `mobile:resetLocationService` to allow users to be able to reset the location service in the session
2. `appium:resetLocationOnRealDevice` to allow reset the location service in the session deletion as teardown.