### PR TITLE
docs: tweak docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 
 <div style="text-align: center">
-  <img src="images/appium-plus-xctest.png" style="max-width: 500px;" />
+  <img src="assets/images/appium-plus-xctest.png" style="max-width: 500px;" />
 </div>
 
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "dev": "npm run build -- --watch",
     "build:docs": "appium-docs build",
     "dev:docs": "appium-docs build --serve",
-    "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
+    "publish:docs": "appium-docs build --deploy -b docs-site -m 'docs: auto-build docs for appium-xcuitest-driver@%s' --rebase",
     "lint": "eslint .",
     "lint:commit": "commitlint",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Eventually the mike command should be like:

```
/Users/kazuaki/.asdf/installs/python/3.10.2/bin/mike deploy --push --config-file /Users/kazuaki/GitHub/appium-xcuitest-driver/mkdocs.yml --remote origin --branch docs-site --message 'docs: auto-build docs for appium-xcuitest-driver@4.24.3' --rebase --update-aliases 4.24 latest
```

but current command generated:

```
 ERROR                                                                                                                                                                                                                 docutils:cli 21:59:24

Command '/Users/kazuaki/.asdf/installs/python/3.10.2/bin/mike deploy --config-file /Users/kazuaki/GitHub/appium-xcuitest-driver/mkdocs.yml --remote origin --branch docs-site --message 'docs: auto-build docs for appium-xcuitest-driver@4.24.3' --rebase --true 4.24.3' exited with code 2
```

probably should fix something in appium/docsutil, but i don't have much knowledge so far. Let me tweak by manual for now
