### PR TITLE
fix: Support network devices with py-ios-device + add missing method map

### DIFF
--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -230,6 +230,12 @@ export const executeMethodMap = {
       optional: ['commonName', 'isRoot'],
     },
   },
+  'mobile: removeCertificate': {
+    command: 'mobileRemoveCertificate',
+    params: {
+      required: ['name'],
+    },
+  },
   'mobile: listCertificates': {
     command: 'mobileListCertificates',
   },
@@ -465,7 +471,7 @@ export const executeMethodMap = {
     command: 'mobileHideKeyboard',
     params: {
       optional: ['keys'],
-    }
+    },
   },
   'mobile: isKeyboardShown': {
     command: 'isKeyboardShown',
@@ -474,16 +480,16 @@ export const executeMethodMap = {
     command: 'lock',
     params: {
       optional: ['seconds'],
-    }
+    },
   },
   'mobile: unlock': {
-    command: 'unlock'
+    command: 'unlock',
   },
   'mobile: isLocked': {
-    command: 'isLocked'
+    command: 'isLocked',
   },
   'mobile: backgroundApp': {
     command: 'background',
-    params: { optional: ['seconds'] },
+    params: {optional: ['seconds']},
   },
 } as const satisfies ExecuteMethodMap<XCUITestDriver>;

--- a/lib/py-ios-device-client.js
+++ b/lib/py-ios-device-client.js
@@ -57,7 +57,7 @@ class Pyidevice {
     await this.assertExists();
     const {cwd, format = 'json', logStdout = false, asynchronous = false} = opts;
 
-    const finalArgs = [...args, '--udid', this.udid];
+    const finalArgs = [...args, '--udid', this.udid, '--network'];
     if (format) {
       finalArgs.push('--format', format);
     }


### PR DESCRIPTION
- Adds --network flag to py-ios-device commands otherwise network devices (like an Apple TV 4K) are [ignored](https://github.com/YueChen-C/py-ios-device/blob/main/ios_device/util/usbmux.py#L158)
- Adds missing command `mobile: removeCertificate` to method map