### PR TITLE
feat: listCertificates command for real devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,11 +619,33 @@ The content of the generated .mobileconfig file as base64-encoded string. This c
 
 ### mobile: listCertificates
 
-On real devices the installed certificates are listed if [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool is available on the server machine.
+Lists installed certificates for real devices only if [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool is available on the server machine since driver version 4.10.0.
 
 #### Returned Result
 
-Returns map of certificates installed on the real device.
+Returns map of certificates installed on the real device. The response looks like:
+
+```
+{
+    'OrderedIdentifiers': ['com.orgname.profile.mdmprofile'],
+    'ProfileManifest': {
+        'com.orgname.profile.mdmprofile': {
+            'Description': 'MDM Profile',
+            'IsActive': True
+        }
+    },
+    'ProfileMetadata': {
+        'com.orgname.profile.mdmprofile': {
+            'PayloadDescription': 'MDM Profile for testing,
+            'PayloadDisplayName': 'MDM Profile',
+            'PayloadOrganization': 'My Org, Inc.',
+            'PayloadRemovalDisallowed': False,
+            'PayloadUUID': '9ab3fa27-cc45-4c23-a94a-714686397a86',
+            'PayloadVersion': 1
+        }
+    },
+    'Status': 'Acknowledged'}
+```
 
 ### mobile: startLogsBroadcast
 

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ Lists installed certificates for real devices only if [py-ios-device](https://gi
 
 Returns map of certificates installed on the real device. The response looks like:
 
-```
+```json
 {
     'OrderedIdentifiers': ['com.orgname.profile.mdmprofile'],
     'ProfileManifest': {
@@ -644,7 +644,8 @@ Returns map of certificates installed on the real device. The response looks lik
             'PayloadVersion': 1
         }
     },
-    'Status': 'Acknowledged'}
+    'Status': 'Acknowledged'
+}
 ```
 
 ### mobile: startLogsBroadcast

--- a/README.md
+++ b/README.md
@@ -617,6 +617,14 @@ isRoot | boolean | no | This option defines where the certificate should be inst
 
 The content of the generated .mobileconfig file as base64-encoded string. This config might be useful for debugging purposes. If the certificate has been successfully set via CLI then nothing is returned.
 
+### mobile: listCertificates
+
+On real devices the installed certificates are listed if [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool is available on the server machine.
+
+#### Returned Result
+
+Returns map of certificates installed on the real device.
+
 ### mobile: startLogsBroadcast
 
 Starts iOS system logs broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/syslog` endpoint. The method will return immediately if the web socket is already listening.

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -410,17 +410,24 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
   }
 };
 
+/**
+ * Lists installed certificates for real devices only
+ * if [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool
+ * is available on the server machine.
+ *
+ * @returns {Object} Returns map of certificates installed on the real device
+ * @throws {Error} If attempting to list certificates for simulated device or if py-ios-device
+ * is not installed
+ */
 commands.mobileListCertificates = async function mobileListCertificates () {
   if (!this.isRealDevice()) {
     throw new errors.NotImplementedError(`This extension is only supported on real devices`);
-  } else {
-    const client = new Pyidevice(this.opts.udid);
-    if (await client.assertExists(false)) {
-      return await client.listProfiles();
-    } else {
-      throw new errors.Error(`pyidevice is not installed on your system, command cannot be executed.`);
-    }
   }
+  const client = new Pyidevice(this.opts.udid);
+  if (await client.assertExists(false)) {
+    return await client.listProfiles();
+  }
+  throw new errors.Error(`pyidevice is not installed on your system, command cannot be executed.`);
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -8,6 +8,7 @@ import http from 'http';
 import { exec } from 'teen_process';
 import { findAPortNotInUse, checkPortStatus } from 'portscanner';
 import Pyidevice from '../py-ios-device-client';
+import { errors } from 'appium/driver';
 
 let extensions = {}, commands = {};
 
@@ -406,6 +407,19 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
   } finally {
     await tmpServer.close();
     await fs.rimraf(tmpRoot);
+  }
+};
+
+commands.mobileListCertificates = async function mobileListCertificates () {
+  if (!this.isRealDevice()) {
+    throw new errors.NotImplementedError(`This extension is only supported on real devices`);
+  } else {
+    const client = new Pyidevice(this.opts.udid);
+    if (await client.assertExists(false)) {
+      return await client.listProfiles();
+    } else {
+      throw new errors.Error(`pyidevice is not installed on your system, command cannot be executed.`);
+    }
   }
 };
 

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -421,13 +421,13 @@ commands.mobileInstallCertificate = async function mobileInstallCertificate (opt
  */
 commands.mobileListCertificates = async function mobileListCertificates () {
   if (!this.isRealDevice()) {
-    throw new errors.NotImplementedError(`This extension is only supported on real devices`);
+    throw new errors.NotImplementedError('This extension is only supported on real devices');
   }
   const client = new Pyidevice(this.opts.udid);
   if (await client.assertExists(false)) {
     return await client.listProfiles();
   }
-  throw new errors.Error(`pyidevice is not installed on your system, command cannot be executed.`);
+  throw new Error('pyidevice is not installed on your system, command cannot be executed.');
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -107,6 +107,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     stopPerfRecord: 'mobileStopPerfRecord',
 
     installCertificate: 'mobileInstallCertificate',
+    listCertificates: 'mobileListCertificates',
 
     startLogsBroadcast: 'mobileStartLogsBroadcast',
     stopLogsBroadcast: 'mobileStopLogsBroadcast',

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
+    "install-driver": "appium driver install --source=local $(pwd)",
+    "reinstall-driver": "(appium driver uninstall xcuitest || exit 0) && appium driver install --source=local $(pwd)",
     "build": "gulp transpile",
     "mocha": "mocha",
     "prepare": "gulp prepublish",

--- a/package.json
+++ b/package.json
@@ -90,8 +90,6 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "install-driver": "appium driver install --source=local $(pwd)",
-    "reinstall-driver": "(appium driver uninstall xcuitest || exit 0) && appium driver install --source=local $(pwd)",
     "build": "gulp transpile",
     "mocha": "mocha",
     "prepare": "gulp prepublish",


### PR DESCRIPTION
Piggybacking off the work @mykola-mokhnach did for https://github.com/appium/appium-xcuitest-driver/pull/1369

This adds a mobile command to list certificates installed on the device. It only works on real devices where [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool is available on the server machine. I did not see a mechanism in WDA, etc for getting this info from simulators.