### PR TITLE
fix: Add missing return to removeApp API

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -179,6 +179,7 @@ const commands = {
   /**
    * @this {XCUITestDriver}
    */
+  // @ts-expect-error Clients expect a boolean value to be returned
   async removeApp(bundleId) {
     return await this.mobileRemoveApp(bundleId);
   },

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -180,7 +180,7 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async removeApp(bundleId) {
-    await this.mobileRemoveApp(bundleId);
+    return await this.mobileRemoveApp(bundleId);
   },
   /**
    * Start the session after it has been started.

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -179,7 +179,6 @@ const commands = {
   /**
    * @this {XCUITestDriver}
    */
-  // @ts-expect-error Clients expect a boolean value to be returned
   async removeApp(bundleId) {
     return await this.mobileRemoveApp(bundleId);
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1939,6 +1939,7 @@ class XCUITestDriver extends BaseDriver {
   mobileGetDeviceTime = commands.generalExtensions.mobileGetDeviceTime;
   getWindowRect = commands.generalExtensions.getWindowRect;
   getStrings = commands.appStringsExtensions.getStrings;
+  // @ts-expect-error Clients expect a boolean value to be returned
   removeApp = commands.generalExtensions.removeApp;
   launchApp = commands.generalExtensions.launchApp;
   closeApp = commands.generalExtensions.closeApp;


### PR DESCRIPTION
This API is expected to return a boolean true value if an app was removed successfully