### PR TITLE
docs: Add documentation on XCUITest usage in a CI environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ where `MyPrivateKey.p12` is the private development key exported from the system
 The full path to the keychain can then be sent to the Appium system using the `keychainPath` desired capability,
 and the password sent through the `keychainPassword` capability.
 
+### CI
+
+[This document](docs/ci-setup.md) covers steps to take in order to use the XCUItest driver in a CI environment.
+
 ## Appium 2.x Server Arguments
 
 These arguments are set when you launch the Appium server, with this driver installed. They are for system administrators.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ where `MyPrivateKey.p12` is the private development key exported from the system
 The full path to the keychain can then be sent to the Appium system using the `keychainPath` desired capability,
 and the password sent through the `keychainPassword` capability.
 
-### CI
+### Continuous Integration
 
 [Continuous Integration Setup document](docs/ci-setup.md) covers steps to take in order to use the XCUItest driver in a CI environment.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and the password sent through the `keychainPassword` capability.
 
 ### CI
 
-[This document](docs/ci-setup.md) covers steps to take in order to use the XCUItest driver in a CI environment.
+[Continuous Integration Setup document](docs/ci-setup.md) covers steps to take in order to use the XCUItest driver in a CI environment.
 
 ## Appium 2.x Server Arguments
 

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,4 +1,4 @@
-## CI Setup
+## Continuous Integration Setup
 
 Setting up XCUItest driver in an automated environment brings a few challenges with it.
 Any scenario where user interaction is required must be automated or avoided all together.

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -2,7 +2,7 @@
 
 Setting up appium in an automated environment brings a few challenges with it.
 Any scenario where user interaction is required must be automated or avoided all together.
