### PR TITLE
chore(test): update some assertions

### DIFF
--- a/test/functional/basic/alert-e2e-specs.js
+++ b/test/functional/basic/alert-e2e-specs.js
@@ -109,6 +109,6 @@ describe('XCUITestDriver - alerts -', function () {
 
   it('should throw a NoAlertOpenError when no alert is open', async function () {
     await driver.acceptAlert()
-      .should.eventually.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
+      .should.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
   });
 });

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -198,7 +198,7 @@ describe('XCUITestDriver - basics -', function () {
 
     describe('retrieval -', function () {
       it('should throw an error when an invalid type is given', async function () {
-        await driver.getLogs('something-random').should.eventually.be.rejected;
+        await driver.getLogs('something-random').should.be.rejected;
       });
       it('should get system logs', async function () {
         (await driver.getLogs('syslog')).should.be.an('array');
@@ -248,7 +248,7 @@ describe('XCUITestDriver - basics -', function () {
   describe('get geo location -', function () {
     it('should fail because of preference error', async function () {
       await driver.getGeoLocation()
-        .should.eventually.be.rejectedWith('Location service must be');
+        .should.be.rejectedWith('Location service must be');
     });
   });
 

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -329,7 +329,7 @@ describe('XCUITestDriver - elements -', function () {
       });
       describe('hide keyboard', function () {
         it('should pass if the keyboard is already hidden', async function () {
-          await driver.hideKeyboard().should.eventually.be.fulfilled;
+          await driver.hideKeyboard().should.be.fulfilled;
         });
       });
     });

--- a/test/functional/device/accessibility-e2e-specs.js
+++ b/test/functional/device/accessibility-e2e-specs.js
@@ -70,12 +70,12 @@ describe('Accessibility', function() {
     it('should enable reduce motion', async function() {
       caps = amendCapabilities(caps, { 'appium:reduceMotion': true });
       driver = await initSession(caps);
-      await getReduceMotion(driver).should.eventually.be.eql('1');
+      await getReduceMotion(driver).should.eventually.eql('1');
     });
     it('should disable reduce motion', async function() {
       caps = amendCapabilities(caps, { 'appium:reduceMotion': false });
       driver = await initSession(caps);
-      await getReduceMotion(driver).should.eventually.be.eql('0');
+      await getReduceMotion(driver).should.eventually.eql('0');
     });
   });
 
@@ -93,12 +93,12 @@ describe('Accessibility', function() {
     it('should enable reduce transparency', async function() {
       caps = amendCapabilities(caps, { 'appium:reduceTransparency': true });
       driver = await initSession(caps);
-      await getReduceTransparency(driver).should.eventually.be.eql('1');
+      await getReduceTransparency(driver).should.eventually.eql('1');
     });
     it('should disable reduce transparency', async function() {
       caps = amendCapabilities(caps, { 'appium:reduceTransparency': false });
       driver = await initSession(caps);
-      await getReduceTransparency(driver).should.eventually.be.eql('0');
+      await getReduceTransparency(driver).should.eventually.eql('0');
     });
   });
 });

--- a/test/functional/device/file-movement-e2e-specs.js
+++ b/test/functional/device/file-movement-e2e-specs.js
@@ -33,7 +33,7 @@ describe('XCUITestDriver - file movement', function() {
   describe('sim relative', function() {
     describe('files', function() {
       it('should not be able to fetch a file from the file system at large', async function() {
-        await driver.pullFile(__filename).should.eventually.be.rejected;
+          await driver.pullFile(__filename).should.be.rejected;
       });
 
       it('should be able to fetch the Address book', async function() {
@@ -43,7 +43,7 @@ describe('XCUITestDriver - file movement', function() {
 
       it('should not be able to fetch something that does not exist', async function() {
         await driver.pullFile('Library/AddressBook/nothere.txt')
-          .should.eventually.be.rejectedWith(/does not exist/);
+            .should.be.rejectedWith(/does not exist/);
       });
 
       it('should be able to push and pull a file', async function() {
@@ -69,18 +69,18 @@ describe('XCUITestDriver - file movement', function() {
 
         await driver.execute('mobile: deleteFile', { remotePath });
 
-        await pullFileAsString(driver, remotePath).should.eventually.be.rejectedWith(/does not exist/);
+          await pullFileAsString(driver, remotePath).should.be.rejectedWith(/does not exist/);
       });
     });
 
     describe('folders', function() {
       it('should not pull folders from file system', async function() {
-        await driver.pullFolder(__dirname).should.eventually.be.rejected;
+          await driver.pullFolder(__dirname).should.be.rejected;
       });
 
       it('should not be able to fetch a folder that does not exist', async function() {
         await driver.pullFolder('Library/Rollodex')
-          .should.eventually.be.rejectedWith(/does not exist/);
+            .should.be.rejectedWith(/does not exist/);
       });
 
       it('should pull all the files in Library/AddressBook', async function() {
@@ -125,7 +125,7 @@ describe('XCUITestDriver - file movement', function() {
 
       await driver.execute('mobile: deleteFile', { remotePath });
 
-      await pullFileAsString(driver, remotePath).should.eventually.be.rejectedWith(/does not exist/);
+        await pullFileAsString(driver, remotePath).should.be.rejectedWith(/does not exist/);
     });
   });
 });

--- a/test/functional/driver/driver-e2e-specs.js
+++ b/test/functional/driver/driver-e2e-specs.js
@@ -91,7 +91,7 @@ describe('XCUITestDriver', function () {
       'appium:noReset': true,
       'appium:app': undefined,
     });
-    await initSession(localCaps).should.not.eventually.be.rejected;
+    await initSession(localCaps).should.not.be.rejected;
   });
 
   it('should start and stop a session with only bundle id when no sim is running', async function () {
@@ -101,7 +101,7 @@ describe('XCUITestDriver', function () {
       'appium:noReset': true,
       'appium:app': undefined,
     });
-    await initSession(localCaps).should.not.eventually.be.rejected;
+    await initSession(localCaps).should.not.be.rejected;
   });
 
   it('should fail to start and stop a session if unknown bundle id used', async function () {
@@ -109,7 +109,7 @@ describe('XCUITestDriver', function () {
       'appium:bundleId': 'io.blahblahblah.blah',
       'appium:app': undefined,
     });
-    await initSession(localCaps).should.eventually.be.rejected;
+    await initSession(localCaps).should.be.rejected;
   });
 
   it('should fail to start and stop a session if unknown bundle id used when no sim is running', async function () {
@@ -118,7 +118,7 @@ describe('XCUITestDriver', function () {
       'appium:bundleId': 'io.blahblahblah.blah',
       'appium:app': undefined,
     });
-    await initSession(localCaps).should.eventually.be.rejected;
+    await initSession(localCaps).should.be.rejected;
   });
 
   describe('WebdriverAgent port', function () {
@@ -141,7 +141,7 @@ describe('XCUITestDriver', function () {
       });
       driver = await initSession(localCaps);
       await axios({url: `http://${HOST}:8100/status`})
-        .should.eventually.be.rejectedWith(/ECONNREFUSED/);
+        .should.be.rejectedWith(/ECONNREFUSED/);
       await axios({url: `http://${HOST}:8100/status`})
         .should.eventually.not.be.rejected;
     });
@@ -265,7 +265,7 @@ describe('XCUITestDriver', function () {
       });
 
       await initSession(caps)
-        .should.eventually.be.rejectedWith('Unknown device or simulator UDID');
+        .should.be.rejectedWith('Unknown device or simulator UDID');
     });
 
     it('with non-existent udid: throws an error', async function () {
@@ -274,7 +274,7 @@ describe('XCUITestDriver', function () {
       const caps = amendCapabilities(UICATALOG_SIM_CAPS, {'appium:udid': udid});
 
       await initSession(caps)
-        .should.eventually.be.rejectedWith('Unknown device or simulator UDID');
+        .should.be.rejectedWith('Unknown device or simulator UDID');
     });
 
     it('with noReset set to true: leaves sim booted', async function () {

--- a/test/functional/web/safari-alerts-e2e-specs.js
+++ b/test/functional/web/safari-alerts-e2e-specs.js
@@ -60,7 +60,7 @@ describe('safari - alerts', function () {
     await alert.click();
     await acceptAlert(driver);
     await driver.getAlertText()
-      .should.eventually.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
+      .should.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
   });
   it.skip('should set text of prompt', async function () {
     const alert = await driver.$('#prompt1');
@@ -75,6 +75,6 @@ describe('safari - alerts', function () {
     const alert = await driver.$('#alert1');
     await alert.click();
     await driver.sendAlertText('yes I do!')
-      .should.eventually.be.rejectedWith(/no input fields/);
+      .should.be.rejectedWith(/no input fields/);
   });
 });

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -464,10 +464,10 @@ describe('Safari - basics -', function () {
               }
             });
             it('should reject all functions', async function () {
-              await driver.addCookie(newCookie).should.eventually.be.rejectedWith(notImplementedRegExp);
-              await driver.getAllCookies().should.eventually.be.rejectedWith(notImplementedRegExp);
-              await driver.deleteCookie(newCookie.name).should.eventually.be.rejectedWith(notImplementedRegExp);
-              await driver.deleteAllCookies().should.eventually.be.rejectedWith(notImplementedRegExp);
+              await driver.addCookie(newCookie).should.be.rejectedWith(notImplementedRegExp);
+              await driver.getAllCookies().should.be.rejectedWith(notImplementedRegExp);
+              await driver.deleteCookie(newCookie.name).should.be.rejectedWith(notImplementedRegExp);
+              await driver.deleteAllCookies().should.be.rejectedWith(notImplementedRegExp);
             });
           });
         });

--- a/test/functional/web/safari-execute-e2e-specs.js
+++ b/test/functional/web/safari-execute-e2e-specs.js
@@ -41,7 +41,7 @@ describe('safari - execute -', function () {
 
     describe('synchronous', function () {
       it('should bubble up javascript errors', async function () {
-        await driver.executeScript(`'nan'--`, []).should.eventually.be.rejected;
+        await driver.executeScript(`'nan'--`, []).should.be.rejected;
       });
 
       it('should eval javascript', async function () {
@@ -70,7 +70,7 @@ describe('safari - execute -', function () {
         it('should catch stale or undefined element as arg', async function () {
           const el = await driver.findElement('id', 'useragent');
           return driver.executeScript(SCROLL_INTO_VIEW, [{'ELEMENT': (el.value + 1)}])
-            .should.eventually.be.rejected;
+            .should.be.rejected;
         });
 
         it('should be able to return multiple elements from javascript', async function () {
@@ -102,13 +102,13 @@ describe('safari - execute -', function () {
 
     //   it('should bubble up errors', async function () {
     //     await driver.executeAsync(`arguments[arguments.length - 1]('nan'--);`)
-    //       .should.eventually.be.rejectedWith(/operator applied to value that is not a reference/);
+    //       .should.be.rejectedWith(/operator applied to value that is not a reference/);
     //   });
 
     //   it('should timeout when callback is not invoked', async function () {
     //     await driver.setAsyncScriptTimeout(1000);
     //     await driver.executeAsync(`return 1 + 2`)
-    //       .should.eventually.be.rejectedWith(/Timed out waiting for/);
+    //       .should.be.rejectedWith(/Timed out waiting for/);
     //   });
     // });
   }

--- a/test/functional/web/safari-window-e2e-specs.js
+++ b/test/functional/web/safari-window-e2e-specs.js
@@ -43,7 +43,7 @@ describe('safari - windows and frames', function () {
 
     it('should not be able to open js popup windows', async function () {
       await driver.executeScript("window.open('/test/guinea-pig2.html', null)", []);
-      await spinTitleEquals(driver, 'I am another page title', 5).should.eventually.be.rejected;
+      await spinTitleEquals(driver, 'I am another page title', 5).should.be.rejected;
     });
   });
 
@@ -86,7 +86,7 @@ describe('safari - windows and frames', function () {
 
       it('should throw nosuchwindow if there is not one', async function () {
         await driver.switchToWindow('noexistman')
-          .should.eventually.be.rejectedWith(/window could not be found/);
+          .should.be.rejectedWith(/window could not be found/);
       });
 
       it('should be able to open and close windows', async function () {
@@ -248,7 +248,7 @@ describe('safari - windows and frames', function () {
 
       it('should not switch to iframe by element of wrong type', async function () {
         const h1 = await driver.findElement('tag name', 'h1');
-        await driver.switchToFrame(h1).should.eventually.be.rejected;
+        await driver.switchToFrame(h1).should.be.rejected;
       });
 
       it('should switch back to default content from iframe', async function () {

--- a/test/unit/commands/activeAppInfo-specs.js
+++ b/test/unit/commands/activeAppInfo-specs.js
@@ -39,6 +39,6 @@ describe('get activeapp commands', function () {
 
   it('get active app info raise an error if the endpoint raises error', async function () {
     proxyStub.throws();
-    await driver.mobileGetActiveAppInfo().should.eventually.be.rejected;
+    await driver.mobileGetActiveAppInfo().should.be.rejected;
   });
 });

--- a/test/unit/commands/alert-specs.js
+++ b/test/unit/commands/alert-specs.js
@@ -54,7 +54,7 @@ describe('alert commands', function () {
 
     it('should reject request to WDA if action parameter is not supported', async function () {
       await driver.execute(`mobile: ${commandName}`, {action: 'blabla'})
-        .should.eventually.be.rejectedWith(/should be either/);
+        .should.be.rejectedWith(/should be either/);
     });
 
     it('should send accept alert request to WDA with encoded button label', async function () {

--- a/test/unit/commands/deviceinfo-specs.js
+++ b/test/unit/commands/deviceinfo-specs.js
@@ -33,6 +33,6 @@ describe('get deviceinfo commands', function () {
 
   it('get device info raise an error if the endpoint raises error', async function () {
     proxyStub.throws();
-    await driver.mobileGetDeviceInfo().should.eventually.be.rejected;
+    await driver.mobileGetDeviceInfo().should.be.rejected;
   });
 });

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -138,13 +138,13 @@ describe('element commands', function () {
         driver.curContext = oldContext;
       });
       it('should throw when in a web context', async function () {
-        await driver.getContentSize(el).should.eventually.be.rejectedWith(/not yet implemented/);
+        await driver.getContentSize(el).should.be.rejectedWith(/not yet implemented/);
       });
     });
 
     it('should throw if trying to get contentSize of something other than table or collection', async function () {
       getAttrStub.returns('XCUIElementTypeStatusBar');
-      await driver.getContentSize(el).should.eventually.be.rejectedWith(/Can't get content size for type/);
+      await driver.getContentSize(el).should.be.rejectedWith(/Can't get content size for type/);
     });
 
     it('should simply get the rect if just one child', async function () {
@@ -248,11 +248,11 @@ describe('element commands', function () {
     describe('failure', function () {
       it('should throw invalid argument exception for null', async function () {
         await driver.setValue(null, elementId)
-          .should.eventually.be.rejectedWith(/supported/);
+          .should.be.rejectedWith(/supported/);
       });
       it('should throw invalid argument exception for object', async function () {
         await driver.setValue({hi: 'there'}, elementId)
-          .should.eventually.be.rejectedWith(/supported/);
+          .should.be.rejectedWith(/supported/);
       });
     });
   });

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -34,7 +34,7 @@ describe('file-movement', function () {
     });
     it('should raise an error if no container path', async function () {
       const mntRoot = await tempDir.openDir();
-      await parseContainerPath('@io.appium.example:documents', mntRoot).should.eventually.be.rejected;
+      await parseContainerPath('@io.appium.example:documents', mntRoot).should.be.rejected;
     });
   });
 

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -63,13 +63,13 @@ describe('general commands', function () {
     it('should reject request for first visible child with no context', async function () {
       await driver.findNativeElementOrElements(
         'xpath', '/*[@firstVisible="true"]', false)
-        .should.eventually.be.rejectedWith(/without a context element/);
+        .should.be.rejectedWith(/without a context element/);
     });
 
     it('should reject request for multiple first visible children', async function () {
       await driver.findNativeElementOrElements(
         'xpath', '/*[@firstVisible="true"]', true)
-        .should.eventually.be.rejectedWith(/Cannot get multiple/);
+        .should.be.rejectedWith(/Cannot get multiple/);
     });
 
     it('should convert magic first visible child xpath to class chain', async function () {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -68,7 +68,7 @@ describe('general commands', function () {
 
     it('should not be called on a real device', async function () {
       deviceStub.object.realDevice = true;
-      await driver.touchId().should.eventually.be.rejected;
+      await driver.touchId().should.be.rejected;
       sendBiometricMatchSpy.notCalled.should.be.true;
     });
   });
@@ -101,7 +101,7 @@ describe('general commands', function () {
     it('should not be called on a real device', async function () {
       deviceStub.object.realDevice = true;
       deviceStub.object.allowTouchIdEnroll = true;
-      await driver.toggleEnrollTouchId().should.eventually.be.rejected;
+      await driver.toggleEnrollTouchId().should.be.rejected;
       enrollBiometricSpy.notCalled.should.be.true;
     });
   });

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -67,14 +67,14 @@ describe('gesture commands', function () {
   describe('mobile methods', function () {
     describe('anything other than scroll', function () {
       it('should throw an error', async function () {
-        await driver.execute('mobile: somesuch').should.eventually.be.rejected;
+        await driver.execute('mobile: somesuch').should.be.rejected;
       });
     });
 
     describe('scroll', function () {
       it('should throw an error if no scroll type is specified', async function () {
         await driver.execute('mobile: scroll', {element: 4})
-          .should.eventually.be.rejectedWith(/Mobile scroll supports the following strategies/);
+          .should.be.rejectedWith(/Mobile scroll supports the following strategies/);
       });
       it('should pass through bare element', async function () {
         await driver.execute('mobile: scroll', {element: 4, direction: 'down'});
@@ -116,12 +116,12 @@ describe('gesture commands', function () {
 
       it('should throw an error if no direction is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4})
-          .should.eventually.be.rejected;
+          .should.be.rejected;
       });
 
       it('should throw an error if invalid direction', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, direction: 'foo'})
-          .should.eventually.be.rejected;
+          .should.be.rejected;
       });
 
       it('should proxy a swipe up request through to WDA', async function () {
@@ -138,16 +138,16 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 4.1})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {element: 4, velocity: -0.5})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, scale: '', velocity: 1})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 0, velocity: null})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should proxy a pinch request through to WDA', async function () {
@@ -164,16 +164,16 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {x: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {y: 200})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {x: '', y: 1})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {x: 1, y: null})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should proxy a doubleTap request for an element through to WDA', async function () {
@@ -208,20 +208,20 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {duration: 100, x: 1})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, y: 200})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {x: 100, y: 200})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {duration: '', x: 1, y: 1})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 1, x: '', y: 1})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 1, x: 1, y: null})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should proxy a touchAndHold request for an element through to WDA', async function () {
@@ -246,18 +246,18 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {x: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {y: 200})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {x: '', y: 1})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {x: 1, y: null})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should proxy a tap request for an element through to WDA', async function () {
@@ -282,21 +282,21 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {})
-          .should.eventually.be.rejectedWith(/Element id is expected to be set/);
+          .should.be.rejectedWith(/Element id is expected to be set/);
         await driver.execute(`mobile: ${commandName}`, {element: 4})
-          .should.eventually.be.rejectedWith(/is expected to be equal/);
+          .should.be.rejectedWith(/is expected to be equal/);
         await driver.execute(`mobile: ${commandName}`, {order: 'next'})
-          .should.eventually.be.rejectedWith(/Element id is expected to be set/);
+          .should.be.rejectedWith(/Element id is expected to be set/);
       });
 
       it('should throw an error if offset value cannot be parsed', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, order: 'next', offset: 'bla'})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, order: 'bla'})
-          .should.eventually.be.rejectedWith(/is expected to be equal/);
+          .should.be.rejectedWith(/is expected to be equal/);
       });
 
       it('should proxy a selectPickerWheel request for an element through to WDA', async function () {
@@ -314,28 +314,28 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {fromX: 1, fromY: 1, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromY: 1, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toY: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100})
-          .should.eventually.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameter is mandatory/);
       });
 
       it('should throw an error if param is invalid', async function () {
         await driver.execute(`mobile: ${commandName}`, {duration: '', fromX: 1, fromY: 1, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: '', fromY: 1, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: null, toX: 100, toY: 100})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 'blabla', toY: 100})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100, toY: NaN})
-          .should.eventually.be.rejectedWith(/should be a valid number/);
+          .should.be.rejectedWith(/should be a valid number/);
       });
 
       it('should proxy a dragFromToForDuration request for an element through to WDA', async function () {

--- a/test/unit/commands/location-specs.js
+++ b/test/unit/commands/location-specs.js
@@ -19,7 +19,7 @@ describe('location commands', function () {
         'GET').returns({authorizationStatus: 0, latitude: 0, longitude: 0});
 
       await driver.getGeoLocation({})
-        .should.eventually.be.rejectedWith('Location service must be');
+        .should.be.rejectedWith('Location service must be');
     });
 
     it('should be authorizationStatus === 3', async function () {
@@ -60,7 +60,7 @@ describe('location commands', function () {
 
     it('should fail when location object is wrong', async function () {
       await driver.setGeoLocation({})
-        .should.eventually.be.rejectedWith('Both latitude and longitude should be set');
+        .should.be.rejectedWith('Both latitude and longitude should be set');
     });
 
     describe('on real device', function () {

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -30,12 +30,12 @@ describe('pasteboard commands', function () {
     });
 
     it('setPasteboard should not be called', async function () {
-      await driver.mobileSetPasteboard({content: 'bla'}).should.eventually.be.rejectedWith(/not supported/);
+      await driver.mobileSetPasteboard({content: 'bla'}).should.be.rejectedWith(/not supported/);
       setPasteboardStub.notCalled.should.be.true;
     });
 
     it('getPasteboard should not be called', async function () {
-      await driver.mobileGetPasteboard().should.eventually.be.rejectedWith(/not supported/);
+      await driver.mobileGetPasteboard().should.be.rejectedWith(/not supported/);
       getPasteboardStub.notCalled.should.be.true;
     });
   });
@@ -46,7 +46,7 @@ describe('pasteboard commands', function () {
     });
 
     it('setPasteboard should fail if no content is provided', async function () {
-      await driver.mobileSetPasteboard().should.eventually.be.rejectedWith(/mandatory to set/);
+      await driver.mobileSetPasteboard().should.be.rejectedWith(/mandatory to set/);
       setPasteboardStub.notCalled.should.be.true;
     });
 

--- a/test/unit/commands/proxy-helper-specs.js
+++ b/test/unit/commands/proxy-helper-specs.js
@@ -31,11 +31,11 @@ describe('proxy commands', function () {
       proxyStub.firstCall.args[2].some.should.eql('stuff');
     });
     it('should throw an error if no endpoint is given', async function () {
-      await driver.proxyCommand(null, 'POST', {some: 'stuff'}).should.eventually.be.rejectedWith(/endpoint/);
+      await driver.proxyCommand(null, 'POST', {some: 'stuff'}).should.be.rejectedWith(/endpoint/);
       proxyStub.callCount.should.eql(0);
     });
     it('should throw an error if no method is given', async function () {
-      await driver.proxyCommand('/some/endpoint', null, {some: 'stuff'}).should.eventually.be.rejectedWith(/GET, POST/);
+      await driver.proxyCommand('/some/endpoint', null, {some: 'stuff'}).should.be.rejectedWith(/GET, POST/);
       proxyStub.callCount.should.eql(0);
     });
     it('should throw an error if wda returns an error (even if http status is 200)', async function () {


### PR DESCRIPTION
`eventually.be.<x>` is used when `x` is not an assertion native to `chai-as-promised`, so it's redundant in the case of `eventually.be.rejected` or `eventually.be.fulfilled`
