### PR TITLE
ci: add a task to update driver version in the package-lock

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Update package lock
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+      with:
+        fetch-depth: 0
+    - run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: create pull request
+      run: gh pr create --title 'chore: bump the driver version in package-lock.json' --body 'Update the driver version after a release'
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/18553

This Pr maybe will create a pr to update the version. Once I have confirmed this will work, I'll run this after the release task