### PR TITLE
fix: Update NOTCHED_DEVICE_SIZES for nativeWebTapStrict (part of #1490)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ the tests locally. These include:
   the root directory of the repo with the extension "xcconfig")
 * `UICATALOG_REAL_DEVICE` - path to the real device build of UICatalog, in case
   the npm installed one is not built for real device
+  
+  


### PR DESCRIPTION
This is a dummy readme update to push a new version to apply `NOTCHED_DEVICE_SIZES` update in https://github.com/appium/appium-xcuitest-driver/pull/1490 to close https://github.com/appium/appium/issues/17014