### PR TITLE
fix: launchApp regression

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -206,7 +206,7 @@ const commands = {
     const appName = this.opts.app || this.opts.bundleId;
     try {
       await this.start();
-      this.log.info(`Successfully started a session with launching '${appName}'.`);
+      this.log.info(`Successfully started a session by launching '${appName}'.`);
     } catch (err) {
       this.log.warn(`Something went wrong while launching the '${appName}' app.`);
       throw err;

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -201,10 +201,12 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async launchApp() {
+    this.log.warn('launchApp is deprecated. Please use activateApp, ' +
+                  'mobile:launchApp or create a new session instead.')
     const appName = this.opts.app || this.opts.bundleId;
     try {
       await this.start();
-      this.log.info(`Successfully launched the '${appName}' app.`);
+      this.log.info(`Successfully started a session with launching '${appName}'.`);
     } catch (err) {
       this.log.warn(`Something went wrong while launching the '${appName}' app.`);
       throw err;
@@ -214,10 +216,12 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async closeApp() {
+    this.log.warn('closeApp is deprecated. Please use terminateApp, ' +
+                  'mobile:terminateApp, mobile:killApp or quit the session instead.')
     const appName = this.opts.app || this.opts.bundleId;
     try {
       await this.stop();
-      this.log.info(`Successfully closed the '${appName}' app.`);
+      this.log.info(`Successfully stopped the sessiuon for '${appName}'.`);
     } catch (err) {
       this.log.warn(`Something went wrong while closing the '${appName}' app.`);
       throw err;

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import {retryInterval} from 'asyncbox';
 import {errors} from 'appium/driver';
 import {util} from 'appium/support';
 import moment from 'moment-timezone';
@@ -202,24 +201,14 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async launchApp() {
-    const APP_LAUNCH_TIMEOUT = 20 * 1000;
-
-    this.logEvent('appLaunchAttempted');
-    await this.opts.device.launchApp(this.opts.bundleId);
-
-    let checkStatus = async () => {
-      let response = await this.proxyCommand('/status', 'GET');
-      let currentApp = response.currentApp.bundleID;
-      if (currentApp !== this.opts.bundleId) {
-        throw new Error(`${this.opts.bundleId} not in foreground. ${currentApp} is in foreground`);
-      }
-    };
-
-    this.log.info(`Waiting for '${this.opts.bundleId}' to be in foreground`);
-    let retries = parseInt(APP_LAUNCH_TIMEOUT / 200, 10);
-    await retryInterval(retries, 200, checkStatus);
-    this.log.info(`${this.opts.bundleId} is in foreground`);
-    this.logEvent('appLaunched');
+    const appName = this.opts.app || this.opts.bundleId;
+    try {
+      await this.start();
+      this.log.info(`Successfully launched the '${appName}' app.`);
+    } catch (err) {
+      this.log.warn(`Something went wrong while launching the '${appName}' app.`);
+      throw err;
+    }
   },
   /**
    * @this {XCUITestDriver}

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -202,7 +202,7 @@ const commands = {
    */
   async launchApp() {
     this.log.warn('launchApp is deprecated. Please use activateApp, ' +
-                  'mobile:launchApp or create a new session instead.')
+                  'mobile:launchApp or create a new session instead.');
     const appName = this.opts.app || this.opts.bundleId;
     try {
       await this.start();
@@ -217,7 +217,7 @@ const commands = {
    */
   async closeApp() {
     this.log.warn('closeApp is deprecated. Please use terminateApp, ' +
-                  'mobile:terminateApp, mobile:killApp or quit the session instead.')
+                  'mobile:terminateApp, mobile:killApp or quit the session instead.');
     const appName = this.opts.app || this.opts.bundleId;
     try {
       await this.stop();


### PR DESCRIPTION
Instead of https://github.com/appium/appium-xcuitest-driver/pull/1539

https://github.com/appium/appium-xcuitest-driver/commit/9b9e6fa860425f3ed2a9130d088889c05e3e10a9#diff-b394cf1ec7843c77eb14478b73321d02c718f7f8123b5416b6d88181627ac690L190-L199 changed the launchApp behavior. The master one did not create a new session between appium/xcuitest and WDA, so after the launchApp method, no commands worked.

This PR brings removed launchApp behavior.

---

The launchApp method removed in this PR was ordinary existed in lib/driver.js, but it seems like nothing used the method in my git history confirmation. `response.currentApp.bundleID` was broken, but has existed since XCUITest driver v2 at least. It means Appium 1.22.3 had the method as well, but no non-reference error occurred for bundleID. We should have removed the method, i guess

---

https://github.com/appium/appium-xcuitest-driver/pull/1534 and this are what I found as regression for now.