### PR TITLE
feat: Use py-ios-device to gather crash reports from the device

### DIFF
--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -1,9 +1,13 @@
-import { fs } from 'appium-support';
+import { fs, tempDir } from 'appium-support';
 import B from 'bluebird';
 import log from '../logger';
 import { utilities } from 'appium-ios-device';
 import path from 'path';
 import _ from 'lodash';
+import Pyidevice from '../py-ios-device-client';
+
+const REAL_DEVICE_MAGIC = '3620bbb0-fb9f-4b62-a668-896f2edc4d88';
+const MAGIC_SEP = '/';
 
 
 class IOSCrashLog {
@@ -20,7 +24,13 @@ class IOSCrashLog {
     this.sim = opts.sim;
   }
 
-  async getCrashes () {
+  async _gatherFromRealDevice () {
+    const client = new Pyidevice(this.udid);
+    if (await client.assertExists(false)) {
+      return (await client.listCrashes())
+        .map((x) => `${REAL_DEVICE_MAGIC}${MAGIC_SEP}${_.last(x)}`);
+    }
+
     let crashLogsRoot = this.logDir;
     if (this.udid) {
       this.phoneName = this.phoneName || await utilities.getDeviceName(this.udid);
@@ -33,9 +43,17 @@ class IOSCrashLog {
     const foundFiles = await fs.glob(`${crashLogsRoot}/**/*.crash`, {
       strict: false
     });
-    if (this.udid) {
-      return foundFiles;
+    return foundFiles;
+  }
+
+  async _gatherFromSimulator () {
+    if (!await fs.exists(this.logDir)) {
+      log.debug(`Crash reports root '${this.logDir}' does not exist. Got nothing to gather.`);
+      return [];
     }
+    const foundFiles = await fs.glob(`${this.logDir}/**/*.crash`, {
+      strict: false
+    });
     // For Simulator only include files, that contain current UDID
     return await B.filter(foundFiles, async (x) => {
       try {
@@ -45,6 +63,12 @@ class IOSCrashLog {
         return false;
       }
     });
+  }
+
+  async getCrashes () {
+    return this.udid
+      ? await this._gatherFromRealDevice()
+      : await this._gatherFromSimulator();
   }
 
   async startCapture () {
@@ -69,14 +93,33 @@ class IOSCrashLog {
   }
 
   async filesToJSON (paths) {
-    return await B.map(paths, async (fullPath) => {
-      const stat = await fs.stat(fullPath);
-      return {
-        timestamp: stat.ctime.getTime(),
-        level: 'ALL',
-        message: await fs.readFile(fullPath, 'utf8')
-      };
-    });
+    const tmpRoot = await tempDir.openDir();
+    const client = this.udid ? new Pyidevice(this.udid) : null;
+    try {
+      return (await B.map(paths, async (fullPath) => {
+        if (_.includes(fullPath, REAL_DEVICE_MAGIC)) {
+          if (!client) {
+            return;
+          }
+          const fileName = _.last(fullPath.split(MAGIC_SEP));
+          try {
+            await client.exportCrash(fileName, tmpRoot);
+          } catch (e) {
+            log.warn(`Cannot export the crash report '${fileName}'. Skipping it. ` +
+              `Original error: ${e.message}`);
+          }
+          fullPath = path.join(tmpRoot, fileName);
+        }
+        const stat = await fs.stat(fullPath);
+        return {
+          timestamp: stat.ctime.getTime(),
+          level: 'ALL',
+          message: await fs.readFile(fullPath, 'utf8')
+        };
+      })).map(Boolean);
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
   }
 }
 

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -28,7 +28,7 @@ class IOSCrashLog {
   async _gatherFromRealDevice () {
     if (await this.pyideviceClient.assertExists(false)) {
       return (await this.pyideviceClient.listCrashes())
-        .map((x) => `${REAL_DEVICE_MAGIC}${MAGIC_SEP}${_.last(x)}`);
+        .map((x) => `${REAL_DEVICE_MAGIC}${MAGIC_SEP}${x}`);
     }
 
     let crashLogsRoot = this.logDir;

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -13,6 +13,7 @@ const MAGIC_SEP = '/';
 class IOSCrashLog {
   constructor (opts = {}) {
     this.udid = opts.udid;
+    this.pyideviceClient = this.udid ? new Pyidevice(this.udid) : null;
     const logDir = opts.udid
       ? path.resolve(process.env.HOME, 'Library', 'Logs', 'CrashReporter', 'MobileDevice')
       : path.resolve(process.env.HOME, 'Library', 'Logs', 'DiagnosticReports');
@@ -25,9 +26,8 @@ class IOSCrashLog {
   }
 
   async _gatherFromRealDevice () {
-    const client = new Pyidevice(this.udid);
-    if (await client.assertExists(false)) {
-      return (await client.listCrashes())
+    if (await this.pyideviceClient.assertExists(false)) {
+      return (await this.pyideviceClient.listCrashes())
         .map((x) => `${REAL_DEVICE_MAGIC}${MAGIC_SEP}${_.last(x)}`);
     }
 
@@ -94,16 +94,12 @@ class IOSCrashLog {
 
   async filesToJSON (paths) {
     const tmpRoot = await tempDir.openDir();
-    const client = this.udid ? new Pyidevice(this.udid) : null;
     try {
       return (await B.map(paths, async (fullPath) => {
         if (_.includes(fullPath, REAL_DEVICE_MAGIC)) {
-          if (!client) {
-            return;
-          }
           const fileName = _.last(fullPath.split(MAGIC_SEP));
           try {
-            await client.exportCrash(fileName, tmpRoot);
+            await this.pyideviceClient.exportCrash(fileName, tmpRoot);
           } catch (e) {
             log.warn(`Cannot export the crash report '${fileName}'. Skipping it. ` +
               `Original error: ${e.message}`);

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -107,6 +107,7 @@ class IOSCrashLog {
           } catch (e) {
             log.warn(`Cannot export the crash report '${fileName}'. Skipping it. ` +
               `Original error: ${e.message}`);
+            return;
           }
           fullPath = path.join(tmpRoot, fileName);
         }

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -113,7 +113,7 @@ class IOSCrashLog {
           level: 'ALL',
           message: await fs.readFile(fullPath, 'utf8')
         };
-      })).map(Boolean);
+      })).filter(Boolean);
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -61,13 +61,9 @@ class Pyidevice {
     return JSON.parse(stdout);
   }
 
-  async installProfile (opts = {}) {
-    const {
-      profilePath,
-      payload,
-    } = opts;
+  async installProfile ({profilePath, payload} = {}) {
     if (!profilePath && !payload) {
-      throw new TypeError('Profile must be defined');
+      throw new Error('Either the full path to the profile or its payload must be provided');
     }
 
     let tmpRoot;

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -70,19 +70,19 @@ class Pyidevice {
       throw new TypeError('Profile must be defined');
     }
 
-    if (profilePath) {
-      await this.execute(['profiles', 'install', '--path', profilePath], {
+    let tmpRoot;
+    let srcPath = profilePath;
+    try {
+      if (!srcPath) {
+        tmpRoot = await tempDir.openDir();
+        srcPath = path.join(tmpRoot, 'cert.pem');
+        await fs.writeFile(srcPath, payload, 'utf8');
+      }
+      await this.execute(['profiles', 'install', '--path', srcPath], {
         logStdout: true
       });
-    } else {
-      const tmpRoot = await tempDir.openDir();
-      const tmpProfilePath = path.join(tmpRoot, 'cert.pem');
-      try {
-        await fs.writeFile(tmpProfilePath, payload, 'utf8');
-        await this.execute(['profiles', 'install', '--path', tmpProfilePath], {
-          logStdout: true
-        });
-      } finally {
+    } finally {
+      if (tmpRoot) {
         await fs.rimraf(tmpRoot);
       }
     }

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -94,7 +94,7 @@ class Pyidevice {
 
   async listCrashes () {
     const {stdout} = await this.execute(['crash', 'list']);
-    return JSON.parse(stdout);
+    return JSON.parse(stdout.replace(/'/g, '"')).filter((x) => !['.', '..'].includes(x));
   }
 
   async exportCrash (name, dstFolder) {

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -34,6 +34,7 @@ class Pyidevice {
   async execute (args, opts = {}) {
     await this.assertExists();
     const {
+      cwd,
       format = 'json',
       logStdout = false,
     } = opts;
@@ -45,7 +46,7 @@ class Pyidevice {
     const cmdStr = util.quote([this.binaryPath, ...finalArgs]);
     log.debug(`Executing ${cmdStr}`);
     try {
-      const result = await exec(this.binaryPath, finalArgs);
+      const result = await exec(this.binaryPath, finalArgs, {cwd});
       if (logStdout) {
         log.debug(`Command output: ${result.stdout}`);
       }
@@ -89,6 +90,19 @@ class Pyidevice {
 
   async removeProfile (name) {
     await this.execute(['profiles', 'remove', name], {logStdout: true});
+  }
+
+  async listCrashes () {
+    const {stdout} = await this.execute(['crash', 'list']);
+    return JSON.parse(stdout);
+  }
+
+  async exportCrash (name, dstFolder) {
+    await this.execute(['crash', 'export', '--name', name], {
+      logStdout: true,
+      // The tool exports crash reports to the current working dir
+      cwd: dstFolder
+    });
   }
 }
 


### PR DESCRIPTION
Before we were collecting crash reports from the local file system, but it looks like they rarely end up there, because one needs some time for sync, which is not the case right after an automated test finishes due to an app crash.
 py-ios-device though allows to gather crash reports directly from the device under test, which would allow us to basically instantly fetch necessary reports.