### PR TITLE
fix: make ips files readable as crash log

### DIFF
--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -51,6 +51,7 @@ class IOSCrashLog {
       log.debug(`Crash reports root '${this.logDir}' does not exist. Got nothing to gather.`);
       return [];
     }
+    // The file format has been changed from '.crash' to '.ips' since Monterey.
     const foundFiles = await fs.glob(`${this.logDir}/**/*.+(crash|ips)`, {
       strict: false
     });

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -51,7 +51,7 @@ class IOSCrashLog {
       log.debug(`Crash reports root '${this.logDir}' does not exist. Got nothing to gather.`);
       return [];
     }
-    const foundFiles = await fs.glob(`${this.logDir}/**/*.crash`, {
+    const foundFiles = await fs.glob(`${this.logDir}/**/*.+(crash|ips)`, {
       strict: false
     });
     // For Simulator only include files, that contain current UDID


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/17346

This PR makes the ips file be read as crash log for the emulator. According to [this post](https://stackoverflow.com/questions/69858174/how-to-read-translate-macos-12-monterey-ips-crash-files)
> Starting in macOS 12 (Monterey), the system apparently writes crash file as .ips files, instead of the traditional .crash file format.

getLogs() [reads ips files on real  device](https://github.com/YueChen-C/py-ios-device#get-crash-syslog) but not on simulator.