### PR TITLE
refactor: Tune Safari initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Capability | Description
 |`appium:safariIgnoreWebHostnames`| Provide a list of hostnames (comma-separated) that the Safari automation tools should ignore. This is to provide a workaround to prevent a webkit bug where the web context is unintentionally changed to a 3rd party website and the test gets stuck. The common culprits are search engines (yahoo, bing, google) and `about:blank` |e.g. `'www.yahoo.com, www.bing.com, www.google.com, about:blank'`|
 |`appium:nativeWebTap` | Enable native, non-javascript-based taps being in web context mode. Defaults to `false`. Warning: sometimes the preciseness of native taps could be broken, because there is no reliable way to map web element coordinates to native ones. | `true` |
 |`appium:nativeWebTapStrict` | Enforce native taps to be done by XCUITest driver rather than WebDriverAgent. Only applicable if `nativeWebTap` is enabled. `false` by default | `false` |
-|`appium:safariInitialUrl`| Initial safari url, default is a local welcome page. Setting it to an empty string will skip the initial navigation. This capability is ignored if `noReset` one is enabled. | e.g. `https://www.github.com` |
+|`appium:safariInitialUrl`| Initial safari url, default is a local welcome page. Setting it to an empty string will skip the initial navigation. | e.g. `https://www.github.com` |
 |`appium:safariAllowPopups`| Allow javascript to open new windows in Safari. Default keeps current sim setting|`true` or `false`|
 |`appium:safariIgnoreFraudWarning`| Prevent Safari from showing a fraudulent website warning. Default keeps current sim setting.|`true` or `false`|
 |`appium:safariOpenLinksInBackground`| Whether Safari should allow links to open in new windows. Default keeps current sim setting.|`true` or `false`|

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Capability | Description
 |`appium:safariIgnoreWebHostnames`| Provide a list of hostnames (comma-separated) that the Safari automation tools should ignore. This is to provide a workaround to prevent a webkit bug where the web context is unintentionally changed to a 3rd party website and the test gets stuck. The common culprits are search engines (yahoo, bing, google) and `about:blank` |e.g. `'www.yahoo.com, www.bing.com, www.google.com, about:blank'`|
 |`appium:nativeWebTap` | Enable native, non-javascript-based taps being in web context mode. Defaults to `false`. Warning: sometimes the preciseness of native taps could be broken, because there is no reliable way to map web element coordinates to native ones. | `true` |
 |`appium:nativeWebTapStrict` | Enforce native taps to be done by XCUITest driver rather than WebDriverAgent. Only applicable if `nativeWebTap` is enabled. `false` by default | `false` |
-|`appium:safariInitialUrl`| Initial safari url, default is a local welcome page | e.g. `https://www.github.com` |
+|`appium:safariInitialUrl`| Initial safari url, default is a local welcome page. Setting it to an empty string will skip the initial navigation. This capability is ignored if `noReset` one is enabled. | e.g. `https://www.github.com` |
 |`appium:safariAllowPopups`| Allow javascript to open new windows in Safari. Default keeps current sim setting|`true` or `false`|
 |`appium:safariIgnoreFraudWarning`| Prevent Safari from showing a fraudulent website warning. Default keeps current sim setting.|`true` or `false`|
 |`appium:safariOpenLinksInBackground`| Whether Safari should allow links to open in new windows. Default keeps current sim setting.|`true` or `false`|

--- a/lib/app-utils.js
+++ b/lib/app-utils.js
@@ -5,6 +5,7 @@ import log from './logger.js';
 
 const STRINGSDICT_RESOURCE = '.stringsdict';
 const STRINGS_RESOURCE = '.strings';
