### PR TITLE
ci: Update unit tests CI job

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Unit Tests
 on: [push, pull_request]
 
 jobs:
@@ -18,9 +18,9 @@ jobs:
         lts2=$(cat eol.list | head -2 | tail -1)
         lts3=$(cat eol.list | head -3 | tail -1)
         VERSIONS="[$lts1, $lts2, $lts3]"
-        echo ::set-output name=versions::${VERSIONS}
+        echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
 
-  build:
+  test:
     runs-on: macos-latest
     needs:
     - prepare_matrix


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/