### PR TITLE
docs: add xcodebuild for general ios/tvos devices way

### DIFF
--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -190,24 +190,28 @@ You ought to get back output something like this:
 
 #### Build for Generic iOS/tvOS devices, run manually
 
-As another way, you can build `WebDriverAgentRunner` for a generic iOS/tvOS device, and install the generated `.app` package to a real device.
-The generic one means for any iOS/tvOS devices similar to creating a release iOS/tvOS package.
+Alternatively, you can build `WebDriverAgentRunner` for a generic iOS/tvOS device, and install the generated `.app` package to a real device.
+Building for a generic device means the package could be installed on any iOS or tvOS device depending on the chosen platform.
 
 ```bash
 # iOS
-$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
 
 # tvOS
-$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=YES
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=YES
 ```
 
-Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has proper condiguratin as this page to do sign properly.
+On successful completion the resulting package `WebDriverAgentRunner-Runner.app` should be located in `Build/Products/Debug-iphoneos/` subfolder under WebDriverAgent sources root, or in the path provided as `derivedDataPath` argument.
+
+> **Note**
+> Please make sure the `WebDriverAgent.xcodeproj` has codesigning properties configured properly according to the above description if the build action fails.
+
 The `WebDriverAgentRunner-Runner.app` can be installed to any real device allowed by the provisiong profile.
 
 You can install the package with 3rd party tools and manage it separately as explained in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
 If the codesign is not correct, the installation will fail because of the package verification error by iOS.
 
-As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
+As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) separately by yourself.
 This would make the device management more flexible, but you'd need to know about advanced codesign usage scenarios.
 
 ### Finding WebDriverAgent project root on the local file system

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -200,7 +200,7 @@ $ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedD
 Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has proper condiguratin as this page to do sign properly.
 The `WebDriverAgentRunner-Runner.app` can be installed to any real devices allowed by the provisiong profile.
 
-You can install the package with 3rd party tools such as listed in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
+You can install the package with 3rd party tools and manage it separately like explained in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
 If the codesign is not correct, the installation will fail because of the package verification error by iOS.
 
 As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -195,14 +195,16 @@ As another way, you can build `WebDriverAgentRunner` for a general iOS device, a
 ```bash
 $ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
 ```
-(tvOS should be `WebDriverAgentRunner_tvOS` instead of `WebDriverAgentRunner` in the above scheme and target.)
+(tvOS should be `WebDriverAgentRunner_tvOS` instead of `WebDriverAgentRunner`  in the above scheme and target, and `generic/platform=tvOS`instead of `generic/platform=iOS` for the destination.)
 
-Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has the proper condiguratin as this page to do sign properly.
-The `WebDriverAgentRunner-Runner.app` can be installed to real devices allowed by the codesign. You can install the app file with 3rd party tools such as listed in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
-If the codesign is not correct, the installation will fail because of the application verification error by iOS.
+Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has proper condiguratin as this page to do sign properly.
+The `WebDriverAgentRunner-Runner.app` can be installed to any real devices allowed by the provisiong profile.
 
-As a more advanced method, you can generate the app package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
-This way allows you to manage devices more flexible, but you may need knowledge about the codesign.
+You can install the package with 3rd party tools such as listed in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
+If the codesign is not correct, the installation will fail because of the package verification error by iOS.
+
+As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
+This way bring you to manage devices more flexible, but you may need knowledge about the codesign.
 
 ### Finding WebDriverAgent project root on the local file system
 

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -117,7 +117,7 @@ is updated, and is _not_ recommended):
 ```bash
     mkdir -p Resources/WebDriverAgent.bundle
 ```