+const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 
 
 async function extractPlistEntry (app, entryName) {
@@ -156,4 +157,7 @@ async function parseLocalizableStrings (opts) {
   return resultStrings;
 }
 
-export { extractBundleId, verifyApplicationPlatform, parseLocalizableStrings };
+export {
+  extractBundleId, verifyApplicationPlatform, parseLocalizableStrings,
+  SAFARI_BUNDLE_ID
+};

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { fs } from '@appium/support';
 import { errors } from '@appium/base-driver';
-import { services, INSTRUMENT_CHANNEL } from 'appium-ios-device';
+import { services } from 'appium-ios-device';
 
 const commands = {};
 
@@ -83,37 +83,7 @@ commands.mobileKillApp = async function mobileKillApp (opts = {}) {
   }
 
   const {bundleId} = requireOptions(opts, ['bundleId']);
-  let instrumentService;
-  let installProxyService;
-  try {
-    installProxyService = await services.startInstallationProxyService(this.opts.device.udid);
-    const apps = await installProxyService.listApplications();
-    if (!apps[bundleId]) {
-      this.log.info(`The bundle id '${bundleId}' did not exist`);
-      return false;
-    }
-    const executableName = apps[bundleId].CFBundleExecutable;
-    this.log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
-    instrumentService = await services.startInstrumentService(this.opts.device.udid);
-    const processes = await instrumentService.callChannel(INSTRUMENT_CHANNEL.DEVICE_INFO, 'runningProcesses');
-    const process = processes.selector.find((process) => process.name === executableName);
-    if (!process) {
-      this.log.info(`The process of the bundle id '${bundleId}' was not running`);
-      return false;
-    }
-    await instrumentService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
-    return true;
-  } catch (err) {
-    this.log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
-    return false;
-  } finally {
-    if (installProxyService) {
-      installProxyService.close();
-    }
-    if (instrumentService) {
-      instrumentService.close();
-    }
-  }
+  return await this.opts.device.terminateApp(bundleId);
 };
 
 /**

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -14,8 +14,12 @@ import {
   hasCertificateLegacy,
 } from './cert-utils';
 import { retryInterval, retry } from 'asyncbox';
-import { verifyApplicationPlatform, extractBundleId } from './app-utils';
-import { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from './desired-caps';
+import {
+  verifyApplicationPlatform, extractBundleId, SAFARI_BUNDLE_ID
+} from './app-utils';
+import {
+  desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS
+} from './desired-caps';
 import commands from './commands/index';
 import {
   detectUdid, getAndCheckXcodeVersion, getAndCheckIosSdkVersion,
@@ -50,7 +54,6 @@ const defaultServerCaps = {
   takesScreenshot: true,
   networkConnectionEnabled: false,
 };
-const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const WDA_SIM_STARTUP_RETRIES = 2;
 const WDA_REAL_DEV_STARTUP_RETRIES = 1;
 const WDA_REAL_DEV_TUTORIAL_URL = 'https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md';
@@ -321,10 +324,6 @@ class XCUITestDriver extends BaseDriver {
       }:${this.opts.port}/welcome`;
   }
 
-  doesSafariSupportUrlArgument () {
-    return util.compareVersions(this.opts.platformVersion, '<', '12.2');
-  }
-
   async start () {
     this.opts.noReset = !!this.opts.noReset;
     this.opts.fullReset = !!this.opts.fullReset;
@@ -375,10 +374,6 @@ class XCUITestDriver extends BaseDriver {
       this.opts.processArguments = this.opts.processArguments || {};
       this.opts.bundleId = SAFARI_BUNDLE_ID;
       this._currentUrl = this.opts.safariInitialUrl || this.getDefaultUrl();
-      if (this.doesSafariSupportUrlArgument()) {
-        // this option does not work on 12.2 and above
-        this.opts.processArguments.args = ['-u', this._currentUrl];
-      }
     } else if (this.opts.app || this.opts.bundleId) {
       await this.configureApp();
     }
@@ -529,9 +524,13 @@ class XCUITestDriver extends BaseDriver {
       await this.activateRecentWebview();
     }
     if (this.isSafari()) {
-      this.log.info(`About to set the initial Safari URL to '${this.getCurrentUrl()}'.` +
-        `Use 'safariInitialUrl' capability in order to customize it`);
-      await this.setUrl(this.getCurrentUrl());
+      if (_.trim(this.opts.safariInitialUrl) !== '' && !this.opts.noReset) {
+        this.log.info(`About to set the initial Safari URL to '${this.getCurrentUrl()}'.` +
+          `Use 'safariInitialUrl' capability in order to customize it`);
+        await this.setUrl(this.getCurrentUrl());
+      } else {
+        this.setCurrentUrl(await this.getUrl());
+      }
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -524,7 +524,8 @@ class XCUITestDriver extends BaseDriver {
       await this.activateRecentWebview();
     }
     if (this.isSafari()) {
-      if (_.trim(this.opts.safariInitialUrl) !== '' && !this.opts.noReset) {
+      if (!(this.opts.safariInitialUrl === ''
+          || (this.opts.noReset && _.isNil(this.opts.safariInitialUrl)))) {
         this.log.info(`About to set the initial Safari URL to '${this.getCurrentUrl()}'.` +
           `Use 'safariInitialUrl' capability in order to customize it`);
         await this.setUrl(this.getCurrentUrl());

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -1,6 +1,6 @@
 import { fs, timing } from '@appium/support';
 import path from 'path';
-import { services, utilities } from 'appium-ios-device';
+import { services, utilities, INSTRUMENT_CHANNEL } from 'appium-ios-device';
 import B from 'bluebird';
 import log from './logger';
 import _ from 'lodash';
@@ -26,10 +26,10 @@ class IOSDeploy {
     this.udid = udid;
   }
 
-  async remove (bundleid) {
+  async remove (bundleId) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
-      await service.uninstallApplication(bundleid);
+      await service.uninstallApplication(bundleId);
     } finally {
       service.close();
     }
@@ -133,7 +133,7 @@ class IOSDeploy {
   /**
    * Return an application object if test app has 'bundleid'.
    * The target bundleid can be User and System apps.
-   * @param {string} bundleid The bundleId to ensure it is installed
+   * @param {string} bundleId The bundleId to ensure it is installed
    * @return {boolean} Returns True if the bundleid exists in the result of 'listApplications' like:
    * { "com.apple.Preferences":{
    *   "UIRequiredDeviceCapabilities":["arm64"],
@@ -142,13 +142,47 @@ class IOSDeploy {
    *   "Entitlements":
    *     {"com.apple.frontboard.delete-application-snapshots":true,..
    */
