### PR TITLE
feat: remove bundle id restriction in get contexts

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -380,10 +380,6 @@ extensions.connectToRemoteDebugger = async function connectToRemoteDebugger () {
 };
 
 extensions.listWebFrames = async function listWebFrames (useUrl = true) {
-  if (!this.opts.bundleId) {
-    log.errorAndThrow('Cannot enter web frame without a bundle ID');
-  }
-
   useUrl = useUrl && !this.isRealDevice() && !!this.getCurrentUrl();
   log.debug(`Selecting by url: ${useUrl} ${useUrl ? `(expected url: '${this.getCurrentUrl()}')` : ''}`);
 


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/16036#issuecomment-960491115

I think we do not need to this restriction.
We currently drop `autoLaunch: false` usage. Alternatively, we provide non-app and non-bundleid pattern to achieve like 

1. launch a bundle id with autoLaunch: false
2. do some setup before launching the bundle id
3. launch the bundle id
4. access to the webview

This was added in https://github.com/appium/appium-xcuitest-driver/pull/1020 , but probably we did not discuss about this point then.
We had `autoLaunch: false` usage then, so the above pattern was not an issue then.