### PR TITLE
fix: tune usePreinstalledWDA to behave as similar to webDriverAgentUrl

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -383,7 +383,7 @@ class XCUITestDriver extends BaseDriver {
     return didMerge;
   }
 
-  needXcodebuild() {
+  isXcodebuildNeeded() {
     return !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA);
   }
 
@@ -532,7 +532,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    if (_.isEmpty(this.xcodeVersion) && (this.needXcodebuild() || !this.opts.realDevice)) {
+    if (_.isEmpty(this.xcodeVersion) && (this.isXcodebuildNeeded() || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
     }
@@ -782,7 +782,7 @@ class XCUITestDriver extends BaseDriver {
         this.log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
         await this.wda.quitAndUninstall();
         this.logEvent('wdaUninstalled');
-      } else if (!util.hasValue(this.wda.webDriverAgentUrl) && this.needXcodebuild()) {
+      } else if (!util.hasValue(this.wda.webDriverAgentUrl) && this.isXcodebuildNeeded()) {
         await this.wda.setupCaching();
       }
 
@@ -926,7 +926,7 @@ class XCUITestDriver extends BaseDriver {
           await quitAndUninstall(errorMsg);
         }
 
-        if (this.opts.clearSystemFiles && this.needXcodebuild()) {
+        if (this.opts.clearSystemFiles && this.isXcodebuildNeeded()) {
           await markSystemFilesForCleanup(this.wda);
         }
 
@@ -977,7 +977,7 @@ class XCUITestDriver extends BaseDriver {
 
     await this.stop();
 
-    if (this.wda && this.needXcodebuild()) {
+    if (this.wda && this.isXcodebuildNeeded()) {
       if (this.opts.clearSystemFiles) {
         let synchronizationKey = XCUITestDriver.name;
         const derivedDataPath = await this.wda.retrieveDerivedDataPath();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -528,7 +528,10 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    if (_.isEmpty(this.xcodeVersion) && (!this.opts.webDriverAgentUrl || !this.opts.realDevice)) {
+    if (
+      _.isEmpty(this.xcodeVersion) &&
+      (!(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA) || !this.opts.realDevice)
+    ) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
     }
@@ -922,7 +925,10 @@ class XCUITestDriver extends BaseDriver {
           await quitAndUninstall(errorMsg);
         }
 
-        if (this.opts.clearSystemFiles && !this.opts.webDriverAgentUrl) {
+        if (
+          this.opts.clearSystemFiles &&
+          !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA)
+        ) {
           await markSystemFilesForCleanup(this.wda);
         }
 
@@ -973,7 +979,7 @@ class XCUITestDriver extends BaseDriver {
 
     await this.stop();
 
-    if (this.wda && !this.opts.webDriverAgentUrl) {
+    if (this.wda && !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA)) {
       if (this.opts.clearSystemFiles) {
         let synchronizationKey = XCUITestDriver.name;
         const derivedDataPath = await this.wda.retrieveDerivedDataPath();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -782,7 +782,7 @@ class XCUITestDriver extends BaseDriver {
         this.log.debug(`Capability 'useNewWDA' set to true, so uninstalling WDA before proceeding`);
         await this.wda.quitAndUninstall();
         this.logEvent('wdaUninstalled');
-      } else if (!util.hasValue(this.wda.webDriverAgentUrl) || !this.opts.usePreinstalledWDA) {
+      } else if (!util.hasValue(this.wda.webDriverAgentUrl) && this.needXcodebuild()) {
         await this.wda.setupCaching();
       }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -383,8 +383,8 @@ class XCUITestDriver extends BaseDriver {
     return didMerge;
   }
 
-  doNotUseXcodebuild() {
-    return this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA;
+  needXcodebuild() {
+    return !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA);
   }
 
   async createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData) {
@@ -532,7 +532,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    if (_.isEmpty(this.xcodeVersion) && (!this.doNotUseXcodebuild() || !this.opts.realDevice)) {
+    if (_.isEmpty(this.xcodeVersion) && (this.needXcodebuild() || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
     }
@@ -926,7 +926,7 @@ class XCUITestDriver extends BaseDriver {
           await quitAndUninstall(errorMsg);
         }
 
-        if (this.opts.clearSystemFiles && !this.doNotUseXcodebuild()) {
+        if (this.opts.clearSystemFiles && this.needXcodebuild()) {
           await markSystemFilesForCleanup(this.wda);
         }
 
@@ -977,7 +977,7 @@ class XCUITestDriver extends BaseDriver {
 
     await this.stop();
 
-    if (this.wda && !this.doNotUseXcodebuild()) {
+    if (this.wda && this.needXcodebuild()) {
       if (this.opts.clearSystemFiles) {
         let synchronizationKey = XCUITestDriver.name;
         const derivedDataPath = await this.wda.retrieveDerivedDataPath();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -383,6 +383,10 @@ class XCUITestDriver extends BaseDriver {
     return didMerge;
   }
 
+  doNotUseXcodebuild() {
+    return this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA;
+  }
+
   async createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData) {
     try {
       let [sessionId, caps] = await super.createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData);
@@ -528,10 +532,7 @@ class XCUITestDriver extends BaseDriver {
     }
 
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    if (
-      _.isEmpty(this.xcodeVersion) &&
-      (!(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA) || !this.opts.realDevice)
-    ) {
+    if (_.isEmpty(this.xcodeVersion) && (!this.doNotUseXcodebuild() || !this.opts.realDevice)) {
       // no `webDriverAgentUrl`, or on a simulator, so we need an Xcode version
       this.xcodeVersion = await getAndCheckXcodeVersion();
     }
@@ -925,10 +926,7 @@ class XCUITestDriver extends BaseDriver {
           await quitAndUninstall(errorMsg);
         }
 
-        if (
-          this.opts.clearSystemFiles &&
-          !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA)
-        ) {
+        if (this.opts.clearSystemFiles && !this.doNotUseXcodebuild()) {
           await markSystemFilesForCleanup(this.wda);
         }
 
@@ -979,7 +977,7 @@ class XCUITestDriver extends BaseDriver {
 
     await this.stop();
 
-    if (this.wda && !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA)) {
+    if (this.wda && !this.doNotUseXcodebuild()) {
       if (this.opts.clearSystemFiles) {
         let synchronizationKey = XCUITestDriver.name;
         const derivedDataPath = await this.wda.retrieveDerivedDataPath();


### PR DESCRIPTION
`usePreinstalledWDA` does not use xcodebuild, so it does not need to get xcode version and xcodebuild something such as xcodebuild system file lock. This PR fixes `this.wda.setupCaching()`'s usage condition.

I think this will also resolve https://github.com/appium/appium/issues/18641