### PR TITLE
fix(deps): change Appium peer dep from pinned to compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "singleQuote": true
   },
   "peerDependencies": {
-    "appium": "2.0.0-rc.2"
+    "appium": "^2.0.0-rc.2"
   },
   "devDependencies": {
     "@appium/docutils": "0.4.1",


### PR DESCRIPTION
This should hopefully fix some warnings about potential incompatibility with Appium 2.0.0-rc.3+.