### PR TITLE
fix: secured connection error between real devices with OpenSSL v3, the default security level of 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/runtime": "^7.0.0",
     "@xmldom/xmldom": "^0.x",
     "appium-idb": "^1.0.0",
-    "appium-ios-device": "^2.1.0",
+    "appium-ios-device": "^2.3.1",
     "appium-ios-simulator": "^4.0.0",
     "appium-remote-debugger": "^9.0.0",
     "appium-webdriveragent": "^4.0.0",


### PR DESCRIPTION
To include https://github.com/appium/appium-ios-device/pull/88 as a npm released version.
Since appium v2, each driver starts including shrinkwrap in their packages. We currently need to create a version and release it to update it.