### PR TITLE
docs: add a link to WDA/releases in the real device config

### DIFF
--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -207,7 +207,7 @@ On successful completion the resulting package `WebDriverAgentRunner-Runner.app`
 > Please make sure the `WebDriverAgent.xcodeproj` has codesigning properties configured properly according to the above description if the build action fails.
 
 > **Note**
-> The generic builds are available in https://github.com/appium/WebDriverAgent/releases as well
+> Generic builds are available for each version tag at https://github.com/appium/WebDriverAgent/releases
 
 The `WebDriverAgentRunner-Runner.app` can be installed to any real device allowed by the provisiong profile.
 

--- a/docs/real-device-config.md
+++ b/docs/real-device-config.md
@@ -206,6 +206,9 @@ On successful completion the resulting package `WebDriverAgentRunner-Runner.app`
 > **Note**
 > Please make sure the `WebDriverAgent.xcodeproj` has codesigning properties configured properly according to the above description if the build action fails.
 
+> **Note**
+> The generic builds are available in https://github.com/appium/WebDriverAgent/releases as well
+
 The `WebDriverAgentRunner-Runner.app` can be installed to any real device allowed by the provisiong profile.
 
 You can install the package with 3rd party tools and manage it separately as explained in [How To Set Up And Customize WebDriverAgent Server](./wda-custom-server.md).


### PR DESCRIPTION
Generic builds are now available in WDA releases page. The link to the releases may help since the packages are generated with the same command of `xcodebuild`