### PR TITLE
fix: /wda/device/appearance as withoutSession

### DIFF
--- a/lib/commands/appearance.js
+++ b/lib/commands/appearance.js
@@ -39,7 +39,7 @@ commands.mobileSetAppearance = async function mobileSetAppearance (opts = {}) {
     }
   }
   try {
-    return void (await this.proxyCommand('/wda/device/appearance', 'POST', {name: style}));
+    return void (await this.proxyCommand('/wda/device/appearance', 'POST', {name: style}, false));
   } catch (e) {
     this.log.debug(e.stack);
   }


### PR DESCRIPTION
fixes https://github.com/appium/appium-xcuitest-driver/issues/1470

Actually, the receiver in WDA has only `withoutSession`.

```
[[FBRoute POST:@"/wda/device/appearance"].withoutSession respondWithTarget:self action:@selector(handleSetDeviceAppearance:)],
```

I haven't tested this yet, will test a bit later