### PR TITLE
test: reuse prebuilt WDA as much as possible among functional tests

### DIFF
--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -19,10 +19,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
       script: |
         npm install --no-save mjpeg-consumer
-        npm run e2e-test:basic -- --grep "XCUITestDriver - basics -"
-        npm run e2e-test:basic -- --grep "XCUITestDriver - alerts -"
-        npm run e2e-test:basic -- --grep "XCUITestDriver - elements -"
-        npm run e2e-test:basic -- --grep "XCUITestDriver - find -"
+        npm run e2e-test:basic -- --grep "XCUITestDriver"
 
   - template: ./ios-e2e-template.yml
     parameters:

--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -2,8 +2,8 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
-import { UICATALOG_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { amendCapabilities, UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 
 
 chai.should();
@@ -14,7 +14,10 @@ describe('XCUITestDriver - alerts -', function () {
 
   let driver;
   before(async function () {
-    driver = await initSession(UICATALOG_CAPS);
+    const caps = amendCapabilities(UICATALOG_CAPS, {
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+    });
+    driver = await initSession(caps);
   });
   after(async function () {
     await deleteSession();

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -90,6 +90,7 @@ describe('XCUITestDriver - basics -', function () {
       actual.viewportRect.height.should.be.a('number');
       actual.viewportRect.width.should.be.a('number');
       delete actual.viewportRect;
+      delete actual.usePrebuiltWDA;
 
       // convert w3c caps into mjswp caps
       let mjswpCaps = {};
@@ -103,6 +104,7 @@ describe('XCUITestDriver - basics -', function () {
       };
       let expected = Object.assign({}, mjswpCaps, extraWdaCaps);
       delete expected.udid; // for real device tests
+      delete expected.usePrebuiltWDA;
 
       if (expected.showXcodeLog === undefined) {
         delete expected.showXcodeLog;

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -4,8 +4,8 @@ import chaiSubset from 'chai-subset';
 import B from 'bluebird';
 import util from 'util';
 import { retryInterval } from 'asyncbox';
-import { extractCapabilityValue, UICATALOG_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { extractCapabilityValue, amendCapabilities, UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { GUINEA_PIG_PAGE } from '../web/helpers';
 import { PNG } from 'pngjs';
 
@@ -19,7 +19,10 @@ describe('XCUITestDriver - basics -', function () {
 
   let driver;
   before(async function () {
-    driver = await initSession(UICATALOG_CAPS);
+    const caps = amendCapabilities(UICATALOG_CAPS, {
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+    });
+    driver = await initSession(caps);
   });
   after(async function () {
     await deleteSession();

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -3,8 +3,8 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
-import { extractCapabilityValue, UICATALOG_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { extractCapabilityValue, amendCapabilities, UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { util } from 'appium/support';
 
 
@@ -16,7 +16,10 @@ describe('XCUITestDriver - elements -', function () {
 
   let driver;
   before(async function () {
-    driver = await initSession(UICATALOG_CAPS);
+    const caps = amendCapabilities(UICATALOG_CAPS, {
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+    });
+    driver = await initSession(caps);
   });
   after(async function () {
     await deleteSession();

--- a/test/functional/basic/find-e2e-specs.js
+++ b/test/functional/basic/find-e2e-specs.js
@@ -3,9 +3,9 @@ import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import _ from 'lodash';
 import { retryInterval } from 'asyncbox';
-import { extractCapabilityValue, UICATALOG_CAPS, PLATFORM_VERSION } from '../desired';
+import { extractCapabilityValue, amendCapabilities, UICATALOG_CAPS, PLATFORM_VERSION } from '../desired';
 import { PREDICATE_SEARCH, CLASS_CHAIN_SEARCH } from '../helpers/element';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { util } from 'appium/support';
 
 
@@ -25,7 +25,10 @@ describe('XCUITestDriver - find -', function () {
 
   let driver;
   before(async function () {
-    driver = await initSession(UICATALOG_CAPS);
+    const caps = amendCapabilities(UICATALOG_CAPS, {
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+    });
+    driver = await initSession(caps);
   });
   after(async function () {
     await deleteSession();

--- a/test/functional/basic/touch-id-e2e-specs.js
+++ b/test/functional/basic/touch-id-e2e-specs.js
@@ -2,8 +2,8 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { TOUCHIDAPP_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { amendCapabilities, TOUCHIDAPP_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import B from 'bluebird';
 import { killAllSimulators } from '../helpers/simulator';
 
@@ -45,7 +45,10 @@ if (!process.env.REAL_DEVICE && !process.env.CI && !process.env.CLOUD) {
 
     describe('touchID enrollment functional tests applied to TouchId sample app', function () {
       beforeEach(async function () {
-        driver = await initSession(TOUCHIDAPP_CAPS);
+        const caps = amendCapabilities(TOUCHIDAPP_CAPS, {
+          'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+        });
+        driver = await initSession(caps);
         await B.delay(2000); // Give the app a couple seconds to open
       });
 

--- a/test/functional/device/accessibility-e2e-specs.js
+++ b/test/functional/device/accessibility-e2e-specs.js
@@ -13,7 +13,7 @@ describe('Accessibility', function() {
   let driver, caps;
 
   beforeEach(function() {
-    caps = amendCapabilities(SETTINGS_CAPS, { 'appium:usePrebuiltWDA': true });
+    caps = amendCapabilities(SETTINGS_CAPS);
   });
 
   afterEach(async function() {

--- a/test/functional/device/accessibility-e2e-specs.js
+++ b/test/functional/device/accessibility-e2e-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { PREDICATE_SEARCH } from '../helpers/element';
-import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
+import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { SETTINGS_CAPS, amendCapabilities } from '../desired';
 
 chai.should();
@@ -13,7 +13,9 @@ describe('Accessibility', function() {
   let driver, caps;
 
   beforeEach(function() {
-    caps = amendCapabilities(SETTINGS_CAPS);
+    caps = amendCapabilities(SETTINGS_CAPS, {
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+    });
   });
 
   afterEach(async function() {

--- a/test/functional/device/file-movement-e2e-specs.js
+++ b/test/functional/device/file-movement-e2e-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { UICATALOG_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { amendCapabilities, UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { fs, tempDir, zip } from 'appium/support';
 import path from 'path';
 
@@ -22,7 +22,10 @@ if (!process.env.REAL_DEVICE && !process.env.CLOUD) {
 
     let driver;
     before(async function() {
-      driver = await initSession(UICATALOG_CAPS);
+      const caps = amendCapabilities(UICATALOG_CAPS, {
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+      });
+      driver = await initSession(caps);
     });
     after(async function() {
       await deleteSession();

--- a/test/functional/device/otherApps-e2e-specs.js
+++ b/test/functional/device/otherApps-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
+import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { MULTIPLE_APPS, amendCapabilities } from '../desired';
 
 chai.should();
@@ -14,7 +14,7 @@ describe('OtherApps', function() {
   let driver;
   before(function() {
     caps = amendCapabilities(MULTIPLE_APPS, {
-      'appium:usePrebuiltWDA': true,
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       'appium:wdaStartupRetries': 0,
     });
   });

--- a/test/functional/device/performance-e2e-specs.js
+++ b/test/functional/device/performance-e2e-specs.js
@@ -1,8 +1,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
-import { UICATALOG_CAPS } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { amendCapabilities, UICATALOG_CAPS } from '../desired';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 
 
 chai.should();
@@ -21,7 +21,10 @@ describe('XCUITestDriver - performance', function () {
         this.skip();
       }
 
-      driver = await initSession(UICATALOG_CAPS);
+      const caps = amendCapabilities(UICATALOG_CAPS, {
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+      });
+      driver = await initSession(caps);
     });
     after(async function () {
       await deleteSession();

--- a/test/functional/device/xctest-e2e-specs.js
+++ b/test/functional/device/xctest-e2e-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
+import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { GENERIC_CAPS, amendCapabilities } from '../desired';
 
 const APP_UNDER_TEST_PATH = 'https://github.com/dpgraham/xctesterapp/releases/download/0.1/XCTesterApp.app.zip';
@@ -20,6 +20,7 @@ if (process.env.LAUNCH_WITH_IDB) {
       const caps = amendCapabilities(GENERIC_CAPS, {
         'appium:app': APP_UNDER_TEST_PATH,
         'appium:launchWithIDB': true,
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       });
       driver = await initSession(caps);
     });

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -1,4 +1,5 @@
 import { remote } from 'webdriverio';
+import { extractCapabilityValue } from '../desired';
 
 const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
 const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT, 10) || 4567;
@@ -20,7 +21,7 @@ async function initSession (caps, remoteOpts = {}) {
   driver.name = undefined;
   driver.errored = false;
 
-  if (!caps.alwaysMatch['appium:usePrebuiltWDA'] && !caps.alwaysMatch['appium:derivedDataPath']) {
+  if (!extractCapabilityValue(caps, 'appium:usePrebuiltWDA') && !extractCapabilityValue(caps, 'appium:derivedDataPath')) {
     builtDefaultWDA = true;
   }
 

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -6,6 +6,7 @@ const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT, 10) || 4567;
 const MOCHA_TIMEOUT = 60 * 1000 * (process.env.CI ? 8 : 4);
 
 let driver;
+let builtDefaultWDA = false;
 
 async function initSession (caps, remoteOpts = {}) {
   driver = await remote({
@@ -18,6 +19,11 @@ async function initSession (caps, remoteOpts = {}) {
   });
   driver.name = undefined;
   driver.errored = false;
+
+  if (!caps.alwaysMatch['appium:usePrebuiltWDA'] && !caps.alwaysMatch['appium:derivedDataPath']) {
+    builtDefaultWDA = true;
+  }
+
   return driver;
 }
 
@@ -30,4 +36,8 @@ async function deleteSession () {
   }
 }
 
-export { initSession, deleteSession, HOST, PORT, MOCHA_TIMEOUT };
+function hasDefaultPrebuiltWDA() {
+  return builtDefaultWDA;
+}
+
+export { initSession, deleteSession, hasDefaultPrebuiltWDA, HOST, PORT, MOCHA_TIMEOUT };

--- a/test/functional/web/safari-alerts-e2e-specs.js
+++ b/test/functional/web/safari-alerts-e2e-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { retryInterval } from 'asyncbox';
 import { SAFARI_CAPS, amendCapabilities } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { GUINEA_PIG_PAGE } from './helpers';
 
 
@@ -17,6 +17,7 @@ describe('safari - alerts', function () {
     const caps = amendCapabilities(SAFARI_CAPS, {
       'appium:safariInitialUrl': GUINEA_PIG_PAGE,
       'appium:safariAllowPopups': true,
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
     });
     driver = await initSession(caps);
   });

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
-import { MOCHA_TIMEOUT, initSession, deleteSession } from '../helpers/session';
+import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { SAFARI_CAPS, amendCapabilities } from '../desired';
 import {
   spinTitle, spinTitleEquals, spinWait, openPage, GUINEA_PIG_PAGE,
@@ -39,14 +39,17 @@ describe('Safari - basics -', function () {
         ? ''
         : 'Appium/welcome';
       driver = await initSession(amendCapabilities(SAFARI_CAPS, {
-        'appium:noReset': false
+        'appium:noReset': false,
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       }));
       const title = await spinTitle(driver);
       title.should.equal(expectedTitle);
     });
 
     it('should start a session with custom init', async function () {
-      driver = await initSession(DEFAULT_CAPS);
+      driver = await initSession(amendCapabilities(DEFAULT_CAPS, {
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+      }));
       const title = await spinTitle(driver);
       const expectedTitle = 'I am a page title';
       title.should.equal(expectedTitle);
@@ -58,6 +61,7 @@ describe('Safari - basics -', function () {
       const caps = amendCapabilities(DEFAULT_CAPS, {
         'appium:safariIgnoreFraudWarning': false,
         'appium:showSafariConsoleLog': true,
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       });
       driver = await initSession(caps);
     });
@@ -484,6 +488,7 @@ describe('Safari - basics -', function () {
       beforeEach(async function () {
         driver = await initSession(amendCapabilities(DEFAULT_CAPS, {
           'appium:safariIgnoreFraudWarning': false,
+          'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
         }));
       });
       afterEach(async function () {
@@ -513,6 +518,7 @@ describe('Safari - basics -', function () {
       beforeEach(async function () {
         driver = await initSession(amendCapabilities(DEFAULT_CAPS, {
           'appium:safariIgnoreFraudWarning': true,
+          'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
         }));
       });
       afterEach(async function () {

--- a/test/functional/web/safari-execute-e2e-specs.js
+++ b/test/functional/web/safari-execute-e2e-specs.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 // import http from 'http';
 import { SAFARI_CAPS, amendCapabilities } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import { openPage, GUINEA_PIG_PAGE } from './helpers';
 
 
@@ -24,6 +24,7 @@ describe('safari - execute -', function () {
     const caps = amendCapabilities(SAFARI_CAPS, {
       'appium:safariInitialUrl': GUINEA_PIG_PAGE,
       'appium:showSafariConsoleLog': true,
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
     });
     driver = await initSession(caps);
   });

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import _ from 'lodash';
 import chaiAsPromised from 'chai-as-promised';
 import { SAFARI_CAPS, amendCapabilities } from '../desired';
-import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
 import {
   openPage, spinTitleEquals,
   GUINEA_PIG_PAGE, GUINEA_PIG_FRAME_PAGE, GUINEA_PIG_IFRAME_PAGE
@@ -32,6 +32,7 @@ describe('safari - windows and frames', function () {
       const caps = amendCapabilities(SAFARI_CAPS, {
         'appium:safariInitialUrl': GUINEA_PIG_PAGE,
         'appium:safariAllowPopups': false,
+      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       });
       driver = await initSession(caps);
       await driver.setTimeout({pageLoad: 100});
@@ -57,6 +58,7 @@ describe('safari - windows and frames', function () {
         // using JS atoms to open new window will, even if safari does not disable
         // popups, open an alert asking if it is ok.
         'appium:nativeWebTap': true,
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       });
       driver = await initSession(caps);
     });

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -32,7 +32,7 @@ describe('safari - windows and frames', function () {
       const caps = amendCapabilities(SAFARI_CAPS, {
         'appium:safariInitialUrl': GUINEA_PIG_PAGE,
         'appium:safariAllowPopups': false,
-      'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
+        'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       });
       driver = await initSession(caps);
       await driver.setTimeout({pageLoad: 100});


### PR DESCRIPTION
see https://github.com/appium/appium-xcuitest-driver/pull/1464#issuecomment-1348286595

Now device CI fails because the test assumes WDA is prebuilt but there is no WDA.
This was fine before I changed the test name in the https://github.com/appium/appium-xcuitest-driver/pull/1464 . This PR changed the order of the test and now the accessibility test is the first one.