### PR TITLE
fix: when revalidating caps, actually send in argument for validation

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -256,7 +256,7 @@ class XCUITestDriver extends BaseDriver {
       // merge cli args to opts, and if we did merge any, revalidate opts to ensure the final set
       // is also consistent
       if (this.mergeCliArgsToOpts()) {
-        this.validateDesiredCaps();
+        this.validateDesiredCaps({...caps, ...this.cliArgs});
       }
 
       await this.start();


### PR DESCRIPTION
(fix appium/appium#16014)