### PR TITLE
fix: cookies regression: send Page commands for cookies handling

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -195,25 +195,28 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async getCookies() {
-  if (!this.isWebContext()) {
-    throw new errors.NotImplementedError();
-  }
-
-    this.log.debug('Retrieving all cookies');
-
-    let script = 'return document.cookie';
-    let jsCookies = await this.executeAtom('execute_script', [script, []]);
-
-    let cookies = [];
-    try {
-      for (let [name, value] of _.toPairs(cookieUtils.createJWPCookie(undefined, jsCookies))) {
-        cookies.push({name, value});
-      }
-      return cookies;
-    } catch (err) {
-      this.log.error(err);
-      throw new errors.UnknownError(`Error parsing cookies from result: '${jsCookies}'`);
+    if (!this.isWebContext()) {
+      throw new errors.NotImplementedError();
     }
+
+    // get the cookies from the remote debugger, or an empty object
+    const cookies = await this.remote.getCookies() || {cookies: []};
+
+    // the value is URI encoded, so decode it safely
+    const decodedCookieValues = cookies.cookies.map((cookie) => {
+      try {
+        return decodeURI(cookie.value);
+      } catch (error) {
+        this.log.debug(`Cookie ${cookie.name} was not decoded successfully. Cookie value: ${cookie.value}`);
+        this.log.warn(error);
+        return undefined;
+      }
+    });
+
+    // zip cookies with decoded value, removing undefined cookie values
+    return _.zip(cookies.cookies, decodedCookieValues)
+      .filter(([, value]) => !_.isUndefined(value))
+      .map(([cookie, value]) => Object.assign({}, cookie, {value}));
   },
   /**
    * @this {XCUITestDriver}
@@ -250,14 +253,15 @@ const commands = {
       throw new errors.NotImplementedError();
     }
 
-    // check cookie existence
-    let cookies = await this.getCookies();
-    if (_.indexOf(_.map(cookies, 'name'), cookieName) === -1) {
+    const cookies = await this.getCookies();
+    const cookie = cookies.find((cookie) => cookie.name === cookieName);
+    if (!cookie) {
       this.log.debug(`Cookie '${cookieName}' not found. Ignoring.`);
       return true;
     }
 
-    return await this._deleteCookie(cookieName);
+    await this._deleteCookie(cookie);
+    return true;
   },
   /**
    * @this {XCUITestDriver}
@@ -267,11 +271,9 @@ const commands = {
       throw new errors.NotImplementedError();
     }
 
-    let cookies = await this.getCookies();
-    if (cookies.length) {
-      for (let cookie of cookies) {
-        await this._deleteCookie(cookie.name);
-      }
+    const cookies = await this.getCookies();
+    for (const cookie of cookies) {
+      await this._deleteCookie(cookie);
     }
     return true;
   },
@@ -282,10 +284,8 @@ const helpers = {
    * @this {XCUITestDriver}
    */
   async _deleteCookie(cookieName) {
-    this.log.debug(`Deleting cookie '${cookieName}'`);
-    let webCookie = cookieUtils.expireCookie(cookieName, {path: '/'});
-    let script = `document.cookie = ${JSON.stringify(webCookie)}`;
-    await this.executeAtom('execute_script', [script, []]);
+    const url = `http${cookie.secure ? 's' : ''}://${cookie.domain}${cookie.path}`;
+    return await this.remote.deleteCookie(cookie.name, url);
   },
   /**
    * @this {XCUITestDriver}

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -283,7 +283,7 @@ const helpers = {
   /**
    * @this {XCUITestDriver}
    */
-  async _deleteCookie(cookieName) {
+  async _deleteCookie(cookie) {
     const url = `http${cookie.secure ? 's' : ''}://${cookie.domain}${cookie.path}`;
     return await this.remote.deleteCookie(cookie.name, url);
   },


### PR DESCRIPTION
Using `this.remote` for cookies handling (except for setCookies) is current intentional behavior instead of JavaScript call. (https://gist.github.com/KazuCocoa/b935fbca6efa1abf4688cc94bc14366a for reference)

https://github.com/appium/appium-xcuitest-driver/issues/1532

This change will send `_rpc_forwardSocketData` with `Page.` commands.

```
[HTTP] --> GET /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie
[HTTP] {}
[debug] [XCUITestDriver@17d4 (8cec8681)] Calling AppiumDriver.getCookies() with args: ["8cec8681-efd8-4b28-a207-393fcb59d679"]
[debug] [XCUITestDriver@17d4 (8cec8681)] Executing command 'getCookies'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:57553', page '1', target 'page-7' (id: 38): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 38): '{"cookies":[]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 34ms
[debug] [XCUITestDriver@17d4 (8cec8681)] Responding to client with driver.getCookies() result: []
[HTTP] <-- GET /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie 200 39 ms - 12
[HTTP]
[HTTP] --> DELETE /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie
[HTTP] {}
[debug] [XCUITestDriver@17d4 (8cec8681)] Calling AppiumDriver.deleteCookies() with args: ["8cec8681-efd8-4b28-a207-393fcb59d679"]
[debug] [XCUITestDriver@17d4 (8cec8681)] Executing command 'deleteCookies'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:57553', page '1', target 'page-7' (id: 40): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 40): '{"cookies":[]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 4ms
[debug] [XCUITestDriver@17d4 (8cec8681)] Responding to client with driver.deleteCookies() result: true
[HTTP] <-- DELETE /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie 200 7 ms - 14
[HTTP]
[HTTP] --> DELETE /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie/name
[HTTP] {}
[debug] [XCUITestDriver@17d4 (8cec8681)] Calling AppiumDriver.deleteCookie() with args: ["name","8cec8681-efd8-4b28-a207-393fcb59d679"]
[debug] [XCUITestDriver@17d4 (8cec8681)] Executing command 'deleteCookie'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:57553', page '1', target 'page-7' (id: 42): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 42): '{"cookies":[]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 31ms
[debug] [XCUITestDriver@17d4 (8cec8681)] Cookie 'name' not found. Ignoring.
[debug] [XCUITestDriver@17d4 (8cec8681)] Responding to client with driver.deleteCookie() result: true
[HTTP] <-- DELETE /session/8cec8681-efd8-4b28-a207-393fcb59d679/cookie/name 200 34 ms - 14
```

After setting cookies once with `driver.manage.add_cookie(name: "key", value: "value")`

```
[HTTP] --> GET /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie
[HTTP] {}
[debug] [XCUITestDriver@8956 (827a81cb)] Calling AppiumDriver.getCookies() with args: ["827a81cb-0306-4706-ad0a-ad4d1dad256d"]
[debug] [XCUITestDriver@8956 (827a81cb)] Executing command 'getCookies'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:58046', page '1', target 'page-7' (id: 40): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 40): '{"cookies":[{"name":"key","value":"value","domain":"0.0.0.0","path":"/","expires":0,"session":true,"httpOnly":false,"secure":false,"sameSite":"None"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 37ms
[debug] [XCUITestDriver@8956 (827a81cb)] Responding to client with driver.getCookies() result: [{"name":"key","value":"value","domain":"0.0.0.0","path":"/","expires":0,"session":true,"httpOnly":false,"secure":false,"sameSite":"None"}]
[HTTP] <-- GET /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie 200 42 ms - 149
[HTTP]
[HTTP] --> DELETE /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie
[HTTP] {}
[debug] [XCUITestDriver@8956 (827a81cb)] Calling AppiumDriver.deleteCookies() with args: ["827a81cb-0306-4706-ad0a-ad4d1dad256d"]
[debug] [XCUITestDriver@8956 (827a81cb)] Executing command 'deleteCookies'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:58046', page '1', target 'page-7' (id: 42): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 42): '{"cookies":[{"name":"key","value":"value","domain":"0.0.0.0","path":"/","expires":0,"session":true,"httpOnly":false,"secure":false,"sameSite":"None"}]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 40ms
[debug] [RemoteDebugger] Deleting cookie 'key' on 'http://0.0.0.0/'
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:58046', page '1', target 'page-7' (id: 44): 'Page.deleteCookie'
[debug] [RemoteDebugger] Received data response from send (id: 44): '{}'
[debug] [RemoteDebugger] Sending to Web Inspector took 4ms
[debug] [XCUITestDriver@8956 (827a81cb)] Responding to client with driver.deleteCookies() result: true
[HTTP] <-- DELETE /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie 200 48 ms - 14
[HTTP]
[HTTP] --> DELETE /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie/name
[HTTP] {}
[debug] [XCUITestDriver@8956 (827a81cb)] Calling AppiumDriver.deleteCookie() with args: ["name","827a81cb-0306-4706-ad0a-ad4d1dad256d"]
[debug] [XCUITestDriver@8956 (827a81cb)] Executing command 'deleteCookie'
[debug] [RemoteDebugger] Getting cookies
[debug] [RemoteDebugger] Sending '_rpc_forwardSocketData:' message to app 'PID:58046', page '1', target 'page-7' (id: 46): 'Page.getCookies'
[debug] [RemoteDebugger] Received data response from send (id: 46): '{"cookies":[]}'
[debug] [RemoteDebugger] Sending to Web Inspector took 4ms
[debug] [XCUITestDriver@8956 (827a81cb)] Cookie 'name' not found. Ignoring.
[debug] [XCUITestDriver@8956 (827a81cb)] Responding to client with driver.deleteCookie() result: true
[HTTP] <-- DELETE /session/827a81cb-0306-4706-ad0a-ad4d1dad256d/cookie/name 200 10 ms - 14
```
