### PR TITLE
fix: added "Strategy" parameter to the ios-deploy.js appInstall()

### DIFF
--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -126,8 +126,8 @@ class IOSDeploy {
     }
   }
 
-  async installApp(app, timeout, strategy = null) {
-    await this.install(app, timeout , strategy);
+  async installApp(...args) {
+    return await this.install(...args);
   }
 
   /**

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -126,8 +126,8 @@ class IOSDeploy {
     }
   }
 
-  async installApp (app, timeout) {
-    await this.install(app, timeout);
+  async installApp(app, timeout, strategy = null) {
+    await this.install(app, timeout , strategy);
   }
 
   /**

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -126,7 +126,7 @@ class IOSDeploy {
     }
   }
 
-  async installApp(...args) {
+  async installApp (...args) {
     return await this.install(...args);
   }
 


### PR DESCRIPTION
Related to appium/appium#16201 
Tested after fix: Pass options to installApp call #1357

Added an extra logging to represent the passed parameters: 
**Before fix** strategy is ignoring: 
```
2021-12-06 09:21:30:834 - [HTTP] --> POST /wd/hub/session/7567419a-5fc0-4760-9c70-26802572d9fd/appium/device/install_app
2021-12-06 09:21:30:834 - [HTTP] {"appPath":"/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/testapp.ipa","options":{"strategy":"ios-deploy"}}
2021-12-06 09:21:30:841 - [debug] [W3C (7567419a)] Calling AppiumDriver.installApp() with args: 
["/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/testapp.ipa",{"strategy":"ios-deploy"},null,null,"7567419a-5fc0-4760-9c70-26802572d9fd"]
2021-12-06 09:21:30:842 - [debug] [XCUITest] Executing command 'installApp'
2021-12-06 09:21:45:449 - [XCUITest] Capability: ios-deploy Option: ios-deploy Installing '/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/build/tmp/2021116-15137-70qx1v.jbz24/testapp.app' to the real device with UDID '13deb6e4a2cbb409a01ceeb3ab212a1c92207399'
2021-12-06 09:21:45:450 - [debug] [XCUITest] Using 'serial' app deployment strategy. You could change it by providing another value to the 'appInstallStrategy' capability
```

**After fix**
```
2021-12-06 09:32:51:208 - [HTTP] --> POST /wd/hub/session/b1e5b820-f477-4d06-97c4-a2bd5450098c/appium/device/install_app
2021-12-06 09:32:51:208 - [HTTP] {"appPath":"/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/testapp.ipa","options":{"strategy":"ios-deploy"}}
2021-12-06 09:32:51:216 - [debug] [W3C (b1e5b820)] Calling AppiumDriver.installApp() with args: 
["/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/testapp.ipa",{"strategy":"ios-deploy"},null,null,"b1e5b820-f477-4d06-97c4-a2bd5450098c"]
2021-12-06 09:32:51:216 - [debug] [XCUITest] Executing command 'installApp'
2021-12-06 09:33:07:643 - [XCUITest] Capability: ios-deploy Option: ios-deploy Installing '/Users/alexandrivanchenko/Projects/aqa-mobile-testapp/build/tmp/2021116-15619-11oh1xe.aook/testapp.app' to the real device with UDID '13deb6e4a2cbb409a01ceeb3ab212a1c92207399'
2021-12-06 09:33:07:644 - [debug] [XCUITest] Using 'ios-deploy' app deployment strategy. You could change it by providing another value to the 'appInstallStrategy' capability
```
