### PR TITLE
chore: Short circuit if the app under test crashes while checking for alerts

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -35,6 +35,7 @@ const ATOM_WAIT_TIMEOUT_MS = 2 * 60000;
 const ATOM_INITIAL_WAIT_MS = 1000;
 
 const ON_OBSTRUCTING_ALERT_EVENT = 'alert';
+const ON_APP_CRASH_EVENT = 'app_crash';
 
 const VISIBLE = 'visible';
 const INVISIBLE = 'invisible';
@@ -573,7 +574,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
       const originalError = (err instanceof B.AggregateError) ? err[0] : err;
       this.log.debug(`Error received while executing atom: ${originalError.message}`);
       if (originalError instanceof B.TimeoutError) {
-        throw new Error(`Did not get any response for atom execution after ` +
+        throw new errors.TimeoutError(`Did not get any response for atom execution after ` +
           `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
       }
       throw originalError;
@@ -597,6 +598,7 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   this._waitingAtoms.count++;
 
   let onAlertCallback;
+  let onAppCrashCallback;
   try {
     // only restart the monitor if it is not running already
     if (this._waitingAtoms.alertMonitor.isResolved()) {
@@ -606,7 +608,11 @@ extensions.waitForAtom = async function waitForAtom (promise) {
             if (await this.checkForAlert()) {
               this._waitingAtoms.alertNotifier.emit(ON_OBSTRUCTING_ALERT_EVENT);
             }
-          } catch (ign) {}
+          } catch (err) {
+            if (isErrorType(err, errors.InvalidElementStateError)) {
+              this._waitingAtoms.alertNotifier.emit(ON_APP_CRASH_EVENT, err);
+            }
+          }
           await B.delay(ATOM_INITIAL_WAIT_MS / 2);
         }
       })());
@@ -614,7 +620,9 @@ extensions.waitForAtom = async function waitForAtom (promise) {
 
     return await new B((resolve, reject) => {
       onAlertCallback = () => reject(new errors.UnexpectedAlertOpenError());
+      onAppCrashCallback = reject;
       this._waitingAtoms.alertNotifier.once(ON_OBSTRUCTING_ALERT_EVENT, onAlertCallback);
+      this._waitingAtoms.alertNotifier.once(ON_APP_CRASH_EVENT, onAppCrashCallback);
       handlePromiseError(timedAtomPromise)
         // eslint-disable-next-line promise/prefer-await-to-then
         .then(resolve)
@@ -623,6 +631,9 @@ extensions.waitForAtom = async function waitForAtom (promise) {
   } finally {
     if (onAlertCallback) {
       this._waitingAtoms.alertNotifier.removeListener(ON_OBSTRUCTING_ALERT_EVENT, onAlertCallback);
+    }
+    if (onAppCrashCallback) {
+      this._waitingAtoms.alertNotifier.removeListener(ON_APP_CRASH_EVENT, onAppCrashCallback);
     }
     this._waitingAtoms.count--;
   }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "appium": "^2.0.0-beta.40"
   },
   "devDependencies": {
-    "@appium/docutils": "^0.2.2",
+    "@appium/docutils": "^0.x",
     "@appium/eslint-config-appium": "^6.0.0",
     "@appium/test-support": "^3.0.0",
     "@babel/cli": "^7.18.10",
@@ -141,7 +141,7 @@
     "@babel/register": "^7.18.9",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "axios": "^1.x",
+    "axios": "^1.3.4",
     "babel-plugin-source-map-support": "^2.2.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
This should avoid xcuitest from waiting for too long if the app under test or Safari crashes while waiting for atom response. See https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=24956&view=logs&j=66348596-d35e-5e67-f0f1-be5c1aa44784&t=71e9a390-e9eb-5265-011c-e30f520bcba6 for an example