### PR TITLE
fix: launch app arguments

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -53,10 +53,14 @@ commands.mobileRemoveApp = async function mobileRemoveApp (opts = {}) {
 };
 
 commands.mobileLaunchApp = async function mobileLaunchApp (opts = {}) {
-  return await this.proxyCommand('/wda/apps/launch', 'POST', {
-    ...requireOptions(opts, ['bundleId']),
-    arguments: _.isArray(opts.arguments) ? opts.arguments : [opts.arguments],
-  });
+  const launchOptions = requireOptions(opts, ['bundleId']);
+  if (opts.arguments) {
+    launchOptions.arguments = _.isArray(opts.arguments) ? opts.arguments : [opts.arguments];
+  }
+  if (opts.environment) {
+    launchOptions.environment = opts.environment;
+  }
+  return await this.proxyCommand('/wda/apps/launch', 'POST', launchOptions);
 };
 
 commands.mobileTerminateApp = async function mobileTerminateApp (opts = {}) {


### PR DESCRIPTION
https://github.com/appium/appium-xcuitest-driver/pull/1341/files#diff-cadf38942bfa2205c3e85f7e37de81f7dc552069916c98d45b2be3b06ab4d544R55 changed the options of `mobileLaunchApp`. It broke `mobileLaunchApp`.

- Only bundle id: -> it sends `"arguments":[null]`. It led an error in WDA.
```
[HTTP] --> POST /wd/hub/session/3f2d3832-5e01-4de5-a0d0-98d130ff2d24/appium/device/activate_app
[HTTP] {"bundleId":"com.kazucocoa.tv-example"}
[debug] [W3C (3f2d3832)] Calling AppiumDriver.activateApp() with args: ["com.kazucocoa.tv-example",null,null,null,"3f2d3832-5e01-4de5-a0d0-98d130ff2d24"]
[debug] [XCUITest] Executing command 'activateApp'
[debug] [WD Proxy] Proxying [POST /wda/apps/launch] to [POST http://127.0.0.1:8100/session/35E97C0C-4657-4367-ACD2-519F74FF047C/wda/apps/launch] with body: {"bundleId":"com.kazucocoa.tv-example","arguments":[null]}
[Xcode]     t =    10.33s Open com.kazucocoa.tv-example
[Xcode]
[Xcode]     t =    10.33s     Launch com.kazucocoa.tv-example
[Xcode]
[Xcode] 2021-10-24 00:09:33.483663-0700 WebDriverAgentRunner_tvOS-Runner[22869:5567526] Enqueue Failure: Failed to launch com.kazucocoa.tv-example: The operation couldn’t be completed. Transaction's process <FBApplicationProcess: 0x7fd567c1d8c0; application<com.kazucocoa.tv-example>:<invalid>> is not running:
[Xcode] <FBApplicationUpdateScenesTransaction: 0x600003a39e00>
[Xcode]     Completed: NO
[Xcode]     ClientIdentity: application<com.kazucocoa.tv-example>
[Xcode]     Waits for scene commits: YES
[Xcode]     Interruptible? YES
[Xcode]     Milestones pending: (none)
[Xcode]     Audit history:
[Xcode]         TIME: 00:09:33.107; DESCRIPTION: Life assertion taken for reason: beginning
[Xcode]         TIME: 00:09:33.108; DESCRIPTION: State changed from 'Initial' to 'Working'
[Xcode]         TIME: 00:09:33.109; DESCRIPTION: Life assertion removed for reason: beginning
[Xcode]     Concurrent child transactions:
[Xcode]         <FBApplicationProcessLaunchTransaction: 0x600003c2abc0>
[Xcode]             Completed: NO
[Xcode]             Process: <FBApplicationProcess: 0x7fd567c1d8c0; application<com.kazucocoa.tv-example>:<invalid>>
[Xcode]             Interruptible? YES
[Xcode]             Milestones pending:
[Xcode]                 processWillBeginLaunching
[Xcode]                 processDidFinishLaunching
[Xcode]             Audit history:
[Xcode]                 TIME: 00:09:33.108; DESCRIPTION: Life assertion taken for reason: beginning
[Xcode]                 TIME: 00:09:33.108; DESCRIPTION: State changed from 'Initial' to 'Working'
[Xcode]                 TIME: 00:09:33.109; DESCRIPTION: Milestones added: processWillBeginLaunching
[Xcode]                 TIME: 00:09:33.109; DESCRIPTION: Life assertion removed for reason: beginning
[Xcode]                 TIME: 00:09:33.124; DESCRIPTION: Milestones added: processDidFinishLaunching
[Xcode]             Concurrent child transactions: (none)
[Xcode]             Serial child transactions: (none)
[Xcode]     Serial child transactions: (none)
[Xcode]  /Users/kazuaki/GitHub/appium/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 43 1
[Xcode]

[Xcode] 2021-10-24 00:09:56.205354-0700 WebDriverAgentRunner_tvOS-Runner[22869:5567526] [BackgroundTask] Background Task 1 ("Called by UIKitCore, from -[UIApplication _deactivateForReason:notify:]"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.
[Xcode]


[Xcode] 2021-10-24 00:10:33.522102-0700 WebDriverAgentRunner_tvOS-Runner[22869:5567526] Enqueue Failure: Application 'com.kazucocoa.tv-example' does not have a process ID /Users/kazuaki/GitHub/appium/node_modules/appium-webdriveragent/WebDriverAgentRunner/UITestingUITests.m 43 1
[Xcode]
[HTTP] <-- POST /wd/hub/session/3f2d3832-5e01-4de5-a0d0-98d130ff2d24/appium/device/activate_app - - ms - -
[HTTP]
```

- After this change:
```
[HTTP] --> POST /wd/hub/session/b54e2a1b-9df7-4c4d-9883-ad8815e40f8a/appium/device/activate_app
[HTTP] {"bundleId":"com.kazucocoa.tv-example"}
[debug] [W3C (b54e2a1b)] Calling AppiumDriver.activateApp() with args: ["com.kazucocoa.tv-example",null,null,null,"b54e2a1b-9df7-4c4d-9883-ad8815e40f8a"]
[debug] [XCUITest] Executing command 'activateApp'
[debug] [WD Proxy] Proxying [POST /wda/apps/launch] to [POST http://127.0.0.1:8100/session/C9214C4B-FEA0-45FF-A66D-1FA122214672/wda/apps/launch] with body: {"bundleId":"com.kazucocoa.tv-example"}
[Xcode]     t =     9.69s Open com.kazucocoa.tv-example
[Xcode]
[Xcode]     t =     9.69s     Launch com.kazucocoa.tv-example
[Xcode]
[Xcode]     t =     9.94s         Setting up automation session
[Xcode]
[Xcode] 2021-10-24 00:24:59.451414-0700 WebDriverAgentRunner_tvOS-Runner[24435:5585122] Waiting up to 10s until com.kazucocoa.tv-example is in idle state (including animations)
[Xcode]     t =    10.75s         Wait for com.kazucocoa.tv-example to idle
[Xcode]
[Xcode] 2021-10-24 00:25:05.583137-0700 WebDriverAgentRunner_tvOS-Runner[24435:5585122] The application 'com.kazucocoa.tv-example' is not running in foreground after 5.00 seconds
[Xcode]
[debug] [WD Proxy] Got response with status 200: {"value":null,"sessionId":"C9214C4B-FEA0-45FF-A66D-1FA122214672"}
[debug] [W3C (b54e2a1b)] Responding to client with driver.activateApp() result: null
[HTTP] <-- POST /wd/hub/session/b54e2a1b-9df7-4c4d-9883-ad8815e40f8a/appium/device/activate_app 200 7199 ms - 14
[HTTP]
```