### PR TITLE
fix: update WDA to include snapshots/maxDepth fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "appium-ios-device": "^2.4.0",
     "appium-ios-simulator": "^5.0.5",
     "appium-remote-debugger": "^9.1.1",
-    "appium-webdriveragent": "^4.10.12",
+    "appium-webdriveragent": "^4.10.23",
     "appium-xcode": "^5.0.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
Latest xcuitest driver still does not have recent wda updates, so we can run a release script once. (package.json update itself is not necessary, but we need to bump published npm-shrinkwrap.json in xcuitest)