### PR TITLE
chore: remove tapWithShortPressDuration cap

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -129,9 +129,6 @@ const desiredCapConstraints = {
   agentPath: {
     isString: true
   },
-  tapWithShortPressDuration: {
-    isNumber: true
-  },
   scaleFactor: {
     isString: true
   },


### PR DESCRIPTION
ref. https://github.com/appium/appium-xcuitest-driver/pull/1479#discussion_r1058298053
It doesn't seem to be used anymore.