### PR TITLE
chore: use execute methods & types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,8 @@
         "@typescript-eslint/no-var-requires": "off"
       }
     }
-  ]
+  ],
+  "rules": {
+    "require-await": "error"
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// transpile:main
 import { XCUITestDriver } from './lib/driver';
 
 export { XCUITestDriver };

--- a/lib/app-utils.js
+++ b/lib/app-utils.js
@@ -16,7 +16,7 @@ const PLIST_CACHE = new WeakMap();
  * @this {Object} Optinal instance used for caching. Ususally the driver instance.
  * @param {string} app Full path to the app bundle root.
  * @param {string} entryName Key name in the plist.
- * @returns {Promise<Any | undefined>} Either the extracted value or undefined if no such key has been found in the plist.
+ * @returns {Promise<any | undefined>} Either the extracted value or undefined if no such key has been found in the plist.
  * @throws {Error} If the application's Info.plist cannot be parsed.
  */
 async function extractPlistEntry (app, entryName) {
@@ -150,7 +150,7 @@ async function parseLocalizableStrings (opts) {
 
   const resourcePaths = [];
   if (stringFile) {
-    const dstPath = path.resolve(lprojRoot, stringFile);
+    const dstPath = path.resolve(String(lprojRoot), stringFile);
     if (await fs.exists(dstPath)) {
       resourcePaths.push(dstPath);
     } else {
@@ -163,8 +163,8 @@ async function parseLocalizableStrings (opts) {
     }
   }
 
-  if (_.isEmpty(resourcePaths) && await fs.exists(lprojRoot)) {
-    const resourceFiles = (await fs.readdir(lprojRoot))
+  if (_.isEmpty(resourcePaths) && await fs.exists(String(lprojRoot))) {
+    const resourceFiles = (await fs.readdir(String(lprojRoot)))
       .filter((name) => _.some([STRINGS_RESOURCE, STRINGSDICT_RESOURCE], (x) => name.endsWith(x)))
       .map((name) => path.resolve(lprojRoot, name));
     resourcePaths.push(...resourceFiles);
@@ -201,7 +201,7 @@ async function parseLocalizableStrings (opts) {
  * Check whether the given path on the file system points to the .app bundle root
  *
  * @param {string} appPath Possible .app bundle root
- * @returns {boolean} Whether the given path points to an .app bundle
+ * @returns {Promise<boolean>} Whether the given path points to an .app bundle
  */
 async function isAppBundle (appPath) {
   return _.endsWith(_.toLower(appPath), APP_EXT)

--- a/lib/commands/activeAppInfo.js
+++ b/lib/commands/activeAppInfo.js
@@ -2,7 +2,7 @@ export default {
   /**
    * Returns ActiveApp info.
    *
-   * @returns {Object} The response of `/wda/activeAppInfo'`
+   * @returns {Promise<object>} The response of `/wda/activeAppInfo'`
    * @throws {Error} if an error raised by command
    * @this {import('../driver').XCUITestDriver}
    */

--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -1,3 +1,8 @@
+/**
+ *
+ * @param { {buttonLabel?: string} } opts
+ * @returns { {name?: string} }
+ */
 function toAlertParams(opts = {}) {
   const params = {};
   if (opts.buttonLabel) {
@@ -14,18 +19,21 @@ export default {
     return await this.proxyCommand('/alert/text', 'GET');
   },
   /**
+   * @param {string} value
    * @this {XCUITestDriver}
    */
   async setAlertText(value) {
     return await this.proxyCommand('/alert/text', 'POST', {value});
   },
   /**
+   * @param { {buttonLabel?: string} } opts
    * @this {XCUITestDriver}
    */
   async postAcceptAlert(opts = {}) {
     return await this.proxyCommand('/alert/accept', 'POST', toAlertParams(opts));
   },
   /**
+   * @param { {buttonLabel?: string} } opts
    * @this {XCUITestDriver}
    */
   async postDismissAlert(opts = {}) {
@@ -38,24 +46,30 @@ export default {
     return await this.proxyCommand('/wda/alert/buttons', 'GET');
   },
   /**
+   * @param {AlertAction} action
+   * @param {string} [buttonLabel]
    * @this {XCUITestDriver}
    */
-  async mobileHandleAlert(opts = {}) {
-    switch (opts.action) {
+  async mobileHandleAlert(action, buttonLabel) {
+    switch (action) {
       case 'accept':
-        return await this.postAcceptAlert(opts);
+        return await this.postAcceptAlert({buttonLabel});
       case 'dismiss':
-        return await this.postDismissAlert(opts);
+        return await this.postDismissAlert({buttonLabel});
       case 'getButtons':
         return await this.getAlertButtons();
       default:
         throw new Error(
           `The 'action' value should be either 'accept', 'dismiss' or 'getButtons'. ` +
-            `'${opts.action}' is provided instead.`
+            `'${action}' is provided instead.`
         );
     }
   },
 };
+
+/**
+ * @typedef {'accept'|'dismiss'|'getButtons'} AlertAction
+ */
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -3,11 +3,17 @@ import {fs} from 'appium/support';
 import {errors} from 'appium/driver';
 import {services} from 'appium-ios-device';
 
-function requireOptions(opts = {}, reqKeys = []) {
+/**
+ * @template [T=import('type-fest').EmptyObject]
+ * @param {T} opts
+ * @param {(keyof T)[]} reqKeys
+ * @returns {T}
+ */
+function requireOptions(opts = /** @type {T} */({}), reqKeys = []) {
   for (const key of reqKeys) {
     if (!_.isString(opts[key]) || _.isEmpty(opts[key])) {
       throw new errors.InvalidArgumentError(
-        `'${key}' is expected to be a valid string. '${opts[key]}' is given instead`
+        `'${String(key)}' is expected to be a valid string. '${opts[key]}' is given instead`
       );
     }
   }
@@ -16,13 +22,16 @@ function requireOptions(opts = {}, reqKeys = []) {
 
 export default {
   /**
+   * @param {string} app
+   * @param {string} [strategy]
+   * @param {number} [timeoutMs]
    * @this {XCUITestDriver}
    */
-  async mobileInstallApp(opts = {}) {
-    const {app, timeoutMs, strategy} = requireOptions(opts, ['app']);
+  async mobileInstallApp(app, timeoutMs, strategy) {
     const srcAppPath = await this.helpers.configureApp(app, '.app');
     this.log.info(
       `Installing '${srcAppPath}' to the ${this.isRealDevice() ? 'real device' : 'Simulator'} ` +
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         `with UDID '${this.opts.device.udid}'`
     );
     if (!(await fs.exists(srcAppPath))) {
@@ -30,6 +39,7 @@ export default {
         `The application at '${srcAppPath}' does not exist or is not accessible`
       );
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.installApp(
       srcAppPath,
       timeoutMs ?? this.opts.appPushTimeout,
@@ -38,26 +48,29 @@ export default {
     this.log.info(`Installation of '${srcAppPath}' succeeded`);
   },
   /**
+   * @param {string} bundleId
    * @this {XCUITestDriver}
    */
-  async mobileIsAppInstalled(opts = {}) {
-    const {bundleId} = requireOptions(opts, ['bundleId']);
+  async mobileIsAppInstalled(bundleId) {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const installed = await this.opts.device.isAppInstalled(bundleId);
     this.log.info(`App '${bundleId}' is${installed ? '' : ' not'} installed`);
     return installed;
   },
   /**
+   * @param {string} bundleId
    * @this {XCUITestDriver}
    */
-  async mobileRemoveApp(opts = {}) {
-    const {bundleId} = requireOptions(opts, ['bundleId']);
+  async mobileRemoveApp(bundleId) {
     this.log.info(
       `Uninstalling the application with bundle identifier '${bundleId}' ` +
         `from the ${this.isRealDevice() ? 'real device' : 'Simulator'} with UDID '${
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           this.opts.device.udid
         }'`
     );
     try {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await this.opts.device.removeApp(bundleId);
       this.log.info(`Removal of '${bundleId}' succeeded`);
       return true;
@@ -67,67 +80,72 @@ export default {
     }
   },
   /**
+   * @param {string} bundleId
+   * @param {any|any[]} [args]
+   * @param {any} [environment]
    * @this {XCUITestDriver}
    */
-  async mobileLaunchApp(opts = {}) {
-    const launchOptions = requireOptions(opts, ['bundleId']);
-    if (opts.arguments) {
-      launchOptions.arguments = _.isArray(opts.arguments) ? opts.arguments : [opts.arguments];
+  async mobileLaunchApp(bundleId, args, environment) {
+    /** @type { {arguments?: any[], environment?: any, bundleId: string} } */
+    const launchOptions = {bundleId};
+    if (args) {
+      launchOptions.arguments = _.isArray(args) ? args : [args];
     }
-    if (opts.environment) {
-      launchOptions.environment = opts.environment;
+    if (environment) {
+      launchOptions.environment = environment;
     }
     return await this.proxyCommand('/wda/apps/launch', 'POST', launchOptions);
   },
   /**
+   * @param {string} bundleId
    * @this {XCUITestDriver}
    */
-  async mobileTerminateApp(opts = {}) {
+  async mobileTerminateApp(bundleId) {
     return await this.proxyCommand(
       '/wda/apps/terminate',
       'POST',
-      requireOptions(opts, ['bundleId'])
+      {bundleId}
     );
   },
   /**
+   * @param {string} bundleId
    * @this {XCUITestDriver}
    */
-  async mobileActivateApp(opts = {}) {
+  async mobileActivateApp(bundleId) {
     return await this.proxyCommand(
       '/wda/apps/activate',
       'POST',
-      requireOptions(opts, ['bundleId'])
+      {bundleId}
     );
   },
 
   /**
    * Kill the given bundle id process via instruments service.
-   * https://github.com/YueChen-C/py-ios-device/blob/51f4683c5c3c385a015858ada07a5f1c62d3cf57/ios_device/cli/base.py#L220
-   *
-   * @param {Object} opts - Options set, which must contain `bundleId` property
-   * @returns {boolean} Returns true if the bundle id process was killed. Otherwise false.
+   * @see https://github.com/YueChen-C/py-ios-device/blob/51f4683c5c3c385a015858ada07a5f1c62d3cf57/ios_device/cli/base.py#L220
+   * @param {string} bundleId
+   * @returns {Promise<boolean>} Returns true if the bundle id process was killed. Otherwise false.
    * @this {XCUITestDriver}
    */
-  async mobileKillApp(opts = {}) {
+  async mobileKillApp(bundleId) {
     if (!this.isRealDevice()) {
       throw new errors.UnsupportedOperationError('A real device is required');
     }
 
-    const {bundleId} = requireOptions(opts, ['bundleId']);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await this.opts.device.terminateApp(bundleId);
   },
 
   /**
    * Returns the current application state
    *
-   * @param {Object} opts - Options set, which must contain `bundleId` property
-   * @returns {number} The actual application state code. See
+   * @param {string} bundleId - Options set, which must contain `bundleId` property
+   * @returns {Promise<import('./types').AppState>} The actual application state code. See
    * https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc
    * to get the list of possible values.
    * @this {XCUITestDriver}
    */
-  async mobileQueryAppState(opts = {}) {
-    return await this.proxyCommand('/wda/apps/state', 'POST', requireOptions(opts, ['bundleId']));
+  async mobileQueryAppState(bundleId) {
+    return await this.proxyCommand('/wda/apps/state', 'POST', {bundleId});
   },
 
   /**
@@ -135,11 +153,8 @@ export default {
    * @param {object} opts
    * @this {XCUITestDriver}
    */
-  async installApp(appPath, opts = {}) {
-    await this.mobileInstallApp({
-      ...(_.isPlainObject(opts) ? opts : {}),
-      app: appPath,
-    });
+  async installApp(appPath, {timeoutMs, strategy} = {}) {
+    await this.mobileInstallApp(appPath, timeoutMs, strategy);
   },
   /**
    * @param {string} bundleId
@@ -147,43 +162,43 @@ export default {
    * @this {XCUITestDriver}
    */
   async activateApp(bundleId, opts = {}) {
-    return await this.mobileLaunchApp(Object.assign({}, opts, {bundleId}));
+    const {environment, arguments: args} = opts;
+    return await this.mobileLaunchApp(bundleId, args, environment);
   },
   /**
    * @param {string} bundleId
    * @this {XCUITestDriver}
    */
   async isAppInstalled(bundleId) {
-    return await this.mobileIsAppInstalled({bundleId});
+    return await this.mobileIsAppInstalled(bundleId);
   },
   /**
    * @param {string} bundleId
    * @this {XCUITestDriver}
    */
   async terminateApp(bundleId) {
-    return await this.mobileTerminateApp({bundleId});
+    return await this.mobileTerminateApp(bundleId);
   },
   /**
    * @param {string} bundleId
    * @this {XCUITestDriver}
    */
   async queryAppState(bundleId) {
-    return await this.mobileQueryAppState({bundleId});
+    return await this.mobileQueryAppState(bundleId);
   },
 
   /**
    * List applications installed on the real device under test
    *
-   * @param {ListAppsOptions} opts
-   * @returns {Record<string,any>[]} A list of apps, where each item is a map where keys are
+   * @param {'User'|'System'} [applicationType='User']
+   * @returns {Promise<Record<string,any>[]>} A list of apps, where each item is a map where keys are
    * bundle identifiers and values are maps of platform-specific app properties.
    */
-  async mobileListApps(opts = {}) {
+  async mobileListApps(applicationType) {
     if (!this.isRealDevice()) {
       throw new errors.NotImplementedError(`This extension is only supported on real devices`);
     }
 
-    const {applicationType = 'User'} = opts;
     const service = await services.startInstallationProxyService(this.opts.device.udid);
     try {
       return await service.listApplications({applicationType});
@@ -195,9 +210,4 @@ export default {
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
- */
-
-/**
- * @typedef {Object} ListAppsOptions
- * @property {'System'|'User'} applicationType [User] The type of applications to list
  */

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -3,23 +3,6 @@ import {fs} from 'appium/support';
 import {errors} from 'appium/driver';
 import {services} from 'appium-ios-device';
 
-/**
- * @template [T=import('type-fest').EmptyObject]
- * @param {T} opts
- * @param {(keyof T)[]} reqKeys
- * @returns {T}
- */
-function requireOptions(opts = /** @type {T} */({}), reqKeys = []) {
-  for (const key of reqKeys) {
-    if (!_.isString(opts[key]) || _.isEmpty(opts[key])) {
-      throw new errors.InvalidArgumentError(
-        `'${String(key)}' is expected to be a valid string. '${opts[key]}' is given instead`
-      );
-    }
-  }
-  return opts;
-}
-
 export default {
   /**
    * @param {string} app
@@ -31,7 +14,7 @@ export default {
     const srcAppPath = await this.helpers.configureApp(app, '.app');
     this.log.info(
       `Installing '${srcAppPath}' to the ${this.isRealDevice() ? 'real device' : 'Simulator'} ` +
-      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         `with UDID '${this.opts.device.udid}'`
     );
     if (!(await fs.exists(srcAppPath))) {
@@ -101,22 +84,14 @@ export default {
    * @this {XCUITestDriver}
    */
   async mobileTerminateApp(bundleId) {
-    return await this.proxyCommand(
-      '/wda/apps/terminate',
-      'POST',
-      {bundleId}
-    );
+    return await this.proxyCommand('/wda/apps/terminate', 'POST', {bundleId});
   },
   /**
    * @param {string} bundleId
    * @this {XCUITestDriver}
    */
   async mobileActivateApp(bundleId) {
-    return await this.proxyCommand(
-      '/wda/apps/activate',
-      'POST',
-      {bundleId}
-    );
+    return await this.proxyCommand('/wda/apps/activate', 'POST', {bundleId});
   },
 
   /**

--- a/lib/commands/appearance.js
+++ b/lib/commands/appearance.js
@@ -6,22 +6,23 @@ export default {
    * Set the device's UI appearance style
    *
    * @since iOS 12.0
-   * @param {SetAppearanceOptions} opts
+   * @param {'dark'|'light'} style - The appearance style to set
    * @throws {Error} if the current platform does not support UI
    * appearance changes
    * @this {XCUITestDriver}
    */
-  async mobileSetAppearance(opts = {}) {
-    const {style} = opts;
+  async mobileSetAppearance(style) {
     if (!['light', 'dark'].includes(_.toLower(style))) {
       throw new Error(`The 'style' value is expected to equal either 'light' or 'dark'`);
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (util.compareVersions(this.opts.platformVersion, '<', '12.0')) {
       throw new Error('Changing appearance is only supported since iOS 12');
     }
 
     if (this.isSimulator()) {
       try {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         return void (await this.opts.device.setAppearance(style));
       } catch (e) {
         this.log.debug(e.stack);
@@ -33,26 +34,26 @@ export default {
       this.log.debug(e.stack);
     }
     // Fall back to the ugly Siri workaround if the current SDK is too old
-    await this.mobileSiriCommand({
-      text: `Turn ${_.toLower(style) === 'dark' ? 'on' : 'off'} dark mode`,
-    });
+    await this.mobileSiriCommand(`Turn ${_.toLower(style) === 'dark' ? 'on' : 'off'} dark mode`);
   },
 
   /**
    * Get the device's UI appearance style.
    *
    * @since Xcode SDK 11
-   * @returns {Promise<Appearance>}
+   * @returns {Promise<{style: 'dark'|'light'|'unsupported'|'unknown'}>}
    * @this {XCUITestDriver}
    */
   async mobileGetAppearance() {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (util.compareVersions(this.opts.platformVersion, '<', '12.0')) {
-      return 'unsupported';
+      return {style: 'unsupported'};
     }
 
     let style;
     if (this.isSimulator()) {
       try {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         style = await this.opts.device.getAppearance();
       } catch (ign) {}
     }
@@ -66,15 +67,5 @@ export default {
 };
 
 /**
- * @typedef {Object} SetAppearanceOptions
- * @property {'dark'|'light'} style - Currently two styles are supported
- */
-
-/**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
- */
-
-/**
- * @typedef {Object} Appearance
- * @property {'dark'|'light'|'unknown'|'unsupported'} style - The device's UI appearance value.
  */

--- a/lib/commands/battery.js
+++ b/lib/commands/battery.js
@@ -3,22 +3,10 @@ export default {
    * Reads the battery information from the device under test.
    * This endpoint only returns reliable result on real devices.
    *
-   * @returns {BatteryInfo} The actual battery info
+   * @returns {Promise<import('./types').BatteryInfo>} The actual battery info
    * @this {import('../driver').XCUITestDriver}
    */
   async mobileGetBatteryInfo() {
     return await this.proxyCommand('/wda/batteryInfo', 'GET');
   },
 };
-
-/**
- * @typedef {Object} BatteryInfo
- *
- * @property {number} level - Battery level in range [0.0, 1.0], where
- *                            1.0 means 100% charge.
- * @property {0|1|2|3} state - Battery state. The following values are possible:
- *   UIDeviceBatteryStateUnknown = 0
- *   UIDeviceBatteryStateUnplugged = 1  // on battery, discharging
- *   UIDeviceBatteryStateCharging = 2   // plugged in, less than 100%
- *   UIDeviceBatteryStateFull = 3       // plugged in, at 100%
- */

--- a/lib/commands/biometric.js
+++ b/lib/commands/biometric.js
@@ -27,7 +27,7 @@ export default {
    * @param {string} type - The biometric feature name.
    * @param {boolean} match - If `true`, simulate biometic match. If `false`, simulate biometric non-match..
    * @throws {Error} If matching fails or the device is not a Simulator.
-   * @group Simulatory Only
+   * @group Simulator Only
    * @this {XCUITestDriver}
    */
   async mobileSendBiometricMatch(type = 'touchId', match = true) {

--- a/lib/commands/biometric.js
+++ b/lib/commands/biometric.js
@@ -8,59 +8,51 @@ export default {
   /**
    * Enrolls biometric authentication on Simulator.
    *
-   * @param {EnrollOptions} [opts] - Enrollment options.
+   * @param {boolean} isEnabled - Whether to enable/disable biometric enrollment.
    * @throws {Error} If enrollment fails or the device is not a Simulator.
+   * @group Simulatory Only
    * @this {XCUITestDriver}
    */
-  async mobileEnrollBiometric(opts = {}) {
-    const {isEnabled = true} = opts;
-
+  async mobileEnrollBiometric(isEnabled = true) {
     assertIsSimulator(this);
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.enrollBiometric(isEnabled);
   },
 
   /**
    * Emulates biometric match/non-match event on Simulator.
-   * The biometric feature is expected to be already enrolled before executing that.
+   * The biometric feature is expected to be already enrolled before executing this.
    *
-   * @param {BiometricMatchOptions} [opts] - Matching options.
+   * @param {string} type - The biometric feature name.
+   * @param {boolean} match - If `true`, simulate biometic match. If `false`, simulate biometric non-match..
    * @throws {Error} If matching fails or the device is not a Simulator.
+   * @group Simulatory Only
    * @this {XCUITestDriver}
    */
-  async mobileSendBiometricMatch(opts = {}) {
-    const {match = true, type = 'touchId'} = opts;
-
+  async mobileSendBiometricMatch(type = 'touchId', match = true) {
     assertIsSimulator(this);
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.sendBiometricMatch(match, type);
   },
 
   /**
    * Checks whether biometric is currently enrolled or not.
    *
-   * @return {boolean} True if biometric is enrolled.
+   * @returns {Promise<boolean>} `true` if biometric is enrolled.
    * @throws {Error} If the detection fails or the device is not a Simulator.
+   * @group Simulator Only
    * @this {XCUITestDriver}
    */
   async mobileIsBiometricEnrolled() {
     assertIsSimulator(this);
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await this.opts.device.isBiometricEnrolled();
   },
 };
 
 /**
- * @typedef EnrollOptions
- * @property {boolean} [isEnabled=true] - Whether to enable/disable biometric enrollment.
- */
-
-/**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
- */
-
-/**
- * @typedef {Object} BiometricMatchOptions
- * @property {string} [type=touchId] - The biometric feature name.
- * @property {boolean} [match=true] - Whether to simulate biometric match or non-match.
  */

--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -13,7 +13,7 @@ import {errors} from 'appium/driver';
 const CONFIG_EXTENSION = 'mobileconfig';
 const HOST_PORT_RANGE = [38200, 38299];
 const TMPSERVER_STARTUP_TIMEOUT = 5000;
-const Settings = {
+const Settings = /** @type {const} */ ({
   General: {
     type: 'accessibility id',
     value: 'General',
@@ -30,8 +30,8 @@ const Settings = {
     type: 'accessibility id',
     value: 'Certificate Trust Settings',
   },
-};
-const Button = {
+});
+const Button = /** @type {const} */ ({
   Install: {
     type: 'accessibility id',
     value: 'Install',
@@ -48,14 +48,14 @@ const Button = {
     type: 'accessibility id',
     value: 'Return to Settings',
   },
-};
-const Alert = {
+});
+const Alert = /** @type {const} */ ({
   Install: {
     type: '-ios class chain',
     value:
       "**/XCUIElementTypeAny[`type == 'XCUIElementTypeAlert' OR type == 'XCUIElementTypeSheet'`]/**/XCUIElementTypeButton[`label == 'Install'`]",
   },
-};
+});
 
 async function extractCommonName(certBuffer) {
   const tempCert = await tempDir.open({
@@ -283,18 +283,6 @@ async function installPost122Certificate(driver, name) {
   return true;
 }
 
-/**
- * @typedef {Object} CertificateInstallationOptions
- *
- * @property {string} content - Base64-encoded content of the public certificate
- * @property {string} [commonName] - Common name of the certificate. If this is not set
- * then the script will try to parse it from the given certificate content.
- * @property {boolean} [isRoot=true] - This option defines where the certificate should be
- * installed to: either Trusted Root Store (`true`, the default option) or
- * the Keychain (`false`). On environments other than Xcode 11.4+ Simulator this
- * option is ignored.
- */
-
 export default {
   /**
    * Installs a custom certificate onto the device.
@@ -309,14 +297,15 @@ export default {
    * Then the algorithm goes through the profile installation procedure by
    * clicking the necessary buttons using WebDriverAgent.
    *
-   * @param {CertificateInstallationOptions} opts
-   * @returns {Promise<string?>} The content of the generated .mobileconfig file as
+   * @param {string} content
+   * @param {string} [commonName]
+   * @param {boolean} [isRoot=true]
+   * @returns {Promise<string|undefined>} The content of the generated .mobileconfig file as
    * base64-encoded string. This config might be useful for debugging purposes.
    * If the certificate has been successfully set via CLI then nothing is returned.
    * @this {XCUITestDriver}
    */
-  async mobileInstallCertificate(opts = {}) {
-    const {content, commonName, isRoot = true} = opts;
+  async mobileInstallCertificate(content, commonName, isRoot) {
     if (_.isEmpty(content)) {
       throw new Error('Certificate content should not be empty');
     }
@@ -324,6 +313,7 @@ export default {
     if (this.isSimulator()) {
       try {
         const methodName = isRoot ? 'addRootCertificate' : 'addCertificate';
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device.simctl[methodName](Buffer.from(content, 'base64').toString(), {
           raw: true,
         });
@@ -404,10 +394,12 @@ export default {
             }
           }
         } else {
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           await this.opts.device.openUrl(certUrl);
         }
 
         let isCertAlreadyInstalled = false;
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         if (util.compareVersions(this.opts.platformVersion, '>=', '12.2')) {
           if (await installPost122Certificate(this, cn)) {
             await clickElement(this, Settings.Profile);
@@ -452,13 +444,13 @@ export default {
    * if [py-ios-device](https://github.com/YueChen-C/py-ios-device) tool
    * is available on the server machine.
    *
-   * @property {!string} name - Name of certificate to remove
-   * @returns {Object} Returns status acknowledgment if successfully removed certificate or 'None'
+   * @param {string} name - Name of certificate to remove
+   * @returns {Promise<object>} Returns status acknowledgment if successfully removed certificate or 'None'
    * @throws {Error} If attempting to remote certificates for simulated device or if py-ios-device
    * is not installed
+   * @group Real Device Only
    */
-  async mobileRemoveCertificate(opts = {}) {
-    const {name} = opts;
+  async mobileRemoveCertificate(name) {
     if (!this.isRealDevice()) {
       throw new errors.NotImplementedError('This extension is only supported on real devices');
     }

--- a/lib/commands/condition.js
+++ b/lib/commands/condition.js
@@ -61,6 +61,7 @@ export default {
    */
   async listConditionInducers() {
     requireConditionInducerCompatibleDevice(this);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const conditionInducerService = await services.startInstrumentService(this.opts.device.udid);
     try {
       const ret = await conditionInducerService.callChannel(
@@ -77,17 +78,18 @@ export default {
    * Enable condition inducer. The socket needs to remain connected during operation
    * conditionID  Condition[0].identifier
    * profileID    Condition[0].profiles[0].identifier
-   * @param {{conditionID: string, profileID: string}} options
+   * @param { {conditionID: string, profileID: string} } options
    * @returns {Promise<boolean>} `true` if enable the condition succeeded
    * @throws {Error} If try to start another Condition and the previous Condition has not stopped, it will throw an error
    * @this {XCUITestDriver}
    */
-  async enableConditionInducer(options = {}) {
+  async enableConditionInducer(options) {
     requireConditionInducerCompatibleDevice(this);
     if (this._conditionInducerService && !this._conditionInducerService._socketClient.destroyed) {
       this.log.errorAndThrow(`Condition inducer has been started. A condition is already active.`);
     }
     const {conditionID, profileID} = options;
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     this._conditionInducerService = await services.startInstrumentService(this.opts.device.udid);
     const ret = await this._conditionInducerService.callChannel(
       INSTRUMENT_CHANNEL.CONDITION_INDUCER,

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -10,6 +10,18 @@ const WEBVIEW_WIN = 'WEBVIEW';
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
 const RECENT_WEBVIEW_DETECTION_TIMEOUT_MS = 90000;
 
+/**
+ * Type guard for a non-empty array.
+ *
+ * @remarks Does not support subclasses of `Array` nor tuples.
+ * @template T
+ * @param {T[]} [value]
+ * @returns {value is [T, ...T[]]}
+ */
+function isNonEmptyArray(value) {
+  return Boolean(value?.length);
+}
+
 const extensions = {
   /**
    * @this {XCUITestDriver}
@@ -34,6 +46,7 @@ const extensions = {
    * @this {XCUITestDriver}
    */
   useNewSafari() {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return !this.isRealDevice() && this.opts.safari;
   },
   /**
@@ -69,6 +82,7 @@ const extensions = {
       }
 
       this.log.warn('Could not find any webviews yet, refreshing/retrying');
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       if (this.isRealDevice() || !this.opts.safari) {
         // on a real device, when not using Safari, we just want to try again
         await B.delay(spinTimeMs);
@@ -76,10 +90,11 @@ const extensions = {
       }
 
       // find the reload button and tap it, if possible
+      /** @type {import('@appium/types').Element} */
       let element;
       try {
         this.log.debug('Finding and tapping reload button');
-        element = await this.findUIElementOrElements('accessibility id', 'ReloadButton', '', false);
+        element = /** @type {import('@appium/types').Element} */(await this.findNativeElementOrElements('accessibility id', 'ReloadButton', '', false));
         await this.nativeClick(element);
       } catch (err) {
         this.log.warn(`Error finding and tapping reload button: ${err.message}`);
@@ -134,13 +149,14 @@ const extensions = {
 
     this.remote.on(RemoteDebugger.EVENT_PAGE_CHANGE, this.onPageChange.bind(this));
     this.remote.on(RemoteDebugger.EVENT_FRAMES_DETACHED, () => {
-      if (!_.isEmpty(this.curWebFrames)) {
+      if (isNonEmptyArray(this.curWebFrames)) {
+        const curWebFrames = this.curWebFrames;
         this.log.debug(
           `Clearing ${util.pluralize(
             'frame',
-            this.curWebFrames.length,
+            curWebFrames.length,
             true
-          )}: ${this.curWebFrames.join(', ')}`
+          )}: ${curWebFrames.join(', ')}`
         );
       }
       this.curWebFrames = [];
@@ -153,14 +169,11 @@ const extensions = {
    * Get the contexts available, with information about the url and title of each
    * webview
    *
-   * @param {Object} opts - Options set, which can include `waitForWebviewMs` to
-   *                        specify the period to poll for available webviews
-   * @returns {Array} List of Context objects
+   * @param {number} [waitForWebviewMs] - The period to poll for available webviews (in ms)
+   * @returns {Promise<Context[]>} List of Context objects
    * @this {XCUITestDriver}
    */
-  async mobileGetContexts(opts = {}) {
-    let {waitForWebviewMs = 0} = opts;
-
+  async mobileGetContexts(waitForWebviewMs = 0) {
     // make sure it is a number, so the duration check works properly
     if (!_.isNumber(waitForWebviewMs)) {
       waitForWebviewMs = parseInt(waitForWebviewMs, 10);
@@ -193,6 +206,7 @@ const extensions = {
     }
   },
   /**
+   * @param {import('./types').PageChangeNotification} pageChangeNotification
    * @this {XCUITestDriver}
    */
   async onPageChange(pageChangeNotification) {
@@ -325,8 +339,8 @@ const extensions = {
 
     // make sure that the page listing isn't indicating a redirect
     if (util.hasValue(this.curContext)) {
-      let currentPageId = parseInt(_.last(this.curContext.split('.')), 10);
-      let page = _.find(pageArray, (p) => parseInt(p.id, 10) === currentPageId);
+      let currentPageId = parseInt(String(_.last(this.curContext.split('.'))), 10);
+      let page = _.find(pageArray, (p) => parseInt(String(p.id), 10) === currentPageId);
       if (page && page.url !== this.getCurrentUrl()) {
         this.log.debug(`Redirected from '${this.getCurrentUrl()}' to '${page.url}'`);
         this.setCurrentUrl(page.url);
@@ -422,6 +436,7 @@ const helpers = {
   async getNewRemoteDebugger() {
     let socketPath;
     if (!this.isRealDevice()) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       socketPath = await this.opts.device.getWebInspectorSocket();
     }
     return createRemoteDebugger(
@@ -464,12 +479,12 @@ const commands = {
   /**
    * Set context
    *
-   * @param {?string} name - The name of context to set. It could be 'null' as NATIVE_WIN.
-   * @param {callback} callback The callback. (It is not called in this method)
+   * @param {string|Context} name - The name of context to set. It could be 'null' as NATIVE_WIN.
+   * @param {any} [callback] The callback. (It is not called in this method)
    * @param {boolean} skipReadyCheck - Whether it waits for the new context is ready
    * @this {XCUITestDriver}
    */
-  async setContext(name, callback, skipReadyCheck) {
+  async setContext(name, callback, skipReadyCheck = false) {
     function alreadyInContext(desired, current) {
       return (
         desired === current ||
@@ -482,25 +497,23 @@ const commands = {
     }
 
     // allow the full context list to be passed in
-    if (name && name.id) {
-      name = name.id;
-    }
+    const strName = String(typeof name === 'object' && name.id ? name.id : name);
 
     this.log.debug(
-      `Attempting to set context to '${name || NATIVE_WIN}' from '${
+      `Attempting to set context to '${strName || NATIVE_WIN}' from '${
         this.curContext ? this.curContext : NATIVE_WIN
       }'`
     );
 
     if (
-      alreadyInContext(name, this.curContext) ||
-      alreadyInContext(_.replace(name, WEBVIEW_BASE, ''), this.curContext)
+      alreadyInContext(strName, this.curContext) ||
+      alreadyInContext(_.replace(strName, WEBVIEW_BASE, ''), this.curContext)
     ) {
       // already in the named context, no need to do anything
-      this.log.debug(`Already in '${name || NATIVE_WIN}' context. Doing nothing.`);
+      this.log.debug(`Already in '${strName || NATIVE_WIN}' context. Doing nothing.`);
       return;
     }
-    if (isNativeContext(name)) {
+    if (isNativeContext(strName)) {
       // switching into the native context
       this.curContext = null;
       return;
@@ -513,12 +526,12 @@ const commands = {
       await this.getContexts();
     }
 
-    let contextId = _.replace(name, WEBVIEW_BASE, '');
+    let contextId = _.replace(strName, WEBVIEW_BASE, '');
     if (contextId === '') {
       // allow user to pass in "WEBVIEW" without an index
       // the second context will be the first webview as
       // the first is always NATIVE_APP
-      contextId = this.contexts[1];
+      contextId = /** @type {string[]} */(this.contexts)[1];
     }
     if (!_.includes(this.contexts, contextId)) {
       throw new errors.NoSuchContextError();
@@ -598,6 +611,9 @@ const commands = {
   async getWindowHandle() {
     if (!this.isWebContext()) {
       throw new errors.NotImplementedError();
+    }
+    if (!this.curContext) {
+      throw new errors.InvalidContextError();
     }
     this.log.debug(`Getting current window handle`);
     return this.curContext;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -30,6 +30,9 @@ const extensions = {
     this.log.debug('Retrieving contexts and views');
     let webviews = await this.listWebFrames(useUrl);
 
+    /**
+     * @type {[import('./types').ViewContext<typeof NATIVE_WIN>]}
+     */
     let ctxs = [{id: NATIVE_WIN, view: {}}];
     this.contexts = [NATIVE_WIN];
     for (let view of webviews) {
@@ -57,6 +60,7 @@ const extensions = {
     const timer = new timing.Timer().start();
     const spinTimeMs = 500;
     const spinHandles = async () => {
+      /** @type {string|undefined} */
       let contextId;
       try {
         contextId = await this.getRecentWebviewContextId(/.*/, /.*/);
@@ -94,7 +98,9 @@ const extensions = {
       let element;
       try {
         this.log.debug('Finding and tapping reload button');
-        element = /** @type {import('@appium/types').Element} */(await this.findNativeElementOrElements('accessibility id', 'ReloadButton', '', false));
+        element = /** @type {import('@appium/types').Element} */ (
+          await this.findNativeElementOrElements('accessibility id', 'ReloadButton', '', false)
+        );
         await this.nativeClick(element);
       } catch (err) {
         this.log.warn(`Error finding and tapping reload button: ${err.message}`);
@@ -152,11 +158,9 @@ const extensions = {
       if (isNonEmptyArray(this.curWebFrames)) {
         const curWebFrames = this.curWebFrames;
         this.log.debug(
-          `Clearing ${util.pluralize(
-            'frame',
-            curWebFrames.length,
-            true
-          )}: ${curWebFrames.join(', ')}`
+          `Clearing ${util.pluralize('frame', curWebFrames.length, true)}: ${curWebFrames.join(
+            ', '
+          )}`
         );
       }
       this.curWebFrames = [];
@@ -187,9 +191,10 @@ const extensions = {
 
     const timer = new timing.Timer().start();
     try {
+      /** @type {FullContext[]} */
       let contexts;
       do {
-        contexts = await this.getContexts();
+        contexts = /** @type {FullContext[]} */(await this.getContexts());
 
         if (contexts.length >= 2) {
           this.log.debug(
@@ -394,6 +399,8 @@ const helpers = {
     return this._currentUrl;
   },
   /**
+   * @param {RegExp} titleRegExp
+   * @param {RegExp} urlRegExp
    * @this {XCUITestDriver}
    */
   async getRecentWebviewContextId(titleRegExp, urlRegExp) {
@@ -531,7 +538,7 @@ const commands = {
       // allow user to pass in "WEBVIEW" without an index
       // the second context will be the first webview as
       // the first is always NATIVE_APP
-      contextId = /** @type {string[]} */(this.contexts)[1];
+      contextId = /** @type {string[]} */ (this.contexts)[1];
     }
     if (!_.includes(this.contexts, contextId)) {
       throw new errors.NoSuchContextError();
@@ -575,22 +582,21 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @returns {Promise<string[]|FullContext[]>}
    */
   async getContexts() {
     this.log.debug('Getting list of available contexts');
     const contexts = await this.getContextsAndViews(false);
 
-    const mapFn = this.opts.fullContextList
-      ? function (context) {
-          return {
-            id: context.id.toString(),
-            title: context.view.title,
-            url: context.view.url,
-            bundleId: context.view.bundleId,
-          };
-        }
-      : (context) => context.id.toString();
-    return contexts.map(mapFn);
+    if (this.opts.fullContextList) {
+      return /** @type {import('./types').FullContext[]} */(contexts.map((context) => ({
+        id: context.id.toString(),
+        title: context.view.title,
+        url: context.view.url,
+        bundleId: context.view.bundleId,
+      })));
+    }
+    return /** @type {string[]} */(contexts.map((context) => context.id.toString()));
   },
 
   /**
@@ -632,7 +638,11 @@ const commands = {
         // get rid of the native app context
         .filter((context) => context.id !== NATIVE_WIN)
         // get the `app.id` format expected
-        .map((context) => context.view.id.toString())
+        .map((context) =>
+        /**
+         * This is non-nullable because the `FullContext` having `id` `NATIVE_WIN` _looks like_ the only with an empty view.
+         * @type {NonNullable<FullContext['view']['id']>}
+         */(context.view.id).toString())
     );
   },
 };
@@ -640,15 +650,8 @@ const commands = {
 export default {...helpers, ...extensions, ...commands};
 
 /**
- * @typedef {Object} Context
- *
- * @property {string} id - The identifier of the context. The native context
- *                          will be 'NATIVE_APP' and the webviews will be
- *                          'WEBVIEW_xxx'
- * @property {string} [title] - The title associated with the webview content
- * @property {string} [url] - The url associated with the webview content
+ * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
+ * @typedef {import('./types').Context} Context
+ * @typedef {import('./types').FullContext} FullContext
  */
 
-/**
- * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
- */

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -3,7 +3,7 @@ export default {
   /**
    * Returns device info.
    *
-   * @returns {Object} The response of `/wda/device/info'`
+   * @returns {Promise<object>} The response of `/wda/device/info'`
    * @throws {Error} if an error raised by command
    * @this {import('../driver').XCUITestDriver}
    */
@@ -11,6 +11,7 @@ export default {
     const infoByWda = await this.proxyCommand('/wda/device/info', 'GET');
 
     if (this.isRealDevice()) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       const lockdownInfo = await utilities.getDeviceInfo(this.opts.device.udid);
       return {...infoByWda, ...{lockdownInfo}};
     }

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -5,14 +5,17 @@ import {util} from 'appium/support';
 /**
  * Prepares the input value to be passed as an argument to WDA.
  *
- * @param {string|Array<string>|number} inp The actual text to type.
- * Acceptable values of `inp`:
- *   ['some text']
- *   ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
- *   'some text'
- *   1234
+ * @param {string|string[]|number} inp The actual text to type.
+ * @example
+ * ```js
+ * // Acceptable values of `inp`:
+ * ['some text']
+ * ['s', 'o', 'm', 'e', ' ', 't', 'e', 'x', 't']
+ * 'some text'
+ * 1234
+ * ```
  * @throws {Error} If the value is not acceptable for input
- * @returns {Array<string>} The preprocessed value
+ * @returns {string[]} The preprocessed value
  */
 function prepareInputValue(inp) {
   if (![_.isArray, _.isString, _.isFinite].some((f) => f(inp))) {
@@ -31,7 +34,7 @@ function prepareInputValue(inp) {
   }
   // The `split` method must not be used on the string
   // to properly handle all Unicode code points
-  return [...inp].map((k) => {
+  return [...String(inp)].map((k) => {
     if (['\uE006', '\uE007'].includes(k)) {
       // RETURN or ENTER
       return '\n';
@@ -163,19 +166,24 @@ const commands = {
     return await this.getNativeRect(el);
   },
   /**
+   * Get the position of an element on screen
+   *
+   * @param {string|Element} elementId - the element ID
+   * @returns {Promise<Position>} The position of the element
+   * @deprecated Use {@linkcode XCUITestDriver.getElementRect} instead
    * @this {XCUITestDriver}
    */
-  async getLocation(el) {
-    el = util.unwrapElement(el);
+  async getLocation(elementId) {
+    const el = util.unwrapElement(elementId);
     if (this.isWebContext()) {
-      const atomsElement = await this.getAtomsElement(el);
+      const atomsElement = this.getAtomsElement(el);
       let loc = await this.executeAtom('get_top_left_coordinates', [atomsElement]);
       if (this.opts.absoluteWebLocations) {
         const script =
           'return [' +
           'Math.max(window.pageXOffset,document.documentElement.scrollLeft,document.body.scrollLeft),' +
           'Math.max(window.pageYOffset,document.documentElement.scrollTop,document.body.scrollTop)];';
-        const [xOffset, yOffset] = await this.execute(script);
+        const [xOffset, yOffset] = /** @type {[number, number]} */(await this.execute(script));
         loc.x += xOffset;
         loc.y += yOffset;
       }
@@ -186,12 +194,19 @@ const commands = {
     return {x: rect.x, y: rect.y};
   },
   /**
+   * Alias for {@linkcode XCUITestDriver.getLocation}
+   * @param {string|Element} elementId - the element ID
+   * @returns {Promise<Position>} The position of the element
+   * @deprecated Use {@linkcode XCUITestDriver.getElementRect} instead
    * @this {XCUITestDriver}
    */
-  async getLocationInView(el) {
-    return await this.getLocation(el);
+  async getLocationInView(elementId) {
+    return this.getLocation(elementId);
   },
   /**
+   * Get the size of an element
+   * @param {string|Element} el - the element ID
+   * @returns {Promise<Size>} The position of the element
    * @this {XCUITestDriver}
    */
   async getSize(el) {
@@ -204,6 +219,11 @@ const commands = {
     return {width: rect.width, height: rect.height};
   },
   /**
+   * Alias for {@linkcode setValue}
+   *
+   * @param {string} value - the value to set
+   * @param {string} el - the element to set the value of
+   * @deprecated
    * @this {XCUITestDriver}
    */
   async setValueImmediate(value, el) {
@@ -230,7 +250,10 @@ const commands = {
     await this.executeAtom('type', [atomsElement, value]);
   },
   /**
+   * Send keys to the app
+   * @param {string[]} value - Array of keys to send
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.setValue} instead
    */
   async keys(value) {
     await this.proxyCommand('/wda/keys', 'POST', {
@@ -356,4 +379,7 @@ export default {...extensions, ...commands};
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
+ * @typedef {import('@appium/types').Element} Element
+ * @typedef {import('@appium/types').Position} Position
+ * @typedef {import('@appium/types').Size} Size
  */

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -183,7 +183,7 @@ const commands = {
           'return [' +
           'Math.max(window.pageXOffset,document.documentElement.scrollLeft,document.body.scrollLeft),' +
           'Math.max(window.pageYOffset,document.documentElement.scrollTop,document.body.scrollTop)];';
-        const [xOffset, yOffset] = /** @type {[number, number]} */(await this.execute(script));
+        const [xOffset, yOffset] = /** @type {[number, number]} */ (await this.execute(script));
         loc.x += xOffset;
         loc.y += yOffset;
       }
@@ -201,7 +201,7 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async getLocationInView(elementId) {
-    return this.getLocation(elementId);
+    return await this.getLocation(elementId);
   },
   /**
    * Get the size of an element

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,134 +1,76 @@
 import _ from 'lodash';
+import {XCUITestDriver} from '../driver';
 import {errors, errorFromCode, errorFromW3CJsonCode} from 'appium/driver';
 import {util} from 'appium/support';
 
-const COMMAND_MAP = /** @type {const} */ ({
-    //region gestures support
-    tap: 'mobileTap',
-    scroll: 'mobileScroll',
-    selectPickerWheelValue: 'mobileSelectPickerWheelValue',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618668-swipeleft?language=objc
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618674-swiperight?language=objc
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618667-swipeup?language=objc
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618664-swipedown?language=objc
-    swipe: 'mobileSwipe',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618669-pinchwithscale?language=objc
-    pinch: 'mobilePinch',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618673-doubletap?language=objc
-    doubleTap: 'mobileDoubleTap',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618675-twofingertap?language=objc
-    twoFingerTap: 'mobileTwoFingerTap',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618671-tapwithnumberoftaps?language=objc
-    tapWithNumberOfTaps: 'mobileTapWithNumberOfTaps',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc
-    touchAndHold: 'mobileTouchAndHold',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618670-pressforduration?language=objc
-    dragFromToForDuration: 'mobileDragFromToForDuration',
-    // https://developer.apple.com/documentation/xctest/xcuielement/1618665-rotate?language=objc
-    rotateElement: 'mobileRotateElement',
-    // https://developer.apple.com/documentation/xctest/xcuicoordinate/3551692-pressforduration?language=objc
-    dragFromToWithVelocity: 'mobileDragFromToWithVelocity',
-    forcePress: 'mobileForcePress',
-    scrollToElement: 'mobileScrollToElement',
+/**
+ * Checks if script expects a particular parameter (either optional or required).
+ * @template {keyof XCUITestDriver.executeMethodMap} Script
+ * @this {XCUITestDriver}
+ * @param {Script} script - Script name
+ * @param {string} param - Parameter name
+ * @returns {boolean}
+ */
+function executeMethodExpectsParam(script, param) {
+  /** @type {ReadonlyArray<string>|undefined} */
+  let required;
+  /** @type {ReadonlyArray<string>|undefined} */
+  let optional;
+  const execMethodDef = XCUITestDriver.executeMethodMap[script];
+  if ('params' in execMethodDef) {
+    if ('required' in execMethodDef.params) {
+      required = execMethodDef.params.required;
+    }
+    if ('optional' in execMethodDef.params) {
+      optional = execMethodDef.params.optional;
+    }
+  }
+  const allParams = new Set(_.flatten([...(required ?? []), ...(optional ?? [])]));
+  return allParams.has(param);
+}
 
-    //endregion gestures support
-    alert: 'mobileHandleAlert',
+/**
+ * @param {any} script
+ * @returns {script is keyof XCUITestDriver.executeMethodMap}
+ */
+function isExecuteMethod(script) {
+  return script.match(/^mobile:/) && script in XCUITestDriver.executeMethodMap;
+}
 
-    setPasteboard: 'mobileSetPasteboard',
-    getPasteboard: 'mobileGetPasteboard',
+/**
+ * Massages the arguments going into an execute method.
+ * @param {keyof XCUITestDriver.executeMethodMap} script
+ * @param {ExecuteMethodArgs} [args]
+ * @returns {StringRecord<unknown>}
+ */
+function preprocessExecuteMethodArgs(script, args) {
+  if (_.isArray(args)) {
+    args = _.first(args);
+  }
+  const executeMethodArgs = /** @type {StringRecord<unknown>} */ (args ?? {});
+  /**
+   * Renames the deprecated `element` key to `elementId`.  Historically,
+   * all of the pre-Execute-Method-Map execute methods accepted an `element` _or_ and `elementId` param.
+   * This assigns the `element` value to `elementId` if `elementId` is not already present.
+   */
+  if (!('elementId' in executeMethodArgs) && 'element' in executeMethodArgs) {
+    executeMethodArgs.elementId = executeMethodArgs.element;
+    delete executeMethodArgs.element;
+  }
 
-    source: 'mobileGetSource',
-    getContexts: 'mobileGetContexts',
+  /**
+   * Automatically unwraps the `elementId` prop _if and only if_ the execute method expects it.
+   *
+   * Most of these Execute Methods (typically beginning with `mobile*`) will accept an `Element|string` for `elementId`, in practice they will only ever get a `string`. `Element|string` in the method's docstring is simply for documentation purposes.
+   */
+  if ('elementId' in executeMethodArgs && executeMethodExpectsParam(script, 'elementId')) {
+    executeMethodArgs.elementId = util.unwrapElement(/** @type {import('@appium/types').Element|string} */(executeMethodArgs.elementId));
+  }
 
-    //region multiple apps management
-    installApp: 'mobileInstallApp',
-    isAppInstalled: 'mobileIsAppInstalled',
-    removeApp: 'mobileRemoveApp',
-    launchApp: 'mobileLaunchApp',
-    terminateApp: 'mobileTerminateApp',
-    killApp: 'mobileKillApp',
-    queryAppState: 'mobileQueryAppState',
-    activateApp: 'mobileActivateApp',
-    listApps: 'mobileListApps',
-    //endregion multiple apps management
-
-    viewportScreenshot: 'getViewportScreenshot',
-    viewportRect: 'getViewportRect',
-
-    startPerfRecord: 'mobileStartPerfRecord',
-    stopPerfRecord: 'mobileStopPerfRecord',
-
-    installCertificate: 'mobileInstallCertificate',
-    removeCertificate: 'mobileRemoveCertificate',
-    listCertificates: 'mobileListCertificates',
-
-    startLogsBroadcast: 'mobileStartLogsBroadcast',
-    stopLogsBroadcast: 'mobileStopLogsBroadcast',
-
-    batteryInfo: 'mobileGetBatteryInfo',
-    deviceInfo: 'mobileGetDeviceInfo',
-    getDeviceTime: 'mobileGetDeviceTime',
-    activeAppInfo: 'mobileGetActiveAppInfo',
-    deviceScreenInfo: 'getScreenInfo',
-
-    pressButton: 'mobilePressButton',
-
-    enrollBiometric: 'mobileEnrollBiometric',
-    sendBiometricMatch: 'mobileSendBiometricMatch',
-    isBiometricEnrolled: 'mobileIsBiometricEnrolled',
-
-    clearKeychains: 'mobileClearKeychains',
-
-    getPermission: 'mobileGetPermission',
-    setPermission: 'mobileSetPermissions',
-    resetPermission: 'mobileResetPermission',
-
-    getAppearance: 'mobileGetAppearance',
-    setAppearance: 'mobileSetAppearance',
-
-    siriCommand: 'mobileSiriCommand',
-
-    pushFile: 'mobilePushFile',
-    pullFile: 'mobilePullFile',
-    pullFolder: 'mobilePullFolder',
-    deleteFile: 'mobileDeleteFile',
-    deleteFolder: 'mobileDeleteFolder',
-
-    startAudioRecording: 'startAudioRecording',
-    stopAudioRecording: 'stopAudioRecording',
-
-    // XCTest
-    runXCTest: 'mobileRunXCTest',
-    installXCTestBundle: 'mobileInstallXCTestBundle',
-    listXCTestBundles: 'mobileListXCTestBundles',
-    listXCTestsInTestBundle: 'mobileListXCTestsInTestBundle',
-
-    pushNotification: 'mobilePushNotification',
-    expectNotification: 'mobileExpectNotification',
-
-    performIoHidEvent: 'mobilePerformIoHidEvent',
-
-    configureLocalization: 'mobileConfigureLocalization',
-
-    resetLocationService: 'mobileResetLocationService',
-
-    startPcap: 'mobileStartPcap',
-    stopPcap: 'mobileStopPcap',
-    listConditionInducers: 'mobileListConditionInducers',
-    enableConditionInducer: 'mobileEnableConditionInducer',
-    disableConditionInducer: 'mobileDisableConditionInducer',
-
-    updateSafariPreferences: 'mobileUpdateSafariPreferences',
-
-    deepLink: 'mobileDeepLink',
-
-    setSimulatedLocation: 'mobileSetSimulatedLocation',
-    getSimulatedLocation: 'mobileGetSimulatedLocation',
-    resetSimulatedLocation: 'mobileResetSimulatedLocation',
-});
+  return executeMethodArgs;
+}
 
 export default {
-  COMMAND_MAP,
   /**
    * Collect the response of an async script execution
    * @this {XCUITestDriver}
@@ -158,16 +100,23 @@ export default {
     }
     return this.asyncPromise.resolve(value);
   },
+
   /**
+   * @template {ExecuteMethodArgs} [TArgs = unknown[]]
+   * @template [TReturn = unknown]
+   * @param {string} script - Either a script to run, or in the case of an Execute Method, the name of the script to execute.
+   * @param {TArgs} [args]
    * @this {XCUITestDriver}
+   * @returns {Promise<TReturn>}
    */
   async execute(script, args) {
-    if (script.match(/^mobile:/)) {
-      script = script.replace(/^mobile:/, '').trim();
-      return await this.executeMobile(script, _.isArray(args) ? args[0] : args);
+    // TODO: create a type that converts args to the parameters of the associated method using the `command` prop of `executeMethodMap`
+    if (isExecuteMethod(script)) {
+      const executeMethodArgs = preprocessExecuteMethodArgs(script, args);
+      return await this.executeMethod(script, [executeMethodArgs]);
     } else if (this.isWebContext()) {
-      args = this.convertElementsForAtoms(args);
-      const result = await this.executeAtom('execute_script', [script, args]);
+      const atomsArgs = this.convertElementsForAtoms(/** @type {readonly any[]} */(args));
+      const result = await this.executeAtom('execute_script', [script, atomsArgs]);
       return this.cacheWebElements(result);
     } else {
       throw new errors.NotImplementedError();
@@ -175,6 +124,7 @@ export default {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async executeAsync(script, args) {
     if (!this.isWebContext()) {
@@ -190,21 +140,13 @@ export default {
     );
     return this.cacheWebElements(await this.waitForAtom(promise));
   },
-  /**
-   * @this {XCUITestDriver}
-   */
-  async executeMobile(mobileCommand, opts = {}) {
-    if (!_.isFunction(this[this.COMMAND_MAP[mobileCommand]])) {
-      throw new errors.UnknownCommandError(
-        `Unknown mobile command '${mobileCommand}'. Only ${_.keys(this.COMMAND_MAP).join(
-          ', '
-        )} commands are supported.`
-      );
-  }
-    return await this[this.COMMAND_MAP[mobileCommand]](opts);
-  },
 };
 
 /**
- * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
+ * @template [T=any]
+ * @typedef {import('@appium/types').StringRecord<T>} StringRecord
+ */
+
+/**
+ * @typedef {readonly any[] | readonly [StringRecord] | Readonly<StringRecord>} ExecuteMethodArgs
  */

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -5,7 +5,6 @@ import log from '../logger';
 import {services} from 'appium-ios-device';
 import {pullFile, pullFolder, pushFile} from '../ios-fs-helpers';
 import {errors} from 'appium/driver';
-import {requireArgs} from '../utils';
 
 const CONTAINER_PATH_MARKER = '@';
 // https://regex101.com/r/PLdB0G/2
@@ -20,11 +19,8 @@ const OBJECT_NOT_FOUND_ERROR_MESSAGE = 'OBJECT_NOT_FOUND';
  * @param {string} remotePath - The given path string. The string should
  * match `CONTAINER_PATH_PATTERN` regexp, otherwise an error is going
  * to be thrown. A valid string example: `@bundle.identifier:container_type/relative_path_in_container`
- * @param {Function|string} containerRootSupplier - Either a string, that contains
- * full path to the mount root for real devices or a function, which accepts two parameters
- * (bundle identifier and optional container type) and returns full path to container
- * root folder on the local file system, for Simulator
- * @returns {Promise<ContainerObject>}
+ * @param {import('./types').ContainerRootSupplier|string} [containerRootSupplier] - Container root path supplier function or string value
+ * @returns {Promise<import('./types').ContainerObject>}
  */
 export async function parseContainerPath(remotePath, containerRootSupplier) {
   const match = CONTAINER_PATH_PATTERN.exec(remotePath);
@@ -150,7 +146,7 @@ async function pushFileToSimulator(device, remotePath, base64Data) {
  * @param {string} remotePath - The remote path on the device. This variable can be prefixed with
  *                              bundle id, so then the file will be uploaded to the corresponding
  *                              application container instead of the default media folder. Use
- *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              `@<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>`
  *                              format to pull a file or a folder from an application container of the given type.
  *                              The only supported container type is 'documents'. If the container type is not set
  *                              explicitly for a bundle id, then the default application container is going to be mounted
@@ -188,10 +184,10 @@ async function deleteFileOrFolder(device, remotePath, isSimulator) {
  *                          valid device ID.
  * @param {string} remotePath - The path to a file or a folder, which exists in the corresponding application
  *                              container on Simulator. Use
- *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              `@<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>`
  *                              format to pull a file or a folder from an application container of the given type.
- *                              Possible container types are 'app', 'data', 'groups', '<A specific App Group container>'.
- *                              The default type is 'app'.
+ *                              Possible container types are `app`, `data`, `groups`, `<A specific App Group container>`.
+ *                              The default type is `app`.
  * @param {boolean} isFile - Whether the destination item is a file or a folder
  * @returns {Promise<string>} Base-64 encoded content of the file.
  */
@@ -235,7 +231,7 @@ async function pullFromSimulator(device, remotePath, isFile) {
  * @param {string} remotePath - The path to an existing remote file on the device. This variable can be prefixed with
  *                              bundle id, so then the file will be downloaded from the corresponding
  *                              application container instead of the default media folder. Use
- *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              `@<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>`
  *                              format to pull a file or a folder from an application container of the given type.
  *                              The only supported container type is 'documents'. If the container type is not set
  *                              explicitly for a bundle id, then the default application container is going to be mounted
@@ -275,7 +271,7 @@ async function pullFromRealDevice(device, remotePath, isFile) {
  *                          valid device ID.
  * @param {string} remotePath - The path to a file or a folder, which exists in the corresponding application
  *                              container on Simulator. Use
- *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              `@<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>`
  *                              format to pull a file or a folder from an application container of the given type.
  *                              Possible container types are 'app', 'data', 'groups', '<A specific App Group container>'.
  *                              The default type is 'app'.
@@ -314,7 +310,7 @@ async function deleteFromSimulator(device, remotePath) {
  * @param {string} remotePath - The path to an existing remote file on the device. This variable can be prefixed with
  *                              bundle id, so then the file will be downloaded from the corresponding
  *                              application container instead of the default media folder. Use
- *                              @<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>
+ *                              `@<app_bundle_id>:<optional_container_type>/<path_to_the_file_or_folder_inside_container>`
  *                              format to pull a file or a folder from an application container of the given type.
  *                              The only supported container type is 'documents'. If the container type is not set
  *                              explicitly for a bundle id, then the default application container is going to be mounted
@@ -365,18 +361,21 @@ export default {
       base64Data = Buffer.from(base64Data).toString('utf8');
     }
     return this.isSimulator()
-      ? await pushFileToSimulator(this.opts.device, remotePath, base64Data)
-      : await pushFileToRealDevice(this.opts.device, remotePath, base64Data);
+      ? // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pushFileToSimulator(this.opts.device, remotePath, base64Data)
+      : // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pushFileToRealDevice(this.opts.device, remotePath, base64Data);
   },
 
   /**
    * Pushes the given data to a file on the remote device.
    *
-   * @param {PushFileOptions} opts
+   * @param {string} remotePath - The full path to the remote file
+   * or a specially formatted path, which points to an item inside an app bundle.
+   * @param {string} payload - Base64-encoded content of the file to be pushed.
    * @this {XCUITestDriver}
    */
-  async mobilePushFile(opts = {}) {
-    const {remotePath, payload} = requireArgs(['remotePath', 'payload'], opts);
+  async mobilePushFile(remotePath, payload) {
     return await this.pushFile(remotePath, payload);
   },
 
@@ -399,50 +398,52 @@ export default {
       );
     }
     return this.isSimulator()
-      ? await pullFromSimulator(this.opts.device, remotePath, true)
-      : await pullFromRealDevice(this.opts.device, remotePath, true);
+      ? // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pullFromSimulator(this.opts.device, remotePath, true)
+      : // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pullFromRealDevice(this.opts.device, remotePath, true);
   },
 
   /**
    * Pulls a remote file from the device.
    *
-   * @param {PullFileOptions} opts
+   * @param {string} remotePath - The full path to the remote file
+   * or a specially formatted path, which points to an item inside app bundle.  See the documentation for `pullFromRealDevice` and `pullFromSimulator` to get more information on acceptable values.
    * @returns {Promise<string>} The same as in `pullFile`
    * @this {XCUITestDriver}
    */
-  async mobilePullFile(opts = {}) {
-    const {remotePath} = requireArgs('remotePath', opts);
+  async mobilePullFile(remotePath) {
     return await this.pullFile(remotePath);
   },
 
   /**
    * Delete a remote folder from the device.
    *
-   * @param {DeleteFolderOptions} opts
+   * @param {string} remotePath - The full path to the remote folder or a specially formatted path, which points to an item inside app bundle. See the documentation for `pullFromRealDevice` and `pullFromSimulator` to get more information on acceptable values.
    * @this {XCUITestDriver}
    */
-  async mobileDeleteFolder(opts = {}) {
-    let {remotePath} = requireArgs('remotePath', opts);
+  async mobileDeleteFolder(remotePath) {
     if (!remotePath.endsWith('/')) {
       remotePath = `${remotePath}/`;
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await deleteFileOrFolder(this.opts.device, remotePath, this.isSimulator());
   },
 
   /**
    * Delete a remote file from the device.
    *
-   * @param {DeleteFileOptions} opts
+   * @param {string} remotePath - The full path to the remote file or a specially formatted path, which points to an item inside app bundle. See the documentation for `pullFromRealDevice` and `pullFromSimulator` to get more information on acceptable values.
    * @this {XCUITestDriver}
    */
-  async mobileDeleteFile(opts = {}) {
-    const {remotePath} = requireArgs('remotePath', opts);
+  async mobileDeleteFile(remotePath) {
     if (remotePath.endsWith('/')) {
       throw new errors.InvalidArgumentError(
         `It is expected that remote path points to a file and not to a folder. ` +
           `'${remotePath}' is given instead`
       );
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await deleteFileOrFolder(this.opts.device, remotePath, this.isSimulator());
   },
 
@@ -460,66 +461,23 @@ export default {
       remotePath = `${remotePath}/`;
     }
     return this.isSimulator()
-      ? await pullFromSimulator(this.opts.device, remotePath, false)
-      : await pullFromRealDevice(this.opts.device, remotePath, false);
+      ? // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pullFromSimulator(this.opts.device, remotePath, false)
+      : // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        await pullFromRealDevice(this.opts.device, remotePath, false);
   },
 
   /**
    * Pulls the whole folder from the device under test.
    *
-   * @param {PullFolderOptions} opts
+   * @param {string} remotePath - The full path to the remote folder
    * @returns {Promise<string>} The same as `pullFolder`
    * @this {XCUITestDriver}
    */
-  async mobilePullFolder(opts = {}) {
-    const {remotePath} = requireArgs('remotePath', opts);
+  async mobilePullFolder(remotePath) {
     return await this.pullFolder(remotePath);
   },
 };
-
-/**
- * @typedef {Object} ContainerObject
- *
- * @property {string} bundleId - The parsed bundle identifier
- * @property {string} pathInContainer - The absolute full path of the item on the local file system
- * @property {string?} containerType - The container type
- */
-
-/**
- * @typedef {Object} PullFolderOptions
- * @property {string} remotePath The full path to the remote folder.
- */
-
-/**
- * @typedef {Object} DeleteFileOptions
- * @property {string} remotePath The full path to the remote file
- * or a specially formatted path, which points to an item inside app bundle.
- * See the documentation for `pullFromRealDevice` and `pullFromSimulator`
- * to get more information on acceptable values.
- */
-
-/**
- * @typedef {Object} DeleteFolderOptions
- * @property {string} remotePath The full path to the remote folder
- * or a specially formatted path, which points to an item inside app bundle.
- * See the documentation for `pullFromRealDevice` and `pullFromSimulator`
- * to get more information on acceptable values.
- */
-
-/**
- * @typedef {Object} PullFileOptions
- * @property {string} remotePath The full path to the remote file
- * or a specially formatted path, which points to an item inside app bundle.
- * See the documentation for `pullFromRealDevice` and `pullFromSimulator`
- * to get more information on acceptable values.
- */
-
-/**
- * @typedef {Object} PushFileOptions
- * @property {string} remotePath The full path to the remote file
- * or a specially formatted path, which points to an item inside an app bundle.
- * @property {string} payload Base64-encoded content of the file to be pushed.
- */
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -26,6 +26,8 @@ export default {
   },
   /**
    * @this {XCUITestDriver}
+   * @privateRemarks I'm not sure what these objects are; they aren't `Element`.
+   * @returns {Promise<any|any[]|undefined>}
    */
   async findNativeElementOrElements(strategy, selector, mult, context) {
     const initSelector = selector;
@@ -107,10 +109,12 @@ export default {
       value: selector,
     };
 
-    let method = 'POST';
+    /** @type {import('./proxy-helper').AllowedHttpMethod} */
+    const method = 'POST';
 
     // This is either an array is mult === true
     // or an object if mult === false
+    /** @type {import('@appium/types').Element[]|undefined} */
     let els;
     try {
       await this.implicitWaitForCondition(async () => {
@@ -171,6 +175,12 @@ export default {
   },
 };
 
+/**
+ *
+ * @param {boolean} mult
+ * @param {import('@appium/types').AppiumLogger|null} log
+ * @returns {[string, string]}
+ */
 function rewriteMagicScrollable(mult, log = null) {
   const pred = ['ScrollView', 'Table', 'CollectionView', 'WebView']
     .map((t) => `type == "XCUIElementType${t}"`)

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -50,9 +50,9 @@ const commands = {
         }
       }
     };
-    if (_.has(seconds, 'timeout')) {
-      const {timeout} = seconds;
-      selectEndpoint(isNaN(timeout) ? timeout : parseFloat(timeout) / 1000.0);
+    if (seconds && !_.isNumber(seconds) && _.has(seconds, 'timeout')) {
+      const timeout = seconds.timeout;
+      selectEndpoint(isNaN(Number(timeout)) ? timeout : parseFloat(String(timeout)) / 1000.0);
     } else {
       selectEndpoint(seconds);
     }
@@ -66,19 +66,28 @@ const commands = {
   },
 
   /**
+   * Trigger a touch/fingerprint match or match failure
+   *
+   * @param {boolean} match - whether the match should be a success or failure
    * @this {XCUITestDriver}
    */
   async touchId(match = true) {
-    await this.mobileSendBiometricMatch({match});
+    await this.mobileSendBiometricMatch('touchId', match);
   },
   /**
+   * Toggle whether the device is enrolled in the touch ID program
+   *
+   * @param {boolean} isEnabled - whether to enable or disable the touch ID program
+   *
    * @this {XCUITestDriver}
    */
   async toggleEnrollTouchId(isEnabled = true) {
-    await this.mobileEnrollBiometric({isEnabled});
+    await this.mobileEnrollBiometric(isEnabled);
   },
   /**
+   * Get the window size
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.getWindowRect} instead.
    */
   async getWindowSize(windowHandle = 'current') {
     if (windowHandle !== 'current') {
@@ -120,6 +129,7 @@ const commands = {
         );
         return stdout;
       }
+      // @ts-expect-error This internal prop of moment is evidently a private API
       return parsedTimestamp.utcOffset(parsedTimestamp._tzm || 0).format(format);
     }
 
@@ -146,12 +156,12 @@ const commands = {
   /**
    * Retrieves the current device time
    *
-   * @param {DeviceTimeOptions} opts
-   * @return {string} Formatted datetime string or the raw command output if formatting fails
+   * @param {string} format - See {@linkcode getDeviceTime.format}
+   * @returns {Promise<string>} Formatted datetime string or the raw command output if formatting fails
    * @this {XCUITestDriver}
    */
-  async mobileGetDeviceTime(opts = {}) {
-    return await this.getDeviceTime(opts.format);
+  async mobileGetDeviceTime(format = MOMENT_FORMAT_ISO8601) {
+    return await this.getDeviceTime(format);
   },
 
   /**
@@ -179,6 +189,13 @@ const commands = {
     await this.proxyCommand('/wda/keyboard/dismiss', 'POST', {keyNames});
   },
   /**
+   * Return the language-specific strings for an app
+   *
+   * @param {string} language - the language to retrieve strings for
+   * @param {string|null} stringFile - the path to the localized strings file if not in the default location
+   *
+   * @returns A record of localized keys to localized text
+   *
    * @this {XCUITestDriver}
    */
   async getStrings(language, stringFile = null) {
@@ -195,10 +212,13 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async removeApp(bundleId) {
-    return await this.mobileRemoveApp({bundleId});
+    await this.mobileRemoveApp(bundleId);
   },
   /**
+   * Start the session after it has been started.
+   *
    * @this {XCUITestDriver}
+   * @privateRemarks Does this make sense?
    */
   async launchApp() {
     this.log.warn('launchApp is deprecated. Please use activateApp, ' +
@@ -213,7 +233,9 @@ const commands = {
     }
   },
   /**
+   * Stop the session without stopping the session
    * @this {XCUITestDriver}
+   * @privateRemarks Does this make sense?
    */
   async closeApp() {
     this.log.warn('closeApp is deprecated. Please use terminateApp, ' +
@@ -244,6 +266,7 @@ const commands = {
     if (this.isRealDevice()) {
       await this.proxyCommand('/url', 'POST', {url});
     } else {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await this.opts.device.simctl.openUrl(url);
     }
   },
@@ -293,11 +316,11 @@ const commands = {
   /**
    * Emulates press the given devive button name.
    *
-   * @param {PressButtonOptions} opts
+   * @param {string} name - The name of the button to be pressed.
+   * @param {number} [durationSeconds] - The duration of the button press in seconds (float).
    * @this {XCUITestDriver}
    */
-  async mobilePressButton(opts = {}) {
-    const {name, durationSeconds} = opts;
+  async mobilePressButton(name, durationSeconds) {
     if (!name) {
       throw new errors.InvalidArgumentError('Button name is mandatory');
     }
@@ -307,11 +330,11 @@ const commands = {
     return await this.proxyCommand('/wda/pressButton', 'POST', {name, duration: durationSeconds});
   },
   /**
+   * @param {string} text - Text to be sent to Siri
    * @this {XCUITestDriver}
    */
-  async mobileSiriCommand(opts = {}) {
-    const {text} = opts;
-    if (!util.hasValue(text)) {
+  async mobileSiriCommand(text) {
+    if (!text) {
       throw new errors.InvalidArgumentError('"text" argument is mandatory');
     }
     return await this.proxyCommand('/wda/siri/activate', 'POST', {text});
@@ -343,9 +366,4 @@ export default {...helpers, ...commands};
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
- */
-
-/**
- * @typedef {Object} DeviceTimeOptions
- * @property {string} [format='YYYY-MM-DDTHH:mm:ssZ'] - See getDeviceTime#format
  */

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -12,7 +12,7 @@ const commands = {};
  * Retrieves simulated geolocation value.
  * Only works since Xcode 14.3/iOS 16.4
  *
- * @returns {GeolocationInfo} All entry values are set to null if no simulated location has
+ * @returns {Promise<GeolocationInfo>} All entry values are set to null if no simulated location has
  * been set prior to calling this API.
  * @throws {Error} If the device under test does not support gelolocation simulation.
  */
@@ -27,7 +27,7 @@ commands.mobileGetSimulatedLocation = async function mobileGetSimulatedLocation 
  * @param {GeolocationInfo} opts
  * @throws {Error} If the device under test does not support gelolocation simulation.
  */
-commands.mobileSetSimulatedLocation = async function mobileGetSimulatedLocation (opts = {}) {
+commands.mobileSetSimulatedLocation = async function mobileGetSimulatedLocation (opts) {
   const {latitude, longitude} = requireArgs(['latitude', 'longitude'], opts);
   return await this.proxyCommand('/wda/simulatedLocation', 'POST', {latitude, longitude});
 };

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -1,55 +1,72 @@
 import {errors} from 'appium/driver';
 import {util} from 'appium/support';
 import _ from 'lodash';
-import log from '../logger';
 
 const SUPPORTED_GESTURE_DIRECTIONS = ['up', 'down', 'left', 'right'];
 
-function toElementId(opts = {}) {
-  if (opts.element) {
-    log.info(`The 'element' argument name is deprecated. Consider using 'elementId' instead`);
+/**
+ * @param {any} [opts]
+ * @returns {string|undefined}
+ */
+function toElementId(opts) {
+  if (_.isUndefined(opts)) {
+    return;
   }
-  const el = opts.elementId || opts.element;
-  return el ? util.unwrapElement(el) : null;
+  if (_.isString(opts) || _.isNumber(opts)) {
+    return String(opts);
+  }
+  if ('elementId' in opts || 'element' in opts) {
+    return util.unwrapElement(opts);
+  }
 }
 
-async function toElementOrApplicationId(driver, opts = {}) {
-  return (
-    toElementId(opts) ||
-    util.unwrapElement(
-      await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false)
-    )
-  );
+/**
+ *
+ * @param {XCUITestDriver} driver
+ * @param {Element|string} [elementId]
+ * @returns {Promise<string>}
+ */
+async function toElementOrApplicationId(driver, elementId) {
+  if (!_.isUndefined(elementId)) {
+    return util.unwrapElement(elementId);
+  }
+  return util.unwrapElement(await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false));
 }
 
-function requireFloatParameter(paramName, paramValue, methodName) {
-  if (_.isUndefined(paramValue)) {
+/**
+ * Converts the given value to a float number.
+ *
+ * @throws If `value` is `NaN`
+ * @param {any} value
+ * @param {string} paramName
+ * @returns {number}
+ */
+function asFloat(value, paramName) {
+  const num = parseFloat(String(value));
+  if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter is mandatory for "${methodName}" call`
+      `"${paramName}" parameter should be a valid number. "${value}" is given instead`
     );
   }
-  const result = parseFloat(paramValue);
-  if (isNaN(result)) {
-    throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter should be a valid number. "${paramValue}" is given instead`
-    );
-  }
-  return result;
+  return num;
 }
 
-function requireIntParameter(paramName, paramValue, methodName) {
-  if (_.isUndefined(paramValue)) {
+/**
+ * Converts the given value to an integer number.
+ *
+ * @throws If `value` is `NaN`
+ * @param {any} value
+ * @param {string} paramName
+ * @returns {number}
+ */
+function asInt(value, paramName) {
+  const num = parseInt(String(value), 10);
+  if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter is mandatory for "${methodName}" call`
+      `"${paramName}" parameter should be a valid integer. "${value}" is given instead`
     );
   }
-  const result = parseInt(paramValue, 10);
-  if (isNaN(result)) {
-    throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter should be a valid integer. "${paramValue}" is given instead`
-    );
-  }
-  return result;
+  return num;
 }
 
 export function gesturesChainToString(gestures, keysToInclude = ['options']) {
@@ -73,7 +90,13 @@ export function gesturesChainToString(gestures, keysToInclude = ['options']) {
 
 const commands = {
   /**
+   * Move the mouse pointer to a particular screen location
+   *
+   * @param {string|Element} el - the element ID if the move is relative to an element
+   * @param {number} xoffset - the x offset
+   * @param {number} yoffset - the y offset
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.performActions} instead
    */
   async moveTo(el, xoffset = 0, yoffset = 0) {
     el = util.unwrapElement(el);
@@ -91,7 +114,7 @@ const commands = {
     } else {
       if (_.isNil(el)) {
         if (!this.curCoords) {
-          throw new errors.UnknownException(
+          throw new errors.UnknownError(
             'Current cursor position unknown, please use moveTo with an element the first time.'
           );
         }
@@ -109,12 +132,15 @@ const commands = {
     }
   },
   /**
+   * Shake the device
    * @this {XCUITestDriver}
+   * @group Simulator Only
    */
   async mobileShake() {
     if (!this.isSimulator()) {
       throw new errors.UnknownError('Shake is not supported on real devices');
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.shake();
   },
   /**
@@ -126,10 +152,8 @@ const commands = {
       return await this.nativeClick(el);
     }
     el = util.unwrapElement(el);
-    if (
-      (await this.settings.getSettings()).nativeWebTap ||
-      (await this.settings.getSettings()).nativeWebTapStrict
-    ) {
+    const {nativeWebTap, nativeWebTapStrict} = this.settings.getSettings();
+    if (nativeWebTap || nativeWebTapStrict) {
       // atoms-based clicks don't always work in safari 7
       this.log.debug('Using native web tap');
       await this.nativeWebTap(el);
@@ -178,7 +202,11 @@ const commands = {
     return await this.proxyCommand('/actions', 'POST', {actions: preprocessedActions});
   },
   /**
+   * Perform a set of touch actions
+   *
+   * @param {any[]} gestures - the old MJSONWP style touch action objects
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.performActions} instead
    */
   async performTouch(gestures) {
     this.log.debug(`Received the following touch action: ${gesturesChainToString(gestures)}`);
@@ -196,7 +224,12 @@ const commands = {
     }
   },
   /**
+   * Perform a set of touch actions
+   *
+   * @param {any[]} actions - the old MJSONWP style touch action objects
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.performActions} instead
+   * @group Native Only
    */
   async performMultiAction(actions) {
     this.log.debug(`Received the following multi touch action:`);
@@ -217,7 +250,9 @@ const commands = {
     }
   },
   /**
+   * @param {import('@appium/types').Element|string} el
    * @this {XCUITestDriver}
+   * @group Native Only
    */
   async nativeClick(el) {
     el = util.unwrapElement(el);
@@ -232,10 +267,10 @@ const commands = {
    * See https://developer.apple.com/reference/xctest/xcuielement and
    * https://developer.apple.com/reference/xctest/xcuicoordinate to get the detailed description of
    * all XCTest gestures
+   * @param {Element|string} elementId
    * @this {XCUITestDriver}
    */
-  async mobileScrollToElement(opts = {}) {
-    const elementId = await toElementId(opts);
+  async mobileScrollToElement(elementId) {
     if (!elementId) {
       throw new errors.InvalidArgumentError('Element id must be provided');
     }
@@ -245,12 +280,27 @@ const commands = {
 
 const helpers = {
   /**
+   * @param {string} [name]
+   * @param {import('./types').Direction} [direction]
+   * @param {string} [predicateString]
+   * @param {boolean} [toVisible]
+   * @param {number} [distance]
+   * @param {Element|string} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileScroll(opts = {}) {
+  async mobileScroll(name, direction, predicateString, toVisible, distance, elementId) {
     // WDA supports four scrolling strategies: predication based on name, direction,
     // predicateString, and toVisible, in that order
-    const {name, direction, predicateString, toVisible, distance} = opts;
+    /**
+     * @typedef WdaScrollParams
+     * @property {string} [name]
+     * @property {import('./types').Direction} [direction]
+     * @property {string} [predicateString]
+     * @property {boolean} [toVisible]
+     * @property {number} [distance]
+     */
+
+    /** @type {WdaScrollParams} */
     const params = {};
     if (name) {
       params.name = name;
@@ -276,14 +326,16 @@ const helpers = {
     if (!_.isNil(distance)) {
       params.distance = distance;
     }
-    const elementId = await toElementOrApplicationId(this, opts);
+    elementId = await toElementOrApplicationId(this, elementId);
     return await this.proxyCommand(`/wda/element/${elementId}/scroll`, 'POST', params);
   },
   /**
+   * @param {import('./types').Direction} direction
+   * @param {number} [velocity]
+   * @param {Element|string} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileSwipe(opts = {}) {
-    const {direction, velocity} = opts;
+  async mobileSwipe(direction, velocity, elementId) {
     if (!SUPPORTED_GESTURE_DIRECTIONS.includes(_.toLower(direction))) {
       throw new errors.InvalidArgumentError(
         `'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`
@@ -293,83 +345,100 @@ const helpers = {
     if (!_.isNil(velocity)) {
       params.velocity = velocity;
     }
-    const elementId = await toElementOrApplicationId(this, opts);
+    elementId = await toElementOrApplicationId(this, elementId);
     return await this.proxyCommand(`/wda/element/${elementId}/swipe`, 'POST', params);
   },
   /**
+   * @param {number} scale
+   * @param {number} velocity
+   * @param {Element|string} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobilePinch(opts = {}) {
+  async mobilePinch(scale, velocity, elementId) {
     const params = {
-      scale: requireFloatParameter('scale', opts.scale, 'pinch'),
-      velocity: requireFloatParameter('velocity', opts.velocity, 'pinch'),
+      scale: asFloat(scale, 'scale'),
+      velocity: asFloat(velocity, 'velocity'),
     };
-    const elementId = await toElementOrApplicationId(this, opts);
+    elementId = await toElementOrApplicationId(this, elementId);
     return await this.proxyCommand(`/wda/element/${elementId}/pinch`, 'POST', params);
   },
   /**
+   * @param {Element|string} [elementId]
+   * @param {number} [x]
+   * @param {number} [y]
    * @this {XCUITestDriver}
    */
-  async mobileDoubleTap(opts = {}) {
-    const elementId = toElementId(opts);
+  async mobileDoubleTap(elementId, x, y) {
     if (elementId) {
       // Double tap element
       return await this.proxyCommand(`/wda/element/${elementId}/doubleTap`, 'POST');
     }
     // Double tap coordinates
     const params = {
-      x: requireFloatParameter('x', opts.x, 'doubleTap'),
-      y: requireFloatParameter('y', opts.y, 'doubleTap'),
+      x: asFloat(x, 'x'),
+      y: asFloat(y, 'y'),
     };
     return await this.proxyCommand('/wda/doubleTap', 'POST', params);
   },
   /**
+   * @param {Element|string} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileTwoFingerTap(opts = {}) {
-    const elementId = await toElementOrApplicationId(this, opts);
+  async mobileTwoFingerTap(elementId) {
+    elementId = await toElementOrApplicationId(this, elementId);
     return await this.proxyCommand(`/wda/element/${elementId}/twoFingerTap`, 'POST');
   },
   /**
+   * @param {number} duration
+   * @param {number} [x]
+   * @param {number} [y]
+   * @param {string|Element} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileTouchAndHold(opts = {}) {
+  async mobileTouchAndHold(duration, x, y, elementId) {
     const params = {
-      duration: requireFloatParameter('duration', opts.duration, 'touchAndHold'),
+      duration: asFloat(duration, 'duration'),
     };
-    const elementId = toElementId(opts);
     if (elementId) {
       // Long tap element
       return await this.proxyCommand(`/wda/element/${elementId}/touchAndHold`, 'POST', params);
     }
     // Long tap coordinates
-    params.x = requireFloatParameter('x', opts.x, 'touchAndHold');
-    params.y = requireFloatParameter('y', opts.y, 'touchAndHold');
+    params.x = asFloat(x, 'x');
+    params.y = asFloat(y, 'y');
     return await this.proxyCommand('/wda/touchAndHold', 'POST', params);
   },
   /**
+   * @param {number} x
+   * @param {number} y
+   * @param {string|Element} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileTap(opts = {}) {
+  async mobileTap(x, y, elementId = '0') {
     const params = {
-      x: requireFloatParameter('x', opts.x, 'tap'),
-      y: requireFloatParameter('y', opts.y, 'tap'),
+      x: asFloat(x, 'x'),
+      y: asFloat(y, 'y'),
     };
-    const elementId = toElementId(opts) || '0';
     return await this.proxyCommand(`/wda/tap/${elementId}`, 'POST', params);
   },
   /**
+   * @param {number} duration
+   * @param {number} fromX
+   * @param {number} fromY
+   * @param {number} toX
+   * @param {number} toY
+   * @param {string|Element} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileDragFromToForDuration(opts = {}) {
+  async mobileDragFromToForDuration(duration, fromX, fromY, toX, toY, elementId) {
     const params = {
-      duration: requireFloatParameter('duration', opts.duration, 'dragFromToForDuration'),
-      fromX: requireFloatParameter('fromX', opts.fromX, 'dragFromToForDuration'),
-      fromY: requireFloatParameter('fromY', opts.fromY, 'dragFromToForDuration'),
-      toX: requireFloatParameter('toX', opts.toX, 'dragFromToForDuration'),
-      toY: requireFloatParameter('toY', opts.toY, 'dragFromToForDuration'),
+      duration: asFloat(duration, 'duration'),
+      fromX: asFloat(fromX, 'fromX'),
+      fromY: asFloat(fromY, 'fromY'),
+      toX: asFloat(toX, 'toX'),
+      toY: asFloat(toY, 'toY'),
     };
-    const elementId = toElementId(opts);
+    elementId = toElementId(elementId);
     return elementId
       ? // Drag element
         await this.proxyCommand(`/wda/element/${elementId}/dragfromtoforduration`, 'POST', params)
@@ -377,107 +446,121 @@ const helpers = {
         await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
   },
   /**
+   * @param {number} pressDuration
+   * @param {number} holdDuration
+   * @param {number} velocity
+   * @param {string|Element} [fromElementId]
+   * @param {string|Element} [toElementId]
+   * @param {number} [fromX]
+   * @param {number} [fromY]
+   * @param {number} [toX]
+   * @param {number} [toY]
    * @this {XCUITestDriver}
    */
-  async mobileDragFromToWithVelocity(opts = {}) {
+  async mobileDragFromToWithVelocity(pressDuration, holdDuration, velocity, fromElementId, toElementId, fromX, fromY, toX, toY) {
     const params = {
-      pressDuration: requireFloatParameter(
-        'pressDuration',
-        opts.pressDuration,
-        'dragFromToWithVelocity'
-      ),
-      holdDuration: requireFloatParameter(
-        'holdDuration',
-        opts.holdDuration,
-        'dragFromToWithVelocity'
-      ),
-      velocity: requireFloatParameter('velocity', opts.velocity, 'dragFromToWithVelocity'),
+      pressDuration: asFloat(pressDuration, 'pressDuration'),
+      holdDuration: asFloat(holdDuration, 'holdDuration'),
+      velocity: asFloat(velocity, 'velocity'),
     };
-    const fromElementId = opts.fromElementId ? util.unwrapElement(opts.fromElementId) : null;
+    fromElementId = fromElementId ? util.unwrapElement(fromElementId) : undefined;
     if (fromElementId) {
-      const toElement = opts.toElementId ? util.unwrapElement(opts.toElementId) : null;
-      if (!toElement) {
+      toElementId = toElementId ? util.unwrapElement(toElementId) : undefined;
+      if (!toElementId) {
         throw new errors.InvalidArgumentError(
           `"toElementId" parameter is mandatory for "dragFromToWithVelocity" call`
         );
       }
-      params.toElement = toElement;
+      params.toElement = toElementId;
       return await this.proxyCommand(
         `/wda/element/${fromElementId}/pressAndDragWithVelocity`,
         'POST',
         params
       );
     }
-    params.fromX = requireFloatParameter('fromX', opts.fromX, 'dragFromToWithVelocity');
-    params.fromY = requireFloatParameter('fromY', opts.fromY, 'dragFromToWithVelocity');
-    params.toX = requireFloatParameter('toX', opts.toX, 'dragFromToWithVelocity');
-    params.toY = requireFloatParameter('toY', opts.toY, 'dragFromToWithVelocity');
+    params.fromX = asFloat(fromX, 'fromX');
+    params.fromY = asFloat(fromY, 'fromY');
+    params.toX = asFloat(toX, 'toX');
+    params.toY = asFloat(toY, 'toY');
     return await this.proxyCommand('/wda/pressAndDragWithVelocity', 'POST', params);
   },
   /**
+   * @param {string|Element} elementId
+   * @param {number} numberOfTaps
+   * @param {number} numberOfTouches
    * @this {XCUITestDriver}
    */
-  async mobileTapWithNumberOfTaps(opts = {}) {
-    const elementId = toElementId(opts);
+  async mobileTapWithNumberOfTaps(elementId, numberOfTaps, numberOfTouches) {
     if (!elementId) {
       throw new errors.InvalidArgumentError(
         'Element id is expected to be set for tapWithNumberOfTaps method'
       );
     }
     const params = {
-      numberOfTaps: requireIntParameter('numberOfTaps', opts.numberOfTaps, 'tapWithNumberOfTaps'),
-      numberOfTouches: requireIntParameter(
-        'numberOfTouches',
-        opts.numberOfTouches,
-        'tapWithNumberOfTaps'
-      ),
+      numberOfTaps: asInt(numberOfTaps, 'numberOfTaps'),
+      numberOfTouches: asInt(numberOfTouches, 'numberOfTouches'),
     };
     return await this.proxyCommand(`/wda/element/${elementId}/tapWithNumberOfTaps`, 'POST', params);
   },
   /**
+   * @param {number} x
+   * @param {number} y
+   * @param {number} duration
+   * @param {number} pressure
+   * @param {string|Element} [elementId]
    * @this {XCUITestDriver}
    */
-  async mobileForcePress(opts = {}) {
-    const {x, y, duration, pressure} = opts;
-    const elementId = toElementId(opts);
+  async mobileForcePress(x, y, duration, pressure, elementId) {
+    elementId = toElementId(elementId);
     const endpoint = elementId ? `/wda/element/${elementId}/forceTouch` : `/wda/forceTouch`;
     return await this.proxyCommand(endpoint, 'POST', {x, y, duration, pressure});
   },
   /**
+   * Performs selection of the next or previous picker wheel value.
+   * This might be useful if these values are populated dynamically (so you
+   * don't know which one to select) or if value selection using the `sendKeys` API does
+   * not work due to an XCTest bug. The method throws an exception if it
+   * fails to change the current picker value.
+   * @param {string|Element} elementId - The element id for the picker wheel
+   * @param {'next'|'previous'} order - The order in which to select the value. Either `next` or `previous`
+   * @param {number} [offset] - The offset from the start of the picker wheel. This is useful if there are multiple picker wheels on the screen
    * @this {XCUITestDriver}
    */
-  async mobileSelectPickerWheelValue(opts = {}) {
-    const elementId = toElementId(opts);
+  async mobileSelectPickerWheelValue(elementId, order, offset) {
+    elementId = /** @type {string} */(toElementId(elementId));
     if (!elementId) {
       throw new errors.InvalidArgumentError(
-        'Element id is expected to be set for selectPickerWheelValue method'
+        'elementId is expected to be set for selectPickerWheelValue method'
       );
     }
-    if (!_.isString(opts.order) || !['next', 'previous'].includes(opts.order.toLowerCase())) {
+    if (!_.isString(order) || !['next', 'previous'].includes(order.toLowerCase())) {
       throw new errors.InvalidArgumentError(
         `The mandatory 'order' parameter is expected to be equal either to 'next' or 'previous'. ` +
-          `'${opts.order}' is given instead`
+          `'${order}' is given instead`
       );
     }
-    const params = {order: opts.order};
-    if (opts.offset) {
-      params.offset = requireFloatParameter('offset', opts.offset, 'selectPickerWheelValue');
+    const params = {order};
+    if (offset) {
+      params.offset = asFloat(offset, 'offset');
     }
     return await this.proxyCommand(`/wda/pickerwheel/${elementId}/select`, 'POST', params);
   },
   /**
+   * @param {string|Element} elementId
+   * @param {number} rotation
+   * @param {number} velocity
    * @this {XCUITestDriver}
    */
-  async mobileRotateElement(opts = {}) {
-    const elementId = toElementId(opts);
+  async mobileRotateElement(elementId, rotation, velocity) {
+    elementId = /** @type {string} */(toElementId(elementId));
     if (!elementId) {
       throw new errors.InvalidArgumentError(
         'Element id is expected to be set for rotateElement method'
       );
     }
     const params = {
-      rotation: requireFloatParameter('rotation', opts.rotation, 'rotateElement'),
-      velocity: requireFloatParameter('velocity', opts.velocity, 'rotateElement'),
+      rotation: asFloat(rotation, 'rotation'),
+      velocity: asFloat(velocity, 'velocity'),
     };
     return await this.proxyCommand(`/wda/element/${elementId}/rotate`, 'POST', params);
   },
@@ -490,11 +573,11 @@ const helpers = {
 
     let optionX = null;
     if (gesture.options.x) {
-      optionX = requireFloatParameter('x', gesture.options.x, 'getCoordinates');
+      optionX = asFloat(gesture.options.x, 'x');
     }
     let optionY = null;
     if (gesture.options.y) {
-      optionY = requireFloatParameter('y', gesture.options.y, 'getCoordinates');
+      optionY = asFloat(gesture.options.y, 'y');
     }
 
     // figure out the element coordinates.
@@ -547,4 +630,5 @@ export default {...helpers, ...commands};
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
+ * @typedef {import('@appium/types').Element} Element
  */

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -69,6 +69,12 @@ function asInt(value, paramName) {
   return num;
 }
 
+/**
+ *
+ * @param {any[]} gestures
+ * @param {string[]|null} keysToInclude
+ * @returns {string}
+ */
 export function gesturesChainToString(gestures, keysToInclude = ['options']) {
   return gestures
     .map((item) => {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,79 +1,79 @@
-import contextExtensions from './context';
-import executeExtensions from './execute';
-import gestureExtensions from './gesture';
-import findExtensions from './find';
-import proxyHelperExtensions from './proxy-helper';
+import activeAppInfoExtensions from './activeAppInfo';
 import alertExtensions from './alert';
-import sourceExtensions from './source';
-import generalExtensions from './general';
-import logExtensions from './log';
-import webExtensions from './web';
-import timeoutExtensions from './timeouts';
-import navigationExtensions from './navigation';
+import appManagementExtensions from './app-management';
+import appearanceExtensions from './appearance';
+import batteryExtensions from './battery';
+import biometricExtensions from './biometric';
+import certificateExtensions from './certificate';
+import clipboardExtensions from './clipboard';
+import conditionExtensions from './condition';
+import contextExtensions from './context';
+import deviceInfoExtensions from './deviceInfo';
 import elementExtensions from './element';
+import executeExtensions from './execute';
 import fileMovementExtensions from './file-movement';
-import screenshotExtensions from './screenshots';
-import pasteboardExtensions from './pasteboard';
+import findExtensions from './find';
+import generalExtensions from './general';
+import geolocationExtensions from './geolocation';
+import gestureExtensions from './gesture';
+import iohidExtensions from './iohid';
+import keychainsExtensions from './keychains';
+import localizationExtensions from './localization';
 import locationExtensions from './location';
+import lockExtensions from './lock';
+import logExtensions from './log';
+import navigationExtensions from './navigation';
+import notificationsExtensions from './notifications';
+import pasteboardExtensions from './pasteboard';
+import pcapExtensions from './pcap';
+import performanceExtensions from './performance';
+import permissionsExtensions from './permissions';
+import proxyHelperExtensions from './proxy-helper';
 import recordAudioExtensions from './record-audio';
 import recordScreenExtensions from './recordscreen';
-import lockExtensions from './lock';
-import appManagementExtensions from './app-management';
-import performanceExtensions from './performance';
-import clipboardExtensions from './clipboard';
-import certificateExtensions from './certificate';
-import batteryExtensions from './battery';
-import deviceInfoExtensions from './deviceInfo';
-import activeAppInfoExtensions from './activeAppInfo';
-import biometricExtensions from './biometric';
-import keychainsExtensions from './keychains';
-import permissionsExtensions from './permissions';
-import appearanceExtensions from './appearance';
+import screenshotExtensions from './screenshots';
+import sourceExtensions from './source';
+import timeoutExtensions from './timeouts';
+import webExtensions from './web';
 import xctestExtensions from './xctest';
-import notificationsExtensions from './notifications';
-import iohidExtensions from './iohid';
-import localizationExtensions from './localization';
-import pcapExtensions from './pcap';
-import conditionExtensions from './condition';
-import geolocationExtensions from './geolocation';
 
 export default {
-  contextExtensions,
-  executeExtensions,
-  gestureExtensions,
-  findExtensions,
-  proxyHelperExtensions,
-  sourceExtensions,
-  generalExtensions,
-  logExtensions,
-  webExtensions,
-  timeoutExtensions,
-  navigationExtensions,
-  elementExtensions,
-  fileMovementExtensions,
+  activeAppInfoExtensions,
   alertExtensions,
-  screenshotExtensions,
-  pasteboardExtensions,
-  locationExtensions,
-  lockExtensions,
-  recordScreenExtensions,
+  appearanceExtensions,
   appManagementExtensions,
-  performanceExtensions,
-  clipboardExtensions,
-  certificateExtensions,
   batteryExtensions,
   biometricExtensions,
-  keychainsExtensions,
-  permissionsExtensions,
-  deviceInfoExtensions,
-  activeAppInfoExtensions,
-  recordAudioExtensions,
-  appearanceExtensions,
-  xctestExtensions,
-  notificationsExtensions,
-  iohidExtensions,
-  localizationExtensions,
-  pcapExtensions,
+  certificateExtensions,
+  clipboardExtensions,
   conditionExtensions,
+  contextExtensions,
+  deviceInfoExtensions,
+  elementExtensions,
+  executeExtensions,
+  fileMovementExtensions,
+  findExtensions,
+  generalExtensions,
   geolocationExtensions,
+  gestureExtensions,
+  iohidExtensions,
+  keychainsExtensions,
+  localizationExtensions,
+  locationExtensions,
+  lockExtensions,
+  logExtensions,
+  navigationExtensions,
+  notificationsExtensions,
+  pasteboardExtensions,
+  pcapExtensions,
+  performanceExtensions,
+  permissionsExtensions,
+  proxyHelperExtensions,
+  recordAudioExtensions,
+  recordScreenExtensions,
+  screenshotExtensions,
+  sourceExtensions,
+  timeoutExtensions,
+  webExtensions,
+  xctestExtensions
 };

--- a/lib/commands/iohid.js
+++ b/lib/commands/iohid.js
@@ -1,38 +1,34 @@
 import {errors} from 'appium/driver';
 
-/**
- * @typedef {Object} HIDEventOptions
- * @property {number|string} page The event page identifier
- * @property {number|string} usage The event usage identifier (usages are defined per-page)
- * @property {number|string} durationSeconds The event duration in float seconds
- * (XCTest uses 0.005 for a single press event)
- */
-
 export default {
   /**
-   * Emulates triggering of the given low-level IO HID device event. The constants for possible events are defined
-   * in https://unix.superglobalmegacorp.com/xnu/newsrc/iokit/IOKit/hidsystem/IOHIDUsageTables.h.html
-   * Popular constants:
-   * - kHIDPage_Consumer = 0x0C
-   * - kHIDUsage_Csmr_VolumeIncrement  = 0xE9 (Volume Up)
-   * - kHIDUsage_Csmr_VolumeDecrement  = 0xEA (Volume Down)
-   * - kHIDUsage_Csmr_Menu = 0x40 (Home)
-   * - kHIDUsage_Csmr_Power  = 0x30 (Power)
-   * - kHIDUsage_Csmr_Snapshot  = 0x65 (Power + Home)
+   * Emulates triggering of the given low-level IO HID device event.
    *
-   * @param {HIDEventOptions} opts
+   * See [this source header](https://opensource.apple.com/source/IOHIDFamily/IOHIDFamily-421.6/IOHIDFamily/IOHIDUsageTables.h.auto.html) for possible constants
+   *
+   * Popular constants:
+   * - `kHIDPage_Consumer` = `0x0C`
+   * - `kHIDUsage_Csmr_VolumeIncrement` = `0xE9` (Volume Up)
+   * - `kHIDUsage_Csmr_VolumeDecrement` = `0xEA` (Volume Down)
+   * - `kHIDUsage_Csmr_Menu` = `0x40` (Home)
+   * - `kHIDUsage_Csmr_Power` = `0x30` (Power)
+   * - `kHIDUsage_Csmr_Snapshot` = `0x65` (Power + Home)
+   *
+   * @param {number|string} page - The event page identifier
+   * @param {number|string} usage - The event usage identifier (usages are defined per-page)
+   * @param {number|string} durationSeconds - The event duration in float seconds (XCTest uses `0.005` for a single press event)
    * @this {import('../driver').XCUITestDriver}
    */
-  async mobilePerformIoHidEvent(opts = {}) {
-    const page = parseInt(opts.page, 10);
+  async mobilePerformIoHidEvent(page, usage, durationSeconds) {
+    page = parseInt(String(page), 10);
     if (Number.isNaN(page)) {
       throw new errors.InvalidArgumentError(`'page' argument must be a valid integer`);
     }
-    const usage = parseInt(opts.usage, 10);
+    usage = parseInt(String(usage), 10);
     if (Number.isNaN(usage)) {
       throw new errors.InvalidArgumentError(`'usage' argument must be a valid integer`);
     }
-    const duration = parseFloat(opts.durationSeconds);
+    const duration = parseFloat(String(durationSeconds));
     if (Number.isNaN(duration)) {
       throw new errors.InvalidArgumentError(`'durationSeconds' argument must be a valid number`);
     }

--- a/lib/commands/keychains.js
+++ b/lib/commands/keychains.js
@@ -14,7 +14,7 @@ export default {
    */
   async mobileClearKeychains() {
     assertIsSimulator(this);
-
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.clearKeychains();
   },
 };

--- a/lib/commands/localization.js
+++ b/lib/commands/localization.js
@@ -4,6 +4,7 @@
  * @property {string} name The name of the keyboard locale, for example `en_US` or `de_CH`
  * @property {string} layout The keyboard layout, for example `QUERTY` or `Ukrainian`
  * @property {'Automatic'?} [hardware] Could either be `Automatic` or `null`
+ * @privateRemarks Should `hardware` allow `undefined`? Because here it does.
  */
 
 /**
@@ -17,28 +18,24 @@
  * @property {string} [calendar] Optional calendar format, for example `gregorian` or `persian`
  */
 
-/**
- * @typedef {Object} LocalizationOptions
- * @property {KeyboardOptions} [keyboard]
- * @property {LanguageOptions} [language]
- * @property {LocaleOptions} [locale]
- */
-
 export default {
   /**
    * Change localization settings on the currently booted simulator
    *
-   * @param {LocalizationOptions} [opts]
+   * @param {KeyboardOptions} [keyboard] - Keyboard options
+   * @param {LanguageOptions} [language] - Language options
+   * @param {LocaleOptions} [locale] - Locale options
    * @throws {Error} If there was a failure while setting the preferences
    * @returns {Promise<boolean>} `true` if any of settings has been successfully changed
+   * @group Simulator Only
    * @this {import('../driver').XCUITestDriver}
    */
-  async mobileConfigureLocalization(opts = {}) {
+  async mobileConfigureLocalization(keyboard, language, locale) {
     if (!this.isSimulator()) {
       throw new Error('This extension is only available for Simulator');
     }
 
-    const {language, locale, keyboard} = opts;
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await this.opts.device.configureLocalization({language, locale, keyboard});
   },
 };

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -59,6 +59,7 @@ export default {
     }
 
     if (this.isSimulator()) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await this.opts.device.setGeolocation(`${latitude}`, `${longitude}`);
       return;
     }

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -3,15 +3,7 @@ import {services} from 'appium-ios-device';
 import {util} from 'appium/support';
 
 /**
- * @typedef {Object} Location
- *
- * @property {number} latitude - The latitude of the device under test
- * @property {number} longitude - The longitude of the device under test
- * @property {number} [altitude] - The altitude of the device under test
- */
-
-/**
- * @typedef {import('type-fest').SetRequired<Location, 'altitude'>} LocationWithAltitude
+ * @typedef {import('type-fest').SetRequired<import('@appium/types').Location, 'altitude'>} LocationWithAltitude
  */
 
 export default {
@@ -48,7 +40,7 @@ export default {
     return {latitude, longitude, altitude};
   },
   /**
-   * @param {Location} location
+   * @param {Partial<import('@appium/types').Location>} location
    * @this {XCUITestDriver}
    */
   async setGeoLocation(location) {

--- a/lib/commands/lock.js
+++ b/lib/commands/lock.js
@@ -1,17 +1,20 @@
 import B from 'bluebird';
 
-export default {
+export default ({
   /**
-   * @param {number|string} seconds
+   * Lock the device (and optionally unlock the device after a certain amount of time)
+   *
+   * @param {number|string} [seconds] - the number of seconds after which to unlock the device. Set to `0` or leave empty to require manual unlock (do not automatically unlock).
+   * @defaultValue 0
    * @this {XCUITestDriver}
    */
   async lock(seconds) {
     await this.proxyCommand('/wda/lock', 'POST');
-    if (isNaN(seconds)) {
+    if (isNaN(Number(seconds))) {
       return;
     }
 
-    const floatSeconds = parseFloat(/** @type {string} */(seconds));
+    const floatSeconds = parseFloat(String(seconds));
     if (floatSeconds <= 0) {
       return;
     }
@@ -20,19 +23,23 @@ export default {
     await this.proxyCommand('/wda/unlock', 'POST');
   },
   /**
+   * Unlock the device
+   *
    * @this {XCUITestDriver}
    */
   async unlock() {
     await this.proxyCommand('/wda/unlock', 'POST');
   },
   /**
+   * Determine whether the device is locked
+   *
    * @this {XCUITestDriver}
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} `true` if the device is locked, `false` otherwise
    */
   async isLocked() {
     return await this.proxyCommand('/wda/locked', 'GET');
   },
-};
+});
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -8,11 +8,21 @@ import WebSocket from 'ws';
 import SafariConsoleLog from '../device-log/safari-console-log';
 import SafariNetworkLog from '../device-log/safari-network-log';
 
+/**
+ * Determines the websocket endpoint based on the `sessionId`
+ * @param {string} sessionId
+ * @returns {string}
+ */
 const WEBSOCKET_ENDPOINT = (sessionId) =>
   `${DEFAULT_WS_PATHNAME_PREFIX}/session/${sessionId}/appium/device/syslog`;
+
 const GET_SERVER_LOGS_FEATURE = 'get_server_logs';
 
-const SUPPORTED_LOG_TYPES = /** @type {const} */({
+/**
+ * @type {import('@appium/types').LogDefRecord}
+ * @privateRemarks The return types for these getters should be specified
+ */
+const SUPPORTED_LOG_TYPES = {
   syslog: {
     description: 'System Logs - Device logs for iOS applications on real devices and simulators',
     getter: async (self) => await self.extractLogs('syslog', self.logs),
@@ -30,31 +40,39 @@ const SUPPORTED_LOG_TYPES = /** @type {const} */({
     getter: async (self) => await self.extractLogs('safariConsole', self.logs),
   },
   safariNetwork: {
-    description:
-      'Safari Network Logs - information about network operations undertaken by Safari',
+    description: 'Safari Network Logs - information about network operations undertaken by Safari',
     getter: async (self) => await self.extractLogs('safariNetwork', self.logs),
   },
   server: {
     description: 'Appium server logs',
-    getter: (self) => {
+    /**
+     * @returns {Promise<AppiumServerLogEntry[]>}
+     */
+    getter: async (self) => {
       self.ensureFeatureEnabled(GET_SERVER_LOGS_FEATURE);
-      return log.unwrap().record.map(function (x) {
-        return {
-          // npmlog does not keep timestamps in the history
-          timestamp: Date.now(),
-          level: 'ALL',
-          message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
-        };
-      });
+      return log.unwrap().record.map((x) => ({
+        timestamp: Date.now(),
+        level: 'ALL',
+        message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
+      }));
     },
   },
-});
+};
+
+/**
+ * Log entry in the array returned by `getLogs('server')`
+ * @typedef AppiumServerLogEntry
+ * @property {number} timestamp
+ * @property {'ALL'} level
+ * @property {string} message
+ */
 
 export default {
+  supportedLogTypes: SUPPORTED_LOG_TYPES,
   /**
    *
    * @param {XCUITestDriverLogTypes} logType
-   * @param {Partial<Record<XCUITestDriverLogTypes,{getLogs(): Promise<any>>}} [logsContainer]
+   * @param {Partial<Record<XCUITestDriverLogTypes,{getLogs(): Promise<any>}>>} [logsContainer]
    * @this {XCUITestDriver}
    */
   async extractLogs(logType, logsContainer = {}) {
@@ -70,10 +88,8 @@ export default {
     if (logs) {
       return logs;
     }
-    throw new Error(`No logs of type '${logType}' found.`);
+    throw new Error(`No logs of type '${String(logType)}' found.`);
   },
-
-  supportedLogTypes: SUPPORTED_LOG_TYPES,
 
   /**
    * @this {XCUITestDriver}
@@ -86,6 +102,7 @@ export default {
     }
     if (_.isUndefined(this.logs.syslog)) {
       this.logs.crashlog = new IOSCrashLog({
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         sim: this.opts.device,
         udid: this.isRealDevice() ? this.opts.udid : undefined,
       });
@@ -97,6 +114,7 @@ export default {
         });
       } else {
         this.logs.syslog = new IOSSimulatorLog({
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           sim: this.opts.device,
           showLogs: this.opts.showIOSLog,
           xcodeVersion: this.xcodeVersion,
@@ -129,8 +147,14 @@ export default {
    * @this {XCUITestDriver}
    */
   async mobileStartLogsBroadcast() {
-    const pathname = WEBSOCKET_ENDPOINT(this.sessionId);
-    if (!_.isEmpty(await this.server.getWebSocketHandlers(pathname))) {
+    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */(this.sessionId));
+    if (
+      !_.isEmpty(
+        await /** @type {import('@appium/types').AppiumServer} */ (
+          this.server
+        ).getWebSocketHandlers(pathname)
+      )
+    ) {
       log.debug(
         `The system logs broadcasting web socket server is already listening at ${pathname}`
       );
@@ -177,7 +201,7 @@ export default {
         log.debug(closeMsg);
       });
     });
-    await this.server.addWebSocketHandler(pathname, wss);
+    await /** @type {AppiumServer} */ (this.server).addWebSocketHandler(pathname, wss);
   },
 
   /**
@@ -186,13 +210,13 @@ export default {
    * @this {XCUITestDriver}
    */
   async mobileStopLogsBroadcast() {
-    const pathname = WEBSOCKET_ENDPOINT(this.sessionId);
-    if (_.isEmpty(await this.server.getWebSocketHandlers(pathname))) {
+    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */(this.sessionId));
+    if (_.isEmpty(await /** @type {AppiumServer} */ (this.server).getWebSocketHandlers(pathname))) {
       return;
     }
 
     log.debug('Stopping the system logs broadcasting web socket server');
-    await this.server.removeWebSocketHandler(pathname);
+    await /** @type {AppiumServer} */ (this.server).removeWebSocketHandler(pathname);
   },
 };
 
@@ -202,4 +226,8 @@ export default {
 
 /**
  * @typedef {keyof typeof SUPPORTED_LOG_TYPES} XCUITestDriverLogTypes
+ */
+
+/**
+ * @typedef {import('@appium/types').AppiumServer} AppiumServer
  */

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -46,9 +46,9 @@ const SUPPORTED_LOG_TYPES = {
   server: {
     description: 'Appium server logs',
     /**
-     * @returns {Promise<AppiumServerLogEntry[]>}
+     * @returns {AppiumServerLogEntry[]}
      */
-    getter: async (self) => {
+    getter: (self) => {
       self.ensureFeatureEnabled(GET_SERVER_LOGS_FEATURE);
       return log.unwrap().record.map((x) => ({
         timestamp: Date.now(),
@@ -147,7 +147,7 @@ export default {
    * @this {XCUITestDriver}
    */
   async mobileStartLogsBroadcast() {
-    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */(this.sessionId));
+    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */ (this.sessionId));
     if (
       !_.isEmpty(
         await /** @type {import('@appium/types').AppiumServer} */ (
@@ -210,7 +210,7 @@ export default {
    * @this {XCUITestDriver}
    */
   async mobileStopLogsBroadcast() {
-    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */(this.sessionId));
+    const pathname = WEBSOCKET_ENDPOINT(/** @type {string} */ (this.sessionId));
     if (_.isEmpty(await /** @type {AppiumServer} */ (this.server).getWebSocketHandlers(pathname))) {
       return;
     }

--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -1,7 +1,6 @@
 import {errors} from 'appium/driver';
 import _ from 'lodash';
 import {waitForCondition} from 'asyncbox';
-import {requireArgs} from '../utils';
 
 // these two constitute the wait after closing a window
 const CLOSE_WINDOW_TIMEOUT = 5000;
@@ -56,12 +55,11 @@ const commands = {
   /**
    * Opens the given URL with the default or the given application
    *
-   * @param {DeepLinkOptions} opts
+   * @param {string} url
+   * @param {string} [bundleId]
    * @this {XCUITestDriver}
    */
-  async mobileDeepLink(opts = {}) {
-    const {url, bundleId} = requireArgs('url', opts);
-
+  async mobileDeepLink(url, bundleId) {
     return await this.proxyCommand('/url', 'POST', {
       url,
       bundleId,
@@ -86,7 +84,7 @@ const helpers = {
         true,
         navBar
       );
-      if (buttons.length === 0) {
+      if (buttons?.length === 0) {
         throw new Error('No buttons found in navigation bar');
       }
 
@@ -95,9 +93,9 @@ const helpers = {
         this.log.debug(`Found navigation bar 'back' button. Clicking.`);
       } else {
         this.log.debug(`Unable to find 'Back' button. Trying first button in navigation bar`);
-        backButton = buttons[0];
+        backButton = buttons?.[0];
       }
-      await this.nativeClick(backButton);
+      await this.nativeClick(/** @type {string} */(backButton));
     } catch (err) {
       this.log.error(`Unable to find navigation bar and back button: ${err.message}`);
     }

--- a/lib/commands/notifications.js
+++ b/lib/commands/notifications.js
@@ -4,22 +4,20 @@ import _ from 'lodash';
 export default {
   /**
    * Simulates push notification delivery to Simulator.
-   * Only application remote push notifications are supported. VoIP, Complication, File Provider,
-   * and other types are not supported
+   *
+   * **Only application remote push notifications are supported.** VoIP, Complication, File Provider, and other types are unsupported.
    *
    * @since Xcode SDK 11.4
-   * @param {PushNotification} opts - The object that describes Apple push notification content.
-   * It must contain a top-level `bundleId` key with a string value matching
-   * the target application‘s bundle identifier and "payload.aps" key with valid Apple Push Notification values.
-   * Check the output of `xcrun simctl help push` command for more details.
+   * @param {string} bundleId - the target application‘s bundle identifier
+   * @param {PushPayload} payload - The push payload
+   * @group Simulator Only
    * @this {XCUITestDriver}
    */
-  async mobilePushNotification(opts = {}) {
+  async mobilePushNotification(bundleId, payload) {
     if (!this.isSimulator()) {
       throw new Error('This extension only works on Simulator');
     }
 
-    const {payload, bundleId} = opts;
     if (!bundleId) {
       throw new errors.InvalidArgumentError(
         `'bundleId' argument must be a valid bundle identifier string`
@@ -37,6 +35,7 @@ export default {
           `Got ${JSON.stringify(payload.aps)} instead`
       );
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await this.opts.device.pushNotification({
       ...payload,
       'Simulator Target Bundle': bundleId,
@@ -45,15 +44,17 @@ export default {
 
   /**
    * Blocks until the expected notification is delivered.
-   * This method is a thin wrapper over XCTNSNotificationExpectation and
-   * XCTDarwinNotificationExpectation entities.
    *
-   * @param {NotificationExpectationOptions} opts
-   * @throws TimeoutError if the expected notification has not been delivered within the given timeout
+   * This method is a thin wrapper over `XCTNSNotificationExpectation` and
+   * `XCTDarwinNotificationExpectation` entities.
+   *
+   * @param {string} name - The name of the notification to expect
+   * @param {NotificationType} type - Which notification type to expect.
+   * @param {number} timeoutSeconds - For how long to wait until the notification is delivered (in float seconds).
+   * @throws `TimeoutError` if the expected notification has not been delivered within the given timeout
    * @this {XCUITestDriver}
    */
-  async mobileExpectNotification(opts = {}) {
-    const {name, type, timeoutSeconds} = opts;
+  async mobileExpectNotification(name, type = 'plain', timeoutSeconds = 60) {
     return await this.proxyCommand('/wda/expectNotification', 'POST', {
       name,
       type,
@@ -63,27 +64,19 @@ export default {
 };
 
 /**
- * @typedef {Object} NotificationExpectationOptions
- *
- * @property {string} name - The name of the notification to expect
- * @property {'plain'|'darwin'} [type='plain'] - Which notification type to expect.
- * Either 'plain' to wait for a notification from the default notification center or 'darwin'
- * to wait for a system notification.
- * @property {number} [timeoutSeconds=60] - For how long to wait until the notification is delivered
- * in float seconds.
- */
-
-
-/**
- * @typedef {Object} PushNotification
- *
- * @property {string} bundleId - The bundle identifier of the target application
- * @property {object} payload - Remote notification payload. Read the `Create the JSON Payload` topic of
- * https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
- * for more details on how to create this payload.
- * @todo document payload keys
- */
-
-/**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
+ */
+
+/**
+ * Either `plain` to wait for a notification from the default notification center or `darwin` to wait for a system notification.
+ * @typedef {'plain'|'darwin'} NotificationType
+ */
+
+/**
+ * Payload for {@linkcode XCUITestDriver.mobilePushNotification}.
+ *
+ * Check the output of `xcrun simctl help push` command for more details.
+ * @typedef PushPayload
+ * @property {object} aps - The aps dictionary. Read the [Setting up a Remote Notification Server documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943359) under "Create a JSON Payload" for more details.
+ * @privateRemarks The keys of `aps` [are documented](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943360) and we should add them.
  */

--- a/lib/commands/pasteboard.js
+++ b/lib/commands/pasteboard.js
@@ -1,26 +1,31 @@
 export default {
   /**
+   * @param {string} content
+   * @param {string} encoding
    * @this {XCUITestDriver}
    */
-  async mobileSetPasteboard(opts = {}) {
+  async mobileSetPasteboard(content, encoding = 'utf8') {
     if (!this.isSimulator()) {
       throw new Error('Setting pasteboard content is not supported on real devices');
     }
-    const {content, encoding} = opts;
     if (!content) {
+      // can be empty string
       throw new Error('Pasteboard content is mandatory to set');
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return await this.opts.device.simctl.setPasteboard(content, encoding);
   },
 
   /**
+   * @param {string} encoding
    * @this {XCUITestDriver}
    */
-  async mobileGetPasteboard(opts = {}) {
+  async mobileGetPasteboard(encoding = 'utf8') {
     if (!this.isSimulator()) {
       throw new Error('Getting pasteboard content is not supported on real devices');
     }
-    return await this.opts.device.simctl.getPasteboard(opts.encoding);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+    return await this.opts.device.simctl.getPasteboard(encoding);
   },
 };
 

--- a/lib/commands/pcap.js
+++ b/lib/commands/pcap.js
@@ -9,6 +9,8 @@ const DEFAULT_EXT = '.pcap';
 const pcapLogger = logger.getLogger('pcapd');
 
 export class TrafficCapture {
+  /** @type {import('teen_process').SubProcess|null} */
+  mainProcess;
   constructor(udid, log, resultPath) {
     this.udid = udid;
     this.log = log;
@@ -17,7 +19,7 @@ export class TrafficCapture {
   }
 
   async start(timeoutSeconds) {
-    this.mainProcess = await new Pyidevice(this.udid).collectPcap(this.resultPath);
+    this.mainProcess = /** @type {import('teen_process').SubProcess} */(await new Pyidevice(this.udid).collectPcap(this.resultPath));
     this.mainProcess.on('output', (stdout, stderr) => {
       if (stderr) {
         pcapLogger.info(`${stderr}`);
@@ -42,7 +44,7 @@ export class TrafficCapture {
 
   async interrupt(force = false) {
     if (this.isCapturing()) {
-      const interruptPromise = this.mainProcess.stop(force ? 'SIGTERM' : 'SIGINT');
+      const interruptPromise = this.mainProcess?.stop(force ? 'SIGTERM' : 'SIGINT');
       this.mainProcess = null;
       try {
         await interruptPromise;
@@ -110,10 +112,10 @@ export default {
       prefix: `appium_${util.uuidV4().substring(0, 8)}`,
       suffix: DEFAULT_EXT,
     });
-
+// @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const trafficCollector = new TrafficCapture(this.opts.device.udid, this.log, resultPath);
 
-    const timeoutSeconds = parseInt(timeLimitSec, 10);
+    const timeoutSeconds = parseInt(String(timeLimitSec), 10);
     if (isNaN(timeoutSeconds) || timeoutSeconds > MAX_CAPTURE_TIME_SEC || timeoutSeconds <= 0) {
       throw new errors.InvalidArgumentError(
         `The timeLimitSec value must be in range [1, ${MAX_CAPTURE_TIME_SEC}] seconds. ` +

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -53,7 +53,9 @@ async function requireInstruments() {
   }
 }
 
-class PerfRecorder {
+export class PerfRecorder {
+  /** @type {import('teen_process').SubProcess|null} */
+  _process;
   constructor(reportRoot, udid, opts = {}) {
     this._process = null;
     this._zippedReportPath = '';
@@ -133,7 +135,7 @@ class PerfRecorder {
           await performCleanup();
           this._archivePromise = null;
         })
-        // eslint-disable-next-line promise/prefer-await-to-then
+        // eslint-disable-next-line promise/prefer-await-to-then, @typescript-eslint/no-empty-function
         .catch(() => {});
     }
     await performCleanup();
@@ -252,7 +254,7 @@ class PerfRecorder {
     }
 
     try {
-      await this._process.stop('SIGINT', STOP_TIMEOUT_MS);
+      await this._process?.stop('SIGINT', STOP_TIMEOUT_MS);
     } catch (e) {
       this._logger.errorAndThrow(
         `Performance recording has failed to exit after ${STOP_TIMEOUT_MS}ms`
@@ -265,29 +267,36 @@ class PerfRecorder {
 export default {
   /**
    * Starts performance profiling for the device under test.
+   *
    * Relaxing security is mandatory for simulators. It can always work for real devices.
    *
    * Since XCode 14 the method tries to use `xctrace` tool to record performance stats.
-   * The `instruments` developer utility is used as a fallback for this purpose if `xctrace`
-   * is not available.
-   * It is possible to record multiple profiles at the same time.
-   * Read https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html
-   * for more details.
    *
-   * @param {StartPerfRecordOptions} [opts] - The set of possible start record options
+   * The `instruments` developer utility is used as a fallback for this purpose if `xctrace` is not available.
+   *
+   * It is possible to record multiple profiles at the same time.
+   *
+   * Read [Recording, Pausing, and Stopping Traces](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Recording,Pausing,andStoppingTraces.html) for more details.
+   *
+   * @param {number} timeout - The maximum count of milliseconds to record the profiling information.
+   * @param {string} profileName - The name of existing performance profile to apply. Can also contain the full path to the chosen template on the server file system. Note: not all profiles are supported on mobile devices.
+   * @param {number|'current'} [pid] -  The ID of the process to measure the performance for. Set it to `current` in order to measure the performance of the process, which belongs to the currently active application.  All processes running on the device are measured if `pid` is unset (the default setting).
    * @this {XCUITestDriver}
    */
-  async mobileStartPerfRecord(opts = {}) {
+  async mobileStartPerfRecord(
+    timeout = DEFAULT_TIMEOUT_MS,
+    profileName = DEFAULT_PROFILE_NAME,
+    pid
+  ) {
     if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
       this.log.errorAndThrow(PERF_RECORD_SECURITY_MESSAGE);
     }
-
-    const {timeout = DEFAULT_TIMEOUT_MS, profileName = DEFAULT_PROFILE_NAME, pid} = opts;
 
     if (!_.isEmpty(this._perfRecorders)) {
       for (const recorder of this._perfRecorders.filter((x) => x.profileName === profileName)) {
         if (recorder.isRunning()) {
           this.log.debug(
+            // @ts-expect-error - do not assign arbitrary properties to `this.opts`
             `Performance recorder for '${profileName}' on device '${this.opts.device.udid}' ` +
               ` is already running. Doing nothing`
           );
@@ -300,15 +309,16 @@ export default {
 
     let realPid;
     if (pid) {
-      if (_.toLower(pid) === DEFAULT_PID) {
+      if (_.toLower(String(pid)) === DEFAULT_PID) {
         const appInfo = await this.proxyCommand('/wda/activeAppInfo', 'GET');
         realPid = appInfo.pid;
       } else {
         realPid = pid;
       }
     }
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const recorder = new PerfRecorder(await tempDir.openDir(), this.opts.device.udid, {
-      timeout: parseInt(timeout, 10),
+      timeout: parseInt(String(timeout), 10),
       profileName,
       pid: parseInt(realPid, 10),
     });
@@ -318,19 +328,34 @@ export default {
 
   /**
    * Stops performance profiling for the device under test.
-   * The resulting file in .trace format can be either returned
-   * directly as base64-encoded zip archive or uploaded to a remote location
-   * (such files can be pretty large). Afterwards it is possible to unarchive and
-   * open such file with Xcode Dev Tools.
    *
-   * @param {StopRecordingOptions} [opts] - The set of possible stop record options
+   * The resulting file in `.trace` format can be either returned directly as base64-encoded zip archive or uploaded to a remote location (such files can be pretty large). Afterwards it is possible to unarchive and open such files with Xcode Dev Tools.
+   *
+   * @param {string} [remotePath] - The path to the remote location, where the resulting zipped `.trace` file should be uploaded.  The following protocols are supported: `http`, `https`, `ftp`. Null or empty string value (the default setting) means the content of resulting file should be zipped, encoded as Base64 and passed as the endpoint response value. An exception will be thrown if the generated file is too big to fit into the available process memory.
+   * @param {string} [user] - The name of the user for the remote authentication. Only works if `remotePath` is provided.
+   * @param {string} [pass] - The password for the remote authentication. Only works if `remotePath` is provided.
+   * @param {import('axios').Method} [method] -  The http multipart upload method name. Only works if `remotePath` is provided. Defaults to `PUT`
+   * @param {string} profileName - The name of an existing performance profile for which the recording has been made.
+   * @param {Record<string,any>} [headers] - Additional headers mapping for multipart http(s) uploads
+   * @param {string} [fileFieldName] -  The name of the form field, where the file content BLOB should be stored for http(s) uploads. Defaults to `file`
+   * @param {Record<string,any>|([string, any])[]} [formFields] - Additional form fields for multipart http(s) uploads
+   *
    * @returns {Promise<string>} Either an empty string if the upload was successful or base-64 encoded
    * content of zipped .trace file.
    * @throws {Error} If no performance recording with given profile name/device udid combination
    * has been started before or the resulting .trace file has not been generated properly.
    * @this {XCUITestDriver}
    */
-  async mobileStopPerfRecord(opts = {}) {
+  async mobileStopPerfRecord(
+    remotePath,
+    user,
+    pass,
+    method,
+    profileName = DEFAULT_PROFILE_NAME,
+    headers,
+    fileFieldName,
+    formFields
+  ) {
     if (!this.isFeatureEnabled(PERF_RECORD_FEAT_NAME) && !this.isRealDevice()) {
       this.log.errorAndThrow(PERF_RECORD_SECURITY_MESSAGE);
     }
@@ -340,63 +365,38 @@ export default {
       return '';
     }
 
-    const {profileName = DEFAULT_PROFILE_NAME, remotePath} = opts;
-
     const recorders = this._perfRecorders.filter((x) => x.profileName === profileName);
     if (_.isEmpty(recorders)) {
       this.log.errorAndThrow(
         `There are no records for performance profile '${profileName}' ` +
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           `and device ${this.opts.device.udid}. Have you started the profiling before?`
       );
     }
 
     const recorder = _.first(recorders);
-    const resultPath = await recorder.stop();
+    const resultPath = await /** @type {PerfRecorder} */ (recorder).stop();
     if (!(await fs.exists(resultPath))) {
       this.log.errorAndThrow(
         `There is no ${DEFAULT_EXT} file found for performance profile '${profileName}' ` +
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           `and device ${this.opts.device.udid}. Make sure the selected profile is supported on this device`
       );
     }
 
-    const result = await encodeBase64OrUpload(resultPath, remotePath, opts);
+    const result = await encodeBase64OrUpload(resultPath, remotePath, {
+      user,
+      pass,
+      method,
+      headers,
+      fileFieldName,
+      formFields,
+    });
     _.pull(this._perfRecorders, recorder);
     await fs.rimraf(resultPath);
     return result;
   },
 };
-
-/**
- * @typedef {Object} StopRecordingOptions
- *
- * @property {string} [remotePath] - The path to the remote location, where the resulting zipped .trace file should be uploaded.
- *                                  The following protocols are supported: http/https, ftp.
- *                                  Null or empty string value (the default setting) means the content of resulting
- *                                  file should be zipped, encoded as Base64 and passed as the endpoint response value.
- *                                  An exception will be thrown if the generated file is too big to
- *                                  fit into the available process memory.
- * @property {string} [user] - The name of the user for the remote authentication. Only works if `remotePath` is provided.
- * @property {string} [pass] - The password for the remote authentication. Only works if `remotePath` is provided.
- * @property {'PUT'|'POST'} [method='PUT'] - The http multipart upload method name. Only works if `remotePath` is provided.
- * @property {string} [profileName] [Activity Monitor] - The name of an existing performance profile for which the recording has been made.
- * @property {Record<string,any>} [headers] - Additional headers mapping for multipart http(s) uploads
- * @property {string} [fileFieldName='file'] - The name of the form field, where the file content BLOB should be stored for http(s) uploads
- * @property {Record<string,any>|([string, any])[]} [formFields] - Additional form fields for multipart http(s) uploads
- */
-
-/**
- * @typedef {Object} StartPerfRecordOptions
- *
- * @property {number|string} [timeout=300000] - The maximum count of milliseconds to record the profiling information.
- * @property {string} [profileName] [Activity Monitor] - The name of existing performance profile to apply.
- *                                                      Can also contain the full path to the chosen template on the server file system.
- *                                                      Note, that not all profiles are supported on mobile devices.
- * @property {string|number} [pid] - The ID of the process to measure the performance for.
- *                                  Set it to `current` in order to measure the performance of
- *                                  the process, which belongs to the currently active application.
- *                                  All processes running on the device are measured if
- *                                  pid is unset (the default setting).
- */
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/permissions.js
+++ b/lib/commands/permissions.js
@@ -1,7 +1,10 @@
 import _ from 'lodash';
 
-// https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc
-const RESOURCE_NAME_TO_ID_MAP = {
+/**
+ * Mapping of resource name to ID.
+ * @see https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc
+ */
+export const RESOURCE_NAME_TO_ID_MAP = {
   calendar: 2,
   camera: 6,
   contacts: 1,
@@ -33,75 +36,78 @@ function requireOptions(opts = {}) {
   return opts;
 }
 export default {
-
-/**
- * Resets the given permission for the active application under test.
- * Works for both Simulator and real devices using Xcode SDK 11.4+
- *
- * @param {ResetPermissionOptions} opts - Permission options.
- * @throws {Error} If permission reset fails on the device.
+  /**
+   * Resets the given permission for the active application under test.
+   * Works for both Simulator and real devices using Xcode SDK 11.4+
+   *
+   * @param {keyof typeof RESOURCE_NAME_TO_ID_MAP|number} service - One of the available service names. This could also be an integer protected resource identifier; see [this list](https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc)
+   * @throws {Error} If permission reset fails on the device.
    * @this {XCUITestDriver}
- */
-  async mobileResetPermission(opts = {}) {
-    const {service} = opts;
-  if (!service) {
-    throw new Error(`The 'service' option is expected to be present`);
-  }
-  let resource;
-  if (_.isString(service)) {
-    resource = RESOURCE_NAME_TO_ID_MAP[_.toLower(service)];
-    if (!resource) {
+   */
+  async mobileResetPermission(service) {
+    if (!service) {
+      throw new Error(`The 'service' option is expected to be present`);
+    }
+    let resource;
+    if (_.isString(service)) {
+      resource = RESOURCE_NAME_TO_ID_MAP[_.toLower(service)];
+      if (!resource) {
         throw new Error(
           `The 'service' value must be one of ` +
             `${JSON.stringify(_.keys(RESOURCE_NAME_TO_ID_MAP))}`
         );
-    }
-  } else if (_.isInteger(service)) {
-    resource = service;
-  } else {
+      }
+    } else if (_.isInteger(service)) {
+      resource = service;
+    } else {
       throw new Error(
         `The 'service' value must be either a string or an integer. ` +
           `'${service}' is passed instead`
       );
-  }
+    }
 
-  await this.proxyCommand('/wda/resetAppAuth', 'POST', {resource});
+    await this.proxyCommand('/wda/resetAppAuth', 'POST', {resource});
   },
 
-/**
- * Gets application permission state on Simulator.
- * This method requires WIX applesimutils to be installed on the server host.
- *
- * @param {GetPermissionOptions} opts - Permission options.
+  /**
+   * Gets application permission state on Simulator.
+   *
+   * This method requires WIX applesimutils to be installed on the server host.
+   *
+   * @param {GetPermissionService} service - Service name
+   * @param {string} bundleId - Bundle identifier of the target application
    * @returns {Promise<'yes'|'no'|'unset'|'limited'>} Either 'yes', 'no', 'unset' or 'limited'
- * @throws {Error} If permission getting fails or the device is not a Simulator.
+   * @throws {Error} If permission getting fails or the device is not a Simulator.
    * @this {XCUITestDriver}
- */
-  async mobileGetPermission(opts = {}) {
-    const {service, bundleId} = requireOptions(opts);
-  if (!service) {
-    throw new Error(`The 'service' option is expected to be present`);
-  }
-  requireSimulator(this);
+   * @group Simulator Only
+   */
+  async mobileGetPermission(service, bundleId) {
+    if (!service) {
+      throw new Error(`The 'service' option is expected to be present`);
+    }
+    requireSimulator(this);
 
-  return await this.opts.device.getPermission(bundleId, service);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+    return await this.opts.device.getPermission(bundleId, service);
   },
 
   /**
    * Set application permission state on Simulator.
    *
+   * @param {Record<Partial<AccessRule>, PermissionState>} access - One or more access rules to set.
+   * @param {string} bundleId - Bundle identifier of the target application
    * @since Xcode SDK 11.4
-   * @param {SetPermissionsOptions} opts - Permissions options.
    * @throws {Error} If permission setting fails or the device is not a Simulator.
+   * @group Simulator Only
    * @this {XCUITestDriver}
    */
-  async mobileSetPermissions(opts = {}) {
-    const {access, bundleId} = requireOptions(opts);
+  async mobileSetPermissions(access, bundleId) {
     if (!_.isPlainObject(access)) {
       throw new Error(`The 'access' option is expected to be a map`);
     }
     requireSimulator(this);
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.setPermissions(bundleId, access);
   },
 };
@@ -111,43 +117,39 @@ export default {
  */
 
 /**
- * @typedef {Object} ResetPermissionOptions
+ * Access rules for the `mobile: setPermission` execute method.
  *
- * @property {string|number} service - One of available service names. See the keys of
- * `RESOURCE_NAME_TO_ID_MAP` to get the list of supported service names.
- * This could also be an integer protected resource identifier taken from
- * https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc
+ * Details:
+ *
+ * - `all`: Apply the action to all services.
+ * - `calendar`: Allow access to calendar.
+ * - `contacts-limited`: Allow access to basic contact info.
+ * - `contacts`: Allow access to full contact details.
+ * - `location`: Allow access to location services when app is in use.
+ * - `location-always`: Allow access to location services at all times.
+ * - `photos-add`: Allow adding photos to the photo library.
+ * - `photos`: Allow full access to the photo library.
+ * - `media-library`: Allow access to the media library.
+ * - `microphone`: Allow access to audio input.
+ * - `motion`: Allow access to motion and fitness data.
+ * - `reminders`: Allow access to reminders.
+ * - `siri`: Allow use of the app with Siri.
+ *
+ * @typedef {'all'|'calendar'|'contacts-limited'|'contacts'|'location'|'location-always'|'photos-add'|'photos'|'media-library'|'microphone'|'motion'|'reminders'|'siri'} AccessRule
  */
 
 /**
- * @typedef {Object} GetPermissionOptions
+ * Permission state
  *
- * @property {'calendar'|'camera'|'contacts'|'homekit'|'microphone'|'photos'|'reminders'|'medialibrary'|'motion'|'health'|'siri'|'speech'} service - One of available service names.
- * @property {string} bundleId - The bundle identifier of the destination app.
+ * Details:
+ *
+ * - `yes`: To grant the permission
+ * - `no`: To revoke the permission
+ * - `unset`: To reset the permission
+ * - `limited`: To grant the permission as limited access (Only for photos)
+ * @typedef {'yes'|'no'|'unset'|'limited'} PermissionState
  */
 
 /**
- * @typedef {Object} SetPermissionsOptions
- *
- * @property {Partial<Record<'all'|'calendar'|'contacts-limited'|'contacts'|'location'|'location-always'|'photos-add'|'photos'|'media-library'|'microphone'|'motion'|'reminders'|'siri','yes'|'no'|'unset'|'limited'>>} access - One or more access rules to set.
- * The following keys are supported:
- * - all: Apply the action to all services.
- * - calendar: Allow access to calendar.
- * - contacts-limited: Allow access to basic contact info.
- * - contacts: Allow access to full contact details.
- * - location: Allow access to location services when app is in use.
- * - location-always: Allow access to location services at all times.
- * - photos-add: Allow adding photos to the photo library.
- * - photos: Allow full access to the photo library.
- * - media-library: Allow access to the media library.
- * - microphone: Allow access to audio input.
- * - motion: Allow access to motion and fitness data.
- * - reminders: Allow access to reminders.
- * - siri: Allow use of the app with Siri.
- * The following values are supported:
- * - yes: To grant the permission
- * - no: To revoke the permission
- * - unset: To reset the permission
- * - limited: To grant the permission as limited access (Only for photos)
- * @property {string} bundleId - The bundle identifier of the destination app.
+ * @typedef {'calendar'|'camera'|'contacts'|'homekit'|'microphone'|'photos'|'reminders'|'medialibrary'|'motion'|'health'|'siri'|'speech'} GetPermissionService
  */

--- a/lib/commands/permissions.js
+++ b/lib/commands/permissions.js
@@ -29,12 +29,6 @@ function requireSimulator(driver) {
   }
 }
 
-function requireOptions(opts = {}) {
-  if (!opts.bundleId) {
-    throw new Error(`The 'bundleId' options must be a valid application bundle identifier`);
-  }
-  return opts;
-}
 export default {
   /**
    * Resets the given permission for the active application under test.

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -73,7 +73,7 @@ export default {
    *
    * @param {string} endpoint
    * @param {AllowedHttpMethod} method
-   * @param {any} body
+   * @param {any} [body]
    * @param {boolean} isSessionCommand
    * @this {import('../driver').XCUITestDriver}
    */

--- a/lib/commands/record-audio.js
+++ b/lib/commands/record-audio.js
@@ -117,7 +117,7 @@ export class AudioRecorder {
 
   async interrupt(force = false) {
     if (this.isRecording()) {
-      const interruptPromise = this.mainProcess.stop(force ? 'SIGTERM' : 'SIGINT');
+      const interruptPromise = this.mainProcess?.stop(force ? 'SIGTERM' : 'SIGINT');
       this.mainProcess = null;
       try {
         await interruptPromise;
@@ -151,8 +151,8 @@ export class AudioRecorder {
  * @property {string} audioInput - The name of the corresponding audio input device to use for the
  * capture. The full list of capture devices could be shown using `ffmpeg -f avfoundation -list_devices true -i ""`
  * Terminal command.
- * @property {string} [audioCodec=aac] - The name of the audio codec. The Advanced Audio Codec is used by default.
- * @property {string} [audioBitrate=128k] - The bitrate of the resulting audio stream. 128k by default.
+ * @property {string} [audioCodec='aac'] - The name of the audio codec. The Advanced Audio Codec is used by default.
+ * @property {string} [audioBitrate='128k'] - The bitrate of the resulting audio stream. 128k by default.
  * @property {string|number} [audioChannels=2] - The count of audio channels in the resulting stream. Setting it to `1`
  * will create a single channel (mono) audio stream.
  * @property {string|number} [audioRate=44100] - The sampling rate of the resulting audio stream.
@@ -174,7 +174,7 @@ export default {
    * @throws {Error} If audio recording has failed to start.
    * @this {XCUITestDriver}
    */
-  async startAudioRecording(options = {}) {
+  async startAudioRecording(options = /** @type {StartRecordingOptions} */({})) {
     if (!this.isFeatureEnabled(AUDIO_RECORD_FEAT_NAME)) {
       this.log.errorAndThrow(
         `Audio capture feature must be enabled on the server side. ` +
@@ -186,7 +186,7 @@ export default {
     const {
       timeLimit = DEFAULT_RECORDING_TIME_SEC,
       audioInput,
-      // Undocumented feature
+      // @ts-expect-error Undocumented feature
       audioSource,
       audioCodec = DEFAULT_CODEC,
       audioBitrate = DEFAULT_BITRATE,
@@ -234,7 +234,7 @@ export default {
       audioRate,
     });
 
-    const timeoutSeconds = parseInt(timeLimit, 10);
+    const timeoutSeconds = parseInt(String(timeLimit), 10);
     if (isNaN(timeoutSeconds) || timeoutSeconds > MAX_RECORDING_TIME_SEC || timeoutSeconds <= 0) {
       this.log.errorAndThrow(
         `The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC}] seconds. ` +

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -180,53 +180,19 @@ export class ScreenRecorder {
   }
 }
 
-/**
- * @typedef {Object} StartRecordingOptions
- *
- * @property {string} [remotePath] - The path to the remote location, where the resulting video should be uploaded.
- *                                  The following protocols are supported: http/https, ftp.
- *                                  Null or empty string value (the default setting) means the content of resulting
- *                                  file should be encoded as Base64 and passed as the endpoint response value.
- *                                  An exception will be thrown if the generated media file is too big to
- *                                  fit into the available process memory.
- *                                  This option only has an effect if there is screen recording process in progress
- *                                  and `forceRestart` parameter is not set to `true`.
- * @property {string} [user] - The name of the user for the remote authentication. Only works if `remotePath` is provided.
- * @property {string} [pass] - The password for the remote authentication. Only works if `remotePath` is provided.
- * @property {string} [method] - The http multipart upload method name. The 'PUT' one is used by default.
- *                              Only works if `remotePath` is provided.
- * @property {string} [videoType] - The video codec type used for encoding of the be recorded screen capture.
- *                                 Execute `ffmpeg -codecs` in the terminal to see the list of supported video codecs.
- *                                 'mjpeg' by default.
- * @property {string|number} [videoQuality] - The video encoding quality (low, medium, high, photo - defaults to medium).
- * @property {string|number} [videoFps] - The Frames Per Second rate of the recorded video. Change this value if the resulting video
- *                                is too slow or too fast. Defaults to 10.
- * @property {string} [videoFilters] - The FFMPEG video filters to apply. These filters allow to scale, flip, rotate and do many
- *                                    other useful transformations on the source video stream. The format of the property
- *                                    must comply with https://ffmpeg.org/ffmpeg-filters.html
- * @property {string} [videoScale] - The scaling value to apply. Read https://trac.ffmpeg.org/wiki/Scaling for possible values.
- *                                  No scale is applied by default. If both `videoFilters` and `videoScale` are set then
- *                                  only `videoFilters` value will be respected.
- * @property {string} [pixelFormat] - Output pixel format. Run `ffmpeg -pix_fmts` to list possible values.
- *                                   For Quicktime compatibility, set to "yuv420p" along with videoType: "libx264".
- * @property {boolean} [forceRestart] - Whether to try to catch and upload/return the currently running screen recording
- *                                     (`false`, the default setting) or ignore the result of it and start a new recording
- *                                     immediately.
- * @property {string|number} [timeLimit] - The maximum recording time, in seconds.
- *                                        The default value is 180, the maximum value is 600 (10 minutes).
- */
-
 export default {
   /** @type {ScreenRecorder?} */
   _recentScreenRecorder: null,
   /**
+   * Direct Appium to start recording the device screen
+   *
    * Record the display of devices running iOS Simulator since Xcode 9 or real devices since iOS 11
    * (ffmpeg utility is required: 'brew install ffmpeg').
    * It records screen activity to a MPEG-4 file. Audio is not recorded with the video file.
    * If screen recording has been already started then the command will stop it forcefully and start a new one.
    * The previously recorded video file will be deleted.
    *
-   * @param {StartRecordingOptions} [options] - The available options.
+   * @param {import('./types').StartRecordingScreenOptions} [options] - The available options.
    * @returns {Promise<string>} Base64-encoded content of the recorded media file if
    *                   any screen recording is currently running or an empty string.
    * @throws {Error} If screen recording has failed to start.
@@ -250,7 +216,7 @@ export default {
         `Checking if there is/was a previous screen recording. ` +
           `Set 'forceRestart' option to 'true' if you'd like to skip this step.`
       );
-      result = await this.stopRecordingScreen(options);
+      result = await this.stopRecordingScreen(options) ?? result;
     }
 
     const videoPath = await tempDir.path({
@@ -259,6 +225,7 @@ export default {
     });
 
     const wdaBaseUrl = this.opts.wdaBaseUrl || WDA_BASE_URL;
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const screenRecorder = new ScreenRecorder(this.opts.device.udid, this.log, videoPath, {
       remotePort: this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT,
       remoteUrl: wdaBaseUrl,
@@ -277,7 +244,7 @@ export default {
       this._recentScreenRecorder = null;
     }
 
-    const timeoutSeconds = parseFloat(timeLimit);
+    const timeoutSeconds = parseFloat(String(timeLimit));
     if (isNaN(timeoutSeconds) || timeoutSeconds > MAX_RECORDING_TIME_SEC || timeoutSeconds <= 0) {
       this.log.errorAndThrow(
         `The timeLimit value must be in range [1, ${MAX_RECORDING_TIME_SEC}] seconds. ` +
@@ -292,7 +259,7 @@ export default {
     if (videoQuality) {
       const quality = _.isInteger(videoQuality)
         ? videoQuality
-        : QUALITY_MAPPING[_.toLower(videoQuality)];
+        : QUALITY_MAPPING[_.toLower(String(videoQuality))];
       if (!quality) {
         throw new Error(
           `videoQuality value should be one of ${JSON.stringify(
@@ -305,7 +272,7 @@ export default {
       mjpegServerScreenshotQuality = undefined;
     }
     if (videoFps) {
-      const fps = parseInt(videoFps, 10);
+      const fps = parseInt(String(videoFps), 10);
       if (isNaN(fps)) {
         throw new Error(
           `videoFps value should be a valid number in range 1..60. ` +
@@ -338,35 +305,20 @@ export default {
   },
 
   /**
-   * @typedef {Object} StopRecordingOptions
+   * Direct Appium to stop screen recording and return the video
    *
-   * @property {string} [remotePath] - The path to the remote location, where the resulting video should be uploaded.
-   *                                  The following protocols are supported: http/https, ftp.
-   *                                  Null or empty string value (the default setting) means the content of resulting
-   *                                  file should be encoded as Base64 and passed as the endpoint response value.
-   *                                  An exception will be thrown if the generated media file is too big to
-   *                                  fit into the available process memory.
-   * @property {string} [user] - The name of the user for the remote authentication. Only works if `remotePath` is provided.
-   * @property {string} [pass] - The password for the remote authentication. Only works if `remotePath` is provided.
-   * @property {string} [method] - The http multipart upload method name. The 'PUT' one is used by default.
-   *                              Only works if `remotePath` is provided.
-   * @property {Record<string,any>} [headers] - Additional headers mapping for multipart http(s) uploads
-   * @property {string} [fileFieldName='file'] - The name of the form field, where the file content BLOB should be stored for
-   *                                            http(s) uploads
-   * @property {Record<string,any>|([string,any])[]} formFields - Additional form fields for multipart http(s) uploads
-   */
-
-  /**
-   * Stop recording the screen. If no screen recording process is running then
-   * the endpoint will try to get the recently recorded file.
-   * If no previously recorded file is found and no active screen recording
-   * processes are running then the method returns an empty string.
+   * If no screen recording process is running then the endpoint will try to get
+   * the recently recorded file. If no previously recorded file is found and no
+   * active screen recording processes are running then the method returns an
+   * empty string.
    *
-   * @param {StopRecordingOptions} [options] - The available options.
-   * @returns {Promise<string>} Base64-encoded content of the recorded media file if 'remotePath'
-   *                   parameter is empty or null or an empty string.
-   * @throws {Error} If there was an error while getting the name of a media file
-   *                 or the file content cannot be uploaded to the remote location.
+   * @param {import('./types').StopRecordingScreenOptions} options - The available
+   * options.
+   * @returns {Promise<string?>} Base64-encoded content of the recorded media
+   * file if `remotePath` parameter is empty or null or an empty string.
+   * @throws {Error} If there was an error while getting the name of a media
+   *                 file or the file content cannot be uploaded to the remote
+   *                 location.
    * @this {XCUITestDriver}
    */
   async stopRecordingScreen(options = {}) {

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -38,6 +38,7 @@ export default {
     // simulator attempt
     if (this.isSimulator()) {
       this.log.info(`Falling back to 'simctl io screenshot' API`);
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       return await this.opts.device.simctl.getScreenshot();
     }
 

--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -16,7 +16,7 @@ const commands = {
     }
 
     if ((await this.settings.getSettings()).useJSONSource) {
-      const srcTree = await this.mobileGetSource({format: 'json'});
+      const srcTree = await this.mobileGetSource('json');
       return getSourceXml(getTreeForXML(srcTree));
     }
     return await this.getNativePageSource();
@@ -42,15 +42,17 @@ const helpers = {
     return new xmldom.XMLSerializer().serializeToString(doc);
   },
   /**
+   * @param {'xml'|'json'} [format='xml']
+   * @param {any} [excludedAttributes]
    * @this {XCUITestDriver}
    */
-  async mobileGetSource(opts = {}) {
+  async mobileGetSource(format, excludedAttributes) {
     const paramsMap = {
-      format: opts.format || 'xml',
+      format: format || 'xml',
       scope: APPIUM_AUT_TAG,
     };
-    if (opts.excludedAttributes) {
-      paramsMap.excluded_attributes = opts.excludedAttributes;
+    if (excludedAttributes) {
+      paramsMap.excluded_attributes = excludedAttributes;
     }
     const query = Object.entries(paramsMap)
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
@@ -84,6 +86,10 @@ function getTreeForXML(srcTree) {
   function getTree(element, elementIndex, parentPath) {
     let curPath = `${parentPath}/${elementIndex}`;
     let rect = element.rect || {};
+    /**
+     * @privateRemarks I don't even want to try to type this right now
+     * @type {any}
+     */
     let subtree = {
       '@': {
         type: `XCUIElementType${element.type}`,

--- a/lib/commands/timeouts.js
+++ b/lib/commands/timeouts.js
@@ -16,20 +16,30 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async scriptTimeoutW3C(ms) {
-    await this.asyncScriptTimeout(ms);
+    this.setAsyncScriptTimeout(this.parseTimeoutArgument(ms));
   },
+
   /**
+   * Alias for {@linkcode XCUITestDriver.scriptTimeoutW3C}.
+   *
+   * @param {number} ms - the timeout
    * @this {XCUITestDriver}
+   * @deprecated Use {@linkcode XCUITestDriver.scriptTimeoutW3C} instead
    */
   async scriptTimeoutMJSONWP(ms) {
     await this.asyncScriptTimeout(ms);
   },
+
   /**
+   * Alias for {@linkcode XCUITestDriver.scriptTimeoutW3C}.
+   *
+   * @param {number} ms - the timeout
+   *
+   * @deprecated Use {@linkcode XCUITestDriver.scriptTimeoutW3C} instead
    * @this {XCUITestDriver}
    */
-  // eslint-disable-next-line require-await
   async asyncScriptTimeout(ms) {
-    this.setAsyncScriptTimeout(this.parseTimeoutArgument(ms));
+    await this.scriptTimeoutW3C(ms);
   },
 };
 

--- a/lib/commands/timeouts.js
+++ b/lib/commands/timeouts.js
@@ -16,7 +16,8 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async scriptTimeoutW3C(ms) {
-    this.setAsyncScriptTimeout(this.parseTimeoutArgument(ms));
+    // XXX: this is synchronous
+    await this.setAsyncScriptTimeout(this.parseTimeoutArgument(ms));
   },
 
   /**

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1,0 +1,240 @@
+import {Element, HTTPHeaders} from '@appium/types';
+import type B from 'bluebird';
+import type {EventEmitter} from 'node:events';
+import {EmptyObject, SetOptional} from 'type-fest';
+import {Page} from '../types';
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+export enum AppState {
+  /**
+   * The application’s current state is not known.
+   */
+  XCUIApplicationStateUnknown = 0,
+  /**
+   * The application is not running
+   */
+  XCUIApplicationStateNotRunning = 1,
+  /**
+   * The application is running in the background, but is suspended.
+   */
+  XCUIApplicationStateRunningBackgroundSuspended = 2,
+  /**
+   * The application is running in the background.
+   */
+  XCUIApplicationStateRunningBackground = 3,
+  /**
+   * The application is running in the foreground.
+   */
+  XCUIApplicationStateRunningForeground = 4,
+}
+
+/**
+ * Battery state
+ * @see {@linkcode BatteryInfo}
+ */
+export enum BatteryState {
+  UIDeviceBatteryStateUnknown = 0,
+  UIDeviceBatteryStateUnplugged = 1, // on battery, discharging
+  UIDeviceBatteryStateCharging = 2, // plugged in, less than 100%
+  UIDeviceBatteryStateFull = 3, // plugged in, at 100%
+}
+
+/**
+ * Battery information. Returned by `mobileGetBatteryInfo` command
+ */
+export interface BatteryInfo {
+  /**
+   * Battery level in range `[0.0, 1.0]`, where `1.0` means 100% charge.
+   */
+  level: number;
+  /**
+   * Battery state
+   */
+  state: BatteryState;
+}
+
+/**
+ * Options for `stopRecordingScreen` command
+ */
+export interface StopRecordingScreenOptions {
+  /**
+   * The path to the remote location, where the resulting video should be
+   * uploaded.
+   *
+   * The following protocols are supported: `http`, `https`, `ftp`. Null or empty
+   * string value (the default setting) means the content of resulting file
+   * should be encoded as Base64 and passed as the endpoint response value. An
+   * exception will be thrown if the generated media file is too big to fit into
+   * the available process memory.
+   */
+  remotePath?: string;
+  /**
+   * The name of the user for the remote authentication.
+   *
+   * Only works if `remotePath` is provided.
+   */
+  user?: string;
+  /**
+   * The password for the remote authentication.
+   *
+   * Only works if `remotePath` is provided.
+   */
+  pass?: string;
+  /**
+   * Additional headers mapping for multipart http(s) uploads
+   */
+  headers?: HTTPHeaders;
+  /**
+   * The name of the form field where the file content BLOB should be stored for
+   * http(s) uploads
+   */
+  fileFieldName?: string;
+  /**
+   * Additional form fields for multipart http(s) uploads
+   */
+  formFields?: Record<string, any> | [string, any][];
+  /**
+   * The http multipart upload method name.
+   *
+   * Only works if `remotePath` is provided.
+   *
+   * @defaultValue 'PUT'
+   */
+  method?: 'PUT' | 'POST' | 'PATCH';
+}
+
+export type VideoQuality = 'low' | 'medium' | 'high' | 'photo';
+
+/**
+ * Options for `startRecordingScreen` command
+ */
+export interface StartRecordingScreenOptions extends StopRecordingScreenOptions {
+  /**
+   * The video codec type used for encoding of the be recorded screen capture.
+   *
+   * Execute `ffmpeg -codecs` in the terminal to see the list of supported video codecs.
+   * @defaultValue 'mjpeg'
+   */
+  videoType?: string;
+  /**
+   * The video encoding quality
+   * @defaultValue 'medium'
+   */
+  videoQuality?: VideoQuality | number;
+  /**
+   * The Frames Per Second rate of the recorded video.
+   *
+   * Change this value if the resulting video is too slow or too fast.
+   * @defaultValue 10
+   */
+  videoFps?: string | number;
+  /**
+   * The FFMPEG video filters to apply.
+   *
+   * These filters allow to scale, flip, rotate and do many other useful transformations on the source video stream.  See [FFMPEG documentation](https://ffmpeg.org/ffmpeg-filters.html) for formatting help.
+   * @see https://ffmpeg.org/ffmpeg-filters.html
+   */
+  videoFilters?: string;
+  /**
+   * The scaling value to apply.
+   *
+   * See [the FFMPEG wiki](https://trac.ffmpeg.org/wiki/Scaling) for possible values.
+   *
+   * No scale is applied by default. If both `videoFilters` and `videoScale` are set then only `videoFilters` value will be respected.
+   * @see https://trac.ffmpeg.org/wiki/Scaling
+   */
+  videoScale?: string;
+  /**
+   * Output pixel format.
+   *
+   * Execute `ffmpeg -pix_fmts` to list possible values. For Quicktime
+   * compatibility, set to `yuv420p` along with videoType: `libx264`.
+   */
+  pixelFormat?: string;
+  /**
+   * If `true`, ignore errors and restart immediately.  If `false` or not provided, try to catch and upload/return the currently running screen recording.
+   * @defaultValue false
+   */
+  forceRestart?: boolean;
+  /**
+   * The maximum recording time, in seconds.
+   * The the maximum value is 600 (10 minutes).
+   * @defaultValue 180
+   */
+  timeLimit?: string | number;
+}
+
+export interface PageChangeNotification {
+  pageArray: Page[];
+  appIdKey: string;
+}
+
+/**
+ * Either a string that contains full path to the mount root for real devices, or a function which accepts two parameters
+ * (bundle identifier and optional container type) and returns (or resolves) the full path to the container root folder on the local filesystem.
+ */
+export type ContainerRootSupplier = (
+  bundleId: string,
+  containerType: string | null
+) => string | Promise<string>;
+
+export interface WaitingAtoms {
+  count: number;
+  alertNotifier: EventEmitter;
+  alertMonitor: B<void>;
+}
+
+export interface ContainerObject {
+  /**
+   * The parsed bundle identifier
+   */
+  bundleId: string;
+  /**
+   * The absolute full path of the item on the local filesystem
+   */
+  pathInContainer: string;
+  /**
+   * The container type
+   */
+  containerType: string | null;
+}
+
+export type AtomsElement<S extends string = string> = Omit<
+  Element<S>,
+  'element-6066-11e4-a52e-4f735466cecf'
+>;
+
+export interface Context {
+  /**
+   * The identifier of the context.
+   *
+   * The native context will be `NATIVE_APP` and the webviews will be `WEBVIEW_xxx`
+   */
+  id: string;
+  /**
+   * The title associated witht he webview content
+   */
+  title?: string;
+  /**
+   * The URL associated with the webview content
+   */
+  url?: string;
+}
+
+export type ViewContext<S extends string = string> = Context &
+  (S extends NativeAppId ? {view: SetOptional<View, 'id'>} : {view: View});
+
+export type NativeAppId = 'NATIVE_APP';
+
+export type FullContext<S extends string = string> = Omit<View, 'id'> & ViewContext<S>;
+
+export interface View {
+  /**
+   * @privateRemarks Type of this is best guess
+   */
+  id: number | string;
+  title?: string;
+  url?: string;
+  bundleId?: string;
+}

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1,7 +1,7 @@
 import {Element, HTTPHeaders} from '@appium/types';
 import type B from 'bluebird';
 import type {EventEmitter} from 'node:events';
-import {EmptyObject, SetOptional} from 'type-fest';
+import {SetOptional} from 'type-fest';
 import {Page} from '../types';
 
 export type Direction = 'up' | 'down' | 'left' | 'right';

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -272,7 +272,6 @@ const commands = {
     }
 
     await this._deleteCookie(cookie);
-    return true;
   },
   /**
    * @this {XCUITestDriver}

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -1,10 +1,9 @@
-import {retryInterval} from 'asyncbox';
-import {util, timing} from 'appium/support';
-import _ from 'lodash';
+import { errors, isErrorType } from 'appium/driver';
+import { timing, util } from 'appium/support';
+import { retryInterval } from 'asyncbox';
 import B from 'bluebird';
-import {errors, isErrorType} from 'appium/driver';
+import _ from 'lodash';
 import cookieUtils from '../cookies';
-import {EventEmitter} from 'events';
 
 const IPHONE_TOP_BAR_HEIGHT = 71;
 const IPHONE_SCROLLED_TOP_BAR_HEIGHT = 41;
@@ -112,6 +111,7 @@ function isValidElementIdentifier(id) {
 const commands = {
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async setFrame(frame) {
   if (!this.isWebContext()) {
@@ -141,6 +141,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async getCssProperty(propertyName, el) {
   if (!this.isWebContext()) {
@@ -151,6 +152,10 @@ const commands = {
   return await this.executeAtom('get_value_of_css_property', [atomsElement, propertyName]);
   },
   /**
+   * Submit the form an element is in
+   *
+   * @param {string|Element} el - the element ID
+   * @group Mobile Web Only
    * @this {XCUITestDriver}
    */
   async submit(el) {
@@ -163,6 +168,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async refresh() {
   if (!this.isWebContext()) {
@@ -173,6 +179,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async getUrl() {
   if (!this.isWebContext()) {
@@ -183,6 +190,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async title() {
     if (!this.isWebContext()) {
@@ -193,6 +201,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async getCookies() {
     if (!this.isWebContext()) {
@@ -220,6 +229,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async setCookie(cookie) {
   if (!this.isWebContext()) {
@@ -247,6 +257,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async deleteCookie(cookieName) {
     if (!this.isWebContext()) {
@@ -257,7 +268,7 @@ const commands = {
     const cookie = cookies.find((cookie) => cookie.name === cookieName);
     if (!cookie) {
       this.log.debug(`Cookie '${cookieName}' not found. Ignoring.`);
-      return true;
+      return;
     }
 
     await this._deleteCookie(cookie);
@@ -265,6 +276,7 @@ const commands = {
   },
   /**
    * @this {XCUITestDriver}
+   * @group Mobile Web Only
    */
   async deleteCookies() {
     if (!this.isWebContext()) {
@@ -275,7 +287,6 @@ const commands = {
     for (const cookie of cookies) {
       await this._deleteCookie(cookie);
     }
-    return true;
   },
 };
 
@@ -322,6 +333,10 @@ const helpers = {
   return response;
   },
   /**
+   * @param {string} atom
+   * @param {unknown[]} args
+   * @returns {Promise<any>}
+   * @privateRemarks This should return `Promise<T>` where `T` extends `unknown`, but that's going to cause a lot of things to break.
    * @this {XCUITestDriver}
    */
   async executeAtom(atom, args, alwaysDefaultFrame = false) {
@@ -341,16 +356,20 @@ const helpers = {
   return await this.waitForAtom(promise);
   },
   /**
+   * @template {string} S
+   * @param {S|Element<S>} elOrId
+   * @returns {import('./types').AtomsElement<S>}
    * @this {XCUITestDriver}
    */
   getAtomsElement(elOrId) {
   const elId = util.unwrapElement(elOrId);
-  if (!this.webElementsCache.has(elId)) {
+    if (!this.webElementsCache?.has(elId)) {
     throw new errors.StaleElementReferenceError();
   }
   return {ELEMENT: this.webElementsCache.get(elId)};
   },
   /**
+   * @param {readonly any[]} [args]
    * @this {XCUITestDriver}
    */
   convertElementsForAtoms(args = []) {
@@ -368,14 +387,12 @@ const helpers = {
     return _.isArray(arg) ? this.convertElementsForAtoms(arg) : arg;
   });
   },
-  /**
-   * @this {XCUITestDriver}
-   */
   getElementId(element) {
   return element.ELEMENT || element[W3C_WEB_ELEMENT_IDENTIFIER];
   },
   /**
-   * @this {XCUITestDriver}
+   * @param {any} element
+   * @returns {element is Element}
    */
   hasElementId(element) {
     return (
@@ -434,7 +451,7 @@ const extensions = {
     return this._isSafariIphone;
   }
   try {
-    const userAgent = await this.execute('return navigator.userAgent');
+      const userAgent = /** @type {string} */(await this.execute('return navigator.userAgent'));
     this._isSafariIphone = userAgent.toLowerCase().includes('iphone');
   } catch (err) {
     this.log.warn(`Unable to find device type from useragent. Assuming iPhone`);
@@ -448,7 +465,7 @@ const extensions = {
   async getSafariDeviceSize() {
     const script =
       'return {height: window.screen.availHeight * window.devicePixelRatio, width: window.screen.availWidth * window.devicePixelRatio};';
-  const {width, height} = await this.execute(script);
+    const {width, height} = /** @type {import('@appium/types').Size} */(await this.execute(script));
   const [normHeight, normWidth] = height > width ? [height, width] : [width, height];
   return {
     width: normWidth,
@@ -492,14 +509,15 @@ const extensions = {
   const {
     nativeWebTapTabBarVisibility,
     nativeWebTapSmartAppBannerVisibility,
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       safariTabBarPosition = util.compareVersions(this.opts.platformVersion, '>=', '15.0') &&
       isIphone
         ? TAB_BAR_POSITION_BOTTOM
         : TAB_BAR_POSITION_TOP,
-  } = await this.settings.getSettings();
-  let tabBarVisibility = _.lowerCase(nativeWebTapTabBarVisibility);
-  let bannerVisibility = _.lowerCase(nativeWebTapSmartAppBannerVisibility);
-  const tabBarPosition = _.lowerCase(safariTabBarPosition);
+    } = this.settings.getSettings();
+    let tabBarVisibility = _.lowerCase(String(nativeWebTapTabBarVisibility));
+    let bannerVisibility = _.lowerCase(String(nativeWebTapSmartAppBannerVisibility));
+    const tabBarPosition = _.lowerCase(String(safariTabBarPosition));
 
   if (!VISIBILITIES.includes(tabBarVisibility)) {
     tabBarVisibility = DETECT;
@@ -519,6 +537,7 @@ const extensions = {
   const orientation = realDims.h > realDims.w ? 'PORTRAIT' : 'LANDSCAPE';
 
   const notchOffset = isNotched
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     ? util.compareVersions(this.opts.platformVersion, '=', '13.0')
       ? IPHONE_X_NOTCH_OFFSET_IOS_13
       : IPHONE_X_NOTCH_OFFSET_IOS
@@ -584,12 +603,12 @@ const extensions = {
         : IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET;
   } else if (bannerVisibility === DETECT) {
     // try to see if there is an Smart App Banner
-      const banners = await this.findNativeElementOrElements(
+      const banners = /** @type {import('@appium/types').Element[]} */(await this.findNativeElementOrElements(
         'accessibility id',
         'Close app download offer',
         true
-      );
-    if (banners.length > 0) {
+      ));
+      if (banners?.length) {
         offset += isIphone
           ? IPHONE_WEB_COORD_SMART_APP_BANNER_OFFSET
           : IPAD_WEB_COORD_SMART_APP_BANNER_OFFSET;
@@ -621,10 +640,10 @@ const extensions = {
     this.executeAtom('get_top_left_coordinates', [atomsElement]),
   ]);
 
-  const [size, coordinates] = await B.Promise.all([
+    const [size, coordinates] = /** @type {[import('@appium/types').Size, import('@appium/types').Position]} */(await B.Promise.all([
     this.executeAtom('get_size', [atomsElement]),
     this.executeAtom('get_top_left_coordinates', [atomsElement]),
-  ]);
+    ]));
   const {width, height} = size;
   let {x, y} = coordinates;
   x += width / 2;
@@ -651,14 +670,15 @@ const extensions = {
   this.log.debug(`Translating coordinates (${JSON.stringify(coords)}) to web coordinates`);
 
   // absolutize web coords
+    /** @type {import('@appium/types').Element|undefined|string} */
   let webview;
   try {
-      webview = await retryInterval(
+      webview = /** @type {import('@appium/types').Element|undefined} */(await retryInterval(
         5,
         100,
         async () =>
           await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false)
-      );
+      ));
   } catch (ign) {}
 
   if (!webview) {
@@ -677,11 +697,11 @@ const extensions = {
   // keep track of implicit wait, and set locally to 0
   // https://github.com/appium/appium/issues/14988
   const implicitWaitMs = this.implicitWaitMs;
-  await this.setImplicitWait(0);
+    this.setImplicitWait(0);
   try {
     await this.getExtraTranslateWebCoordsOffset(wvPos, realDims);
   } finally {
-    await this.setImplicitWait(implicitWaitMs);
+      this.setImplicitWait(implicitWaitMs);
   }
 
   if (wvDims && realDims && wvPos) {
@@ -717,6 +737,7 @@ const extensions = {
   },
 
   /**
+   * @param {Promise<any>} promise
    * @this {XCUITestDriver}
    */
   async waitForAtom(promise) {
@@ -732,8 +753,10 @@ const extensions = {
         const originalError = err instanceof B.AggregateError ? err[0] : err;
       this.log.debug(`Error received while executing atom: ${originalError.message}`);
       if (originalError instanceof B.TimeoutError) {
-        throw new errors.TimeoutError(`Did not get any response for atom execution after ` +
-          `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+          throw new errors.TimeoutError(
+            `Did not get any response for atom execution after ` +
+              `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`
+          );
       }
       throw originalError;
     }
@@ -746,13 +769,6 @@ const extensions = {
   }
 
   // ...otherwise make sure there is no unexpected alert covering the element
-  if (!_.isPlainObject(this._waitingAtoms)) {
-    this._waitingAtoms = {
-      count: 0,
-      alertNotifier: new EventEmitter(),
-      alertMonitor: B.resolve(),
-    };
-  }
   this._waitingAtoms.count++;
 
   let onAlertCallback;
@@ -803,6 +819,7 @@ const extensions = {
   },
 
   /**
+   * @param {string} navType
    * @this {XCUITestDriver}
    */
   async mobileWebNav(navType) {
@@ -831,19 +848,26 @@ const extensions = {
 /**
  * Updates preferences of Mobile Safari on Simulator
  *
- * @param {SafariOpts} opts
+   * @param {object} preferences - An object containing Safari settings to be
+   * updated. The list of available setting names and their values could be
+   * retrieved by changing the corresponding Safari settings in the UI and then
+   * inspecting `Library/Preferences/com.apple.mobilesafari.plist` file inside
+   * of `com.apple.mobilesafari` app container. The full path to the Mobile
+   * Safari's container could be retrieved from `xcrun simctl get_app_container <sim_udid> com.apple.mobilesafari data` command output. Use the `xcrun simctl spawn <sim_udid> defaults read <path_to_plist>` command to print the
+   * plist content to the Terminal.
+   * @group Simulator Only
    * @this {XCUITestDriver}
  */
-  async mobileUpdateSafariPreferences(opts = {}) {
+  async mobileUpdateSafariPreferences(preferences) {
   if (!this.isSimulator()) {
     throw new Error('This extension is only available for Simulator');
   }
-    const {preferences} = opts;
   if (!_.isPlainObject(preferences)) {
     throw new errors.InvalidArgumentError('"preferences" argument must be a valid object');
   }
 
   this.log.debug(`About to update Safari preferences: ${JSON.stringify(preferences)}`);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   await this.opts.device.updateSafariSettings(preferences);
   },
 };
@@ -853,3 +877,9 @@ export default {...helpers, ...extensions, ...commands};
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver
  */
+
+/**
+ * @template {string} [S=string]
+ * @typedef {import('@appium/types').Element<S>} Element
+ */
+

--- a/lib/commands/xctest.js
+++ b/lib/commands/xctest.js
@@ -96,7 +96,7 @@ export function parseXCTestStdout(stdout) {
 
     // Parse each property
     /** @type {XCTestResult} */
-    const output = /** @type {any} */({});
+    const output = /** @type {any} */ ({});
     let entryIndex = 0;
     for (const prop of properties) {
       if (entryIndex === 0) {
@@ -185,7 +185,15 @@ export default {
    * @returns {Promise<RunXCUITestResponse>}
    * @this {XCUITestDriver}
    */
-  async mobileRunXCTest(testRunnerBundleId, appUnderTestBundleId, xcTestBundleId, args, testType = 'ui', env, timeout = XCTEST_TIMEOUT) {
+  async mobileRunXCTest(
+    testRunnerBundleId,
+    appUnderTestBundleId,
+    xcTestBundleId,
+    args = [],
+    testType = 'ui',
+    env,
+    timeout = XCTEST_TIMEOUT
+  ) {
     const subproc = await assertIDB(this.opts).runXCUITest(
       testRunnerBundleId,
       appUnderTestBundleId,
@@ -233,7 +241,7 @@ export default {
       subproc.on('exit', (code, signal) => {
         clearTimeout(xctestTimeout);
         if (code !== 0) {
-          const err = /** @type {any} */(new Error(lastErrorMessage || mostRecentLogObject));
+          const err = /** @type {any} */ (new Error(lastErrorMessage || mostRecentLogObject));
           err.code = code;
           if (signal != null) {
             err.signal = signal;
@@ -283,13 +291,13 @@ export default {
   },
 
   /**
- * List XCTests in a test bundle
- *
- * @param {string} bundle - Bundle ID of the XCTest
- *
- * @returns {Promise<string[]>} The list of xctests in the test bundle (e.g., `['XCTesterAppUITests.XCTesterAppUITests/testExample', 'XCTesterAppUITests.XCTesterAppUITests/testLaunchPerformance']`)
- * @this {XCUITestDriver}
- */
+   * List XCTests in a test bundle
+   *
+   * @param {string} bundle - Bundle ID of the XCTest
+   *
+   * @returns {Promise<string[]>} The list of xctests in the test bundle (e.g., `['XCTesterAppUITests.XCTesterAppUITests/testExample', 'XCTesterAppUITests.XCTesterAppUITests/testLaunchPerformance']`)
+   * @this {XCUITestDriver}
+   */
   async mobileListXCTestsInTestBundle(bundle) {
     if (!_.isString(bundle)) {
       throw new errors.InvalidArgumentError(

--- a/lib/commands/xctest.js
+++ b/lib/commands/xctest.js
@@ -13,12 +13,14 @@ const xctestLog = logger.getLogger('XCTest');
  * @param {XCUITestDriver['opts']} opts Opts object from the driver instance
  */
 export function assertIDB(opts) {
+  // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   if (!opts.device?.idb || !opts.launchWithIDB) {
     throw new Error(
       `To use XCTest runner, IDB (https://github.com/facebook/idb) must be installed ` +
         `and sessions must be run with the "launchWithIDB" capability`
     );
   }
+  // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   return opts.device.idb;
 }
 
@@ -31,13 +33,13 @@ export function assertIDB(opts) {
  * @property {string} status Test result status (e.g.: 'passed', 'failed', 'crashed')
  * @property {number} duration How long did the tests take (in seconds)
  * @property {string} [failureMessage] Failure message (if applicable)
- * @property {number} [location] The geolocation of the tests (if applicable)
+ * @property {string} [location] The geolocation of the tests (if applicable)
  */
 
 /**
  * Parse the stdout of XC test log
  * @param {string} stdout A line of standard out from `idb xctest run ...`
- * @returns {XCTestResult[]} results The final output of the XCTest run
+ * @returns {XCTestResult[]|string[]} results The final output of the XCTest run
  */
 export function parseXCTestStdout(stdout) {
   // Parses a 'key' into JSON format
@@ -85,6 +87,7 @@ export function parseXCTestStdout(stdout) {
     return [lines[0]];
   }
 
+  /** @type {XCTestResult[]} */
   const results = [];
   for (const line of lines) {
     // The properties are split up by pipes and each property
@@ -92,7 +95,8 @@ export function parseXCTestStdout(stdout) {
     const properties = line.split('|');
 
     // Parse each property
-    const output = {};
+    /** @type {XCTestResult} */
+    const output = /** @type {any} */({});
     let entryIndex = 0;
     for (const prop of properties) {
       if (entryIndex === 0) {
@@ -138,6 +142,7 @@ export function parseXCTestStdout(stdout) {
  * @property {XCTestResult[]} results The results of all the tests with information
  * @property {number} code The exit code of the process
  * @property {string} signal The signal that terminated the process (or null) (e.g.: SIGTERM)
+ * @property {boolean} passed Did all the tests pass?
  *
  */
 
@@ -163,30 +168,28 @@ export function parseXCTestStdout(stdout) {
 
 export default {
   /**
-   * Run an XCTest. Launches a subprocess that runs the XC Test and blocks
-   * until it is complete. Parses the stdout of the process and returns
-   * result as an array
+   * Run an XCTest.
    *
-   * See https://fbidb.io/docs/test_execution for reference
+   * Launches a subprocess that runs the XC Test and blocks until it is complete. Parses the stdout of the process and returns result as an array.
    *
-   * @param {MobileRunXCTestOptions} opts
+   * See [the idb docs](https://fbidb.io/docs/test-execution/) for reference.
+   *
+   * @param {string} testRunnerBundleId - Test app bundle (e.g.: `io.appium.XCTesterAppUITests.xctrunner`)
+   * @param {string} appUnderTestBundleId - App-under-test bundle
+   * @param {string} xcTestBundleId - XCTest bundle ID
+   * @param {string[]} args - Launch arguments to start the test with (see [reference documentation](https://developer.apple.com/documentation/xctest/xcuiapplication/1500477-launcharguments))
+   * @param {'app'|'ui'|'logic'} testType - XC test type
+   * @param {object} [env] - Environment variables passed to test
+   * @param {number} timeout - Timeout if session doesn't complete after given time (in milliseconds)
    * @throws {XCUITestError} Error thrown if subprocess returns non-zero exit code
    * @returns {Promise<RunXCUITestResponse>}
    * @this {XCUITestDriver}
    */
-  async mobileRunXCTest({
-    testRunnerBundleId,
-    appUnderTestBundleId,
-    xctestBundleId,
-    testType = 'ui',
-    env,
-    args,
-    timeout = XCTEST_TIMEOUT,
-  }) {
+  async mobileRunXCTest(testRunnerBundleId, appUnderTestBundleId, xcTestBundleId, args, testType = 'ui', env, timeout = XCTEST_TIMEOUT) {
     const subproc = await assertIDB(this.opts).runXCUITest(
       testRunnerBundleId,
       appUnderTestBundleId,
-      xctestBundleId,
+      xcTestBundleId,
       {env, args, testType}
     );
     return await new B((resolve, reject) => {
@@ -230,7 +233,7 @@ export default {
       subproc.on('exit', (code, signal) => {
         clearTimeout(xctestTimeout);
         if (code !== 0) {
-          const err = new Error(lastErrorMessage || mostRecentLogObject);
+          const err = /** @type {any} */(new Error(lastErrorMessage || mostRecentLogObject));
           err.code = code;
           if (signal != null) {
             err.signal = signal;
@@ -251,19 +254,12 @@ export default {
   },
 
   /**
-   * @typedef {Object} MobileInstallXCTestBundleOpts
-   *
-   * @property {xctestApp} xctestBundle Path of the XCTest app (URL or .app)
-   */
-
-  /**
    * Install an XCTestBundle
    *
-   * @param {MobileInstallXCTestBundleOpts} opts Install xctest bundle opts
+   * @param {string} xctestApp - Path of the XCTest app (URL or filename with extension `.app`)
    * @this {XCUITestDriver}
    */
-  async mobileInstallXCTestBundle(opts) {
-    const {xctestApp} = opts;
+  async mobileInstallXCTestBundle(xctestApp) {
     if (!_.isString(xctestApp)) {
       throw new errors.InvalidArgumentError(
         `'xctestApp' is a required parameter for 'installXCTestBundle' and ` +
@@ -287,23 +283,14 @@ export default {
   },
 
   /**
-   * @typedef {Object} ListXCTestsOpts
-   *
-   * @property {string} bundle Bundle ID of the XCTest
-   */
-
-  /**
  * List XCTests in a test bundle
  *
- * @param {ListXCTestsOpts} opts XCTest list options
+ * @param {string} bundle - Bundle ID of the XCTest
  *
- * @returns {Promise<string[]>} The list of xctests in the test bundle
- *    (e.g.: [ 'XCTesterAppUITests.XCTesterAppUITests/testExample',
-                'XCTesterAppUITests.XCTesterAppUITests/testLaunchPerformance' ] )
+ * @returns {Promise<string[]>} The list of xctests in the test bundle (e.g., `['XCTesterAppUITests.XCTesterAppUITests/testExample', 'XCTesterAppUITests.XCTesterAppUITests/testLaunchPerformance']`)
  * @this {XCUITestDriver}
  */
-  async mobileListXCTestsInTestBundle(opts) {
-    const {bundle} = opts;
+  async mobileListXCTestsInTestBundle(bundle) {
     if (!_.isString(bundle)) {
       throw new errors.InvalidArgumentError(
         `'bundle' is a required parameter for 'listXCTestsInTestBundle' and ` +

--- a/lib/css-converter.js
+++ b/lib/css-converter.js
@@ -28,6 +28,9 @@ const ALL_ATTRS = [
   ...STR_ATTRS,
 ];
 
+/**
+ * @type {[string, string[]][]}
+ */
 const ATTRIBUTE_ALIASES = [
   ['name', ['id']],
   ['index', ['nth-child']],
@@ -50,8 +53,8 @@ function toCamelCase (str) {
 
 /**
  * @typedef {Object} CssNameValueObject
- * @property {?name} name The name of the CSS object
- * @property {?string} value The value of the CSS object
+ * @property {string} [name] The name of the CSS object
+ * @property {string} [value] The value of the CSS object
  */
 
 /**
@@ -103,16 +106,17 @@ function requireAttributeName (css) {
 
 /**
  * @typedef {Object} CssAttr
- * @property {?string} valueType Type of attribute (must be string or empty)
- * @property {?string} value Value of the attribute
- * @property {?string} operator The operator between value and value type (=, *=, , ^=, $=)
+ * @property {string} [name]
+ * @property {string} [valueType] Type of attribute (must be string or empty)
+ * @property {string} [value] Value of the attribute
+ * @property {string} [operator] The operator between value and value type (=, *=, , ^=, $=)
  */
 
 /**
  * Convert a CSS attribute into a UiSelector method call
  *
  * @param {CssAttr} cssAttr CSS attribute object
- * @returns {string} CSS attribute parsed as UiSelector
+ * @returns {string|{index: string|undefined}} CSS attribute parsed as UiSelector
  */
 function parseAttr (cssAttr) {
   if (cssAttr.valueType && cssAttr.valueType !== 'string') {
@@ -160,16 +164,16 @@ function parseAttr (cssAttr) {
 
 /**
  * @typedef {Object} CssPseudo
- * @property {?string} valueType The type of CSS pseudo selector (https://www.npmjs.com/package/css-selector-parser for reference)
- * @property {?string} name The name of the pseudo selector
- * @property {?string} value The value of the pseudo selector
+ * @property {string} [valueType] The type of CSS pseudo selector (https://www.npmjs.com/package/css-selector-parser for reference)
+ * @property {string} [name] The name of the pseudo selector
+ * @property {string} [value] The value of the pseudo selector
  */
 
 /**
  * Convert a CSS pseudo class to a UiSelector
  *
  * @param {CssPseudo} cssPseudo CSS Pseudo class
- * @returns {string} Pseudo selector parsed as UiSelector
+ * @returns {string|{index: string|undefined}|undefined} Pseudo selector parsed as UiSelector
  */
 function parsePseudo (cssPseudo) {
   if (cssPseudo.valueType && cssPseudo.valueType !== 'string') {
@@ -190,13 +194,13 @@ function parsePseudo (cssPseudo) {
 
 /**
  * @typedef {Object} CssRule
- * @property {?string} nestingOperator The nesting operator (aka: combinator https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
- * @property {?string} tagName The tag name (aka: type selector https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors)
- * @property {?string[]} classNames An array of CSS class names
- * @property {?CssAttr[]} attrs An array of CSS attributes
- * @property {?CssPseudo[]} attrs An array of CSS pseudos
- * @property {?string} id CSS identifier
- * @property {?CssRule} rule A descendant of this CSS rule
+ * @property {string} [nestingOperator] The nesting operator (aka: combinator https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)
+ * @property {string} [tagName] The tag name (aka: type selector https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors)
+ * @property {string[]} [classNames] An array of CSS class names
+ * @property {CssAttr[]} [attrs] An array of CSS attributes
+ * @property {CssPseudo[]} [pseudos] An array of CSS pseudos
+ * @property {string} [id] CSS identifier
+ * @property {CssRule} [rule] A descendant of this CSS rule
  */
 
 /**
@@ -243,7 +247,7 @@ function parseCssRule (cssRule) {
 
   const indexAttr = attrs.find((attr) => _.isObject(attr) && attr.index);
   if (indexAttr) {
-    iosClassChainSelector += `[${indexAttr.index}]`;
+    iosClassChainSelector += `[${/** @type { {index: string} } */(indexAttr).index}]`;
   }
 
   if (cssRule.rule) {
@@ -259,7 +263,7 @@ function parseCssRule (cssRule) {
 
 /**
  * @typedef {Object} CssObject
- * @property {?string} type Type of CSS object. 'rule', 'ruleset' or 'selectors'
+ * @property {string} [type] Type of CSS object. 'rule', 'ruleset' or 'selectors'
  */
 
 /**
@@ -270,10 +274,13 @@ function parseCssRule (cssRule) {
 function parseCssObject (css) {
   switch (css.type) {
     case 'rule':
+      // @ts-expect-error this is extremely broken
       return parseCssRule(css);
     case 'ruleSet':
+      // @ts-expect-error this is extremely broken
       return parseCssObject(css.rule);
     case 'selectors':
+      // @ts-expect-error this is extremely broken
       return css.selectors.map((selector) => parseCssObject(selector)).join('; ');
 
     default:

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -2,7 +2,7 @@
 const PLATFORM_NAME_IOS = 'iOS';
 const PLATFORM_NAME_TVOS = 'tvOS';
 
-const desiredCapConstraints = {
+const desiredCapConstraints = /** @type {const} */({
   platformName: { // override
     presence: true,
     isString: true,
@@ -339,7 +339,7 @@ const desiredCapConstraints = {
   enforceAppInstall: {
     isBoolean: true,
   }
-};
+});
 
 export { desiredCapConstraints, PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS };
 export default desiredCapConstraints;

--- a/lib/device-connections-factory.js
+++ b/lib/device-connections-factory.js
@@ -54,8 +54,8 @@ class iProxy {
       remoteSocket.pipe(localSocket);
     });
     const listeningPromise = new B((resolve, reject) => {
-      this.localServer.once('listening', resolve);
-      this.localServer.once('error', reject);
+      /** @type {net.Server} */(this.localServer).once('listening', resolve);
+      /** @type {net.Server} */(this.localServer).once('error', reject);
     });
     this.localServer.listen(this.localport);
     try {

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -14,11 +14,12 @@ class IOSCrashLog {
   constructor (opts = {}) {
     this.udid = opts.udid;
     this.pyideviceClient = this.udid ? new Pyidevice(this.udid) : null;
+    const HOME = String(process.env.HOME);
     const logDir = opts.udid
-      ? path.resolve(process.env.HOME, 'Library', 'Logs', 'CrashReporter', 'MobileDevice')
-      : path.resolve(process.env.HOME, 'Library', 'Logs', 'DiagnosticReports');
+      ? path.resolve(HOME, 'Library', 'Logs', 'CrashReporter', 'MobileDevice')
+      : path.resolve(HOME, 'Library', 'Logs', 'DiagnosticReports');
     this.logDir = logDir
-      || path.resolve(process.env.HOME || '/', 'Library', 'Logs', 'DiagnosticReports');
+      || path.resolve(HOME || '/', 'Library', 'Logs', 'DiagnosticReports');
     this.prevLogs = [];
     this.logsSinceLastRequest = [];
     this.phoneName = null;
@@ -26,8 +27,8 @@ class IOSCrashLog {
   }
 
   async _gatherFromRealDevice () {
-    if (await this.pyideviceClient.assertExists(false)) {
-      return (await this.pyideviceClient.listCrashes())
+    if (await this.pyideviceClient?.assertExists(false)) {
+      return (await /** @type {Pyidevice} */(this.pyideviceClient).listCrashes())
         .map((x) => `${REAL_DEVICE_MAGIC}${MAGIC_SEP}${x}`);
     }
 
@@ -100,6 +101,7 @@ class IOSCrashLog {
         if (_.includes(fullPath, REAL_DEVICE_MAGIC)) {
           const fileName = _.last(fullPath.split(MAGIC_SEP));
           try {
+            // @ts-expect-error If pyideviceClient is not defined, then the exception will be caught below
             await this.pyideviceClient.exportCrash(fileName, tmpRoot);
           } catch (e) {
             log.warn(`Cannot export the crash report '${fileName}'. Skipping it. ` +

--- a/lib/device-log/ios-device-log.js
+++ b/lib/device-log/ios-device-log.js
@@ -1,19 +1,20 @@
-import { logger } from 'appium/support';
-import { IOSLog } from './ios-log';
-import { services } from 'appium-ios-device';
+import {logger} from 'appium/support';
+import {IOSLog} from './ios-log';
+import {services} from 'appium-ios-device';
 
 const log = logger.getLogger('IOSDeviceLog');
 
 class IOSDeviceLog extends IOSLog {
-
-  constructor (opts) {
+  constructor(opts) {
     super();
     this.udid = opts.udid;
     this.showLogs = !!opts.showLogs;
     this.service = null;
   }
-
-  async startCapture () {
+  /**
+   * @override
+   */
+  async startCapture() {
     if (this.service) {
       return;
     }
@@ -21,18 +22,24 @@ class IOSDeviceLog extends IOSLog {
     this.service.start(this.onLog.bind(this));
   }
 
-  onLog (logLine) {
+  onLog(logLine) {
     this.broadcast(logLine);
     if (this.showLogs) {
       log.info(logLine);
     }
   }
 
-  get isCapturing () {
+  /**
+   * @override
+   */
+  get isCapturing() {
     return !!this.service;
   }
 
-  stopCapture () {
+  /**
+   * @override
+   */
+  async stopCapture() {
     if (!this.service) {
       return;
     }
@@ -41,5 +48,5 @@ class IOSDeviceLog extends IOSLog {
   }
 }
 
-export { IOSDeviceLog };
+export {IOSDeviceLog};
 export default IOSDeviceLog;

--- a/lib/device-log/ios-device-log.js
+++ b/lib/device-log/ios-device-log.js
@@ -39,6 +39,8 @@ class IOSDeviceLog extends IOSLog {
   /**
    * @override
    */
+  // XXX: superclass is async, but this is not
+  // eslint-disable-next-line require-await
   async stopCapture() {
     if (!this.service) {
       return;

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -12,14 +12,17 @@ class IOSLog extends EventEmitter {
     this.maxBufferSize = MAX_LOG_ENTRIES_COUNT;
   }
 
+  /** @returns {Promise<void>} */
   async startCapture () { // eslint-disable-line require-await
     throw new Error(`Sub-classes need to implement a 'startCapture' function`);
   }
 
+  /** @returns {Promise<void>} */
   async stopCapture () { // eslint-disable-line require-await
     throw new Error(`Sub-classes need to implement a 'stopCapture' function`);
   }
 
+  /** @returns {boolean} */
   get isCapturing () {
     throw new Error(`Sub-classes need to implement a 'isCapturing' function`);
   }

--- a/lib/device-log/ios-performance-log.js
+++ b/lib/device-log/ios-performance-log.js
@@ -7,7 +7,7 @@ const MAX_EVENTS = 5000;
 class IOSPerformanceLog {
   constructor (remoteDebugger, maxEvents = MAX_EVENTS) {
     this.remoteDebugger = remoteDebugger;
-    this.maxEvents = parseInt(maxEvents, 10);
+    this.maxEvents = parseInt(String(maxEvents), 10);
 
     this.timelineEvents = [];
   }

--- a/lib/device-log/rotating-log.js
+++ b/lib/device-log/rotating-log.js
@@ -23,10 +23,11 @@ class RotatingLog {
     this.isCapturing = false;
   }
 
-  /*
-   * @override
+  /**
+   * @privateRemarks Subclasses must implement this.
    */
   addLogLine () {
+    throw new Error('Not implemented');
   }
 
   async getLogs () { // eslint-disable-line require-await

--- a/lib/device-log/safari-console-log.js
+++ b/lib/device-log/safari-console-log.js
@@ -1,17 +1,20 @@
-import { RotatingLog, MAX_LOG_ENTRIES_COUNT } from './rotating-log';
+import {RotatingLog, MAX_LOG_ENTRIES_COUNT} from './rotating-log';
 import _ from 'lodash';
-import { util } from 'appium/support';
-
+import {util} from 'appium/support';
 
 class SafariConsoleLog extends RotatingLog {
-  constructor (showLogs) {
+  constructor(showLogs) {
     super(showLogs, 'SafariConsole');
 
     // js console has `warning` level, so map to `warn`
-    this.log.warning = this.log.warn;
+    this.log = new Proxy(this.log, {
+      get(target, prop, receiver) {
+        return Reflect.get(target, prop === 'warning' ? 'warn' : prop, receiver);
+      },
+    });
   }
 
-  addLogLine (err, out) {
+  addLogLine(err, out) {
     if (this.isCapturing) {
       this.logs = this.logs || [];
       while (this.logs.length >= MAX_LOG_ENTRIES_COUNT) {
@@ -48,11 +51,12 @@ class SafariConsoleLog extends RotatingLog {
        * object, stringified.
        */
       const entry = {
-        level: {
-          error: 'SEVERE',
-          warning: 'WARNING',
-          log: 'FINE',
-        }[out.level] || 'INFO',
+        level:
+          {
+            error: 'SEVERE',
+            warning: 'WARNING',
+            log: 'FINE',
+          }[out.level] || 'INFO',
         timestamp: Date.now(),
         message: JSON.stringify(out),
       };
@@ -88,5 +92,5 @@ class SafariConsoleLog extends RotatingLog {
   }
 }
 
-export { SafariConsoleLog };
+export {SafariConsoleLog};
 export default SafariConsoleLog;

--- a/lib/device-log/safari-network-log.js
+++ b/lib/device-log/safari-network-log.js
@@ -101,7 +101,7 @@ class SafariNetworkLog extends RotatingLog {
       if (entry.response) {
         const url = URL.parse(entry.response.url);
         // get the last part of the url, along with the query string, if possible
-        record.name = `${_.last(url.pathname.split('/'))}${url.search ? `?${url.search}` : ''}` || url.host;
+        record.name = `${_.last(String(url.pathname).split('/'))}${url.search ? `?${url.search}` : ''}` || url.host;
         record.status = entry.response.status;
         if (entry.response.timing) {
           record.time = entry.response.timing.receiveHeadersEnd

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -59,6 +59,8 @@ import IDB from 'appium-idb';
 import DEVICE_CONNECTIONS_FACTORY from './device-connections-factory';
 import Pyidevice from './py-ios-device-client';
 import commands from './commands';
+import EventEmitter from 'node:events';
+import {executeMethodMap} from './execute-method-map';
 
 const SHUTDOWN_OTHER_FEAT_NAME = 'shutdown_other_sims';
 const CUSTOMIZE_RESULT_BUNDPE_PATH = 'customize_result_bundle_path';
@@ -100,6 +102,7 @@ const SHARED_RESOURCES_GUARD = new AsyncLock();
 const WEB_ELEMENTS_CACHE_SIZE = 500;
 const SUPPORTED_ORIENATIONS = ['LANDSCAPE', 'PORTRAIT'];
 /* eslint-disable no-useless-escape */
+/** @type {import('@appium/types').RouteMatcher[]} */
 const NO_PROXY_NATIVE_LIST = [
   ['DELETE', /window/],
   ['GET', /^\/session\/[^\/]+$/],
@@ -148,7 +151,8 @@ const NO_PROXY_NATIVE_LIST = [
   ['GET', /cookie/],
   ['POST', /cookie/],
 ];
-const NO_PROXY_WEB_LIST = [
+
+const NO_PROXY_WEB_LIST = /** @type {import('@appium/types').RouteMatcher[]} */ ([
   ['GET', /attribute/],
   ['GET', /element/],
   ['GET', /text/],
@@ -160,7 +164,7 @@ const NO_PROXY_WEB_LIST = [
   ['POST', /frame/],
   ['POST', /keys/],
   ['POST', /refresh/],
-].concat(NO_PROXY_NATIVE_LIST);
+]).concat(NO_PROXY_NATIVE_LIST);
 /* eslint-enable no-useless-escape */
 
 const MEMOIZED_FUNCTIONS = ['getStatusBarHeight', 'getDevicePixelRatio', 'getScreenInfo'];
@@ -176,7 +180,81 @@ const BUNDLE_VERSION_PATTERN = /CFBundleVersion\s+=\s+"?([^(;|")]+)/;
 class XCUITestDriver extends BaseDriver {
   static newMethodMap = newMethodMap;
 
-  constructor(opts = {}, shouldValidateCaps = true) {
+  static executeMethodMap = executeMethodMap;
+
+  /** @type {string|null|undefined} */
+  curWindowHandle;
+
+  /**
+   * @type {boolean|undefined}
+   */
+  selectingNewPage;
+
+  /** @type {string[]} */
+  contexts;
+
+  /** @type {string|null} */
+  curContext;
+
+  /**
+   * @type {import('@appium/types').Position|null}
+   */
+  curWebCoords;
+
+  /**
+   * @type {import('@appium/types').Position|null}
+   */
+  curCoords;
+
+  /** @type {string[]} */
+  curWebFrames;
+
+  /**
+   * @type {import('./types').Page[]|undefined}
+   */
+  windowHandleCache;
+
+  /** @type {import('./types').AsyncPromise|undefined} */
+  asyncPromise;
+
+  /** @type {number|undefined} */
+  asyncWaitMs;
+
+  /** @type {((logRecord: {message: string}) => void)|null} */
+  _syslogWebsocketListener;
+
+  /** @type {import('./commands/performance').PerfRecorder[]} */
+  _perfRecorders;
+
+  /** @type {LRU} */
+  webElementsCache;
+
+  /**
+   * @type {any|null}
+   * @privateRemarks needs types
+   **/
+  _conditionInducerService;
+
+  /** @type {boolean|undefined} */
+  _isSafariIphone;
+
+  /** @type {boolean|undefined} */
+  _isSafariNotched;
+
+  /** @type {import('./commands/types').WaitingAtoms} */
+  _waitingAtoms;
+
+  /** @type {import('./types').LifecycleData} */
+  lifecycleData;
+
+  /** @type {XCUITestDriverOpts} */
+  opts;
+  /**
+   *
+   * @param {XCUITestDriverOpts} opts
+   * @param {boolean} shouldValidateCaps
+   */
+  constructor(opts = /** @type {XCUITestDriverOpts} */ ({}), shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
 
     this.locatorStrategies = [
@@ -196,7 +274,17 @@ class XCUITestDriver extends BaseDriver {
       'link text',
       'partial link text',
     ];
+    this.curWebFrames = [];
+    this._perfRecorders = [];
     this.desiredCapConstraints = desiredCapConstraints;
+    this.webElementsCache = new LRU({
+      max: WEB_ELEMENTS_CACHE_SIZE,
+    });
+    this._waitingAtoms = {
+      count: 0,
+      alertNotifier: new EventEmitter(),
+      alertMonitor: B.resolve(),
+    };
     this.resetIos();
     this.settings = new DeviceSettings(DEFAULT_SETTINGS, this.onSettingsUpdate.bind(this));
     this.logs = {};
@@ -205,6 +293,7 @@ class XCUITestDriver extends BaseDriver {
     for (const fn of MEMOIZED_FUNCTIONS) {
       this[fn] = _.memoize(this[fn]);
     }
+    this.lifecycleData = {};
   }
 
   async onSettingsUpdate(key, value) {
@@ -219,10 +308,10 @@ class XCUITestDriver extends BaseDriver {
   resetIos() {
     this.opts = this.opts || {};
     this.wda = null;
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     this.opts.device = null;
     this.jwpProxyActive = false;
     this.proxyReqRes = null;
-    this.jwpProxyAvoid = [];
     this.safari = false;
     this.cachedWdaStatus = null;
 
@@ -241,6 +330,12 @@ class XCUITestDriver extends BaseDriver {
     this.webElementsCache = new LRU({
       max: WEB_ELEMENTS_CACHE_SIZE,
     });
+
+    this._waitingAtoms = {
+      count: 0,
+      alertNotifier: new EventEmitter(),
+      alertMonitor: B.resolve(),
+    };
   }
 
   get driverData() {
@@ -274,10 +369,10 @@ class XCUITestDriver extends BaseDriver {
     return didMerge;
   }
 
-  async createSession(...args) {
-    this.lifecycleData = {}; // this is used for keeping track of the state we start so when we delete the session we can put things back
+  async createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData) {
     try {
-      let [sessionId, caps] = await super.createSession(...args);
+      let [sessionId, caps] = await super.createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData);
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       this.opts.sessionId = sessionId;
 
       // merge cli args to opts, and if we did merge any, revalidate opts to ensure the final set
@@ -310,15 +405,19 @@ class XCUITestDriver extends BaseDriver {
         shouldUseCompactResponses: DEFAULT_SETTINGS.shouldUseCompactResponses,
       };
       if (_.has(this.opts, 'elementResponseAttributes')) {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         wdaSettings.elementResponseAttributes = this.opts.elementResponseAttributes;
       }
       if (_.has(this.opts, 'shouldUseCompactResponses')) {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         wdaSettings.shouldUseCompactResponses = this.opts.shouldUseCompactResponses;
       }
       if (_.has(this.opts, 'mjpegServerScreenshotQuality')) {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         wdaSettings.mjpegServerScreenshotQuality = this.opts.mjpegServerScreenshotQuality;
       }
       if (_.has(this.opts, 'mjpegServerFramerate')) {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         wdaSettings.mjpegServerFramerate = this.opts.mjpegServerFramerate;
       }
       if (_.has(this.opts, 'screenshotQuality')) {
@@ -334,7 +433,10 @@ class XCUITestDriver extends BaseDriver {
         this.mjpegStream = new mjpeg.MJpegStream(this.opts.mjpegScreenshotUrl);
         await this.mjpegStream.start();
       }
-      return [sessionId, caps];
+      return /** @type {[string, import('@appium/types').DriverCaps<XCUITestDriverConstraints>]} */ ([
+        sessionId,
+        caps,
+      ]);
     } catch (e) {
       this.log.error(JSON.stringify(e));
       await this.deleteSession();
@@ -360,14 +462,16 @@ class XCUITestDriver extends BaseDriver {
     this.opts.fullReset = !!this.opts.fullReset;
 
     await printUser();
-
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     this.opts.iosSdkVersion = null; // For WDA and xcodebuild
     const {device, udid, realDevice} = await this.determineDevice();
     this.log.info(
       `Determining device to run tests on: udid: '${udid}', real device: ${realDevice}`
     );
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     this.opts.device = device;
     this.opts.udid = udid;
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     this.opts.realDevice = realDevice;
 
     if (this.opts.simulatorDevicesSetPath) {
@@ -379,18 +483,22 @@ class XCUITestDriver extends BaseDriver {
         this.log.info(
           `Setting simulator devices set path to '${this.opts.simulatorDevicesSetPath}'`
         );
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         this.opts.device.devicesSetPath = this.opts.simulatorDevicesSetPath;
       }
     }
 
     // at this point if there is no platformVersion, get it from the device
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (!this.opts.platformVersion && this.opts.device) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       this.opts.platformVersion = await this.opts.device.getPlatformVersion();
       this.log.info(
         `No platformVersion specified. Using device version: '${this.opts.platformVersion}'`
       );
     }
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const normalizedVersion = normalizePlatformVersion(this.opts.platformVersion);
     if (this.opts.platformVersion !== normalizedVersion) {
       this.log.info(
@@ -404,6 +512,7 @@ class XCUITestDriver extends BaseDriver {
       );
     }
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
@@ -465,6 +574,7 @@ class XCUITestDriver extends BaseDriver {
     if (this.isSimulator()) {
       if (this.opts.shutdownOtherSimulators) {
         this.ensureFeatureEnabled(SHUTDOWN_OTHER_FEAT_NAME);
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await shutdownOtherSimulators(this.opts.device);
       }
 
@@ -472,25 +582,30 @@ class XCUITestDriver extends BaseDriver {
 
       if (this.opts.customSSLCert) {
         // Simulator must be booted in order to call this helper
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device.addCertificate(this.opts.customSSLCert);
         this.logEvent('customCertInstalled');
       }
 
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       if (await setSafariPrefs(this.opts.device, this.opts)) {
         this.log.debug('Safari preferences have been updated');
       }
 
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       if (await setLocalizationPrefs(this.opts.device, this.opts)) {
         this.log.debug('Localization preferences have been updated');
       }
 
       if (_.isBoolean(this.opts.reduceMotion)) {
         this.log.info(`Setting reduceMotion to ${this.opts.reduceMotion}`);
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device.setReduceMotion(this.opts.reduceMotion);
       }
 
       if (_.isBoolean(this.opts.reduceTransparency)) {
         this.log.info(`Setting reduceTransparency to ${this.opts.reduceTransparency}`);
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device.setReduceTransparency(this.opts.reduceTransparency);
       }
 
@@ -498,6 +613,7 @@ class XCUITestDriver extends BaseDriver {
         try {
           const idb = new IDB({udid});
           await idb.connect();
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           this.opts.device.idb = idb;
         } catch (e) {
           this.log.debug(e.stack);
@@ -527,6 +643,7 @@ class XCUITestDriver extends BaseDriver {
       !this.opts.app &&
       this.opts.bundleId &&
       !this.isSafari() &&
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       !(await this.opts.device.isAppInstalled(this.opts.bundleId))
     ) {
       this.log.errorAndThrow(`App with bundle identifier '${this.opts.bundleId}' unknown`);
@@ -536,6 +653,7 @@ class XCUITestDriver extends BaseDriver {
       if (this.opts.permissions) {
         this.log.debug('Setting the requested permissions before WDA is started');
         for (const [bundleId, permissionsMapping] of _.toPairs(JSON.parse(this.opts.permissions))) {
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           await this.opts.device.setPermissions(bundleId, permissionsMapping);
         }
       }
@@ -549,10 +667,12 @@ class XCUITestDriver extends BaseDriver {
         const methodName = `${
           this.opts.calendarAccessAuthorized ? 'enable' : 'disable'
         }CalendarAccess`;
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device[methodName](this.opts.bundleId);
       }
     }
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.startWda(this.opts.sessionId, realDevice);
 
     if (this.opts.orientation) {
@@ -738,11 +858,17 @@ class XCUITestDriver extends BaseDriver {
     });
   }
 
-  async runReset(opts = null) {
+  /**
+   *
+   * @param {XCUITestDriverOpts} [opts]
+   */
+  async runReset(opts) {
     this.logEvent('resetStarted');
     if (this.isRealDevice()) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await runRealDeviceReset(this.opts.device, opts || this.opts);
     } else {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await runSimulatorReset(this.opts.device, opts || this.opts);
     }
     this.logEvent('resetComplete');
@@ -766,7 +892,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     if (this._conditionInducerService) {
-      this.mobileDisableConditionInducer();
+      this.disableConditionInducer();
     }
 
     await this.stop();
@@ -798,11 +924,13 @@ class XCUITestDriver extends BaseDriver {
         })
       );
     }
-
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (this.isSimulator() && !this.opts.noReset && !!this.opts.device) {
       if (this.lifecycleData.createSim) {
         this.log.debug(`Deleting simulator created for this run (udid: '${this.opts.udid}')`);
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await shutdownSimulator(this.opts.device);
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await this.opts.device.delete();
       }
     }
@@ -852,6 +980,12 @@ class XCUITestDriver extends BaseDriver {
     DEVICE_CONNECTIONS_FACTORY.releaseConnection(this.opts.udid);
   }
 
+  /**
+   *
+   * @param {string} cmd
+   * @param {...any} args
+   * @returns {Promise<any>}
+   */
   async executeCommand(cmd, ...args) {
     this.log.debug(`Executing command '${cmd}'`);
 
@@ -909,7 +1043,7 @@ class XCUITestDriver extends BaseDriver {
    * @param {string} appPath The path to the archive.
    * @param {number} depth [0] the current nesting depth. App bundles whose nesting level
    * is greater than 1 are not supported.
-   * @returns {string} Full path to the first matching .app bundle..
+   * @returns {Promise<string>} Full path to the first matching .app bundle..
    * @throws If no matching .app bundles were found in the provided archive.
    */
   async unzipApp(appPath, depth = 0) {
@@ -1009,13 +1143,18 @@ class XCUITestDriver extends BaseDriver {
     this.opts.deviceName = translateDeviceName(this.opts.platformVersion, this.opts.deviceName);
 
     const setupVersionCaps = async () => {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       this.opts.iosSdkVersion = await getAndCheckIosSdkVersion();
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       this.log.info(`iOS SDK Version set to '${this.opts.iosSdkVersion}'`);
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       if (!this.opts.platformVersion && this.opts.iosSdkVersion) {
         this.log.info(
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           `No platformVersion specified. Using the latest version Xcode supports: '${this.opts.iosSdkVersion}'. ` +
             `This may cause problems if a simulator does not exist for this platform version.`
         );
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         this.opts.platformVersion = normalizePlatformVersion(this.opts.iosSdkVersion);
       }
     };
@@ -1029,6 +1168,7 @@ class XCUITestDriver extends BaseDriver {
           this.log.warn(
             `Cannot detect any connected real devices. Falling back to Simulator. Original error: ${err.message}`
           );
+          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           const device = await getExistingSim(this.opts);
           if (!device) {
             // No matching Simulator is found. Throw an error
@@ -1079,6 +1219,7 @@ class XCUITestDriver extends BaseDriver {
       );
     } else {
       // figure out the correct simulator to use, given the desired capabilities
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       const device = await getExistingSim(this.opts);
 
       // check for an existing simulator
@@ -1106,7 +1247,9 @@ class XCUITestDriver extends BaseDriver {
     };
 
     // add the window center, if it is specified
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     if (this.opts.SimulatorWindowCenter) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       runOpts.devicePreferences.SimulatorWindowCenter = this.opts.SimulatorWindowCenter;
     }
 
@@ -1128,6 +1271,7 @@ class XCUITestDriver extends BaseDriver {
         break;
     }
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.run(runOpts);
   }
 
@@ -1187,13 +1331,16 @@ class XCUITestDriver extends BaseDriver {
       maxTypingFrequency: this.opts.maxTypingFrequency ?? 60,
       shouldUseSingletonTestManager: this.opts.shouldUseSingletonTestManager ?? true,
       waitForIdleTimeout: this.opts.waitForIdleTimeout,
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       shouldUseCompactResponses: this.opts.shouldUseCompactResponses,
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       elementResponseFields: this.opts.elementResponseFields,
       disableAutomaticScreenshots: this.opts.disableAutomaticScreenshots,
       shouldTerminateApp: this.opts.shouldTerminateApp ?? true,
       forceAppLaunch: this.opts.forceAppLaunch ?? true,
       useNativeCachingStrategy: this.opts.useNativeCachingStrategy ?? true,
       forceSimulatorSoftwareKeyboardPresence:
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         this.opts.forceSimulatorSoftwareKeyboardPresence ??
         (this.opts.connectHardwareKeyboard === true ? false : true),
     };
@@ -1213,7 +1360,7 @@ class XCUITestDriver extends BaseDriver {
 
   // Override Proxy methods from BaseDriver
   proxyActive() {
-    return this.jwpProxyActive;
+    return Boolean(this.jwpProxyActive);
   }
 
   getProxyAvoidList() {
@@ -1232,10 +1379,12 @@ class XCUITestDriver extends BaseDriver {
   }
 
   isRealDevice() {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return this.opts.realDevice;
   }
 
   isSimulator() {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     return !this.opts.realDevice;
   }
 
@@ -1247,6 +1396,11 @@ class XCUITestDriver extends BaseDriver {
     super.validateLocatorStrategy(strategy, this.isWebContext());
   }
 
+  /**
+   *
+   * @param {any} caps
+   * @returns {caps is import('@appium/types').DriverCaps<XCUITestDriverConstraints>}
+   */
   validateDesiredCaps(caps) {
     if (!super.validateDesiredCaps(caps)) {
       return false;
@@ -1260,7 +1414,7 @@ class XCUITestDriver extends BaseDriver {
       );
     }
 
-    if (!util.coerceVersion(caps.platformVersion, false)) {
+    if (!util.coerceVersion(String(caps.platformVersion), false)) {
       this.log.warn(
         `'platformVersion' capability ('${caps.platformVersion}') is not a valid version number. ` +
           `Consider fixing it or be ready to experience an inconsistent driver behavior.`
@@ -1381,6 +1535,7 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async checkAutInstallationState() {
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const {enforceAppInstall, fullReset, noReset, bundleId, device, app} = this.opts;
 
     const wasAppInstalled = await device.isAppInstalled(bundleId);
@@ -1463,15 +1618,17 @@ class XCUITestDriver extends BaseDriver {
     const {install, skipUninstall} = await this.checkAutInstallationState();
     if (install) {
       if (this.isRealDevice()) {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await installToRealDevice(this.opts.device, this.opts.app, this.opts.bundleId, {
           skipUninstall,
           timeout: this.opts.appPushTimeout,
           strategy: this.opts.appInstallStrategy,
         });
       } else {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         await installToSimulator(this.opts.device, this.opts.app, this.opts.bundleId, {
           skipUninstall,
-          newSimulator: this.lifecycleData.createSim,
+          newSimulator: this.lifecycleData?.createSim,
         });
       }
       if (util.hasValue(this.opts.iosInstallPause)) {
@@ -1492,6 +1649,7 @@ class XCUITestDriver extends BaseDriver {
       this.log.warn('Capability otherApps is only supported for Simulators');
       return;
     }
+    /** @type {string[]|undefined} */
     let appsList;
     try {
       appsList = this.helpers.parseCapsArray(otherApps);
@@ -1503,8 +1661,11 @@ class XCUITestDriver extends BaseDriver {
       return;
     }
 
-    const appPaths = await B.all(appsList.map((app) => this.helpers.configureApp(app, '.app')));
+    const appPaths = await B.all(
+      /** @type {string[]} */ (appsList).map((app) => this.helpers.configureApp(app, '.app'))
+    );
     for (const otherApp of appPaths) {
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       await installToSimulator(this.opts.device, otherApp, undefined, {
         newSimulator: this.lifecycleData.createSim,
       });
@@ -1570,6 +1731,9 @@ class XCUITestDriver extends BaseDriver {
     );
   }
 
+  /**
+   * Reset the current session (run the delete session and create session subroutines)
+   */
   async reset() {
     if (this.opts.noReset) {
       // This is to make sure reset happens even if noReset is set to true
@@ -1711,6 +1875,7 @@ class XCUITestDriver extends BaseDriver {
   getLocation = commands.elementExtensions.getLocation;
   getLocationInView = commands.elementExtensions.getLocationInView;
   getSize = commands.elementExtensions.getSize;
+  /** @deprecated */
   setValueImmediate = commands.elementExtensions.setValueImmediate;
   setValue = commands.elementExtensions.setValue;
   keys = commands.elementExtensions.keys;
@@ -1999,9 +2164,14 @@ export default XCUITestDriver;
 export {XCUITestDriver};
 
 /**
- * @typedef {import('@appium/types').ExternalDriver} ExternalDriver
+ * @template {import('@appium/types').Constraints} C
+ * @typedef {import('@appium/types').ExternalDriver<C>} ExternalDriver
  */
 
 /**
  * @typedef {typeof desiredCapConstraints} XCUITestDriverConstraints
+ */
+
+/**
+ * @typedef {import('@appium/types').DriverOpts<XCUITestDriverConstraints>} XCUITestDriverOpts
  */

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -172,7 +172,7 @@ const MEMOIZED_FUNCTIONS = ['getStatusBarHeight', 'getDevicePixelRatio', 'getScr
 const BUNDLE_VERSION_PATTERN = /CFBundleVersion\s+=\s+"?([^(;|")]+)/;
 
 /**
- * @implements {ExternalDriver<XCUITestDriverConstraints>}
+ * @implements {ExternalDriver<XCUITestDriverConstraints, FullContext|string>}
  * @extends {BaseDriver<XCUITestDriverConstraints>}
  * @privateRemarks **This class should be considered "final"**. It cannot be extended
  * due to use of public class field assignments.  If extending this class becomes a hard requirement, refer to the implementation of `BaseDriver` on how to do so.
@@ -249,6 +249,7 @@ class XCUITestDriver extends BaseDriver {
 
   /** @type {XCUITestDriverOpts} */
   opts;
+
   /**
    *
    * @param {XCUITestDriverOpts} opts
@@ -2165,13 +2166,12 @@ export {XCUITestDriver};
 
 /**
  * @template {import('@appium/types').Constraints} C
- * @typedef {import('@appium/types').ExternalDriver<C>} ExternalDriver
+ * @template [Ctx=string]
+ * @typedef {import('@appium/types').ExternalDriver<C, Ctx>} ExternalDriver
  */
 
 /**
  * @typedef {typeof desiredCapConstraints} XCUITestDriverConstraints
- */
-
-/**
  * @typedef {import('@appium/types').DriverOpts<XCUITestDriverConstraints>} XCUITestDriverOpts
+ * @typedef {import('./commands/types').FullContext} FullContext
  */

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1378,10 +1378,13 @@ class XCUITestDriver extends BaseDriver {
   isSafari() {
     return !!this.safari;
   }
-
+  /**
+   *
+   * @returns {boolean}
+   */
   isRealDevice() {
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    return this.opts.realDevice;
+    return Boolean(this.opts.realDevice);
   }
 
   isSimulator() {

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -342,8 +342,8 @@ export const executeMethodMap = {
   'mobile: runXCTest': {
     command: 'mobileRunXCTest',
     params: {
-      required: ['testRunnerBundleId', 'appUnderTestBundleId', 'xcTestBundleId', 'args'],
-      optional: ['testType', 'env', 'timeout'],
+      required: ['testRunnerBundleId', 'appUnderTestBundleId', 'xctestBundleId'],
+      optional: ['args', 'testType', 'env', 'timeout'],
     },
   },
   'mobile: installXCTestBundle': {

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -1,0 +1,441 @@
+import {ExecuteMethodMap} from '@appium/types';
+import {XCUITestDriver} from './driver';
+
+export const executeMethodMap = {
+  'mobile: tap': {
+    command: 'mobileTap',
+    params: {required: ['x', 'y'], optional: ['elementId']},
+  },
+  'mobile: scroll': {
+    command: 'mobileScroll',
+    params: {
+      optional: ['name', 'direction', 'predicateString', 'toVisible', 'distance', 'elementId'],
+    },
+  },
+  'mobile: selectPickerWheelValue': {
+    command: 'mobileSelectPickerWheelValue',
+    params: {
+      required: ['elementId', 'order'],
+      optional: ['offset'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618668-swipeleft?language=objc
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618674-swiperight?language=objc
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618667-swipeup?language=objc
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618664-swipedown?language=objc
+  'mobile: swipe': {
+    command: 'mobileSwipe',
+    params: {
+      required: ['direction'],
+      optional: ['velocity', 'elementId'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618669-pinchwithscale?language=objc
+  'mobile: pinch': {
+    command: 'mobilePinch',
+    params: {
+      required: ['scale', 'velocity'],
+      optional: ['elementId'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618673-doubletap?language=objc
+  'mobile: doubleTap': {
+    command: 'mobileDoubleTap',
+    params: {
+      optional: ['elementId', 'x', 'y'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618671-tapwithnumberoftaps?language=objc
+  'mobile: twoFingerTap': {
+    command: 'mobileTwoFingerTap',
+    params: {
+      optional: ['elementId'],
+    },
+  },
+  'mobile: tapWithNumberOfTaps': {
+    command: 'mobileTapWithNumberOfTaps',
+    params: {
+      required: ['numberOfTouches', 'numberOfTaps'],
+      optional: ['elementId'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc
+  'mobile: touchAndHold': {
+    command: 'mobileTouchAndHold',
+    params: {
+      required: ['duration'],
+      optional: ['x', 'y', 'elementId'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618670-pressforduration?language=objc
+  'mobile: dragFromToForDuration': {
+    command: 'mobileDragFromToForDuration',
+    params: {
+      required: ['duration', 'fromX', 'fromY', 'toX', 'toY'],
+      optional: ['elementId'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuielement/1618665-rotate?language=objc
+  'mobile: rotateElement': {
+    command: 'mobileRotateElement',
+    params: {
+      required: ['elementId', 'rotation', 'velocity'],
+    },
+  },
+  // https://developer.apple.com/documentation/xctest/xcuicoordinate/3551692-pressforduration?language=objc
+  'mobile: dragFromToWithVelocity': {
+    command: 'mobileDragFromToWithVelocity',
+    params: {
+      required: ['pressDuration', 'holdDuration', 'velocity'],
+      optional: ['fromElementId', 'toElementId', 'fromX', 'fromY', 'toX', 'toY'],
+    },
+  },
+  'mobile: forcePress': {
+    command: 'mobileForcePress',
+    params: {
+      optional: ['x', 'y', 'duration', 'pressure', 'elementId'],
+    },
+  },
+  'mobile: scrollToElement': {
+    command: 'mobileScrollToElement',
+    params: {
+      required: ['elementId'],
+    },
+  },
+  'mobile: alert': {
+    command: 'mobileHandleAlert',
+    params: {
+      required: ['action'],
+      optional: ['buttonLabel'],
+    },
+  },
+  'mobile: setPasteboard': {
+    command: 'mobileSetPasteboard',
+    params: {
+      required: ['content'],
+      optional: ['encoding'],
+    },
+  },
+  'mobile: getPasteboard': {
+    command: 'mobileGetPasteboard',
+    params: {
+      optional: ['encoding'],
+    },
+  },
+  'mobile: source': {
+    command: 'mobileGetSource',
+    params: {
+      optional: ['format', 'excludedAttributes'],
+    },
+  },
+  'mobile: getContexts': {
+    command: 'mobileGetContexts',
+    params: {
+      optional: ['waitForWebviewMs'],
+    },
+  },
+  'mobile: installApp': {
+    command: 'mobileInstallApp',
+    params: {
+      required: ['app'],
+      optional: ['strategy', 'timeoutMs'],
+    },
+  },
+  'mobile: isAppInstalled': {
+    command: 'mobileIsAppInstalled',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: removeApp': {
+    command: 'mobileRemoveApp',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: launchApp': {
+    command: 'mobileLaunchApp',
+    params: {
+      required: ['bundleId'],
+      optional: ['arguments', 'environment'],
+    },
+  },
+  'mobile: terminateApp': {
+    command: 'mobileTerminateApp',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: killApp': {
+    command: 'mobileKillApp',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: queryAppState': {
+    command: 'mobileQueryAppState',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: activateApp': {
+    command: 'mobileActivateApp',
+    params: {
+      required: ['bundleId'],
+    },
+  },
+  'mobile: listApps': {
+    command: 'mobileListApps',
+    params: {
+      optional: ['applicationType'],
+    },
+  },
+  'mobile: viewportScreenshot': {
+    command: 'getViewportScreenshot',
+  },
+  'mobile: viewportRect': {
+    command: 'getViewportRect',
+  },
+  'mobile: startPerfRecord': {
+    command: 'mobileStartPerfRecord',
+    params: {
+      optional: ['timeout', 'profileName', 'pid'],
+    },
+  },
+  'mobile: stopPerfRecord': {
+    command: 'mobileStopPerfRecord',
+    params: {
+      optional: [
+        'remotePath',
+        'user',
+        'pass',
+        'method',
+        'profileName',
+        'headers',
+        'fileFieldName',
+        'formFields',
+      ],
+    },
+  },
+  'mobile: installCertificate': {
+    command: 'mobileInstallCertificate',
+    params: {
+      required: ['content'],
+      optional: ['commonName', 'isRoot'],
+    },
+  },
+  'mobile: listCertificates': {
+    command: 'mobileListCertificates',
+  },
+  'mobile: startLogsBroadcast': {
+    command: 'mobileStartLogsBroadcast',
+  },
+  'mobile: stopLogsBroadcast': {
+    command: 'mobileStopLogsBroadcast',
+  },
+  'mobile: batteryInfo': {
+    command: 'mobileGetBatteryInfo',
+  },
+  'mobile: deviceInfo': {
+    command: 'mobileGetDeviceInfo',
+  },
+  'mobile: getDeviceTime': {
+    command: 'mobileGetDeviceTime',
+    params: {
+      optional: ['format'],
+    },
+  },
+  'mobile: activeAppInfo': {
+    command: 'mobileGetActiveAppInfo',
+  },
+  'mobile: deviceScreenInfo': {
+    command: 'getScreenInfo',
+  },
+  'mobile: pressButton': {
+    command: 'mobilePressButton',
+    params: {
+      required: ['name'],
+      optional: ['durationSeconds'],
+    },
+  },
+  'mobile: enrollBiometric': {
+    command: 'mobileEnrollBiometric',
+    params: {
+      optional: ['isEnabled'],
+    },
+  },
+  'mobile: sendBiometricMatch': {
+    command: 'mobileSendBiometricMatch',
+    params: {
+      optional: ['type', 'match'],
+    },
+  },
+  'mobile: isBiometricEnrolled': {
+    command: 'mobileIsBiometricEnrolled',
+  },
+  'mobile: clearKeychains': {
+    command: 'mobileClearKeychains',
+  },
+  'mobile: getPermission': {
+    command: 'mobileGetPermission',
+    params: {
+      required: ['service', 'bundleId'],
+    },
+  },
+  'mobile: setPermission': {
+    command: 'mobileSetPermissions',
+    params: {
+      required: ['access', 'bundleId'],
+    },
+  },
+  'mobile: resetPermission': {
+    command: 'mobileResetPermission',
+    params: {
+      required: ['service'],
+    },
+  },
+  'mobile: getAppearance': {
+    command: 'mobileGetAppearance',
+  },
+  'mobile: setAppearance': {
+    command: 'mobileSetAppearance',
+    params: {
+      required: ['style'],
+    },
+  },
+  'mobile: siriCommand': {
+    command: 'mobileSiriCommand',
+    params: {
+      required: ['text'],
+    },
+  },
+  'mobile: pushFile': {
+    command: 'mobilePushFile',
+    params: {
+      required: ['remotePath', 'payload'],
+    },
+  },
+  'mobile: pullFile': {
+    command: 'mobilePullFile',
+    params: {
+      required: ['remotePath'],
+    },
+  },
+  'mobile: pullFolder': {
+    command: 'mobilePullFolder',
+    params: {
+      required: ['remotePath'],
+    },
+  },
+  'mobile: deleteFile': {
+    command: 'mobileDeleteFile',
+    params: {
+      required: ['remotePath'],
+    },
+  },
+  'mobile: deleteFolder': {
+    command: 'mobileDeleteFolder',
+    params: {
+      required: ['remotePath'],
+    },
+  },
+  'mobile: runXCTest': {
+    command: 'mobileRunXCTest',
+    params: {
+      required: ['testRunnerBundleId', 'appUnderTestBundleId', 'xcTestBundleId', 'args'],
+      optional: ['testType', 'env', 'timeout'],
+    },
+  },
+  'mobile: installXCTestBundle': {
+    command: 'mobileInstallXCTestBundle',
+    params: {
+      required: ['xctestApp'],
+    },
+  },
+  'mobile: listXCTestBundles': {
+    command: 'mobileListXCTestBundles',
+  },
+  'mobile: listXCTestsInTestBundle': {
+    command: 'mobileListXCTestsInTestBundle',
+    params: {
+      required: ['bundle'],
+    },
+  },
+  'mobile: pushNotification': {
+    command: 'mobilePushNotification',
+    params: {
+      required: ['bundleId', 'payload'],
+    },
+  },
+  'mobile: expectNotification': {
+    command: 'mobileExpectNotification',
+    params: {
+      required: ['name'],
+      optional: ['type', 'timeoutSeconds'],
+    },
+  },
+  'mobile: performIoHidEvent': {
+    command: 'mobilePerformIoHidEvent',
+    params: {
+      required: ['page', 'usage', 'durationSeconds'],
+    },
+  },
+  'mobile: configureLocalization': {
+    command: 'mobileConfigureLocalization',
+    params: {
+      optional: ['keyboard', 'language', 'locale'],
+    },
+  },
+  'mobile: resetLocationService': {
+    command: 'mobileResetLocationService',
+  },
+  'mobile: startPcap': {
+    command: 'mobileStartPcap',
+    params: {
+      optional: ['timeLimitSec', 'forceRestart'],
+    },
+  },
+  'mobile: stopPcap': {
+    command: 'mobileStopPcap',
+  },
+  'mobile: listConditionInducers': {
+    command: 'listConditionInducers',
+  },
+  'mobile: enableConditionInducer': {
+    command: 'enableConditionInducer',
+    params: {
+      required: ['conditionID', 'profileID'],
+    },
+  },
+  'mobile: disableConditionInducer': {
+    command: 'disableConditionInducer',
+  },
+  'mobile: updateSafariPreferences': {
+    command: 'mobileUpdateSafariPreferences',
+    params: {
+      required: ['preferences'],
+    },
+  },
+  'mobile: deepLink': {
+    command: 'mobileDeepLink',
+    params: {
+      required: ['url'],
+      optional: ['bundleId'],
+    },
+  },
+  'mobile: setSimulatedLocation': {
+    command: 'mobileSetSimulatedLocation',
+    params: {
+      required: ['latitude', 'longitude'],
+    },
+  },
+  'mobile: getSimulatedLocation': {
+    command: 'mobileGetSimulatedLocation',
+  },
+  'mobile: resetSimulatedLocation': {
+    command: 'mobileResetSimulatedLocation',
+  },
+  'mobile: shake': {
+    command: 'mobileShake',
+  },
+} as const satisfies ExecuteMethodMap<XCUITestDriver>;

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -1,12 +1,12 @@
-import { fs, timing } from 'appium/support';
+import {fs, timing} from 'appium/support';
 import path from 'path';
-import { services, utilities, INSTRUMENT_CHANNEL } from 'appium-ios-device';
+import {services, utilities, INSTRUMENT_CHANNEL} from 'appium-ios-device';
 import B from 'bluebird';
 import log from './logger';
 import _ from 'lodash';
-import { exec } from 'teen_process';
-import { extractBundleId } from './app-utils';
-import { pushFolder } from './ios-fs-helpers';
+import {exec} from 'teen_process';
+import {extractBundleId} from './app-utils';
+import {pushFolder} from './ios-fs-helpers';
 
 const APPLICATION_INSTALLED_NOTIFICATION = 'com.apple.mobile.application_installed';
 const INSTALLATION_STAGING_DIR = 'PublicStaging';
@@ -19,14 +19,12 @@ const APP_INSTALL_STRATEGY = Object.freeze({
   IOS_DEPLOY,
 });
 
-
 class IOSDeploy {
-
-  constructor (udid) {
+  constructor(udid) {
     this.udid = udid;
   }
 
-  async remove (bundleId) {
+  async remove(bundleId) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
       await service.uninstallApplication(bundleId);
@@ -35,17 +33,28 @@ class IOSDeploy {
     }
   }
 
-  async removeApp (bundleId) {
+  async removeApp(bundleId) {
     await this.remove(bundleId);
   }
 
-  async install (app, timeout, strategy = null) {
-    if (strategy && !_.values(APP_INSTALL_STRATEGY).includes(_.toLower(strategy))) {
-      throw new Error(`App installation strategy '${strategy}' is unknown. ` +
-        `Only the following strategies are supported: ${_.values(APP_INSTALL_STRATEGY)}`);
+  /**
+   *
+   * @param {string} app
+   * @param {number} [timeout]
+   * @param {'ios-deploy'|'serial'|'parallel'|null} strategy
+   * @privateRemarks This really needs type guards built out
+   */
+  async install(app, timeout, strategy = null) {
+    if (strategy && !_.values(APP_INSTALL_STRATEGY).includes(/** @type {any} */(_.toLower(strategy)))) {
+      throw new Error(
+        `App installation strategy '${strategy}' is unknown. ` +
+          `Only the following strategies are supported: ${_.values(APP_INSTALL_STRATEGY)}`
+      );
     }
-    log.debug(`Using '${strategy ?? APP_INSTALL_STRATEGY.SERIAL}' app deployment strategy. ` +
-      `You could change it by providing another value to the 'appInstallStrategy' capability`);
+    log.debug(
+      `Using '${strategy ?? APP_INSTALL_STRATEGY.SERIAL}' app deployment strategy. ` +
+        `You could change it by providing another value to the 'appInstallStrategy' capability`
+    );
 
     const installWithIosDeploy = async () => {
       try {
@@ -54,17 +63,16 @@ class IOSDeploy {
         throw new Error(`'${IOS_DEPLOY}' utility has not been found in PATH. Is it installed?`);
       }
       try {
-        await exec(IOS_DEPLOY, [
-          '--id', this.udid,
-          '--bundle', app,
-        ], {timeout: timeout ?? IOS_DEPLOY_TIMEOUT_MS});
+        await exec(IOS_DEPLOY, ['--id', this.udid, '--bundle', app], {
+          timeout: timeout ?? IOS_DEPLOY_TIMEOUT_MS,
+        });
       } catch (err) {
         throw new Error(err.stderr || err.stdout || err.message);
       }
     };
 
     const timer = new timing.Timer().start();
-    if (_.toLower(strategy) === APP_INSTALL_STRATEGY.IOS_DEPLOY) {
+    if (_.toLower(/** @type {'ios-deploy'} */(strategy)) === APP_INSTALL_STRATEGY.IOS_DEPLOY) {
       await installWithIosDeploy();
     } else {
       const afcService = await services.startAfcService(this.udid);
@@ -73,9 +81,12 @@ class IOSDeploy {
         const bundlePathOnPhone = path.join(INSTALLATION_STAGING_DIR, bundleId);
         await pushFolder(afcService, app, bundlePathOnPhone, {
           timeoutMs: timeout,
-          enableParallelPush: _.toLower(strategy) === APP_INSTALL_STRATEGY.PARALLEL,
+          enableParallelPush: _.toLower(/** @type {'parallel'} */(strategy)) === APP_INSTALL_STRATEGY.PARALLEL,
         });
-        await this.installOrUpgradeApplication(bundlePathOnPhone, await this.isAppInstalled(bundleId));
+        await this.installOrUpgradeApplication(
+          bundlePathOnPhone,
+          await this.isAppInstalled(bundleId)
+        );
       } catch (err) {
         log.warn(`Error installing app '${app}': ${err.message}`);
         if (err instanceof B.TimeoutError) {
@@ -85,9 +96,9 @@ class IOSDeploy {
         try {
           await installWithIosDeploy();
         } catch (err1) {
-          throw new Error(`Could not install '${app}':\n` +
-            `  - ${err.message}\n` +
-            `  - ${err1.message}`);
+          throw new Error(
+            `Could not install '${app}':\n` + `  - ${err.message}\n` + `  - ${err1.message}`
+          );
         }
       } finally {
         afcService.close();
@@ -96,12 +107,12 @@ class IOSDeploy {
     log.info(`App installation succeeded after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
   }
 
-  async installOrUpgradeApplication (bundlePathOnPhone, isUpgrade = false) {
+  async installOrUpgradeApplication(bundlePathOnPhone, isUpgrade = false) {
     const notificationService = await services.startNotificationProxyService(this.udid);
     const installationService = await services.startInstallationProxyService(this.udid);
     const appInstalledNotification = new B((resolve) => {
       notificationService.observeNotification(APPLICATION_INSTALLED_NOTIFICATION, {
-        notification: resolve
+        notification: resolve,
       });
     });
     const clientOptions = {PackageType: 'Developer'};
@@ -114,9 +125,11 @@ class IOSDeploy {
         await installationService.installApplication(bundlePathOnPhone, clientOptions);
       }
       try {
-        await appInstalledNotification.timeout(APPLICATION_NOTIFICATION_TIMEOUT_MS,
+        await appInstalledNotification.timeout(
+          APPLICATION_NOTIFICATION_TIMEOUT_MS,
           `Could not get the application installed notification within ` +
-          `${APPLICATION_NOTIFICATION_TIMEOUT_MS}ms but we will continue`);
+            `${APPLICATION_NOTIFICATION_TIMEOUT_MS}ms but we will continue`
+        );
       } catch (e) {
         log.warn(`Failed to receive the notification. Error: ${e.message}`);
       }
@@ -126,8 +139,14 @@ class IOSDeploy {
     }
   }
 
-  async installApp (...args) {
-    return await this.install(...args);
+  /**
+   * Alias for {@linkcode install}
+   * @param {string} app
+   * @param {number} timeout
+   * @param {'ios-deploy'|'serial'|'parallel'|null} strategy
+   */
+  async installApp(app, timeout, strategy) {
+    return await this.install(app, timeout, strategy);
   }
 
   /**
@@ -142,20 +161,20 @@ class IOSDeploy {
    *   "Entitlements":
    *     {"com.apple.frontboard.delete-application-snapshots":true,..
    */
-  async isAppInstalled (bundleId) {
+  async isAppInstalled(bundleId) {
     return Boolean(await this.fetchAppInfo(bundleId));
   }
 
-  async fetchAppInfo (bundleId) {
+  async fetchAppInfo(bundleId) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
-      return (await service.lookupApplications({ bundleIds: bundleId }))[bundleId];
+      return (await service.lookupApplications({bundleIds: bundleId}))[bundleId];
     } finally {
       service.close();
     }
   }
 
-  async terminateApp (bundleId) {
+  async terminateApp(bundleId) {
     let instrumentService;
     let installProxyService;
     try {
@@ -168,13 +187,20 @@ class IOSDeploy {
       const executableName = apps[bundleId].CFBundleExecutable;
       log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
       instrumentService = await services.startInstrumentService(this.udid);
-      const processes = await instrumentService.callChannel(INSTRUMENT_CHANNEL.DEVICE_INFO, 'runningProcesses');
+      const processes = await instrumentService.callChannel(
+        INSTRUMENT_CHANNEL.DEVICE_INFO,
+        'runningProcesses'
+      );
       const process = processes.selector.find((process) => process.name === executableName);
       if (!process) {
         log.info(`The process of the bundle id '${bundleId}' was not running`);
         return false;
       }
-      await instrumentService.callChannel(INSTRUMENT_CHANNEL.PROCESS_CONTROL, 'killPid:', `${process.pid}`);
+      await instrumentService.callChannel(
+        INSTRUMENT_CHANNEL.PROCESS_CONTROL,
+        'killPid:',
+        `${process.pid}`
+      );
       return true;
     } catch (err) {
       log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
@@ -192,25 +218,29 @@ class IOSDeploy {
   /**
    * @param {string} bundleName The name of CFBundleName in Info.plist
    *
-   * @returns {Array<string>} A list of User level apps' bundle ids which has
+   * @returns {Promise<string[]>} A list of User level apps' bundle ids which has
    *                          'CFBundleName' attribute as 'bundleName'.
    */
-  async getUserInstalledBundleIdsByBundleName (bundleName) {
+  async getUserInstalledBundleIdsByBundleName(bundleName) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
       const applications = await service.listApplications({applicationType: 'User'});
-      return _.reduce(applications, (acc, {CFBundleName}, key) => {
-        if (CFBundleName === bundleName) {
-          acc.push(key);
-        }
-        return acc;
-      }, []);
+      return _.reduce(
+        applications,
+        (acc, {CFBundleName}, key) => {
+          if (CFBundleName === bundleName) {
+            acc.push(key);
+          }
+          return acc;
+        },
+        /** @type {string[]} */([])
+      );
     } finally {
       service.close();
     }
   }
 
-  async getPlatformVersion () {
+  async getPlatformVersion() {
     return await utilities.getOSVersion(this.udid);
   }
 }

--- a/lib/ios-fs-helpers.js
+++ b/lib/ios-fs-helpers.js
@@ -12,10 +12,10 @@ const MAX_IO_CHUNK_SIZE = 8;
 /**
  * Retrieve a file from a real device
  *
- * @param {AfcService} afcService Apple File Client service instance from
+ * @param {any} afcService Apple File Client service instance from
  * 'appium-ios-device' module
  * @param {string} remotePath Relative path to the file on the device
- * @returns {Buffer} The file content as a buffer
+ * @returns {Promise<Buffer>} The file content as a buffer
  */
 async function pullFile (afcService, remotePath) {
   const stream = await afcService.createReadStream(remotePath, { autoDestroy: true });
@@ -33,7 +33,7 @@ async function pullFile (afcService, remotePath) {
  * Checks a presence of a local folder.
  *
  * @param {string} folderPath Full path to the local folder
- * @returns {boolean} True if the folder exists and is actually a folder
+ * @returns {Promise<boolean>} True if the folder exists and is actually a folder
  */
 async function folderExists (folderPath) {
   try {
@@ -46,10 +46,10 @@ async function folderExists (folderPath) {
 /**
  * Retrieve a folder from a real device
  *
- * @param {AfcService} afcService Apple File Client service instance from
+ * @param {any} afcService Apple File Client service instance from
  * 'appium-ios-device' module
  * @param {string} remoteRootPath Relative path to the folder on the device
- * @returns {Buffer} The folder content as a zipped base64-encoded buffer
+ * @returns {Promise<Buffer>} The folder content as a zipped base64-encoded buffer
  */
 async function pullFolder (afcService, remoteRootPath) {
   const tmpFolder = await tempDir.openDir();
@@ -118,7 +118,7 @@ async function pullFolder (afcService, remoteRootPath) {
  * Creates remote folder path recursively. Noop if the given path
  * already exists
  *
- * @param {AfcService} afcService Apple File Client service instance from
+ * @param {any} afcService Apple File Client service instance from
  * 'appium-ios-device' module
  * @param {string} remoteRoot The relative path to the remote folder structure
  * to be created
@@ -141,7 +141,7 @@ async function remoteMkdirp (afcService, remoteRoot) {
 /**
  * Pushes a file to a real device
  *
- * @param {AfcService} afcService Apple File Client service instance from
+ * @param {any} afcService Apple File Client service instance from
  * 'appium-ios-device' module
  * @param {string} remotePath Relative path to the file on the device. The remote
  * folder structure is created automatically if necessary.
@@ -171,16 +171,16 @@ async function pushFile (afcService, remotePath, base64Data) {
 /**
  * @typedef {Object} PushFolderOptions
  *
- * @property {number} timeoutMs [240000] The maximum timeout to wait until a
+ * @property {number} [timeoutMs=240000] The maximum timeout to wait until a
  * single file is copied
- * @param {boolean} enableParallelPush [false] Whether to push files in parallel.
+ * @property {boolean} [enableParallelPush=false] Whether to push files in parallel.
  * This usually gives better performance, but might sometimes be less stable.
  */
 
 /**
  * Pushes a folder to a real device
  *
- * @param {AfcService} afcService Apple File Client service instance from
+ * @param {any} afcService Apple File Client service instance from
  * 'appium-ios-device' module
  * @param {string} srcRootPath The full path to the source folder
  * @param {string} dstRootPath The relative path to the destination folder. The folder
@@ -203,7 +203,7 @@ async function pushFolder (afcService, srcRootPath, dstRootPath, opts = {}) {
   const [foldersToPush, filesToPush] = itemsToPush.reduce((acc, x) => {
     acc[_.endsWith(x, path.sep) ? 0 : 1].push(x);
     return acc;
-  }, [[], []]);
+  }, /** @type {[string[], string[]]} */([[], []]));
   log.debug(`Got ${util.pluralize('folder', foldersToPush.length, true)} and ` +
     `${util.pluralize('file', filesToPush.length, true)} to push`);
   // create the folder structure first

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -1,4 +1,4 @@
-export const newMethodMap = /** type {const} */ ({
+export const newMethodMap = /** @type {const} */ ({
   '/session/:sessionId/timeouts/async_script': {
     POST: {
       command: 'asyncScriptTimeout',

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -48,11 +48,11 @@ class Pyidevice {
     log.debug(`Executing ${cmdStr}`);
     try {
       if (asynchronous) {
-        const result = new SubProcess(this.binaryPath, finalArgs, {cwd});
+        const result = new SubProcess(/** @type {string} */(this.binaryPath), finalArgs, {cwd});
         await result.start(0);
         return result;
       }
-      const result = await exec(this.binaryPath, finalArgs, {cwd});
+      const result = await exec(/** @type {string} */(this.binaryPath), finalArgs, {cwd});
       if (logStdout) {
         log.debug(`Command output: ${result.stdout}`);
       }
@@ -63,11 +63,17 @@ class Pyidevice {
   }
 
   async listProfiles () {
-    const {stdout} = await this.execute(['profiles', 'list']);
+    const {stdout} = /** @type {import('teen_process').TeenProcessExecResult} */(await this.execute(['profiles', 'list']));
     return JSON.parse(stdout);
   }
 
-  async installProfile ({profilePath, payload} = {}) {
+  /**
+   *
+   * @param { {profilePath?: string, payload: string|Buffer} } opts
+   * @privateRemarks The error below seems to suggest that `payload` can be undefined, but the code suggests otherwise
+   */
+  async installProfile (opts) {
+    const {profilePath, payload} = opts ?? {};
     if (!profilePath && !payload) {
       throw new Error('Either the full path to the profile or its payload must be provided');
     }
@@ -95,7 +101,7 @@ class Pyidevice {
   }
 
   async listCrashes () {
-    const {stdout} = await this.execute(['crash', 'list']);
+    const {stdout} = /** @type {import('teen_process').TeenProcessExecResult} */(await this.execute(['crash', 'list']));
     return JSON.parse(stdout.replace(/'/g, '"')).filter((x) => !['.', '..'].includes(x));
   }
 

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -56,18 +56,18 @@ async function runRealDeviceReset (device, opts) {
 /**
  * @typedef {Object} InstallOptions
  *
- * @property {boolean?} skipUninstall Whether to skip app uninstall before installing it
- * @property {string} strategy [serial] One of possible install strategies ('serial', 'parallel', 'ios-deploy')
- * @property {number?} timeout App install timeout
+ * @property {boolean} [skipUninstall] Whether to skip app uninstall before installing it
+ * @property {'serial'|'parallel'|'ios-deploy'} [strategy='serial'] One of possible install strategies ('serial', 'parallel', 'ios-deploy')
+ * @property {number} [timeout] App install timeout
  */
 
 /**
  * @param {IOSDeploy} device The device instance
- * @param {string?} app The app to the path
- * @param {string?} bundleId The bundle id to ensure it is already installed and uninstall it
- * @param {InstallOptions?} opts
+ * @param {string} [app] The app to the path
+ * @param {string} [bundleId] The bundle id to ensure it is already installed and uninstall it
+ * @param {InstallOptions} [opts]
  */
-async function installToRealDevice (device, app, bundleId, opts = {}) {
+async function installToRealDevice (device, app, bundleId, opts) {
   if (!device.udid || !app) {
     log.debug('No device id or app, not installing to real device.');
     return;
@@ -77,7 +77,7 @@ async function installToRealDevice (device, app, bundleId, opts = {}) {
     skipUninstall,
     strategy,
     timeout,
-  } = opts;
+  } = opts ?? {};
 
   if (!skipUninstall && bundleId && await device.isAppInstalled(bundleId)) {
     log.debug(`Reset requested. Removing app with id '${bundleId}' from the device`);

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -8,7 +8,7 @@ import { PLATFORM_NAME_IOS } from './desired-caps';
 
 
 const APPIUM_SIM_PREFIX = 'appiumTest';
-const SAFARI_OPTS_ALIASES_MAP = {
+const SAFARI_OPTS_ALIASES_MAP = /** @type {const} */({
   safariAllowPopups: [
     ['WebKitJavaScriptCanOpenWindowsAutomatically', 'JavaScriptCanOpenWindowsAutomatically'],
     (x) => Number(Boolean(x)),
@@ -21,7 +21,7 @@ const SAFARI_OPTS_ALIASES_MAP = {
     ['OpenLinksInBackground'],
     (x) => Number(Boolean(x)),
   ]
-};
+});
 
 /**
  * Capability set by a user
@@ -32,9 +32,9 @@ const SAFARI_OPTS_ALIASES_MAP = {
 /**
  * Create a new simulator with `appiumTest-` prefix and return the object.
  *
- * @param {object} SimCreationCaps - Capability set by a user. The options available are:
+ * @param {object} caps - Capability set by a user. The options available are:
  * @property {string} platform [iOS] - Platform name in order to specify runtime such as 'iOS', 'tvOS', 'watchOS'
- * @returns {object} Simulator object associated with the udid passed in.
+ * @returns {Promise<object>} Simulator object associated with the udid passed in.
  */
 async function createSim (caps, platform = PLATFORM_NAME_IOS) {
   const devicesSetPath = caps.simulatorDevicesSetPath;
@@ -53,18 +53,18 @@ async function createSim (caps, platform = PLATFORM_NAME_IOS) {
 
 /**
  * @typedef {Object} SimulatorLookupOptions
- * @property {string?} deviceName - The name of the device to lookup
- * @property {string!} platformVersion - The platform version string
- * @property {string?} simulatorDevicesSetPath - The full path to the simulator devices set
+ * @property {string} [deviceName] - The name of the device to lookup
+ * @property {string} platformVersion - The platform version string
+ * @property {string} [simulatorDevicesSetPath] - The full path to the simulator devices set
  */
 
 /**
  * Get a simulator which is already running.
  *
- * @param {SimulatorLookupOptions?} opts
- * @returns {Simulator?} The matched Simulator instance or `null` if no matching  device is found.
+ * @param {SimulatorLookupOptions} opts
+ * @returns {Promise<any|null>} The matched Simulator instance or `null` if no matching  device is found.
  */
-async function getExistingSim (opts = {}) {
+async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({})) {
   const {
     platformVersion,
     deviceName,
@@ -183,17 +183,17 @@ async function runSimulatorReset (device, opts) {
 /**
  * @typedef {Object} InstallOptions
  *
- * @property {boolean?} skipUninstall Whether to skip app uninstall before installing it
- * @property {boolean?} newSimulator [false] Whether the simulator is brand new
+ * @property {boolean} [skipUninstall] Whether to skip app uninstall before installing it
+ * @property {boolean} [newSimulator=false] Whether the simulator is brand new
  */
 
 /**
- * @param {Object} device The simulator device object
- * @param {string?} app The app to the path
- * @param {string?} bundleId The bundle id to ensure it is already installed and uninstall it
- * @param {InstallOptions?} opts
+ * @param {any} device The simulator device object
+ * @param {string} app The app to the path
+ * @param {string} [bundleId] The bundle id to ensure it is already installed and uninstall it
+ * @param {InstallOptions} opts
  */
-async function installToSimulator (device, app, bundleId, opts = {}) {
+async function installToSimulator (device, app, bundleId, opts = /** @type {InstallOptions} */({})) {
   if (!app) {
     log.debug('No app path is given. Nothing to install.');
     return;
@@ -245,9 +245,9 @@ async function shutdownOtherSimulators (currentDevice) {
 /**
  * Configures Safari options based on the given session capabilities
  *
- * @param {*} sim Simulator instance
+ * @param {any} sim Simulator instance
  * @param {object} opts Session capabilities
- * @return {boolean} true if any preferences have been updated
+ * @return {Promise<boolean>} true if any preferences have been updated
  */
 async function setSafariPrefs (sim, opts = {}) {
   const safariSettings = _.cloneDeep(opts.safariGlobalPreferences ?? {});
@@ -273,9 +273,9 @@ async function setSafariPrefs (sim, opts = {}) {
 /**
  * Changes Simulator localization preferences
  *
- * @param {*} sim Simulator instance
+ * @param {any} sim Simulator instance
  * @param {object} opts Session capabilities
- * @returns {boolean} True if preferences were changed
+ * @returns {Promise<boolean>} True if preferences were changed
  */
 async function setLocalizationPrefs (sim, opts = {}) {
   const {

--- a/lib/stubs.ts
+++ b/lib/stubs.ts
@@ -1,0 +1,2 @@
+declare module 'appium-ios-device';
+declare module 'appium-xcode';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,32 @@
+export interface Page {
+  id: number | string;
+  isKey?: boolean;
+  url: string;
+}
+
+export interface AsyncPromise {
+  resolve: (value: any) => void;
+  reject: (reason: any) => void;
+}
+
+export interface LifecycleData {
+  createSim?: boolean;
+}
+
+/**
+ * All of these options are manually added to the `opts` property of the driver, which is strongly discouraged.
+ *
+ * Future versions of this driver should move these properties somewhere else.
+ */
+export type CustomOpts = {
+  device: any;
+  realDevice: any;
+  SimulatorWindowCenter: any;
+  forceSimulatorSoftwareKeyboardPresence: any;
+  iosSdkVersion: string;
+  platformVersion: string;
+  safari: any;
+  sessionId: string | null;
+  elementResponseAttributes: any;
+};
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,7 @@ function getGenericSimulatorForIosVersion (platformVersion, deviceName) {
   let result = null;
   const compareVersions = ([simOne], [simTwo]) => util.compareVersions(simOne, '<', simTwo) ? -1 : 1;
   for (const [platformVersionFromList, iosSimulator] of genericSimulators.sort(compareVersions)) {
-    if (util.compareVersions(platformVersionFromList, '>', platformVersion)) {
+    if (util.compareVersions(platformVersionFromList, '>', String(platformVersion))) {
       break;
     }
     result = iosSimulator;
@@ -226,7 +226,7 @@ async function getDriverInfo () {
 
   // get the package.json and the version from it
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const pkg = require(__filename.includes('build/lib/utils') ? '../../package.json' : '../package.json');
+  const pkg = fs.readPackageJsonFrom(fs.findRoot(__filename));
   const version = pkg.version;
 
   return {
@@ -243,7 +243,7 @@ function normalizeCommandTimeouts (value) {
 
   let result = {};
   // Use as default timeout for all commands if a single integer value is provided
-  if (!isNaN(value)) {
+  if (!isNaN(Number(value))) {
     result[DEFAULT_TIMEOUT_KEY] = _.toInteger(value);
     return result;
   }
@@ -285,7 +285,7 @@ async function printUser () {
  *                                    listening on given port, and is expected to return
  *                                    either true or false to include/exclude the corresponding PID
  *                                    from the resulting array.
- * @returns {Array<string>} - the list of matched process ids.
+ * @returns {Promise<string[]>} - the list of matched process ids.
  */
 async function getPIDsListeningOnPort (port, filteringFunc = null) {
   const result = [];
@@ -309,14 +309,14 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
 /**
  * @typedef {Object} UploadOptions
  *
- * @property {?string} user - The name of the user for the remote authentication. Only works if `remotePath` is provided.
- * @property {?string} pass - The password for the remote authentication. Only works if `remotePath` is provided.
- * @property {?string} method - The http multipart upload method name. The 'PUT' one is used by default.
+ * @property {string} [user] - The name of the user for the remote authentication. Only works if `remotePath` is provided.
+ * @property {string} [pass] - The password for the remote authentication. Only works if `remotePath` is provided.
+ * @property {import('axios').Method} [method] - The http multipart upload method name. The 'PUT' one is used by default.
  *                              Only works if `remotePath` is provided.
- * @property {?Object} headers - Additional headers mapping for multipart http(s) uploads
- * @property {?string} fileFieldName [file] - The name of the form field, where the file content BLOB should be stored for
+ * @property {import('@appium/types').HTTPHeaders} [headers] - Additional headers mapping for multipart http(s) uploads
+ * @property {string} [fileFieldName] [file] - The name of the form field, where the file content BLOB should be stored for
  *                                            http(s) uploads
- * @property {?Object|Array<Pair>} formFields - Additional form fields for multipart http(s) uploads
+ * @property {Record<string, any> | [string, any][]} [formFields] - Additional form fields for multipart http(s) uploads
  */
 
 
@@ -326,9 +326,9 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
  * if `remotePath` is set
  *
  * @param {string} localPath - The path to an existing local file
- * @param {?string} remotePath - The path to the remote location, where
+ * @param {string|null} [remotePath] - The path to the remote location, where
  *                               this file should be uploaded
- * @param {?UploadOptions} uploadOptions - Set of upload options
+ * @param {UploadOptions} uploadOptions - Set of upload options
  * @returns {Promise<string>} Either an empty string if the upload was successful or
  * base64-encoded file representation if `remotePath` is falsy
  */
@@ -353,7 +353,7 @@ async function encodeBase64OrUpload (localPath, remotePath = null, uploadOptions
   if (user && pass) {
     options.auth = {user, pass};
   }
-  await net.uploadFile(localPath, remotePath, options);
+  await net.uploadFile(localPath, /** @type {string} */(remotePath), options);
   return '';
 }
 
@@ -363,7 +363,7 @@ async function encodeBase64OrUpload (localPath, remotePath = null, uploadOptions
  *
  * @param {Object} server - The instance of NodeJs HTTP server,
  * which hosts Appium
- * @param {string} sessionId - The id of the current session
+ * @param {string|null} sessionId - The id of the current session
  */
 async function removeAllSessionWebSocketHandlers (server, sessionId) {
   if (!server || !_.isFunction(server.getWebSocketHandlers)) {
@@ -378,12 +378,12 @@ async function removeAllSessionWebSocketHandlers (server, sessionId) {
 
 /**
  * Returns true if the urlString is localhost
- * @param {?string} urlString
+ * @param {string} urlString
  * @returns {boolean} Return true if the urlString is localhost
  */
 function isLocalHost (urlString) {
   try {
-    const {hostname} = url.parse(urlString);
+    const hostname = /** @type {string} */(url.parse(urlString).hostname);
     return ['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(hostname);
   } catch (ign) {
     log.warn(`'${urlString}' cannot be parsed as a valid URL`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-xcuitest-driver",
-  "version": "4.21.25",
+  "version": "4.21.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-xcuitest-driver",
-      "version": "4.21.25",
+      "version": "4.21.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "0.8.7",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "e2e-test:long": "mocha \"./test/functional/long\" --exit --timeout 10m",
     "e2e-test:parallel": "mocha \"./test/functional/parallel\" --exit --timeout 10m",
     "e2e-test:web": "mocha \"./test/functional/web\" --exit --timeout 10m",
-    "e2e-test:native-web-tap": "mocha \"./test/functional/web/safari-nativewebtap-e2e-specs.js\" --exit --timeout 10m"
+    "e2e-test:native-web-tap": "mocha \"./test/functional/web/safari-nativewebtap-e2e-specs.js\" --exit --timeout 10m",
+    "start": "appium --relaxed-security --port 4567 --keep-alive-timeout 1200"
   },
   "lint-staged": {
     "*.(js|ts)": [

--- a/test/functional/basic/face-id-e2e-specs.js
+++ b/test/functional/basic/face-id-e2e-specs.js
@@ -1,4 +1,3 @@
-// transpile:mocha
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/test/functional/basic/touch-id-e2e-specs.js
+++ b/test/functional/basic/touch-id-e2e-specs.js
@@ -1,4 +1,3 @@
-// transpile:mocha
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -5,9 +5,10 @@ import { util, node } from 'appium/support';
 
 // translate integer environment variable to a boolean 0=false, !0=true
 function checkFeatureInEnv (envArg) {
-  let feature = parseInt(process.env[envArg], 10);
+  /** @type {string|number} */
+  let feature = parseInt(String(process.env[envArg]), 10);
   if (isNaN(feature)) {
-    feature = process.env[envArg];
+    feature = String(process.env[envArg]);
   }
   return !!feature;
 }

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -2,7 +2,7 @@ import { remote } from 'webdriverio';
 import { extractCapabilityValue } from '../desired';
 
 const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
-const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT, 10) || 4567;
+const PORT = parseInt(String(process.env.APPIUM_TEST_SERVER_PORT), 10) || 4567;
 // on CI the timeout needs to be long, mostly so WDA can be built the first time
 const MOCHA_TIMEOUT = 60 * 1000 * (process.env.CI ? 16 : 4);
 
@@ -26,7 +26,9 @@ async function initSession (caps, remoteOpts = {}) {
     didBuildWda = false;
     throw e;
   }
+  // @ts-expect-error private API, apparently
   driver.name = undefined;
+  // @ts-expect-error private API, apparently
   driver.errored = false;
   return driver;
 }

--- a/test/functional/long/typing-stress-e2e-specs.js
+++ b/test/functional/long/typing-stress-e2e-specs.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { UICATALOG_CAPS, amendCapabilities } from '../desired';
@@ -15,6 +17,7 @@ const TYPING_TRIES = process.env.CI ? 100 : 10;
 describe('XCUITestDriver - long tests', function () {
   this.timeout(0);
 
+  /** @type {import('webdriverio').Browser} */
   let driver;
   before(async function () {
     const caps = amendCapabilities(UICATALOG_CAPS, { 'appium:maxTypingFrequency': 20 });

--- a/test/functional/tv/tvos-e2e-specs.js
+++ b/test/functional/tv/tvos-e2e-specs.js
@@ -49,6 +49,7 @@ describe('tvOS', function () {
   it('should launch com.apple.TVSettings', async function () {
     baseCaps.autoLaunch = true;
     const driver = await initSession(baseCaps);
+    // @ts-expect-error does this exist? I guess it does?
     (await driver.elementByAccessibilityId('General')).should.exist;
   });
 
@@ -56,6 +57,7 @@ describe('tvOS', function () {
     baseCaps.autoLaunch = false;
     const driver = await initSession(baseCaps);
     await driver.execute('mobile: activateApp', {bundleId: 'com.apple.TVSettings'});
+    // @ts-expect-error does this exist? I guess it does?
     (await driver.elementByAccessibilityId('General')).should.exist;
   });
 });

--- a/test/functional/web/helpers.js
+++ b/test/functional/web/helpers.js
@@ -65,7 +65,7 @@ async function spinTitleNotEquals (driver, wrongTitle, tries = 10, interval = 50
 }
 
 async function spinWait (fn, waitMs = 10000, intMs = 500) {
-  const tries = parseInt(waitMs / intMs, 10);
+  const tries = parseInt(String(waitMs / intMs), 10);
   await retryInterval(tries, intMs, fn);
 }
 

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -406,7 +406,7 @@ describe('Safari - basics -', function () {
 
           it('should be able to set a cookie with expiry', async function () {
             const expiredCookie = Object.assign({}, newCookie, {
-              expiry: parseInt(Date.now() / 1000, 10) - 1000, // set cookie in past
+              expiry: parseInt(String(Date.now() / 1000), 10) - 1000, // set cookie in past
               name: 'expiredcookie',
             });
 

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -22,7 +22,7 @@ describe('Safari SSL', function () {
 
   /** @type {import('node:https').Server} */
   let sslServer;
-  /** @type {import('webdriverio').Browser<'async'>} */
+  /** @type {import('webdriverio').Browser} */
   let driver;
   /** @type {string} */
   let localHttpsUrl;

--- a/test/unit/commands/alert-specs.js
+++ b/test/unit/commands/alert-specs.js
@@ -75,8 +75,8 @@ describe('alert commands', function () {
 
     it('should send get alert buttons request to WDA', async function () {
       const buttonLabel = 'OK';
-      proxySpy.returns({value: [buttonLabel], sessionId: '05869B62-C559-43AD-A343-BAACAAE00CBB', status: 0});
-      const response = await driver.execute(`mobile: ${commandName}`, {action: 'getButtons'});
+      proxySpy.resolves({value: [buttonLabel], sessionId: '05869B62-C559-43AD-A343-BAACAAE00CBB', status: 0});
+      const response = /** @type { {value: string[]} } */(await driver.execute(`mobile: ${commandName}`, {action: 'getButtons'}));
       proxySpy.calledOnce.should.be.true;
       proxySpy.firstCall.args[0].should.eql('/wda/alert/buttons');
       proxySpy.firstCall.args[1].should.eql('GET');

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -37,7 +37,8 @@ describe('context', function () {
       let driver = new XCUITestDriver();
       driver.curContext = '5191.5';
       driver.contexts = ['5191.5', '5191.3', '5191.4'];
-      let selectPageArgs = null;
+      /** @type {undefined|(string|number)[]} */
+      let selectPageArgs;
       const remoteMock = {
         isConnected: true,
         selectPage: (...args) => {
@@ -48,7 +49,7 @@ describe('context', function () {
       driver.remote = remoteMock;
       driver.opts.safariIgnoreWebHostnames = 'www.google.com, www.bing.com,yahoo.com, about:blank, ';
       await driver.onPageChange(pageChangeNotification);
-      selectPageArgs.should.eql(['5191', 1]);
+      /** @type {(string|number)[]} */(selectPageArgs).should.eql(['5191', 1]);
     });
     it('should not call selectPage if a new page is introduced and that page is blacklisted', async function () {
       let driver = new XCUITestDriver();

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -38,8 +38,8 @@ describe('element commands', function () {
     });
 
     it('should call setValue', async function () {
-      await driver.setValueImmediate('hello', 2);
-      driver.setValue.should.have.been.calledOnceWithExactly('hello', 2);
+      await driver.setValueImmediate('hello', '2');
+      driver.setValue.should.have.been.calledOnceWithExactly('hello', '2');
       driver.setValue.should.have.returned(undefined);
     });
   });
@@ -295,7 +295,7 @@ describe('element commands', function () {
     /** @type {XCUITestDriver} */
     let driver;
 
-    const webEl = {ELEMENT: '5000'};
+    const webEl = {ELEMENT: '5000', 'element-6066-11e4-a52e-4f735466cecf': '5000'};
     const fixtureXOffset = 100;
     const fixtureYOffset = 200;
 

--- a/test/unit/commands/file-movement-specs.js
+++ b/test/unit/commands/file-movement-specs.js
@@ -14,7 +14,7 @@ describe('file-movement', function () {
 
       bundleId.should.eql('io.appium.example');
       pathInContainer.should.eql(`${mntRoot}/Documents/file.txt`);
-      containerType.should.eql('app');
+      /** @type {string} */(containerType).should.eql('app');
     });
     it('should parse with container root', async function () {
       const mntRoot = await tempDir.openDir();
@@ -22,7 +22,7 @@ describe('file-movement', function () {
 
       bundleId.should.eql('io.appium.example');
       pathInContainer.should.eql(mntRoot);
-      containerType.should.eql('documents');
+      /** @type {string} */(containerType).should.eql('documents');
     });
     it('should parse without container', async function () {
       const mntRoot = await tempDir.openDir();

--- a/test/unit/commands/find-specs.js
+++ b/test/unit/commands/find-specs.js
@@ -12,6 +12,14 @@ describe('general commands', function () {
 
   describe('findNativeElementOrElements', function () {
 
+    /**
+     *
+     * @param {string} strategy
+     * @param {string} selector
+     * @param {string} modSelector
+     * @param {string|null} modStrategy
+     * @param {boolean} mult
+     */
     async function verifyFind (strategy, selector, modSelector, modStrategy = null, mult = false) {
       try {
         await driver.findNativeElementOrElements(strategy, selector, mult);
@@ -84,14 +92,14 @@ describe('general commands', function () {
           '/element/ctx/element',
           'POST',
           {using: 'class chain', value: '*[1]'}
-        ).returns({ELEMENT: 1});
+        ).resolves({ELEMENT: 1});
         proxySpy.withArgs(
           '/element/ctx/element',
           'POST',
           {using: 'class chain', value: '*[2]'}
-        ).returns({ELEMENT: 2});
-        attribSpy.withArgs('visible', {ELEMENT: 1}).returns('false');
-        attribSpy.withArgs('visible', {ELEMENT: 2}).returns('true');
+        ).resolves({ELEMENT: 2});
+        attribSpy.withArgs('visible', {ELEMENT: 1}).resolves('false');
+        attribSpy.withArgs('visible', {ELEMENT: 2}).resolves('true');
         let el = await driver.findNativeElementOrElements('xpath',
           variant, false, {ELEMENT: 'ctx'});
         proxySpy.calledTwice.should.be.true;

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -1,6 +1,9 @@
 import sinon from 'sinon';
 import _ from 'lodash';
 import XCUITestDriver from '../../../lib/driver';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
 
 
 describe('general commands', function () {
@@ -27,7 +30,7 @@ describe('general commands', function () {
     });
 
     it('should switch to home screen if seconds is null', async function () {
-      await driver.background(null);
+      await driver.background();
       proxyStub.calledOnce.should.be.true;
       proxyStub.firstCall.args[0].should.eql('/wda/homescreen');
       proxyStub.firstCall.args[1].should.eql('POST');
@@ -35,74 +38,83 @@ describe('general commands', function () {
   });
 
   describe('touch id', function () {
-    let deviceStub;
-    let sendBiometricMatchSpy;
+    /** @type {import('sinon').SinonSandbox} */
+    let sandbox;
+
+    /** @type { {sendBiometricMatch: import('sinon').SinonStub} } */
+    let device;
 
     beforeEach(function () {
-      deviceStub = sinon.mock(driver.opts, 'device');
-      deviceStub.object.device = {
-        sendBiometricMatch: () => {},
+      sandbox = sinon.createSandbox();
+      // @ts-expect-error random stuff on opts again
+      driver.opts.device = device = {
+        sendBiometricMatch: sandbox.stub()
       };
-      sendBiometricMatchSpy = sinon.spy(driver.opts.device, 'sendBiometricMatch');
-      deviceStub.object.realDevice = false;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.realDevice = false;
     });
 
     afterEach(function () {
-      deviceStub.restore();
-      sendBiometricMatchSpy.restore();
+      sandbox.restore();
     });
 
     it('should send default request to Simulator', async function () {
       await driver.touchId();
-      sendBiometricMatchSpy.calledOnce.should.be.true;
-      sendBiometricMatchSpy.firstCall.args[0].should.eql(true);
-      sendBiometricMatchSpy.firstCall.args[1].should.eql('touchId');
+      device.sendBiometricMatch.should.have.been.calledOnceWith(true, 'touchId');
     });
 
     it('should send request to Simulator with false', async function () {
       await driver.touchId(false);
-      sendBiometricMatchSpy.calledOnce.should.be.true;
-      sendBiometricMatchSpy.firstCall.args[0].should.eql(false);
-      sendBiometricMatchSpy.firstCall.args[1].should.eql('touchId');
+      device.sendBiometricMatch.should.have.been.calledOnceWith(false, 'touchId');
     });
 
     it('should not be called on a real device', async function () {
-      deviceStub.object.realDevice = true;
+      // deviceStub.object.realDevice = true;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.realDevice = true;
       await driver.touchId().should.be.rejected;
-      sendBiometricMatchSpy.notCalled.should.be.true;
+      device.sendBiometricMatch.should.not.have.been.called;
+      // sendBiometricMatchSpy.notCalled.should.be.true;
     });
   });
 
   describe('toggleEnrollTouchID', function () {
-    let deviceStub, enrollBiometricSpy, optsStub;
+      /** @type {import('sinon').SinonSandbox} */
+      let sandbox;
+
+      /** @type { {enrollBiometric: import('sinon').SinonStub} } */
+      let device;
 
     beforeEach(function () {
-      optsStub = sinon.mock(driver.opts);
-      deviceStub = sinon.mock(driver.opts, 'device');
-      deviceStub.object.device = {
-        enrollBiometric: () => {},
+      sandbox = sinon.createSandbox();
+      // @ts-expect-error random stuff on opts again
+      driver.opts.device = device = {
+        enrollBiometric: sandbox.stub()
       };
-      enrollBiometricSpy = sinon.spy(driver.opts.device, 'enrollBiometric');
+      // @ts-expect-error random stuff on opts again
+      driver.opts.realDevice = false;
     });
 
     afterEach(function () {
-      deviceStub.restore();
-      optsStub.restore();
-      enrollBiometricSpy.restore();
+      sandbox.restore();
     });
 
     it('should be called on a Simulator', async function () {
-      deviceStub.object.realDevice = false;
-      deviceStub.object.allowTouchIdEnroll = true;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.realDevice = false;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.allowTouchIdEnroll = true;
       await driver.toggleEnrollTouchId();
-      enrollBiometricSpy.calledOnce.should.be.true;
+      device.enrollBiometric.should.have.been.calledOnce;
     });
 
     it('should not be called on a real device', async function () {
-      deviceStub.object.realDevice = true;
-      deviceStub.object.allowTouchIdEnroll = true;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.realDevice = true;
+      // @ts-expect-error random stuff on opts again
+      driver.opts.allowTouchIdEnroll = true;
       await driver.toggleEnrollTouchId().should.be.rejected;
-      enrollBiometricSpy.notCalled.should.be.true;
+      device.enrollBiometric.should.not.have.been.called;
     });
   });
 
@@ -110,7 +122,7 @@ describe('general commands', function () {
     it('should be able to get the current window size with Rect', async function () {
       proxyStub
         .withArgs('/window/size', 'GET')
-        .returns({width: 100, height: 20});
+        .resolves({width: 100, height: 20});
 
       await driver.getWindowRect();
       proxyStub.calledOnce.should.be.true;
@@ -170,7 +182,7 @@ describe('general commands', function () {
     beforeEach(function () {
       proxyStub
         .withArgs('/wda/screen', 'GET')
-        .returns({
+        .resolves({
           statusBarSize: {
             width: 100,
             height: 20,

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -1,10 +1,10 @@
 import sinon from 'sinon';
 import _ from 'lodash';
 import XCUITestDriver from '../../../lib/driver';
+import chai from 'chai';
 import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
-
 
 describe('general commands', function () {
   const driver = new XCUITestDriver();
@@ -48,7 +48,7 @@ describe('general commands', function () {
       sandbox = sinon.createSandbox();
       // @ts-expect-error random stuff on opts again
       driver.opts.device = device = {
-        sendBiometricMatch: sandbox.stub()
+        sendBiometricMatch: sandbox.stub(),
       };
       // @ts-expect-error random stuff on opts again
       driver.opts.realDevice = false;
@@ -79,17 +79,17 @@ describe('general commands', function () {
   });
 
   describe('toggleEnrollTouchID', function () {
-      /** @type {import('sinon').SinonSandbox} */
-      let sandbox;
+    /** @type {import('sinon').SinonSandbox} */
+    let sandbox;
 
-      /** @type { {enrollBiometric: import('sinon').SinonStub} } */
-      let device;
+    /** @type { {enrollBiometric: import('sinon').SinonStub} } */
+    let device;
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
       // @ts-expect-error random stuff on opts again
       driver.opts.device = device = {
-        enrollBiometric: sandbox.stub()
+        enrollBiometric: sandbox.stub(),
       };
       // @ts-expect-error random stuff on opts again
       driver.opts.realDevice = false;
@@ -120,9 +120,7 @@ describe('general commands', function () {
 
   describe('window size', function () {
     it('should be able to get the current window size with Rect', async function () {
-      proxyStub
-        .withArgs('/window/size', 'GET')
-        .resolves({width: 100, height: 20});
+      proxyStub.withArgs('/window/size', 'GET').resolves({width: 100, height: 20});
 
       await driver.getWindowRect();
       proxyStub.calledOnce.should.be.true;
@@ -139,8 +137,8 @@ describe('general commands', function () {
       alwaysMatch: {
         platformName: 'iOS',
         'appium:deviceName': 'bar',
-        'appium:app': '/fake'
-      }
+        'appium:app': '/fake',
+      },
     };
 
     beforeEach(function () {
@@ -159,11 +157,15 @@ describe('general commands', function () {
 
     it('should default to value sent in caps after session starts', async function () {
       (await driver.getSettings()).nativeWebTap.should.eql(false);
-      await driver.createSession(null, null, _.merge({}, baseCaps, {
-        alwaysMatch: {
-          'appium:nativeWebTap': true,
-        }
-      }));
+      await driver.createSession(
+        null,
+        null,
+        _.merge({}, baseCaps, {
+          alwaysMatch: {
+            'appium:nativeWebTap': true,
+          },
+        })
+      );
       (await driver.getSettings()).nativeWebTap.should.eql(true);
     });
 
@@ -180,15 +182,13 @@ describe('general commands', function () {
 
   describe('getDevicePixelRatio and getStatusBarHeight', function () {
     beforeEach(function () {
-      proxyStub
-        .withArgs('/wda/screen', 'GET')
-        .resolves({
-          statusBarSize: {
-            width: 100,
-            height: 20,
-          },
-          scale: 3,
-        });
+      proxyStub.withArgs('/wda/screen', 'GET').resolves({
+        statusBarSize: {
+          width: 100,
+          height: 20,
+        },
+        scale: 3,
+      });
     });
 
     it('should get the pixel ratio from WDA', async function () {

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -138,9 +138,9 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {element: 4, scale: 4.1})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {element: 4, velocity: -0.5})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
       });
 
       it('should throw an error if param is invalid', async function () {
@@ -164,9 +164,9 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {x: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/"y" parameter should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {y: 200})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/"x" parameter should be a valid number/);
       });
 
       it('should throw an error if param is invalid', async function () {
@@ -208,11 +208,11 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {duration: 100, x: 1})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/"y" parameter should be a valid number/);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, y: 200})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/"x" parameter should be a valid number/i);
         await driver.execute(`mobile: ${commandName}`, {x: 100, y: 200})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
       });
 
       it('should throw an error if param is invalid', async function () {
@@ -246,11 +246,11 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {x: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {y: 200})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
       });
 
       it('should throw an error if param is invalid', async function () {
@@ -282,11 +282,11 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {})
-          .should.be.rejectedWith(/Element id is expected to be set/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {element: 4})
-          .should.be.rejectedWith(/is expected to be equal/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {order: 'next'})
-          .should.be.rejectedWith(/Element id is expected to be set/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
       });
 
       it('should throw an error if offset value cannot be parsed', async function () {
@@ -314,15 +314,15 @@ describe('gesture commands', function () {
 
       it('should throw an error if no mandatory parameter is specified', async function () {
         await driver.execute(`mobile: ${commandName}`, {fromX: 1, fromY: 1, toX: 100, toY: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromY: 1, toX: 100, toY: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, toX: 100, toY: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toY: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
         await driver.execute(`mobile: ${commandName}`, {duration: 100, fromX: 1, fromY: 1, toX: 100})
-          .should.be.rejectedWith(/parameter is mandatory/);
+          .should.be.rejectedWith(/parameters were incorrect/i);
       });
 
       it('should throw an error if param is invalid', async function () {

--- a/test/unit/commands/location-specs.js
+++ b/test/unit/commands/location-specs.js
@@ -16,16 +16,16 @@ describe('location commands', function () {
     it('should be authorizationStatus !== 3', async function () {
       proxySpy.withArgs(
         '/wda/device/location',
-        'GET').returns({authorizationStatus: 0, latitude: 0, longitude: 0});
+        'GET').resolves({authorizationStatus: 0, latitude: 0, longitude: 0});
 
-      await driver.getGeoLocation({})
+      await driver.getGeoLocation()
         .should.be.rejectedWith('Location service must be');
     });
 
     it('should be authorizationStatus === 3', async function () {
       proxySpy.withArgs(
         '/wda/device/location',
-        'GET').returns(
+        'GET').resolves(
           {
             authorizationStatus: 3,
             latitude: -100.395050048828125,
@@ -33,7 +33,7 @@ describe('location commands', function () {
             altitude: 26.267269134521484
           });
 
-      await driver.getGeoLocation({})
+      await driver.getGeoLocation()
         .should.eventually.eql({
           altitude: 26.267269134521484,
           latitude: -100.395050048828125,
@@ -66,6 +66,7 @@ describe('location commands', function () {
     describe('on real device', function () {
       beforeEach(function () {
         driver.opts.udid = udid;
+        // @ts-expect-error do not put random stuff on opts
         driver.opts.realDevice = true;
       });
 
@@ -89,9 +90,11 @@ describe('location commands', function () {
     describe('on simulator', function () {
       let deviceSetLocationSpy;
       beforeEach(function () {
+        // @ts-expect-error do not put random stuff on opts
         driver.opts.realDevice = false;
 
         deviceSetLocationSpy = sinon.spy();
+        // @ts-expect-error do not put random stuff on opts
         driver.opts.device = {
           setGeolocation: deviceSetLocationSpy,
         };
@@ -100,6 +103,7 @@ describe('location commands', function () {
         deviceSetLocationSpy.resetHistory();
       });
       it('should set string coordinates', async function () {
+        // @ts-expect-error this API accepts strings, but this is undocumented
         await driver.setGeoLocation({latitude: '1.234', longitude: '2.789'});
         deviceSetLocationSpy.firstCall.args[0].should.eql('1.234');
         deviceSetLocationSpy.firstCall.args[1].should.eql('2.789');

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -51,14 +51,12 @@ describe('pasteboard commands', function () {
     });
 
     it('setPasteboard should invoke correct simctl method', async function () {
-      const opts = {
-        content: 'bla',
-        encoding: 'latin1',
-      };
-      await driver.mobileSetPasteboard(opts);
+      const content = 'bla';
+      const encoding = 'latin1';
+      await driver.mobileSetPasteboard(content, encoding);
       setPasteboardStub.calledOnce.should.be.true;
-      setPasteboardStub.firstCall.args[0].should.eql(opts.content);
-      setPasteboardStub.firstCall.args[1].should.eql(opts.encoding);
+      setPasteboardStub.firstCall.args[0].should.eql(content);
+      setPasteboardStub.firstCall.args[1].should.eql(encoding);
     });
 
     it('getPasteboard should invoke correct simctl method', async function () {

--- a/test/unit/commands/pasteboard-specs.js
+++ b/test/unit/commands/pasteboard-specs.js
@@ -6,6 +6,7 @@ import Simctl from 'node-simctl';
 describe('pasteboard commands', function () {
   const driver = new XCUITestDriver();
   driver.opts = {
+    // @ts-expect-error do not put random stuff on opts object
     device: {
       simctl: new Simctl(),
     }
@@ -30,6 +31,7 @@ describe('pasteboard commands', function () {
     });
 
     it('setPasteboard should not be called', async function () {
+      // @ts-expect-error incorrect usage
       await driver.mobileSetPasteboard({content: 'bla'}).should.be.rejectedWith(/not supported/);
       setPasteboardStub.notCalled.should.be.true;
     });
@@ -46,6 +48,7 @@ describe('pasteboard commands', function () {
     });
 
     it('setPasteboard should fail if no content is provided', async function () {
+      // @ts-expect-error incorrect usage
       await driver.mobileSetPasteboard().should.be.rejectedWith(/mandatory to set/);
       setPasteboardStub.notCalled.should.be.true;
     });

--- a/test/unit/commands/proxy-helper-specs.js
+++ b/test/unit/commands/proxy-helper-specs.js
@@ -31,10 +31,12 @@ describe('proxy commands', function () {
       proxyStub.firstCall.args[2].some.should.eql('stuff');
     });
     it('should throw an error if no endpoint is given', async function () {
+      // @ts-expect-error incorrect usage
       await driver.proxyCommand(null, 'POST', {some: 'stuff'}).should.be.rejectedWith(/endpoint/);
       proxyStub.callCount.should.eql(0);
     });
     it('should throw an error if no method is given', async function () {
+      // @ts-expect-error incorrect usage
       await driver.proxyCommand('/some/endpoint', null, {some: 'stuff'}).should.be.rejectedWith(/GET, POST/);
       proxyStub.callCount.should.eql(0);
     });

--- a/test/unit/commands/screenshots-specs.js
+++ b/test/unit/commands/screenshots-specs.js
@@ -12,6 +12,7 @@ describe('screenshots commands', function () {
   beforeEach(function () {
     driver = new XCUITestDriver();
     driver.opts = {
+      // @ts-expect-error do not put random stuff on opts object
       device: {
         simctl: new Simctl(),
       }

--- a/test/unit/commands/session-specs.js
+++ b/test/unit/commands/session-specs.js
@@ -40,7 +40,7 @@ describe('session commands', function () {
 
   describe('getSession', function () {
     it('should merge caps with WDA response', async function () {
-      driver.caps = { ...driver.caps, platformName: 'iOS', app: 'NOTLOL.app' };
+      driver.caps = {...driver.caps, platformName: 'iOS', app: 'NOTLOL.app'};
       driver.deviceCaps = undefined;
       let res = await driver.getSession();
       proxySpy.calledOnce.should.be.true;
@@ -50,7 +50,7 @@ describe('session commands', function () {
         platformName: 'iOS',
         udid: 'cecinestpasuneudid',
         statBarHeight: 20,
-        viewportRect: {x: 1, y: 2, height: 3, width: 4},
+        viewportRect: {x: 1, y: 2, height: 3, width: 4, left: 0, top: 0},
         pixelRatio: 3,
       });
     });

--- a/test/unit/commands/session-specs.js
+++ b/test/unit/commands/session-specs.js
@@ -8,16 +8,17 @@ describe('session commands', function () {
   let driver = new XCUITestDriver();
   driver.opts.udid = 'cecinestpasuneudid';
   let proxySpy = sinon.stub(driver, 'proxyCommand').callsFake(async (endpoint, method) => {
-    // eslint-disable-line require-await
     if (endpoint === '/' && method === 'GET') {
-      return {
+      // XXX this is synchronous
+      return await {
         capabilities: {
           sillyCap: true,
           app: 'LOL.app',
         },
       };
     }
-    return {};
+    // XXX this is synchronous
+    return await {};
   });
   let otherStubs = [
     sinon.stub(driver, 'getStatusBarHeight').resolves(20),

--- a/test/unit/commands/session-specs.js
+++ b/test/unit/commands/session-specs.js
@@ -7,25 +7,28 @@ chai.should();
 describe('session commands', function () {
   let driver = new XCUITestDriver();
   driver.opts.udid = 'cecinestpasuneudid';
-  let proxySpy = sinon.stub(driver, 'proxyCommand').callsFake(async (endpoint, method) => { // eslint-disable-line require-await
+  let proxySpy = sinon.stub(driver, 'proxyCommand').callsFake(async (endpoint, method) => {
+    // eslint-disable-line require-await
     if (endpoint === '/' && method === 'GET') {
       return {
         capabilities: {
           sillyCap: true,
           app: 'LOL.app',
-        }
+        },
       };
     }
     return {};
   });
   let otherStubs = [
-    sinon.stub(driver, 'getStatusBarHeight').returns(20),
-    sinon.stub(driver, 'getViewportRect').returns({x: 1, y: 2, height: 3, width: 4}),
-    sinon.stub(driver, 'getScreenInfo').returns({
+    sinon.stub(driver, 'getStatusBarHeight').resolves(20),
+    sinon
+      .stub(driver, 'getViewportRect')
+      .resolves({x: 1, y: 2, height: 3, width: 4, left: 0, top: 0}),
+    sinon.stub(driver, 'getScreenInfo').resolves({
       statusBarSize: {width: 400, height: 20},
-      scale: 3
+      scale: 3,
     }),
-    sinon.stub(driver, 'getDevicePixelRatio').returns(3)
+    sinon.stub(driver, 'getDevicePixelRatio').resolves(3),
   ];
 
   afterEach(function () {
@@ -37,11 +40,7 @@ describe('session commands', function () {
 
   describe('getSession', function () {
     it('should merge caps with WDA response', async function () {
-      driver.caps = {
-        platformName: 'iOS',
-        javascript_enabled: true,
-        app: 'NOTLOL.app',
-      };
+      driver.caps = { ...driver.caps, platformName: 'iOS', app: 'NOTLOL.app' };
       driver.deviceCaps = undefined;
       let res = await driver.getSession();
       proxySpy.calledOnce.should.be.true;
@@ -49,7 +48,6 @@ describe('session commands', function () {
         sillyCap: true,
         app: 'LOL.app',
         platformName: 'iOS',
-        javascript_enabled: true,
         udid: 'cecinestpasuneudid',
         statBarHeight: 20,
         viewportRect: {x: 1, y: 2, height: 3, width: 4},
@@ -58,11 +56,7 @@ describe('session commands', function () {
     });
 
     it('should merge caps with WDA response without screen info', async function () {
-      driver.caps = {
-        platformName: 'iOS',
-        javascript_enabled: true,
-        app: 'NOTLOL.app',
-      };
+      driver.caps = {...driver.caps, platformName: 'iOS', app: 'NOTLOL.app'};
       driver.deviceCaps = undefined;
       driver.opts.includeDeviceCapsToSessionInfo = false;
       let res = await driver.getSession();
@@ -71,8 +65,7 @@ describe('session commands', function () {
         sillyCap: true,
         app: 'LOL.app',
         platformName: 'iOS',
-        javascript_enabled: true,
-        udid: 'cecinestpasuneudid'
+        udid: 'cecinestpasuneudid',
       });
     });
   });

--- a/test/unit/css-converter-specs.js
+++ b/test/unit/css-converter-specs.js
@@ -45,13 +45,13 @@ describe('css-converter.js', function () {
     }
   });
   describe('unsupported css', function () {
-    const testCases = [
+    const testCases = /** @type {const} */([
       ['*[visible="ItS ViSiBlE"]', /'visible' must be true, false or empty. Found 'ItS ViSiBlE'/],
       ['*[foo="bar"]', /'foo' is not a valid attribute. Supported attributes are */],
       ['*:visible("isvisible")', /'visible' must be true, false or empty. Found 'isvisible'/],
       [`This isn't valid[ css`, /Invalid CSS selector/],
       ['p ~ a', /'~' is not a supported combinator. /],
-    ];
+    ]);
     for (const [cssSelector, error] of testCases) {
       it(`should reject '${cssSelector}' with '${error}'`, function () {
         (() => CssConverter.toIosClassChainSelector(cssSelector)).should.throw(error);

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -41,7 +41,7 @@ describe('language and locale', function () {
           alwaysMatch: {},
         }
       };
-      let desiredCapabilities = {
+      let desiredCapabilities = /** @type {import('@appium/types').DriverOpts<import('../../lib/driver').XCUITestDriverConstraints>} */({
         platformName: 'iOS',
         platformVersion: '9.3',
         deviceName: 'iPhone 6',
@@ -49,7 +49,7 @@ describe('language and locale', function () {
         language: LANGUAGE,
         locale: LOCALE,
         bundleId: BUNDLE_ID,
-      };
+      });
 
       let driver = new XCUITestDriver(desiredCapabilities);
       let proxySpy = sinon.stub(driver, 'proxyCommand');
@@ -90,7 +90,7 @@ describe('language and locale', function () {
         }
       };
 
-      const desiredCapabilities = {
+      const desiredCapabilities = /** @type {import('@appium/types').DriverOpts<import('../../lib/driver').XCUITestDriverConstraints>} */({
         platformName: 'iOS',
         platformVersion: '9.3',
         deviceName: 'iPhone 6',
@@ -99,7 +99,7 @@ describe('language and locale', function () {
         locale: LOCALE,
         bundleId: BUNDLE_ID,
         processArguments
-      };
+      });
       let driver = new XCUITestDriver(desiredCapabilities);
       let proxySpy = sinon.stub(driver, 'proxyCommand');
       driver.validateDesiredCaps(desiredCapabilities);

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -25,15 +25,19 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      // @ts-ignore withMocks is wonky
       mocks.fs.expects('glob')
         .once()
         .returns([]);
+      // @ts-ignore withMocks is wonky
       mocks.fs.expects('walkDir')
         .once()
         .returns();
+        // @ts-ignore withMocks is wonky
       mocks.fs.expects('exists')
         .atLeast(1)
         .returns(true);
+      // @ts-ignore withMocks is wonky
       mocks.iosUtils.expects('clearLogs')
         .once()
         .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
@@ -47,15 +51,19 @@ describe('utils', function () {
           return DERIVED_DATA_ROOT;
         }
       };
+      // @ts-ignore withMocks is wonky
       mocks.fs.expects('glob')
         .once()
         .returns([]);
+      // @ts-ignore withMocks is wonky
       mocks.fs.expects('walkDir')
         .once()
         .returns();
+      // @ts-ignore withMocks is wonky
       mocks.fs.expects('exists')
         .atLeast(1)
         .returns(true);
+      // @ts-ignore withMocks is wonky
       mocks.iosUtils.expects('clearLogs')
         .once()
         .withExactArgs([`${DERIVED_DATA_ROOT}/Logs`])
@@ -71,6 +79,7 @@ describe('utils', function () {
           return null;
         }
       };
+      // @ts-ignore withMocks is wonky
       mocks.iosUtils.expects('clearLogs')
         .never();
       await clearSystemFiles(wda);
@@ -125,6 +134,7 @@ describe('utils', function () {
 
   describe('isLocalHost', function () {
     it('should be false with invalid input, undefined', function () {
+      // @ts-expect-error invalid input
       isLocalHost(undefined).should.be.false;
     });
     it('should be false with invalid input, empty', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "types": ["node", "mocha", "chai", "chai-as-promised", "sinon-chai", "sinon"]
+    "types": ["node", "mocha", "chai", "chai-as-promised", "sinon-chai", "sinon"],
+    "checkJs": true
   },
   "include": [
     "index.js",


### PR DESCRIPTION
This PR:

1. Replaces the hand-rolled Execute Methods with the builtin execute method facilities
2. Typechecks the entire project, which is basically needed if we're going to get reasonable docs.
3. Cleans up various docstrings (since they will be actually used in the documentation!)

Each method corresponding to an Execute Method (I think these methods always have prefix `mobile`) has had its function signature changed.  Instead of passing in an "options object", each now accepts discrete arguments.  I don't believe this is ideal, and I _expect these changes to churn_ later once we revisit how execute methods work (they _should_ allow "options objects").

It's possible that--because some methods (perhaps unwisely) allow arbitrary data to be sent thru Appium into other endpoints (like wda)--that the changes to the signatures will break somebody.  We will need to address these on a case-by-case basis, because it's simply not safe to do this, and we need to be explicit about what data we pass through.  Consider this a vulnerability mitigation. 😜

There are a few helper methods I've written or rewrote to support both the signature change and type changes.  There was also at least one legit bugfix (see `gesture.js:L117`)!

This line appears often in the changes:

```js
// @ts-expect-error - do not assign arbitrary properties to `this.opts`
```

Before we started typing things, `this.opts` (or anything else really) was fair game for whatever arbitrary stuff a driver wanted to put anywhere.  That's no longer the case.  Everything that this (or any other) driver is putting on `this.opts` which is not already declared should _not_ live there.  A better place may just be to use the instance's own context; I don't see any real distinction between the data already stored in the context vs. the data added to `this.opts`.

Some types have been moved out of `@typedef`s and into TS sources.

