### PR TITLE
feat: add device info via lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ The actual battery info map, which consists of the following entries:
 ### mobile: deviceInfo
 
 Returns the miscellaneous information about the device under test.
+It includes device information via lockdown in a real device since XCUITest driver 4.2.0.
 
 #### Returned Result
 

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -1,3 +1,5 @@
+import { utilities } from 'appium-ios-device';
+
 const extensions = {}, commands = {};
 
 /**
@@ -7,7 +9,14 @@ const extensions = {}, commands = {};
  * @throws {Error} if an error raised by command
  */
 commands.mobileGetDeviceInfo = async function mobileGetDeviceInfo () {
-  return await this.proxyCommand('/wda/device/info', 'GET');
+  const infoByWda = await this.proxyCommand('/wda/device/info', 'GET');
+
+  if (this.isRealDevice()) {
+    const infoByLockdown = await utilities.getDeviceInfo(this.opts.device.udid);
+    return {...infoByWda, ...{lockdownInfo: infoByLockdown}};
+  }
+
+  return infoByWda;
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -12,8 +12,8 @@ commands.mobileGetDeviceInfo = async function mobileGetDeviceInfo () {
   const infoByWda = await this.proxyCommand('/wda/device/info', 'GET');
 
   if (this.isRealDevice()) {
-    const infoByLockdown = await utilities.getDeviceInfo(this.opts.device.udid);
-    return {...infoByWda, ...{lockdownInfo: infoByLockdown}};
+    const lockdownInfo = await utilities.getDeviceInfo(this.opts.device.udid);
+    return {...infoByWda, ...{lockdownInfo}};
   }
 
   return infoByWda;

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/runtime": "^7.0.0",
     "@xmldom/xmldom": "^0.x",
     "appium-idb": "^1.0.0",
-    "appium-ios-device": "^2.0.0",
+    "appium-ios-device": "^2.1.0",
     "appium-ios-simulator": "^4.0.0",
     "appium-remote-debugger": "^9.0.0",
     "appium-webdriveragent": "^4.0.0",


### PR DESCRIPTION
```
> @driver.execute_script 'mobile: deviceInfo', {}
=> {"timeZone"=>"GMT-0800",
 "currentLocale"=>"ja_JP",
 "model"=>"iPhone",
 "uuid"=>"B3D4A74D-8B4B-4F4E-8859-CDE8F3D917BE",
 "thermalState"=>0,
 "userInterfaceIdiom"=>0,
 "userInterfaceStyle"=>"light",
 "name"=>"🦉kazu",
 "isSimulator"=>false,
 "lockdownInfo"=>
  {"BasebandCertId"=>3840149528,
   "BasebandKeyHashInformation"=> ...,
   "BuildVersion"=>"19C56",
   "CPUArchitecture"=>"arm64",
   "ChipID"=>32768,
   "DeviceClass"=>"iPhone",
   "DeviceColor"=>"#c8caca",
   "DeviceName"=>"🦉kazu",
    ....}}
```