### PR TITLE
chore(cli): remove ARGS_CONSTRAINTS

### DIFF
--- a/lib/arg-constraints.js
+++ b/lib/arg-constraints.js
@@ -1,8 +1,0 @@
-export const ARGS_CONSTRAINTS = {
-  webkitDebugProxyPort: {
-    isNumber: true
-  },
-  wdaLocalPort: {
-    isNumber: true
-  },
-};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -35,7 +35,6 @@ import AsyncLock from 'async-lock';
 import path from 'path';
 import IDB from 'appium-idb';
 import DEVICE_CONNECTIONS_FACTORY from './device-connections-factory';
-import { ARGS_CONSTRAINTS } from './arg-constraints';
 
 
 const SHUTDOWN_OTHER_FEAT_NAME = 'shutdown_other_sims';
@@ -177,10 +176,6 @@ class XCUITestDriver extends BaseDriver {
     }
   }
 
-  static get argsConstraints () {
-    return ARGS_CONSTRAINTS;
-  }
-
   async onSettingsUpdate (key, value) {
     if (key !== 'nativeWebTap' && key !== 'nativeWebTapStrict') {
       return await this.proxyCommand('/appium/settings', 'POST', {
@@ -234,13 +229,11 @@ class XCUITestDriver extends BaseDriver {
 
   mergeCliArgsToOpts () {
     let didMerge = false;
-    for (const arg of Object.keys(ARGS_CONSTRAINTS)) {
-      if (_.has(this.cliArgs, arg)) {
-        log.info(`Using ${arg} value of '${this.cliArgs[arg]}' from CLI`);
-        if (_.has(this.opts, arg)) {
-          log.info(`(This overwrites value of '${this.opts[arg]}' sent in via caps)`);
-        }
-        this.opts[arg] = this.cliArgs[arg];
+    // this.cliArgs should never include anything we do not expect.
+    for (const [key, value] of Object.entries(this.cliArgs ?? {})) {
+      if (_.has(this.opts, key)) {
+        this.opts[key] = value;
+        log.info(`CLI arg '${key}' with value '${value}' overwrites value '${this.opts[key]}' sent in via caps)`);
         didMerge = true;
       }
     }


### PR DESCRIPTION
Constraints are now handled in the schema, and the latest version of Appium supports schemas, so we can remove this.

The logging which previously displayed arguments values passed in through the CLI now only displays values if they overwrite capabilities.