### PR TITLE
fix: launchApp

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -208,8 +208,8 @@ const commands = {
     await this.opts.device.launchApp(this.opts.bundleId);
 
     let checkStatus = async () => {
-      let response = await this.proxyCommand('/status', 'GET');
-      let currentApp = response.currentApp.bundleID;
+      let response = await this.proxyCommand('/wda/activeAppInfo', 'GET', null, false);
+      let currentApp = response.bundleId;
       if (currentApp !== this.opts.bundleId) {
         throw new Error(`${this.opts.bundleId} not in foreground. ${currentApp} is in foreground`);
       }


### PR DESCRIPTION
I know of this launchApp is deprecated, but still remains. I noticed the endpoint is broken because the `/status` does not `currentApp` and `bundleID`. It caused an error below. This was broken long time.

```
[debug] [XCUITestDriver@c5c3 (8337d19e)] Proxying [GET /status] to [GET http://127.0.0.1:8100/status] with no body
[debug] [XCUITestDriver@c5c3 (8337d19e)] Got response with status 200: {"value":{"message":"WebDriverAgent is ready to accept commands","state":"success","os":{"testmanagerdVersion":28,"name":"iOS","sdkVersion":"14.2","version":"14.3"},"ios":{"simulatorVersion":"14.3","ip":"192.168.4.21"},"ready":true,"build":{"upgradedAt":"1680152839813","time":"Mar 30 2023 23:53:29","productBundleIdentifier":"com.facebook.WebDriverAgentRunner"}},"sessionId":null}
[debug] [XCUITestDriver@c5c3 (8337d19e)] Encountered internal error running command: TypeError: Cannot read properties of undefined (reading 'bundleID')
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at checkStatus (/Users/kazu/.appium/node_modules/appium-xcuitest-driver/lib/commands/general.js:212:44)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at runMicrotasks (<anonymous>)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at wrapped (/Users/kazu/.appium/node_modules/appium-xcuitest-driver/node_modules/asyncbox/lib/asyncbox.js:95:13)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at retry (/Users/kazu/.appium/node_modules/appium-xcuitest-driver/node_modules/asyncbox/lib/asyncbox.js:68:13)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at retryInterval (/Users/kazu/.appium/node_modules/appium-xcuitest-driver/node_modules/asyncbox/lib/asyncbox.js:105:10)
[debug] [XCUITestDriver@c5c3 (8337d19e)]     at XCUITestDriver.launchApp (/Users/kazu/.appium/node_modules/appium-xcuitest-driver/lib/commands/general.js:220:5)
[HTTP] <-- POST /session/8337d19e-c784-41f8-821e-138e51e072a5/appium/app/launch 500 22153 ms - 670
```

The new endpoint returns current active app as `bundleId`
e.g.
```
{"value":{"processArguments":{"env":{},"args":[]},"name":"","pid":86657,"bundleId":"com.example.apple-samplecode.UICatalog"},"sessionId":null}
```

so it can use for the purpose.