### PR TITLE
[do not merge] add webinspector mobile command for development

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -166,6 +166,8 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     listConditionInducers: 'mobileListConditionInducers',
     enableConditionInducer: 'mobileEnableConditionInducer',
     disableConditionInducer: 'mobileDisableConditionInducer',
+
+    webInspector: 'mobileWebInspector',
   };
 
   if (!_.has(commandMap, mobileCommand)) {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -203,7 +203,7 @@ commands.deleteCookies = async function deleteCookies () {
 
 
 commands.mobileWebInspector = async function mobileWebInspector(opts) {
-  // TODO: add a security flag?
+  // TODO: add a security flag if we add this in the main
 
   if (this.remote) {
     return false;

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -201,6 +201,23 @@ commands.deleteCookies = async function deleteCookies () {
   return true;
 };
 
+
+commands.mobileWebInspector = async function mobileWebInspector(opts) {
+  // TODO: add a security flag?
+
+  if (this.remote) {
+    return false;
+  }
+
+  const { method, args } = opts;
+  await this.remote.rpcClient.send(method, {
+    args,
+    appIdKey: this.remote.appIdKey,
+    pageIdKey: this.remote.pageIdKey,
+  });
+  return true;
+};
+
 helpers._deleteCookie = async function _deleteCookie (cookieName) {
   this.log.debug(`Deleting cookie '${cookieName}'`);
   let webCookie = cookieUtils.expireCookie(cookieName, {path: '/'});


### PR DESCRIPTION
**this is for dev purpose right now**

```ruby
# Ruby client
@driver.execute_script 'mobile:webInspector', {method: 'Page.reload'}
```

Then, the server had (for a simulator):
```
[HTTP] --> POST /wd/hub/session/e8676215-b4c7-4dd5-af73-26e8330c35f8/execute/sync
[HTTP] {"script":"mobile:webInspector","args":[{"method":"Page.reload"}]}
[debug] [XCUITestDriver@dc5d (e8676215)] Calling AppiumDriver.execute() with args: ["mobile:webInspector",[{"method":"Page.reload"}],"e8676215-b4c7-4dd5-af73-26e8330c35f8"]
[debug] [XCUITestDriver@dc5d (e8676215)] Executing command 'execute'
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:12456', page '1', target 'page-18' (id: 38): 'Page.reload'
[debug] [ios-device] Sending message to Web Inspector:
[debug] [ios-device] {
[debug] [ios-device]   "__argument": {
[debug] [ios-device]     "WIRSocketDataKey": "{\"method\":\"Target.sendMessageToTarget\",\"params\":{\"targetId\":\"page-18\",\"message\":\"{\\\"id\\\":38,\\\"method\\\":\\\"Page.reload\\\",\\\"params\\\":{\\\"objectGroup\\\":\\\"console\\\",\\\"includeCommandLineAPI\\\":true,\\\"doNotPauseOnExceptionsAndMuteConsole\\\":false,\\\"emulateUserGesture\\\":false,\\\"generatePreview\\\":false,\\\"saveResult\\\":false}}\"},\"id\":39}",
[debug] [ios-device]     "WIRConnectionIdentifierKey": "7590b918-572f-42bd-b2a4-a88d5e41670b",
[debug] [ios-device]     "WIRSenderKey": "7ab531a7-3002-4cf3-b318-b6c6db708654",
[debug] [ios-device]     "WIRApplicationIdentifierKey": "PID:12456",
[debug] [ios-device]     "WIRPageIdentifierKey": 1
[debug] [ios-device]   },
[debug] [ios-device]   "__selector": "_rpc_forwardSocketData:"
[debug] [ios-device] }
[debug] [ios-device] Received message from Web Inspector:
[debug] [ios-device] {
[debug] [ios-device]   "__argument": {
[debug] [ios-device]     "WIRApplicationIdentifierKey": "PID:12456",
[debug] [ios-device]     "WIRMessageDataTypeKey": "WIRMessageDataTypeFull",
[debug] [ios-device]     "WIRDestinationKey": "7ab531a7-3002-4cf3-b318-b6c6db708654",
[debug] [ios-device]     "WIRMessageDataKey": "{\"result\":{},\"id\":39}"
[debug] [ios-device]   },
[debug] [ios-device]   "__selector": "_rpc_applicationSentData:"
[debug] [ios-device] }
[debug] [ios-device] Received message from Web Inspector:
[debug] [ios-device] {
[debug] [ios-device]   "__argument": {
[debug] [ios-device]     "WIRApplicationIdentifierKey": "PID:12456",
[debug] [ios-device]     "WIRMessageDataTypeKey": "WIRMessageDataTypeFull",
[debug] [ios-device]     "WIRDestinationKey": "7ab531a7-3002-4cf3-b318-b6c6db708654",
[debug] [ios-device]     "WIRMessageDataKey": "{\"method\":\"Target.dispatchMessageFromTarget\",\"params\":{\"targetId\":\"page-18\",\"message\":\"{\\\"result\\\":{},\\\"id\\\":38}\"}}"
[debug] [ios-device]   },
[debug] [ios-device]   "__selector": "_rpc_applicationSentData:"
[debug] [ios-device] }
[debug] [RemoteDebugger] Received data response from send (id: 38): '{}'
[debug] [RemoteDebugger] Sending to Web Inspector took 44ms
[debug] [XCUITestDriver@dc5d (e8676215)] Responding to client with driver.execute() result: true
[HTTP] <-- POST /wd/hub/session/e8676215-b4c7-4dd5-af73-26e8330c35f8/execute/sync 200 48 ms - 14
[HTTP]
[debug] [ios-device] Received message from Web Inspector:
[debug] [ios-device] {
[debug] [ios-device]   "__argument": {
[debug] [ios-device]     "WIRApplicationIdentifierKey": "PID:12456",
[debug] [ios-device]     "WIRListingKey": {
[debug] [ios-device]       "1": {
[debug] [ios-device]         "WIRTitleKey": "YouTube",
[debug] [ios-device]         "WIRTypeKey": "WIRTypeWebPage",
[debug] [ios-device]         "WIRURLKey": "https://m.youtube.com/",
[debug] [ios-device]         "WIRPageIdentifierKey": 1,
[debug] [ios-device]         "WIRConnectionIdentifierKey": "7590b918-572f-42bd-b2a4-a88d5e41670b"
[debug] [ios-device]       }
[debug] [ios-device]     }
[debug] [ios-device]   },
[debug] [ios-device]   "__selector": "_rpc_applicationSentListing:"
[debug] [ios-device] }
[debug] [RemoteDebugger] Page changed: {
[debug] [RemoteDebugger]   "1": {
[debug] [RemoteDebugger]     "WIRTitleKey": "YouTube",
[debug] [RemoteDebugger]     "WIRTypeKey": "WIRTypeWebPage",
[debug] [RemoteDebugger]     "WIRURLKey": "https://m.youtube.com/",
[debug] [RemoteDebugger]     "WIRPageIdentifierKey": 1,
[debug] [RemoteDebugger]     "WIRConnectionIdentifierKey": "7590b918-572f-42bd-b2a4-a88d5e41670b"
[debug] [RemoteDebugger]   }
[debug] [RemoteDebugger] }
[debug] [XCUITestDriver@dc5d (e8676215)] Remote debugger notified us of a new page listing: {"appIdKey":"12456","pageArray":[{"id":1,"title":"YouTube","url":"https://m.youtube.com/","isKey":true}]}
[debug] [XCUITestDriver@dc5d (e8676215)] Checking if page needs to load
[debug] [XCUITestDriver@dc5d (e8676215)] New page listing is same as old, doing nothing
[debug] [ios-device] Received message from Web Inspector:
[debug] [ios-device] {
[debug] [ios-device]   "__argument": {
[debug] [ios-device]     "WIRApplicationIdentifierKey": "PID:12456",
[debug] [ios-device]     "WIRListingKey": {
[debug] [ios-device]       "1": {
[debug] [ios-device]         "WIRTitleKey": "Home - YouTube",
[debug] [ios-device]         "WIRTypeKey": "WIRTypeWebPage",
[debug] [ios-device]         "WIRURLKey": "https://m.youtube.com/",
[debug] [ios-device]         "WIRPageIdentifierKey": 1,
[debug] [ios-device]         "WIRConnectionIdentifierKey": "7590b918-572f-42bd-b2a4-a88d5e41670b"
[debug] [ios-device]       }
[debug] [ios-device]     }
[debug] [ios-device]   },
[debug] [ios-device]   "__selector": "_rpc_applicationSentListing:"
[debug] [ios-device] }
[debug] [RemoteDebugger] Page changed: {
[debug] [RemoteDebugger]   "1": {
[debug] [RemoteDebugger]     "WIRTitleKey": "Home - YouTube",
[debug] [RemoteDebugger]     "WIRTypeKey": "WIRTypeWebPage",
[debug] [RemoteDebugger]     "WIRURLKey": "https://m.youtube.com/",
[debug] [RemoteDebugger]     "WIRPageIdentifierKey": 1,
[debug] [RemoteDebugger]     "WIRConnectionIdentifierKey": "7590b918-572f-42bd-b2a4-a88d5e41670b"
[debug] [RemoteDebugger]   }
[debug] [RemoteDebugger] }
[debug] [XCUITestDriver@dc5d (e8676215)] Remote debugger notified us of a new page listing: {"appIdKey":"12456","pageArray":[{"id":1,"title":"Home - YouTube","url":"https://m.youtube.com/","isKey":true}]}
[debug] [XCUITestDriver@dc5d (e8676215)] Checking if page needs to load
[debug] [XCUITestDriver@dc5d (e8676215)] New page listing is same as old, doing nothing
```

with https://github.com/appium/appium-remote-debugger/pull/274

Not sure which is better, the `Page.reload` vs atom's reload, but this is an example of this command for dev purpose.
With `safariLogAllCommunication: true` option, we can easily try to send commands to observe the event in Appium's log.