### PR TITLE
chore: Only call appropriate setters if their capabilities are defined

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -80,7 +80,7 @@ const DEFAULT_SETTINGS = {
 // affect shared resources of the other parallel sessions
 const SHARED_RESOURCES_GUARD = new AsyncLock();
 const WEB_ELEMENTS_CACHE_SIZE = 500;
-
+const SUPPORTED_ORIENATIONS = ['LANDSCAPE', 'PORTRAIT'];
 /* eslint-disable no-useless-escape */
 const NO_PROXY_NATIVE_LIST = [
   ['DELETE', /window/],
@@ -521,10 +521,14 @@ class XCUITestDriver extends BaseDriver {
 
     await this.startWda(this.opts.sessionId, realDevice);
 
-    await this.setReduceMotion(this.opts.reduceMotion);
+    if (_.isBoolean(this.opts.reduceMotion)) {
+      await this.setReduceMotion(this.opts.reduceMotion);
+    }
 
-    await this.setInitialOrientation(this.opts.orientation);
-    this.logEvent('orientationSet');
+    if (this.opts.orientation) {
+      await this.setInitialOrientation(this.opts.orientation);
+      this.logEvent('orientationSet');
+    }
 
     if (this.isSafari() || this.opts.autoWebview) {
       await this.activateRecentWebview();
@@ -1357,20 +1361,18 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async setInitialOrientation (orientation) {
-    if (!_.isString(orientation)) {
-      this.log.info('Skipping setting of the initial display orientation. ' +
-        'Set the "orientation" capability to either "LANDSCAPE" or "PORTRAIT", if this is an undesired behavior.');
+    const dstOrientation = _.toUpper(orientation);
+    if (!SUPPORTED_ORIENATIONS.includes(dstOrientation)) {
+      this.log.debug(
+        `The initial orientation value '${orientation}' is unknown. ` +
+        `Only ${JSON.stringify(SUPPORTED_ORIENATIONS)} are supported.`
+      );
       return;
     }
-    orientation = orientation.toUpperCase();
-    if (!_.includes(['LANDSCAPE', 'PORTRAIT'], orientation)) {
-      this.log.debug(`Unable to set initial orientation to '${orientation}'`);
-      return;
-    }
-    this.log.debug(`Setting initial orientation to '${orientation}'`);
+
+    this.log.debug(`Setting initial orientation to '${dstOrientation}'`);
     try {
-      await this.proxyCommand('/orientation', 'POST', {orientation});
-      this.opts.curOrientation = orientation;
+      await this.proxyCommand('/orientation', 'POST', {orientation: dstOrientation});
     } catch (err) {
       this.log.warn(`Setting initial orientation failed with: ${err.message}`);
     }


### PR DESCRIPTION
It just takes additional time if setters are called for `undefined` values