-For real device set up you should first follow the steps in [this guide](https://github.com/PowerOfCreation/appium-xcuitest-driver/blob/master/docs/real-device-config.md).
+For real device set up you should first follow the steps in [this guide](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md).
 
 ### Keychains
 
@@ -29,8 +29,8 @@ Make sure to start XCode at least once and do the initial set up and install the
 ### Linking Apple Account
 
 This only applies for real device set up.
-Make sure to link your 'Apple Developer Account' in the machine's system wide "Account Panel" when using the "Basic (automatic) configuration" described [here](https://github.com/PowerOfCreation/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration).
+Make sure to link your 'Apple Developer Account' in the machine's system wide "Account Panel" when using the "Basic (automatic) configuration" described [here](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration).
 
 ### Troubleshooting
 
-Enable the `appium:showXcodeLog` [capability](https://github.com/PowerOfCreation/appium-xcuitest-driver#webdriveragent) and check the appium server output.
+Enable the `appium:showXcodeLog` [capability](https://github.com/appium/appium-xcuitest-driver#webdriveragent) and check the appium server output.

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -2,7 +2,7 @@
 
 Setting up XCUItest driver in an automated environment brings a few challenges with it.
 Any scenario where user interaction is required must be automated or avoided all together.
-For real device set up you should first follow the steps in [this guide](real-device-config.md).
+For real device set up you should first follow the steps in [Real Device Configuration tutorial](real-device-config.md).
 
 ### Keychains
 
@@ -13,7 +13,7 @@ There are multiple possible solutions for this:
 2. [It is possible to create a second keychain](../README.md#real-device-security-settings), which just stores the required certificate to sign the WebDriverAgent.
 The issue with this approach is, that Codesign wants to unlock all listed keychains regardless of the specified keychain, thus leading to a password prompt.
 This can be avoided by setting the default keychain and basically hiding the login keychain at the start of building.
-[This](https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails) shows how to utelize this approach.
+[Stackoverflow article](https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails) shows how to utelize this approach.
 Impractical when running other build jobs simultaneously.
 3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using [fastlane unlock_keychain](https://docs.fastlane.tools/actions/unlock_keychain/) or by using [security unlock-keychain](https://www.unix.com/man-page/osx/1/security/) directly.
 The password can be saved as a CI variable/secret or on the machine itself.

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -15,7 +15,7 @@ The issue with this approach is, that Codesign wants to unlock all listed keycha
 This can be avoided by setting the default keychain and basically hiding the login keychain at the start of building.
 [This](https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails) shows how to utelize this approach.
 Impractical when running other build jobs simultaneously.
-3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using [fastlane unlock_keychain](https://docs.fastlane.tools/actions/unlock_keychain/) or by using [security unlock-keychain](https://stackoverflow.com/a/9678612/8182823) directly.
+3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using [fastlane unlock_keychain](https://docs.fastlane.tools/actions/unlock_keychain/) or by using [security unlock-keychain](https://www.unix.com/man-page/osx/1/security/) directly.
 The password can be saved as a CI variable/secret, but this doesn't work for multiple machines with different keychain passwords. Setting the keychain password in each machine's .bashrc as an environment variable does the trick.
 
 It is recommended to go with the second or third option.

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -16,7 +16,7 @@ This can be avoided by setting the default keychain and basically hiding the log
 [This](https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails) shows how to utelize this approach.
 Impractical when running other build jobs simultaneously.
 3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using [fastlane unlock_keychain](https://docs.fastlane.tools/actions/unlock_keychain/) or by using [security unlock-keychain](https://www.unix.com/man-page/osx/1/security/) directly.
-The password can be saved as a CI variable/secret, but this doesn't work for multiple machines with different keychain passwords. Setting the keychain password in each machine's .bashrc as an environment variable does the trick.
+The password can be saved as a CI variable/secret or on the machine itself.
 
 It is recommended to go with the second or third option.
 The third one is the easiest and most reliable one to set up at the cost of having to set the keychain password as an environment variable.

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,36 +1,36 @@
 ## CI Setup
 
-Setting up appium in an automated environment brings a few challenges with it.
+Setting up XCUItest driver in an automated environment brings a few challenges with it.
 Any scenario where user interaction is required must be automated or avoided all together.
-For real device set up you should first follow the steps in [this guide](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md).
+For real device set up you should first follow the steps in [this guide](real-device-config.md).
 
 ### Keychains
 
-One common such scenario is a prompt asking for a keychain to be unlocked in order to sign the WebdriverAgent.
+One common such scenario is a prompt asking for a keychain to be unlocked in order to sign the WebDriverAgent.
 There are multiple possible solutions for this:
 
-1. Keychains can be set to have no timeout and be unlocked manually once. This can be done using the keychain access application. Sometimes keychains still unlock themselves though and this approach is not recommended.
-2. [It is possible to create a second keychain](https://github.com/appium/appium-xcuitest-driver/blob/master/README.md#real-device-security-settings), which just stores the required certificate to sign the WebdriverAgent.
+1. Keychains can be set to have no timeout and be unlocked manually once. This can be done using the keychain access application. Sometimes keychains still lock themselves though and this approach is not recommended.
+2. [It is possible to create a second keychain](../README.md#real-device-security-settings), which just stores the required certificate to sign the WebDriverAgent.
 The issue with this approach is, that Codesign wants to unlock all listed keychains regardless of the specified keychain, thus leading to a password prompt.
 This can be avoided by setting the default keychain and basically hiding the login keychain at the start of building.
-https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails
-Not practically when running other build jobs simultaneously.
-3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using fastlane `unlock_keychain` or by using `security unlock-keychain` directly.
+[This](https://stackoverflow.com/questions/16550594/jenkins-xcode-build-works-codesign-fails) shows how to utelize this approach.
+Impractical when running other build jobs simultaneously.
+3. Stick with the existing keychains as in approach number one, but explicitly call unlock keychain before **each** build. This can be done using [fastlane unlock_keychain](https://docs.fastlane.tools/actions/unlock_keychain/) or by using [security unlock-keychain](https://stackoverflow.com/a/9678612/8182823) directly.
 The password can be saved as a CI variable/secret, but this doesn't work for multiple machines with different keychain passwords. Setting the keychain password in each machine's .bashrc as an environment variable does the trick.
 
 It is recommended to go with the second or third option.
 The third one is the easiest and most reliable one to set up at the cost of having to set the keychain password as an environment variable.
 
-### XCode
+### Xcode
 
-When setting up a new machine as a CI server you are probably going to install XCode, without executing it once, because you are not going to use it for development.
-Make sure to start XCode at least once and do the initial set up and install the suggested extensions for iPhone, watchOS and similar.
+When setting up a new machine as a CI server you are probably going to install Xcode, without executing it once, because you are not going to use it for development.
+Make sure to start Xcode at least once and do the initial set up and install the suggested extensions for iPhone, watchOS and similar.
 
 ### Linking Apple Account
 
 This only applies for real device set up.
-Make sure to link your 'Apple Developer Account' in the machine's system wide "Account Panel" when using the "Basic (automatic) configuration" described [here](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/real-device-config.md#basic-automatic-configuration).
+Make sure to link your 'Apple Developer Account' in the machine's system wide "Account Panel" when using the "Basic (automatic) configuration" described [here](real-device-config.md#basic-automatic-configuration).
 
 ### Troubleshooting
 
-Enable the `appium:showXcodeLog` [capability](https://github.com/appium/appium-xcuitest-driver#webdriveragent) and check the appium server output.
+Enable the `appium:showXcodeLog` [capability](../README.md#webdriveragent) and check the appium server output.


### PR DESCRIPTION
Summary of some pitfalls and solutions to save some time when setting up Appium with CI.

https://github.com/appium/appium/issues/17818