### PR TITLE
fix: Add missing --name option to removeProfile

### DIFF
--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -91,7 +91,7 @@ class Pyidevice {
   }
 
   async removeProfile (name) {
-    await this.execute(['profiles', 'remove', name], {logStdout: true});
+    await this.execute(['profiles', 'remove', '--name', name], {logStdout: true});
   }
 
   async listCrashes () {


### PR DESCRIPTION
@mykola-mokhnach I missed this in https://github.com/appium/appium-xcuitest-driver/pull/1529
The py-ios-device client expects the profile name to be passed in with the `--name` option