### PR TITLE
chore: drop unused webkitDebugProxyPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Usage: `appium --driver-args='{"xcuitest": {[argName]: [argValue]}}'`
 
 |Argument|Default|Description|Example|
 |----|-------|-----------|-------|
-|`"webkitDebugProxyPort"`|27753|Local port used for communication with ios-webkit-debug-proxy|`--driver-args='{"xcuitest": {"webkitDebugProxyPort": 27753}}'`|
 |`"wdaLocalPort"`|8100| Local port used for communication with ios-web-driver-agent|`--driver-args='{"xcuitest": {"wdaLocalPort": 8100}}'`|
 
 ## Capabilities

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -81,9 +81,6 @@ const desiredCapConstraints = {
   webkitResponseTimeout: {
     isNumber: true
   },
-  webkitDebugProxyPort: {
-    isNumber: true
-  },
   remoteDebugProxy: {
     isString: true
   },

--- a/package.json
+++ b/package.json
@@ -43,14 +43,6 @@
           "maximum": 65535,
           "minimum": 1,
           "type": "integer"
-        },
-        "webkit-debug-proxy-port": {
-          "appiumCliDest": "webkitDebugProxyPort",
-          "default": 27753,
-          "description": "(Real device only) Port to which `ios-webkit-debug-proxy` is connected",
-          "maximum": 65535,
-          "minimum": 1,
-          "type": "integer"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Btw, current xcuitest driver no longer depends on webkit debug proxy, so I think we can remove it