### PR TITLE
test: Enable xctest ci (but it requires xcode 14)

### DIFF
--- a/ci-jobs/templates/ios-e2e-template.yml
+++ b/ci-jobs/templates/ios-e2e-template.yml
@@ -43,7 +43,11 @@ jobs:
         versionSpec: '3.7'
     - bash: |
         brew tap facebook/fb
+        # use 1.1.7 because xctest doesn't seem to work with 1.1.8 https://github.com/facebook/idb/issues/811
+        pushd /usr/local/Homebrew/Library/Taps/facebook/homebrew-fb
+        git checkout f660049bdec9965934973052e6331119a4985096
         brew install idb-companion
+        popd
         python -m pip install --user fb-idb
       displayName: Install IDB
       condition: eq('${{ parameters.launchWithIDB }}', true)

--- a/ci-jobs/templates/xcuitest-e2e-template.yml
+++ b/ci-jobs/templates/xcuitest-e2e-template.yml
@@ -38,6 +38,7 @@ jobs:
       xcodeVersion: ${{ parameters.xcodeVersion }}
       deviceName: ${{ parameters.deviceName }}
       vmImage: ${{ parameters.vmImage }}
+      launchWithIDB: true
       timeoutMin: 90
       script: npm run e2e-test:driver
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@xmldom/xmldom": "^0.x",
-    "appium-idb": "^1.6.6",
+    "appium-idb": "^1.6.9",
     "appium-ios-device": "^2.4.0",
     "appium-ios-simulator": "^5.0.2",
     "appium-remote-debugger": "^9.1.1",

--- a/test/functional/device/xctest-e2e-specs.js
+++ b/test/functional/device/xctest-e2e-specs.js
@@ -3,6 +3,7 @@ import path from 'path';
 import chaiAsPromised from 'chai-as-promised';
 import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { GENERIC_CAPS, amendCapabilities } from '../desired';
+import xcode from 'appium-xcode';
 
 const APP_UNDER_TEST_PATH = path.resolve(__dirname, '..', '..', 'assets', 'XCTesterApp.app');
 const TEST_BUNDLE_PATH = path.resolve(__dirname, '..', '..', 'assets', 'XCTesterAppUITests-Runner.app');
@@ -16,8 +17,11 @@ if (process.env.LAUNCH_WITH_IDB) {
     this.timeout(MOCHA_TIMEOUT);
 
     let driver;
-
     before(async function () {
+      // idb_companion doesn't work with xcode 13 or lower due to concurrency lib issue.
+      if ((await xcode.getVersion(true)).major < 14) {
+        this.skip();
+      }
       const caps = amendCapabilities(GENERIC_CAPS, {
         'appium:app': APP_UNDER_TEST_PATH,
         'appium:launchWithIDB': true,


### PR DESCRIPTION
I thought I enabled the XCTest on CI in [the previous PR](https://github.com/appium/appium-xcuitest-driver/pull/1471) but I forgot to enable `LAUNCH_WITH_IDB` variable 🤦 
And I think it's unable to run it because the CI uses XCode 13.2 that has an issue with concurrency library (see [this issue](https://github.com/appium/appium-idb/pull/66)). I just added the code to skip it by checking xcode version.
Is it possible to update the XCode version in CI?