### PR TITLE
fix: make whitespace in execute methods insignificant

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -34,7 +34,7 @@ function executeMethodExpectsParam(script, param) {
  * @returns {script is keyof XCUITestDriver.executeMethodMap}
  */
 function isExecuteMethod(script) {
-  return script.match(/^mobile:/) && script in XCUITestDriver.executeMethodMap;
+  return script in XCUITestDriver.executeMethodMap;
 }
 
 /**
@@ -64,7 +64,9 @@ function preprocessExecuteMethodArgs(script, args) {
    * Most of these Execute Methods (typically beginning with `mobile*`) will accept an `Element|string` for `elementId`, in practice they will only ever get a `string`. `Element|string` in the method's docstring is simply for documentation purposes.
    */
   if ('elementId' in executeMethodArgs && executeMethodExpectsParam(script, 'elementId')) {
-    executeMethodArgs.elementId = util.unwrapElement(/** @type {import('@appium/types').Element|string} */(executeMethodArgs.elementId));
+    executeMethodArgs.elementId = util.unwrapElement(
+      /** @type {import('@appium/types').Element|string} */ (executeMethodArgs.elementId)
+    );
   }
 
   return executeMethodArgs;
@@ -111,11 +113,12 @@ export default {
    */
   async execute(script, args) {
     // TODO: create a type that converts args to the parameters of the associated method using the `command` prop of `executeMethodMap`
+    script = script.trim().replace(/^mobile:\s*/, 'mobile: ');
     if (isExecuteMethod(script)) {
       const executeMethodArgs = preprocessExecuteMethodArgs(script, args);
       return await this.executeMethod(script, [executeMethodArgs]);
     } else if (this.isWebContext()) {
-      const atomsArgs = this.convertElementsForAtoms(/** @type {readonly any[]} */(args));
+      const atomsArgs = this.convertElementsForAtoms(/** @type {readonly any[]} */ (args));
       const result = await this.executeAtom('execute_script', [script, atomsArgs]);
       return this.cacheWebElements(result);
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-xcuitest-driver",
-  "version": "4.23.1",
+  "version": "4.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-xcuitest-driver",
-      "version": "4.23.1",
+      "version": "4.24.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "0.8.7",


### PR DESCRIPTION
How this works may change in the future, but XCUITestDriver users expect to be able to use `mobile:foo` instead of or in addition to `mobile: foo`.

Any change on the Appium side affects more than just this driver, so the change should happen here for now to fix the extant regression.

In addition, updated `package-lock.json` since it was out-of-date w/r/t the package version.  See https://github.com/appium/appium/issues/18553

Closes https://github.com/appium/appium/issues/18551