### PR TITLE
ci: remove unnecessary npm install

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -16,8 +16,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 16.x
-    - name: install newer npm
-      run: npm install -g npm
     - run: npm install
       name: Install dependencies
     - run: npm test


### PR DESCRIPTION
npm v8 in NodeJS 16 is enough as a release task. `npm install -g npm` is not necessary.