### PR TITLE
feat: Update application bundles processing

### DIFF
--- a/lib/app-utils.js
+++ b/lib/app-utils.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import path from 'path';
-import { plist, fs, util } from 'appium/support';
+import { plist, fs, util, tempDir, zip } from 'appium/support';
 import log from './logger.js';
 
 const STRINGSDICT_RESOURCE = '.stringsdict';
 const STRINGS_RESOURCE = '.strings';
 const SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
-
+const APP_EXT = '.app';
+const IPA_EXT = '.ipa';
 
 async function extractPlistEntry (app, entryName) {
   const plistPath = path.resolve(app, 'Info.plist');
@@ -21,6 +22,22 @@ async function extractBundleId (app) {
   const bundleId = await extractPlistEntry(app, 'CFBundleIdentifier');
   log.debug(`Getting bundle ID from app '${app}': '${bundleId}'`);
   return bundleId;
+}
+
+async function fetchSupportedAppPlatforms (app) {
+  try {
+    const result = await extractPlistEntry(app, 'CFBundleSupportedPlatforms');
+    if (!_.isArray(result)) {
+      log.warn(`${path.basename(app)}': CFBundleSupportedPlatforms is not a valid list`);
+      return [];
+    }
+    return result;
+  } catch (err) {
+    log.warn(
+      `Cannot extract the list of supported platforms from '${path.basename(app)}': ${err.message}`
+    );
+    return [];
+  }
 }
 
 /**
@@ -41,18 +58,8 @@ async function extractBundleId (app) {
 async function verifyApplicationPlatform (app, expectedPlatform) {
   log.debug('Verifying application platform');
 
-  let supportedPlatforms;
-  try {
-    supportedPlatforms = await extractPlistEntry(app, 'CFBundleSupportedPlatforms');
-  } catch (err) {
-    log.debug(err.message);
-    return;
-  }
+  const supportedPlatforms = await fetchSupportedAppPlatforms(app);
   log.debug(`CFBundleSupportedPlatforms: ${JSON.stringify(supportedPlatforms)}`);
-  if (!_.isArray(supportedPlatforms)) {
-    log.debug(`CFBundleSupportedPlatforms key does not exist in '${path.basename(app)}'`);
-    return;
-  }
 
   const {
     isSimulator,
@@ -157,7 +164,57 @@ async function parseLocalizableStrings (opts) {
   return resultStrings;
 }
 
+/**
+ * Check whether the given path on the file system points to the .app bundle root
+ *
+ * @param {string} appPath Possible .app bundle root
+ * @returns {boolean} Whether the given path points to an .app bundle
+ */
+async function isAppBundle (appPath) {
+  return _.endsWith(_.toLower(appPath), APP_EXT)
+    && (await fs.stat(appPath)).isDirectory()
+    && await fs.exists(path.join(appPath, 'Info.plist'));
+}
+
+/**
+ * Extract the given archive and looks for items with given extensions in it
+ *
+ * @param {string} archivePath Full path to a .zip archive
+ * @param {Array<string>} appExtensions List of matching item extensions
+ * @returns {[string, Array<String>]} Tuple, where the first element points to
+ * a temporary folder root where the archive has been extracted and the second item
+ * contains a list of relative paths to matched items
+ */
+async function findApps (archivePath, appExtensions) {
+  const useSystemUnzipEnv = process.env.APPIUM_PREFER_SYSTEM_UNZIP;
+  const useSystemUnzip = _.isEmpty(useSystemUnzipEnv)
+    || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
+  const tmpRoot = await tempDir.openDir();
+  await zip.extractAllTo(archivePath, tmpRoot, {useSystemUnzip});
+  const globPattern = `**/*.+(${appExtensions.map((ext) => ext.replace(/^\./, '')).join('|')})`;
+  const sortedBundleItems = (await fs.glob(globPattern, {
+    cwd: tmpRoot,
+    strict: false,
+  })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+  return [tmpRoot, sortedBundleItems];
+}
+
+/**
+ * Moves the application bundle to a newly created temporary folder
+ *
+ * @param {string} appRoot Full path to the .app bundle
+ * @returns {string} The new path to the app bundle.
+ * The name of the app bundle remains though
+ */
+async function isolateAppBundle (appRoot) {
+  const tmpRoot = await tempDir.openDir();
+  const dstRoot = path.join(tmpRoot, path.basename(appRoot));
+  await fs.mv(appRoot, dstRoot, {mkdirp: true});
+  return dstRoot;
+}
+
 export {
   extractBundleId, verifyApplicationPlatform, parseLocalizableStrings,
-  SAFARI_BUNDLE_ID
+  SAFARI_BUNDLE_ID, fetchSupportedAppPlatforms, APP_EXT, IPA_EXT,
+  isAppBundle, findApps, isolateAppBundle,
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -885,15 +885,16 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
-    if (_.isPlainObject(cachedAppInfo) && (await fs.stat(appPath)).isFile()) {
-      if (await fs.hash(appPath) === cachedAppInfo.packageHash
-          && await fs.exists(cachedAppInfo.fullPath)
-          && (await fs.glob('**/*', {
-            cwd: cachedAppInfo.fullPath, strict: false, nosort: true
-          })).length === cachedAppInfo.integrity.folder) {
-        this.log.info(`Using '${cachedAppInfo.fullPath}' which was cached from '${appPath}'`);
-        return {appPath: cachedAppInfo.fullPath};
-      }
+    // Pick the previously cached entry if its integrity has been preserved
+    if (_.isPlainObject(cachedAppInfo)
+        && (await fs.stat(appPath)).isFile()
+        && await fs.hash(appPath) === cachedAppInfo.packageHash
+        && await fs.exists(cachedAppInfo.fullPath)
+        && (await fs.glob('**/*', {
+          cwd: cachedAppInfo.fullPath, strict: false, nosort: true
+        })).length === cachedAppInfo.integrity.folder) {
+      this.log.info(`Using '${cachedAppInfo.fullPath}' which was cached from '${appPath}'`);
+      return {appPath: cachedAppInfo.fullPath};
     }
 
     // Only local .app bundles that are available in-place should not be cached
@@ -901,6 +902,7 @@ class XCUITestDriver extends BaseDriver {
       return false;
     }
 
+    // Extract the app bundle and cache it
     try {
       return {appPath: await this.unzipApp(appPath)};
     } finally {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -886,8 +886,11 @@ class XCUITestDriver extends BaseDriver {
 
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
     if (_.isPlainObject(cachedAppInfo) && (await fs.stat(appPath)).isFile()) {
-      const packageHash = await fs.hash(appPath);
-      if (packageHash === cachedAppInfo.packageHash && await fs.exists(cachedAppInfo.fullPath)) {
+      if (await fs.hash(appPath) === cachedAppInfo.packageHash
+          && await fs.exists(cachedAppInfo.fullPath)
+          && (await fs.glob('**/*', {
+            cwd: cachedAppInfo.fullPath, strict: false, nosort: true
+          })).length === cachedAppInfo.integrity.folder) {
         this.log.info(`Using '${cachedAppInfo.fullPath}' which was cached from '${appPath}'`);
         return {appPath: cachedAppInfo.fullPath};
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,5 +1,5 @@
 import { BaseDriver, DeviceSettings } from 'appium/driver';
-import { util, mjpeg } from 'appium/support';
+import { util, mjpeg, fs } from 'appium/support';
 import _ from 'lodash';
 import url from 'url';
 import { WebDriverAgent } from 'appium-webdriveragent';
@@ -15,7 +15,9 @@ import {
 } from './cert-utils';
 import { retryInterval, retry } from 'asyncbox';
 import {
-  verifyApplicationPlatform, extractBundleId, SAFARI_BUNDLE_ID
+  verifyApplicationPlatform, extractBundleId, SAFARI_BUNDLE_ID,
+  fetchSupportedAppPlatforms, APP_EXT, IPA_EXT,
+  isAppBundle, findApps, isolateAppBundle,
 } from './app-utils';
 import {
   desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS
@@ -44,6 +46,8 @@ import Pyidevice from './py-ios-device-client';
 const SHUTDOWN_OTHER_FEAT_NAME = 'shutdown_other_sims';
 const CUSTOMIZE_RESULT_BUNDPE_PATH = 'customize_result_bundle_path';
 
+const SUPPORTED_EXTENSIONS = [IPA_EXT, APP_EXT];
+const MAX_ARCHIVE_SCAN_DEPTH = 1;
 const defaultServerCaps = {
   webStorageEnabled: false,
   locationContextEnabled: false,
@@ -145,6 +149,7 @@ const MEMOIZED_FUNCTIONS = [
   'getDevicePixelRatio',
   'getScreenInfo',
 ];
+
 
 class XCUITestDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
@@ -817,14 +822,91 @@ class XCUITestDriver extends BaseDriver {
         return;
     }
 
-    try {
-      // download if necessary
-      this.opts.app = await this.helpers.configureApp(this.opts.app, '.app');
-    } catch (err) {
-      this.log.error(err);
-      throw new Error(`Bad app: ${this.opts.app}. ` +
-        `App paths need to be absolute or an URL to a compressed app file: ${err.message}`);
+    this.opts.app = await this.helpers.configureApp(this.opts.app, {
+      onPostProcess: this.onPostConfigureApp.bind(this),
+      supportedExtensions: SUPPORTED_EXTENSIONS
+    });
+  }
+
+  /**
+   * Unzip the given archive and find a matching .app bundle in it
+   *
+   * @param {string} appPath The path to the archive.
+   * @param {number} depth [0] the current nesting depth. App bundles whose nesting level
+   * is greater than 1 are not supported.
+   * @returns {string} Full path to the first matching .app bundle..
+   * @throws If no matching .app bundles were found in the provided archive.
+   */
+  async unzipApp (appPath, depth = 0) {
+    if (depth > MAX_ARCHIVE_SCAN_DEPTH) {
+      throw new Error('Nesting of package bundles is not supported');
     }
+    const [rootDir, matchedPaths] = await findApps(appPath, SUPPORTED_EXTENSIONS);
+    if (_.isEmpty(matchedPaths)) {
+      this.log.debug(`'${path.basename(appPath)}' has no bundles`);
+    } else {
+      this.log.debug(
+        `Found ${util.pluralize('bundle', matchedPaths.length, true)} in ` +
+        `'${path.basename(appPath)}': ${matchedPaths}`
+      );
+    }
+    try {
+      for (const matchedPath of matchedPaths) {
+        const fullPath = path.join(rootDir, matchedPath);
+        if (await isAppBundle(fullPath)) {
+          const supportedPlatforms = await fetchSupportedAppPlatforms(fullPath);
+          if (this.isSimulator() && !supportedPlatforms.some((p) => _.includes(p, 'Simulator'))) {
+            this.log.info(`'${matchedPath}' does not have Simulator devices in the list of supported platforms ` +
+              `(${supportedPlatforms.join(',')}). Skipping it`);;
+            continue;
+          }
+          if (this.isRealDevice() && !supportedPlatforms.some((p) => _.includes(p, 'OS'))) {
+            this.log.info(`'${matchedPath}' does not have real devices in the list of supported platforms. ` +
+              `(${supportedPlatforms.join(',')}). Skipping it`);;
+            continue;
+          }
+          this.log.info(`'${matchedPath}' is the resulting application bundle selected from '${appPath}'`);
+          return await isolateAppBundle(fullPath);
+        } else if (_.endsWith(_.toLower(fullPath), IPA_EXT) && (await fs.stat(fullPath)).isFile()) {
+          try {
+            return await this.unzipApp(fullPath, depth + 1);
+          } catch (e) {
+            this.log.warn(`Skipping processing of '${matchedPath}': ${e.message}`);
+          }
+        }
+      }
+    } finally {
+      await fs.rimraf(rootDir);
+    }
+    throw new Error(`${this.opts.app} did not have any matching ${APP_EXT} or ${IPA_EXT} ` +
+      `bundles. Please make sure the provided package is valid and contains at least one matching ` +
+      `application bundle which is not nested.`
+    );
+  }
+
+  async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
+    const isAppPathLocalBundle = await isAppBundle(appPath);
+    let pathInCache = null;
+    if (_.isPlainObject(cachedAppInfo) && isAppPathLocalBundle) {
+      const itemsCount = await (await fs.glob('**/*', {
+        cwd: appPath, strict: false, nosort: true
+      })).length;
+      if (itemsCount === cachedAppInfo.integrity.folder && await fs.exists(cachedAppInfo.fullPath)) {
+        this.log.info(`Using '${cachedAppInfo.fullPath}' which was cached from '${appPath}'`);
+        pathInCache = cachedAppInfo.fullPath;
+      }
+    }
+
+    // Only local .app bundles that are available in-place should not be cached
+    if (!pathInCache && !isAppPathLocalBundle) {
+      pathInCache = await this.unzipApp(appPath);
+
+      // Cleanup previously downloaded archive
+      if (isUrl) {
+        await fs.rimraf(appPath);
+      }
+    }
+    return pathInCache ? {appPath: pathInCache} : false;
   }
 
   async determineDevice () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -861,7 +861,7 @@ class XCUITestDriver extends BaseDriver {
             continue;
           }
           if (this.isRealDevice() && !supportedPlatforms.some((p) => _.includes(p, 'OS'))) {
-            this.log.info(`'${matchedPath}' does not have real devices in the list of supported platforms. ` +
+            this.log.info(`'${matchedPath}' does not have real devices in the list of supported platforms ` +
               `(${supportedPlatforms.join(',')}). Skipping it`);;
             continue;
           }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -885,28 +885,27 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
-    const isAppPathLocalBundle = await isAppBundle(appPath);
-    let pathInCache = null;
-    if (_.isPlainObject(cachedAppInfo) && isAppPathLocalBundle) {
-      const itemsCount = await (await fs.glob('**/*', {
-        cwd: appPath, strict: false, nosort: true
-      })).length;
-      if (itemsCount === cachedAppInfo.integrity.folder && await fs.exists(cachedAppInfo.fullPath)) {
+    if (_.isPlainObject(cachedAppInfo) && (await fs.stat(appPath)).isFile()) {
+      const packageHash = await fs.hash(appPath);
+      if (packageHash === cachedAppInfo.packageHash && await fs.exists(cachedAppInfo.fullPath)) {
         this.log.info(`Using '${cachedAppInfo.fullPath}' which was cached from '${appPath}'`);
-        pathInCache = cachedAppInfo.fullPath;
+        return {appPath: cachedAppInfo.fullPath};
       }
     }
 
     // Only local .app bundles that are available in-place should not be cached
-    if (!pathInCache && !isAppPathLocalBundle) {
-      pathInCache = await this.unzipApp(appPath);
+    if (await isAppBundle(appPath)) {
+      return false;
+    }
 
+    try {
+      return {appPath: await this.unzipApp(appPath)};
+    } finally {
       // Cleanup previously downloaded archive
       if (isUrl) {
         await fs.rimraf(appPath);
       }
     }
-    return pathInCache ? {appPath: pathInCache} : false;
   }
 
   async determineDevice () {


### PR DESCRIPTION
This PR updates the way application bundles are processed in the driver and moves the appropriate logic to the xcuitest driver instead of having it in the base driver.

Also added some tasty improvements like the one requested by @nextlevelbeard in https://github.com/appium/appium-xcuitest-driver/pull/1408

The PR needs some more attention and extensive testing for different app/platform scenarios.

Main scenarios are:
Real device
- .app bundle
- .ipa bundle
- .zip bundle with .app
- .zip bundle with .ipa
- .zip bundle with multiple .app/.ipa, where only one bundle matches the target platform
- url to .ipa bundle
- url to a .zip bundle
- invalid bundle

Simulator
- all the same above

All cases except the first one must also be verified regarding valid caching.

I would be very grateful @KazuCocoa and @nextlevelbeard if you could assist with testing of the listed scenarios