### PR TITLE
feat: replace killApp instrumentation with appium-ios-device/instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,9 +507,11 @@ Either `true` if the app was successfully terminated, otherwise `false`
 
 ### mobile: killApp
 
-Kill the given app on the real device under test by instruments service via [py-ios-device](https://github.com/YueChen-C/py-ios-device) if it is installed on the server machine since XCUITest driver 4.3.0.
+Kill the given app on the real device under test by instruments service.
 If the app is not running or failed to kill, then nothing is done.
-Note that this method takes a few more time than `mobile:terminateApp` for now since it calls the instruments service via external command, `py-ios-device`.
+
+XCUITest driver 4.4 and higher does not require external library.
+XCUITest driver 4.3 requires [py-ios-device](https://github.com/YueChen-C/py-ios-device).
 
 #### Arguments
 
@@ -1355,5 +1357,5 @@ the tests locally. These include:
   the root directory of the repo with the extension "xcconfig")
 * `UICATALOG_REAL_DEVICE` - path to the real device build of UICatalog, in case
   the npm installed one is not built for real device
-  
-  
+
+

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Either `true` if the app was successfully terminated, otherwise `false`
 Kill the given app on the real device under test by instruments service.
 If the app is not running or failed to kill, then nothing is done.
 
-XCUITest driver 4.4 and higher does not require external library.
+XCUITest driver 4.4 and higher does not require [py-ios-device](https://github.com/YueChen-C/py-ios-device).
 XCUITest driver 4.3 requires [py-ios-device](https://github.com/YueChen-C/py-ios-device).
 
 #### Arguments

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -1,9 +1,7 @@
 import _ from 'lodash';
 import { fs } from '@appium/support';
 import { errors } from '@appium/base-driver';
-import { services } from 'appium-ios-device';
-// TODO: fix me
-import { SERVICE } from 'appium-ios-device/build/lib/instrument';
+import { services, INSTRUMENT_CHANNEL } from 'appium-ios-device';
 
 const commands = {};
 
@@ -94,13 +92,13 @@ commands.mobileKillApp = async function mobileKillApp (opts = {}) {
     }
     const executableName = apps[bundleId].CFBundleExecutable;
     const instrumentService = await services.startInstrumentService(this.opts.device.udid);
-    const processes = await instrumentService.callChannel(SERVICE.DEVICE_INFO, 'runningProcesses');
+    const processes = await instrumentService.callChannel(INSTRUMENT_CHANNEL.DEVICE_INFO, 'runningProcesses');
     const process = processes.selector.find((process) => process.name === executableName);
     if (!process) {
       this.log.info(`The process of the bundle id '${bundleId}' did not start`);
       return true;
     }
-    await instrumentService.callChannel(SERVICE.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
+    await instrumentService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
     return true;
   } catch (err) {
     this.log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -83,26 +83,36 @@ commands.mobileKillApp = async function mobileKillApp (opts = {}) {
   }
 
   const {bundleId} = requireOptions(opts, ['bundleId']);
+  let instrumentService;
+  let installProxyService;
   try {
-    const installProxy = await services.startInstallationProxyService(this.opts.device.udid);
-    const apps = await installProxy.listApplications();
+    installProxyService = await services.startInstallationProxyService(this.opts.device.udid);
+    const apps = await installProxyService.listApplications();
     if (!apps[bundleId]) {
       this.log.info(`The bundle id '${bundleId}' did not exist`);
       return false;
     }
     const executableName = apps[bundleId].CFBundleExecutable;
-    const instrumentService = await services.startInstrumentService(this.opts.device.udid);
+    this.log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
+    instrumentService = await services.startInstrumentService(this.opts.device.udid);
     const processes = await instrumentService.callChannel(INSTRUMENT_CHANNEL.DEVICE_INFO, 'runningProcesses');
     const process = processes.selector.find((process) => process.name === executableName);
     if (!process) {
-      this.log.info(`The process of the bundle id '${bundleId}' did not start`);
-      return true;
+      this.log.info(`The process of the bundle id '${bundleId}' was not running`);
+      return false;
     }
     await instrumentService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
     return true;
   } catch (err) {
     this.log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
     return false;
+  } finally {
+    if (installProxyService) {
+      installProxyService.close();
+    }
+    if (instrumentService) {
+      instrumentService.close();
+    }
   }
 };
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import { fs } from '@appium/support';
 import { errors } from '@appium/base-driver';
 import { services } from 'appium-ios-device';
-import Pyidevice from '../py-ios-device-client';
+// TODO: fix me
+import { SERVICE } from 'appium-ios-device/build/lib/instrument';
 
 const commands = {};
 
@@ -85,12 +86,21 @@ commands.mobileKillApp = async function mobileKillApp (opts = {}) {
 
   const {bundleId} = requireOptions(opts, ['bundleId']);
   try {
-    // TODO: eventually we'd like to call the instruments kill method via appium-ios-device.
-    const {stdout, stderr} = await new Pyidevice(this.opts.device.udid).killApp(bundleId);
-    if ((stdout + stderr).includes('did not start')) {
-      this.log.info(`The bundle id '${bundleId}' did not start or it was already killed`);
+    const installProxy = await services.startInstallationProxyService(this.opts.device.udid);
+    const apps = await installProxy.listApplications();
+    if (!apps[bundleId]) {
+      this.log.info(`The bundle id '${bundleId}' did not exist`);
       return false;
     }
+    const executableName = apps[bundleId].CFBundleExecutable;
+    const instrumentService = await services.startInstrumentService(this.opts.device.udid);
+    const processes = await instrumentService.callChannel(SERVICE.DEVICE_INFO, 'runningProcesses');
+    const process = processes.selector.find((process) => process.name === executableName);
+    if (!process) {
+      this.log.info(`The process of the bundle id '${bundleId}' did not start`);
+      return true;
+    }
+    await instrumentService.callChannel(SERVICE.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
     return true;
   } catch (err) {
     this.log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -113,13 +113,6 @@ class Pyidevice {
       asynchronous: true
     });
   }
-
-  async killApp (bundleId) {
-    if (!bundleId) {
-      throw new Error('bundleId is required');
-    }
-    return await this.execute(['apps', 'kill', '--bundle_id', bundleId]);
-  }
 }
 
 export { Pyidevice };

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/runtime": "^7.0.0",
     "@xmldom/xmldom": "^0.x",
     "appium-idb": "^1.0.0",
-    "appium-ios-device": "^2.3.1",
+    "appium-ios-device": "^2.4.0",
     "appium-ios-simulator": "^4.0.0",
     "appium-remote-debugger": "^9.0.0",
     "appium-webdriveragent": "^4.4.0",


### PR DESCRIPTION
replace appKill implementation with https://github.com/appium/appium-ios-device 's instrument.

After https://github.com/appium/appium-ios-device/pull/89 , I'd like to replace `import { SERVICE } from 'appium-ios-device/build/lib/instrument';` part with `INSTRUMENT_SERVICE`

---

I've tested mobile:killApp command manually on my local.