### PR TITLE
fix: releaseActions fails due to unhandled endpoint

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -96,6 +96,7 @@ const NO_PROXY_NATIVE_LIST = [
   ['GET', /window/],
   ['POST', /accept_alert/],
   ['POST', /actions$/],
+  ['DELETE', /actions$/],
   ['POST', /alert_text/],
   ['POST', /alert\/[^\/]+/],
   ['POST', /appium/],


### PR DESCRIPTION
releaseActions() and actions() (which [calls releaseActions](https://github.com/webdriverio/webdriverio/blob/3f551214691d14eebabff84f2625b2624fae9ef4/packages/webdriverio/src/commands/browser/actions.ts#L34)) of webdriverio doesn't work because it's routed to WDA:
```
[debug] [XCUITestDriver@65de (dc729734)] Matched '/session/dc729734-1137-4405-8808-b2f2eadc0c60/actions' to command name 'releaseActions'
[debug] [XCUITestDriver@65de (dc729734)] Proxying [DELETE /session/dc729734-1137-4405-8808-b2f2eadc0c60/actions] to [DELETE http://127.0.0.1:8100/session/A9A3C9DC-6CC4-4DEC-B352-62518C890856/actions] with no body
[XCUITestDriver@65de (dc729734)] Got response with status 404: {"value":{"error":"unknown command","message":"Unhandled endpoint: /session/A9A3C9DC-6CC4-4DEC-B352-62518C890856/actions -- http://127.0.0.1:8100/ with parameters {\n    wildcards =     (\n        \"session/A9A3C9DC-6CC4-4DEC-B352-62518C890856/actions\"\n    );\n}","traceback":""},"sessionId":"A9A3C9DC-6CC4-4DEC-B352-62518C890856"}
[debug] [W3C] Matched W3C error code 'unknown command' to UnknownCommandError
```
but it looks that it's supposed to be handled by driver https://github.com/appium/appium-xcuitest-driver/blob/b1e1bf05a73fcffdd509e4581cf722707935408f/lib/commands/gesture.js#L134

I will fix [gesture specs](https://github.com/appium/appium-xcuitest-driver/blob/master/test/functional/basic/gesture-e2e-specs.js) with another PR later on.