-If you build an WebDriverAgent with a version before 2.32.0 (e.g. as part of
+If you build WebDriverAgent with a version before 2.32.0 (e.g. as part of
 an Appium release before 1.20.0) you also have to run
 ```bash
     ./Scripts/bootstrap.sh -d
@@ -188,23 +188,27 @@ You ought to get back output something like this:
     }
 ```
 
-#### Build for general devicces, run it by manual
+#### Build for Generic iOS/tvOS devices, run manually
 
-As another way, you can build `WebDriverAgentRunner` for a general iOS device, and install the generated `.app` package to a real device.
+As another way, you can build `WebDriverAgentRunner` for a generic iOS/tvOS device, and install the generated `.app` package to a real device.
+The generic one means for any iOS/tvOS devices similar to creating a release iOS/tvOS package.
 
 ```bash
+# iOS
 $ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
+
+# tvOS
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=YES
 ```
-(tvOS should be `WebDriverAgentRunner_tvOS` instead of `WebDriverAgentRunner`  in the above scheme and target, and `generic/platform=tvOS`instead of `generic/platform=iOS` for the destination.)
 
 Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has proper condiguratin as this page to do sign properly.
-The `WebDriverAgentRunner-Runner.app` can be installed to any real devices allowed by the provisiong profile.
+The `WebDriverAgentRunner-Runner.app` can be installed to any real device allowed by the provisiong profile.
 
-You can install the package with 3rd party tools and manage it separately like explained in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
+You can install the package with 3rd party tools and manage it separately as explained in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
 If the codesign is not correct, the installation will fail because of the package verification error by iOS.
 
 As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
-This way bring you to manage devices more flexible, but you may need knowledge about the codesign.
+This would make the device management more flexible, but you'd need to know about advanced codesign usage scenarios.
 
 ### Finding WebDriverAgent project root on the local file system
 

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -6,7 +6,7 @@ The easiest way to get up-and-running with Appium's XCUITest support on iOS
 real devices is to use the automatic configuration strategy. There are two ways
 to do this:
 
-*   Use the `xcodeOrgId` and `xcodeSigningId` desired capabilities:
+*   Use the `xcodeOrgId` and `xcodeSigningId` [capabilities](../README.md#webdriveragent):
 ```json
     {
       "xcodeOrgId": "<Team ID>",
@@ -117,8 +117,8 @@ is updated, and is _not_ recommended):
 ```bash
     mkdir -p Resources/WebDriverAgent.bundle
 ```
-    If you build an WebDriverAgent with a version before 2.32.0 (e.g. as part of
-    an Appium release before 1.20.0) you also have to run
+If you build an WebDriverAgent with a version before 2.32.0 (e.g. as part of
+an Appium release before 1.20.0) you also have to run
 ```bash
     ./Scripts/bootstrap.sh -d
 ```
@@ -127,7 +127,6 @@ is updated, and is _not_ recommended):
     in the "General" tab, and then select your `Development Team`. This
     should also auto select `Signing Ceritificate`. The outcome should look as
     shown below:
-
     ![WebDriverAgent in Xcode project](xcode-config.png)
 
     * Xcode may fail to create a provisioning profile for the `WebDriverAgentRunner`
@@ -148,7 +147,7 @@ is updated, and is _not_ recommended):
 
 *   Finally, you can verify that everything works. Build the project:
 ```bash
-    xcodebuild -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'id=<udid>' test
+    xcodebuild build-for-testing test-without-building -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'id=<udid>'
 ```
 If this was successful, the output should end with something like:
 ```
@@ -167,7 +166,7 @@ If this was successful, the output should end with something like:
     export JSON_HEADER='-H "Content-Type: application/json;charset=UTF-8, accept: application/json"'
     curl -X GET $JSON_HEADER $DEVICE_URL/status
 ```
-    You ought to get back output something like this:
+You ought to get back output something like this:
 ```json
     {
       "value" : {
@@ -188,6 +187,19 @@ If this was successful, the output should end with something like:
       "status" : 0
     }
 ```
+
+#### Build for general devicces, run it by manual
+
+As another way, you can build `WebDriverAgentRunner` for a general iOS device, and install the generated `.app` package to a real device.
+
+```bash
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
+```
+(tvOS should be `WebDriverAgentRunner_tvOS` instead of `WebDriverAgentRunner` in the above scheme and target.)
+
+Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `xcodeproj` has the proper condiguratin as the above to do sign properly.
+The `WebDriverAgentRunner-Runner.app` can be installed to real devices allowed by the codesign. You can install the app file with 3rd party tools such as listed in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
+As a more advanced method, you can generate the app package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
 
 ### Finding WebDriverAgent project root on the local file system
 

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -195,10 +195,10 @@ The generic one means for any iOS/tvOS devices similar to creating a release iOS
 
 ```bash
 # iOS
-$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=YES
 
 # tvOS
-$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=YES
+$ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=YES
 ```
 
 Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has proper condiguratin as this page to do sign properly.

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -197,9 +197,12 @@ $ xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedD
 ```
 (tvOS should be `WebDriverAgentRunner_tvOS` instead of `WebDriverAgentRunner` in the above scheme and target.)
 
-Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `xcodeproj` has the proper condiguratin as the above to do sign properly.
+Then, `WebDriverAgentRunner-Runner.app` will be in `appium_wda/Build/Products/Debug-iphoneos/WebDriverAgentRunner-Runner.app` with the proper codesign by xcodebuild. Please make sure the `WebDriverAgent.xcodeproj` has the proper condiguratin as this page to do sign properly.
 The `WebDriverAgentRunner-Runner.app` can be installed to real devices allowed by the codesign. You can install the app file with 3rd party tools such as listed in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).
+If the codesign is not correct, the installation will fail because of the application verification error by iOS.
+
 As a more advanced method, you can generate the app package with `CODE_SIGNING_ALLOWED=NO` and do [`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format) by yourself.
+This way allows you to manage devices more flexible, but you may need knowledge about the codesign.
 
 ### Finding WebDriverAgent project root on the local file system
 

--- a/docs/wda-custom-server.md
+++ b/docs/wda-custom-server.md
@@ -159,7 +159,7 @@ public class WDAServer {
     private List<String> generateXcodebuildCmdline() {
         final List<String> result = new ArrayList<>();
         result.add(XCODEBUILD_EXECUTABLE.getAbsolutePath());
-        result.add("clean build test");
+        result.add("clean build-for-testing test-without-building");
         result.add(String.format("-project %s", WDA_PROJECT.getAbsolutePath()));
         result.add(String.format("-scheme %s", WDA_SCHEME));
         result.add(String.format("-destination id=%s", deviceId));

--- a/docs/wda-custom-server.md
+++ b/docs/wda-custom-server.md
@@ -47,7 +47,7 @@ address for Simulator and for real device.
 
 You can use [appium-ios-device](https://github.com/appium/appium-ios-device) to connect to
 a remote device requiring the module from your JavaScript code as same as Appium.
-Alternatively, you can also use [iproxy](https://github.com/libimobiledevice/libusbmuxd#iproxy), [go-ios](https://github.com/danielpaulus/go-ios) or [tidevice](https://github.com/alibaba/taobao-iphone-device) to handle WebDriverAgent process outside Appium. For instance, `iproxy` could be installed using npm: `npm install -g iproxy`.
+Alternatively, you can also use [iproxy](https://github.com/libimobiledevice/libusbmuxd#iproxy), [go-ios](https://github.com/danielpaulus/go-ios) or [tidevice](https://github.com/alibaba/taobao-iphone-device) to handle WebDriverAgent process outside Appium by installing and launching the WebDriverAgent package. For instance, `iproxy` could be installed using npm: `npm install -g iproxy`.
 
 This helper class written in Java illustrates the main implementation details
 wit _iproxy_:


### PR DESCRIPTION
This is a bit advanced, but potentially this will help users who would like to manage signed `.app` package.
Btw, this method (generate .app -> start it without xcodebuild command) can use free account as well.

Codesign thing is more advanced, but we may be able to add more example here, real-device-config or wda-custom-server, in the future