### PR TITLE
fix(command): flip args for mobile: getPermission

### DIFF
--- a/lib/commands/permissions.js
+++ b/lib/commands/permissions.js
@@ -75,7 +75,7 @@ export default {
    * @this {XCUITestDriver}
    * @group Simulator Only
    */
-  async mobileGetPermission(service, bundleId) {
+  async mobileGetPermission(bundleId, service) {
     if (!service) {
       throw new Error(`The 'service' option is expected to be present`);
     }

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -285,7 +285,7 @@ export const executeMethodMap = {
   'mobile: getPermission': {
     command: 'mobileGetPermission',
     params: {
-      required: ['service', 'bundleId'],
+      required: ['bundleId', 'service'],
     },
   },
   'mobile: setPermission': {


### PR DESCRIPTION
These were backwards, per the documentation.
