### PR TITLE
feat: add mobile:webInspector to send webinspector command

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -869,6 +869,26 @@ const extensions = {
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   await this.opts.device.updateSafariSettings(preferences);
   },
+
+  /**
+   * Send Web Inspector command to the remote debugger.
+   * https://github.com/appium/appium-remote-debugger/blob/717a6310dba7ccf14db8aeef28b8eac3d7f6abf9/lib/protocol/index.js
+   *
+   * @param {string} method A command method name. e.g. Page.reload
+   * @param {object} args Arguments for the method. Please check what arguments are available in
+   * https://github.com/appium/appium-remote-debugger/blob/717a6310dba7ccf14db8aeef28b8eac3d7f6abf9/lib/protocol/index.js
+   */
+  async mobileWebInspector(method, args) {
+    if (this.remote) {
+      return;
+    }
+
+    await this.remote.rpcClient.send(method, {
+      args,
+      appIdKey: this.remote.appIdKey,
+      pageIdKey: this.remote.pageIdKey,
+    });
+  },
 };
 
 export default {...helpers, ...extensions, ...commands};
@@ -881,4 +901,3 @@ export default {...helpers, ...extensions, ...commands};
  * @template {string} [S=string]
  * @typedef {import('@appium/types').Element<S>} Element
  */
-

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2159,6 +2159,7 @@ class XCUITestDriver extends BaseDriver {
   mobileWebNav = commands.webExtensions.mobileWebNav;
   mobileUpdateSafariPreferences = commands.webExtensions.mobileUpdateSafariPreferences;
   clickCoords = commands.webExtensions.clickCoords;
+  mobileWebInspector = commands.webExtensions.mobileWebInspector;
 
   /*--------+
    | XCTEST |

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -461,4 +461,11 @@ export const executeMethodMap = {
   'mobile: stopAudioRecording': {
     command: 'stopAudioRecording',
   },
+  'mobile: webInspector': {
+    command: 'mobileWebInspector',
+    params: {
+      required: ['method'],
+      optional: ['args']
+    }
+  }
 } as const satisfies ExecuteMethodMap<XCUITestDriver>;


### PR DESCRIPTION
Instead of https://github.com/appium/appium-xcuitest-driver/pull/1455

I haven't tested yet, but I'd like to do somehing laster:

- `Animation.enable`,`Animation.disable`
- `ApplicationCache.enable`,`ApplicationCache.disable`
- `DOMStorage.enable`, `DOMStorage.disable`
- `Memory.enable`, `Memory.disable`
- `Network.setEmulatedConditions`

Perhaps this pr needs to have some documentation with a couple of example code.

I'm thinking to add this command to send some of webinspector commands 
https://github.com/appium/appium-remote-debugger/blob/717a6310dba7ccf14db8aeef28b8eac3d7f6abf9/lib/protocol/index.js

Maybe it does not work fully, so we may need to append more code, or need to update the remote debugger side such as https://github.com/appium/appium-remote-debugger/blob/717a6310dba7ccf14db8aeef28b8eac3d7f6abf9/lib/rpc/remote-messages.js#L13.

example usage:

```
# Ruby client
@driver.execute_script 'mobile:webInspector', {method: 'Page.reload'}
```