### PR TITLE
fix(driver): correct logic in assignment from cli args

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -233,10 +233,10 @@ class XCUITestDriver extends BaseDriver {
     // this.cliArgs should never include anything we do not expect.
     for (const [key, value] of Object.entries(this.cliArgs ?? {})) {
       if (_.has(this.opts, key)) {
-        this.opts[key] = value;
         log.info(`CLI arg '${key}' with value '${value}' overwrites value '${this.opts[key]}' sent in via caps)`);
         didMerge = true;
       }
+      this.opts[key] = value;
     }
     return didMerge;
   }


### PR DESCRIPTION
I think this fixes appium/appium#16340.  My bad

It would only set the value from `wdaLocalPort` if it was going to overwrite caps