### PR TITLE
feat: add appKill mobile command via instruments service

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Either `true` if the app was successfully terminated, otherwise `false`
 
 Kill the given app on the real device under test by instruments service via [py-ios-device](https://github.com/YueChen-C/py-ios-device) if it is installed on the server machine.
 If the app is not running or failed to kill, then nothing is done.
-Note that this method takes a few time than `mobile:terminateApp` for now since it calls the instruments service via external command, `py-ios-device`.
+Note that this method takes a few more time than `mobile:terminateApp` for now since it calls the instruments service via external command, `py-ios-device`.
 
 #### Arguments
 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ environment | dict | no | Environment variables mapping for the app. If the app 
 
 ### mobile: terminateApp
 
-Terminates the given app on the device under test. If the app is not installed an exception is thrown. If the app is not running then nothing is done.
+Terminates the given app on the device under test via [XCTest's terminate](https://developer.apple.com/documentation/xctest/xcuiapplication/1500637-terminate) API. If the app is not installed an exception is thrown. If the app is not running then nothing is done.
 
 #### Arguments
 
@@ -504,6 +504,21 @@ bundleId | string | yes | The bundle identifier of the application to be termina
 #### Returned Result
 
 Either `true` if the app was successfully terminated, otherwise `false`
+
+### mobile: killApp
+
+Kill the given app on the real device under test by instruments service via [py-ios-device](https://github.com/YueChen-C/py-ios-device) if it is installed on the server machine.
+If the app is not running or failed to kill, then nothing is done.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+bundleId | string | yes | The bundle identifier of the application to be terminated | com.mycompany.myapp
+
+#### Returned Result
+
+Either `true` if the app was successfully killed, otherwise `false`
 
 ### mobile: queryAppState
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Either `true` if the app was successfully terminated, otherwise `false`
 
 Kill the given app on the real device under test by instruments service via [py-ios-device](https://github.com/YueChen-C/py-ios-device) if it is installed on the server machine.
 If the app is not running or failed to kill, then nothing is done.
+Note that this method takes a few time than `mobile:terminateApp` for now since it calls the instruments service via external command, `py-ios-device`.
 
 #### Arguments
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -3,6 +3,7 @@ import { fs } from '@appium/support';
 import log from '../logger';
 import { errors } from '@appium/base-driver';
 import { services } from 'appium-ios-device';
+import Pyidevice from '../py-ios-device-client';
 
 const commands = {};
 
@@ -69,6 +70,37 @@ commands.mobileTerminateApp = async function mobileTerminateApp (opts = {}) {
 
 commands.mobileActivateApp = async function mobileActivateApp (opts = {}) {
   return await this.proxyCommand('/wda/apps/activate', 'POST', requireOptions(opts, ['bundleId']));
+};
+
+/**
+ * Kill the given bundle id process via instruments service.
+ * https://github.com/YueChen-C/py-ios-device/blob/51f4683c5c3c385a015858ada07a5f1c62d3cf57/ios_device/cli/base.py#L220
+ *
+ * @param {Object} opts - Options set, which must contain `bundleId` property
+ * @returns {boolean} Returns true if the bundle id process was killed. Otherwise false.
+ */
+commands.mobileKillApp = async function mobileKillApp (opts = {}) {
+  if (!this.isRealDevice()) {
+    throw new errors.UnsupportedOperationError('A real device is required');
+  }
+
+  if (!this.opts.device.udid) {
+    throw new errors.InvalidArgumentError('No valid UDID is given');
+  }
+
+  const {bundleId} = requireOptions(opts, ['bundleId']);
+  try {
+    // TODO: eventually we'd like to call the instruments kill method via appium-ios-device.
+    const {stdout, stderr} = await new Pyidevice(this.opts.device.udid).killApp(bundleId);
+    if ((`${stdout}${stderr}`).includes('did not start')) {
+      log.info(`The bundle id '${bundleId}' did not start or it was already killed`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.warn(`Failed to kill '${bundleId}'. Original error: ${err.message}`);
+    return false;
+  }
 };
 
 /**

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -84,21 +84,17 @@ commands.mobileKillApp = async function mobileKillApp (opts = {}) {
     throw new errors.UnsupportedOperationError('A real device is required');
   }
 
-  if (!this.opts.device.udid) {
-    throw new errors.InvalidArgumentError('No valid UDID is given');
-  }
-
   const {bundleId} = requireOptions(opts, ['bundleId']);
   try {
     // TODO: eventually we'd like to call the instruments kill method via appium-ios-device.
     const {stdout, stderr} = await new Pyidevice(this.opts.device.udid).killApp(bundleId);
-    if ((`${stdout}${stderr}`).includes('did not start')) {
+    if ((stdout + stderr).includes('did not start')) {
       log.info(`The bundle id '${bundleId}' did not start or it was already killed`);
       return false;
     }
     return true;
   } catch (err) {
-    log.warn(`Failed to kill '${bundleId}'. Original error: ${err.message}`);
+    log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
     return false;
   }
 };

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -91,6 +91,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     removeApp: 'mobileRemoveApp',
     launchApp: 'mobileLaunchApp',
     terminateApp: 'mobileTerminateApp',
+    killApp: 'mobileKillApp',
     queryAppState: 'mobileQueryAppState',
     activateApp: 'mobileActivateApp',
     listApps: 'mobileListApps',

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -113,6 +113,13 @@ class Pyidevice {
       asynchronous: true
     });
   }
+
+  async killApp (bundleId) {
+    if (!bundleId) {
+      throw new Error('bundleId is required');
+    }
+    return await this.execute(['apps', 'kill', '--bundle_id', bundleId]);
+  }
 }
 
 export { Pyidevice };


### PR DESCRIPTION
Close https://github.com/appium/appium-xcuitest-driver/issues/1385

We now have `py-ios-device`, so this driver can kill an app via instruments service.
Ideally, it would be nice to add such instruments service in appium-ios-device, but currently not.


I wonder the method shold always return `true` though...

I tested this killApp against `com.apple.Maps`. Then, the existing `terminateApp` also killed the app process expectedly. So killApp could take additional preparation time thank the terminateApp so far, but potentially the killApp could kill well than terminateApp in some cases.

Btw, app history by double home button clicks still show the killed app even via `killApp` command sometimes. This is iOS's behavior.