### PR TITLE
fix: update platformNames in package.json for appium 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "driverName": "xcuitest",
     "automationName": "XCUITest",
     "platformNames": [
-      "iOS"
+      "iOS", "tvOS"
     ],
     "mainClass": "XCUITestDriver",
     "scripts": {


### PR DESCRIPTION
`platformNames` is `tvOS` for tvOS.