-  async isAppInstalled (bundleid) {
+  async isAppInstalled (bundleId) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
-      const applications = await service.lookupApplications({ bundleIds: bundleid });
-      return !!applications[bundleid];
+      const applications = await service.lookupApplications({ bundleIds: bundleId });
+      return !!applications[bundleId];
     } finally {
       service.close();
+    }
+  }
+
+  async terminateApp (bundleId) {
+    let instrumentService;
+    let installProxyService;
+    try {
+      installProxyService = await services.startInstallationProxyService(this.udid);
+      const apps = await installProxyService.listApplications();
+      if (!apps[bundleId]) {
+        log.info(`The bundle id '${bundleId}' did not exist`);
+        return false;
+      }
+      const executableName = apps[bundleId].CFBundleExecutable;
+      log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
+      instrumentService = await services.startInstrumentService(this.udid);
+      const processes = await instrumentService.callChannel(INSTRUMENT_CHANNEL.DEVICE_INFO, 'runningProcesses');
+      const process = processes.selector.find((process) => process.name === executableName);
+      if (!process) {
+        log.info(`The process of the bundle id '${bundleId}' was not running`);
+        return false;
+      }
+      await instrumentService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
+      return true;
+    } catch (err) {
+      log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
+      return false;
+    } finally {
+      if (installProxyService) {
+        installProxyService.close();
+      }
+      if (instrumentService) {
+        instrumentService.close();
+      }
     }
   }
 

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -1,6 +1,7 @@
 import { utilities } from 'appium-ios-device';
 import IOSDeploy from './ios-deploy';
 import log from './logger';
+import { SAFARI_BUNDLE_ID } from './app-utils';
 
 
 async function getConnectedDevices () {
@@ -12,11 +13,21 @@ async function getOSVersion (udid) {
 }
 
 async function resetRealDevice (device, opts) {
-  if (!opts.bundleId || !opts.fullReset) {
+  const { bundleId, fullReset } = opts;
+  if (!bundleId) {
     return;
   }
 
-  let bundleId = opts.bundleId;
+  if (bundleId === SAFARI_BUNDLE_ID) {
+    log.debug('Reset requested. About to terminate Safari');
+    await device.terminateApp(bundleId);
+    return;
+  }
+
+  if (!fullReset) {
+    return;
+  }
+
   log.debug(`Reset: fullReset requested. Will try to uninstall the app '${bundleId}'.`);
   if (!await device.isAppInstalled(bundleId)) {
     log.debug('Reset: app not installed. No need to uninstall');

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -57,9 +57,11 @@ describe('Safari - basics -', function () {
 
     it('should start a session with default init', async function () {
       const expectedTitle = process.env.REAL_DEVICE
-        ? 'Appium: Mobile App Automation Made Awesome.'
+        ? ''
         : 'Appium/welcome';
-      driver = await initSession(SAFARI_CAPS);
+      driver = await initSession(amendCapabilities(SAFARI_CAPS, {
+        'appium:noReset': false
+      }));
       const title = await spinTitle(driver);
       title.should.equal(expectedTitle);
     });


### PR DESCRIPTION
This PR includes:
- Improved logic for `safariInitialUrl` capability. Now setting it to an empty strings makes the driver to skip setting of the initial URL, which saves some time on startup. Also, setting `noReset` to `true` has the same effect if `safariInitialUrl` is not provided
- Device reset now terminates Safari on real devices, previously it had no effect
- Removed some related conditions for legacy platforms (e.g. iOS 12)