### PR TITLE
fix: Configure app extension for real devices

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -830,7 +830,10 @@ class XCUITestDriver extends BaseDriver {
 
     try {
       // download if necessary
-      this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
+      this.opts.app = await this.helpers.configureApp(
+        this.opts.app,
+        this.opts.realDevice ? '.ipa' : '.app'
+      );
     } catch (err) {
       this.log.error(err);
       throw new Error(`Bad app: ${this.opts.app}. ` +


### PR DESCRIPTION
Calls to `configureApp` on real devices were expecting an `.app` extension.
This fixes it.