### PR TITLE
fix: revert "chore: Bump get-port from 5.1.1 to 6.1.2 (#1535)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "get-port": "^6.1.2",
+    "get-port": "^5.1.1",
     "glob": "^8.0.1",
     "lint-staged": "^13.0.3",
     "mocha": "^10.0.0",


### PR DESCRIPTION
This reverts commit ff96d7cfa209783f58fc053602b7e37889c6241f.

I'm not sure why dependabot merged this, because `get-port` v6 is ESM only and the build should be broken.

I've disabled dependabot entirely.
