### PR TITLE
Decode cookies safely

### DIFF
--- a/lib/commands/cookies.js
+++ b/lib/commands/cookies.js
@@ -14,7 +14,7 @@ commands.getCookies = async function getCookies () {
   const cookies = await this.remote.getCookies() || {cookies: []};
 
   // the value is URI encoded, so decode it safely
-  const decodedCookieValues = cookies.cookies.map(function mapCookieValue (cookie) {
+  const decodedCookieValues = cookies.cookies.map((cookie) => {
     try {
       return decodeURI(cookie.value);
     } catch (error) {
@@ -26,8 +26,8 @@ commands.getCookies = async function getCookies () {
 
   // zip cookes with decoded value, removing undefined cookie values
   return _.zip(cookies.cookies, decodedCookieValues)
-  .filter(([, value]) => !_.isUndefined(value))
-  .map(([cookie, value]) => Object.assign({}, cookie, {value}));
+    .filter(([, value]) => !_.isUndefined(value))
+    .map(([cookie, value]) => Object.assign({}, cookie, {value}));
 };
 
 commands.deleteCookie = async function deleteCookie (cookieName) {

--- a/lib/commands/cookies.js
+++ b/lib/commands/cookies.js
@@ -13,11 +13,18 @@ commands.getCookies = async function getCookies () {
   const cookies = await this.remote.getCookies() || {cookies: []};
   // the value is URI encoded, so decode it
   // but keep all the rest of the info intact
-  return cookies.cookies.map(function mapCookie (cookie) {
-    return Object.assign({}, cookie, {
-      value: decodeURI(cookie.value),
-    });
+  let decodedCookies = [];
+  cookies.cookies.forEach(function mapCookie (cookie) {
+    try {
+      decodedCookies.push(Object.assign({}, cookie, {
+        value: decodeURI(cookie.value),
+      }));
+    } catch (error) {
+      log.debug(`Cookie ${cookie.name} was not decoded successfully. Cookie value: ${cookie.value}`);
+      log.error(error);
+    }
   });
+  return decodedCookies;
 };
 
 commands.deleteCookie = async function deleteCookie (cookieName) {

--- a/lib/commands/cookies.js
+++ b/lib/commands/cookies.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import log from '../logger';
 import { errors } from 'appium-base-driver';
 
@@ -11,20 +12,22 @@ commands.getCookies = async function getCookies () {
 
   // get the cookies from the remote debugger, or an empty object
   const cookies = await this.remote.getCookies() || {cookies: []};
-  // the value is URI encoded, so decode it
-  // but keep all the rest of the info intact
-  let decodedCookies = [];
-  cookies.cookies.forEach(function mapCookie (cookie) {
+
+  // the value is URI encoded, so decode it safely
+  const decodedCookieValues = cookies.cookies.map(function mapCookieValue (cookie) {
     try {
-      decodedCookies.push(Object.assign({}, cookie, {
-        value: decodeURI(cookie.value),
-      }));
+      return decodeURI(cookie.value);
     } catch (error) {
       log.debug(`Cookie ${cookie.name} was not decoded successfully. Cookie value: ${cookie.value}`);
-      log.error(error);
+      log.warn(error);
+      return undefined;
     }
   });
-  return decodedCookies;
+
+  // zip cookes with decoded value, removing undefined cookie values
+  return _.zip(cookies.cookies, decodedCookieValues)
+  .filter(([, value]) => !_.isUndefined(value))
+  .map(([cookie, value]) => Object.assign({}, cookie, {value}));
 };
 
 commands.deleteCookie = async function deleteCookie (cookieName) {


### PR DESCRIPTION
👋  Hi folks, 

Currently using appium to run real device tests, however, running into issues with incorrectly encoded cookie values causing difficulty. On inspection of the code I found that there was no guard against a malformed cookie value. 

I've raised this PR to start a conversation if this is a change that you folks would consider? 

Many thanks! 