### PR TITLE
chore: update .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,10 +1,7 @@
 {
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "releaseRules": [
-        {"type": "chore", "release": "patch"}
-      ]
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits",
@@ -14,7 +11,7 @@
           {"type": "fix", "section": "Bug Fixes"},
           {"type": "perf", "section": "Performance Improvements"},
           {"type": "revert", "section": "Reverts"},
-          {"type": "chore", "section": "Miscellaneous Chores"},
+          {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
           {"type": "refactor", "section": "Code Refactoring"},
           {"type": "docs", "section": "Documentation", "hidden": true},
           {"type": "style", "section": "Styles", "hidden": true},


### PR DESCRIPTION
This changes three things in `.releaserc` (which controls how `semantic-release` works):

1. Switched the preset from `angular` to `conventionalcommits` to match our changelog and commitlint configurations.
2. Removed the rule which causes `chore`-type commits to be released as patch versions.  This was causing many unnecessary releases.
3. Hide `chore`- and `refactor`-type commits from the changelog.  These are typically not useful to end users.

@KazuCocoa I see that you explicitly added the configuration to make `chore`-type commits cause patch releases, but I could not find any reasoning/intent as the original PR text (#1458) was empty.