### PR TITLE
chore: remove unused cookies code

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -131,28 +131,6 @@ commands.title = async function title () {
   return await this.executeAtom('title', [], true);
 };
 
-commands.getCookies = async function getCookies () {
-  if (!this.isWebContext()) {
-    throw new errors.NotImplementedError();
-  }
-
-  this.log.debug('Retrieving all cookies');
-
-  let script = 'return document.cookie';
-  let jsCookies = await this.executeAtom('execute_script', [script, []]);
-
-  let cookies = [];
-  try {
-    for (let [name, value] of _.toPairs(cookieUtils.createJWPCookie(undefined, jsCookies))) {
-      cookies.push({name, value});
-    }
-    return cookies;
-  } catch (err) {
-    this.log.error(err);
-    throw new errors.UnknownError(`Error parsing cookies from result: '${jsCookies}'`);
-  }
-};
-
 commands.setCookie = async function setCookie (cookie) {
   if (!this.isWebContext()) {
     throw new errors.NotImplementedError();
@@ -174,42 +152,6 @@ commands.setCookie = async function setCookie (cookie) {
     secure: cookie.secure
   });
   let script = `document.cookie = ${JSON.stringify(jsCookie)}`;
-  await this.executeAtom('execute_script', [script, []]);
-};
-
-commands.deleteCookie = async function deleteCookie (cookieName) {
-  if (!this.isWebContext()) {
-    throw new errors.NotImplementedError();
-  }
-
-  // check cookie existence
-  let cookies = await this.getCookies();
-  if (_.indexOf(_.map(cookies, 'name'), cookieName) === -1) {
-    this.log.debug(`Cookie '${cookieName}' not found. Ignoring.`);
-    return true;
-  }
-
-  return await this._deleteCookie(cookieName);
-};
-
-commands.deleteCookies = async function deleteCookies () {
-  if (!this.isWebContext()) {
-    throw new errors.NotImplementedError();
-  }
-
-  let cookies = await this.getCookies();
-  if (cookies.length) {
-    for (let cookie of cookies) {
-      await this._deleteCookie(cookie.name);
-    }
-  }
-  return true;
-};
-
-helpers._deleteCookie = async function _deleteCookie (cookieName) {
-  this.log.debug(`Deleting cookie '${cookieName}'`);
-  let webCookie = cookieUtils.expireCookie(cookieName, {path: '/'});
-  let script = `document.cookie = ${JSON.stringify(webCookie)}`;
   await this.executeAtom('execute_script', [script, []]);
 };
 


### PR DESCRIPTION
In https://github.com/appium/appium-xcuitest-driver/pull/1484#discussion_r1085993711, I noticed https://github.com/appium/appium-xcuitest-driver/blob/master/lib/commands/cookies.js had `getCookies`, `deleteCookie` and `_deleteCookie` via remote-debugger's WebInspector code instead of JS script right now.

So it probably would be nice to remove the unused methods in `web.js`.

I checked in a real device, so not in a simulator yet. I'll do a double-check with a simulator later if the current mater uses which code.