### PR TITLE
chore: Tune Simulator device retrieval and cleanup

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -47,6 +47,7 @@ import {
 } from './simulator-management';
 import {
   DEFAULT_TIMEOUT_KEY,
+  UDID_AUTO,
   checkAppPresent,
   clearSystemFiles,
   detectUdid,
@@ -1241,7 +1242,7 @@ class XCUITestDriver extends BaseDriver {
     };
 
     if (this.opts.udid) {
-      if (this.opts.udid.toLowerCase() === 'auto') {
+      if (this.opts.udid.toLowerCase() === UDID_AUTO) {
         try {
           this.opts.udid = await detectUdid();
         } catch (err) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1004,15 +1004,13 @@ class XCUITestDriver extends BaseDriver {
         })
       );
     }
+
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    if (this.isSimulator() && !this.opts.noReset && !!this.opts.device) {
-      if (this.lifecycleData.createSim) {
-        this.log.debug(`Deleting simulator created for this run (udid: '${this.opts.udid}')`);
-        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-        await shutdownSimulator(this.opts.device);
-        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-        await this.opts.device.delete();
-      }
+    const simulatorDevice = this.isSimulator() ? this.opts.device : null;
+    if (simulatorDevice && this.lifecycleData.createSim) {
+      this.log.debug(`Deleting simulator created for this run (udid: '${simulatorDevice.udid}')`);
+      await shutdownSimulator(simulatorDevice);
+      await simulatorDevice.delete();
     }
 
     const shouldResetLocationServivce = this.isRealDevice() && !!this.opts.resetLocationService;

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -57,6 +57,7 @@ async function createSim (caps, platform = PLATFORM_NAME_IOS) {
  * @property {string} platformVersion - The platform version string
  * @property {string} [simulatorDevicesSetPath] - The full path to the simulator devices set
  * @property {string} [udid] - Simulator udid
+ * @property {string} [platformName] The name of the current platform
  */
 
 /**
@@ -68,6 +69,7 @@ async function createSim (caps, platform = PLATFORM_NAME_IOS) {
 async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({})) {
   const {
     platformVersion,
+    platformName = PLATFORM_NAME_IOS,
     deviceName,
     udid,
     simulatorDevicesSetPath: devicesSetPath,
@@ -85,7 +87,7 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
   let devicesMap;
   if (udid) {
     log.debug(`Selecting the requested Simulator with UDID '${udid}'`);
-    devicesMap = await simctl.getDevices();
+    devicesMap = await simctl.getDevices(null, platformName);
     for (const device of _.flatMap(_.values(devicesMap))) {
       if (device.udid === udid) {
         return await selectSim(device);
@@ -99,7 +101,8 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
     return null;
   }
 
-  for (const device of (devicesMap?.[platformVersion] ?? await simctl.getDevices(platformVersion))) {
+  const devices = devicesMap?.[platformVersion] ?? await simctl.getDevices(platformVersion, platformName);
+  for (const device of devices) {
     if ((deviceName && device.name === deviceName) || !deviceName) {
       if (!deviceName) {
         log.debug(`The 'deviceName' capability value is empty. Selecting the first matched device`);

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -87,7 +87,7 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
   const simctl = new Simctl({devicesSetPath});
   let devicesMap;
   if (udid && _.toLower(udid) !== UDID_AUTO) {
-    log.debug(`Selecting the requested Simulator with UDID '${udid}'`);
+    log.debug(`Looking for an existing Simulator with UDID '${udid}'`);
     devicesMap = await simctl.getDevices(null, platformName);
     for (const device of _.flatMap(_.values(devicesMap))) {
       if (device.udid === udid) {
@@ -103,10 +103,18 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
   }
 
   const devices = devicesMap?.[platformVersion] ?? await simctl.getDevices(platformVersion, platformName);
+  log.debug(
+    `Looking for an existing Simulator with platformName: ${platformName}, ` +
+    `platformVersion: ${platformVersion}, deviceName: ${deviceName}`
+  );
   for (const device of devices) {
     if ((deviceName && device.name === deviceName) || !deviceName) {
       if (!deviceName) {
-        log.debug(`The 'deviceName' capability value is empty. Selecting the first matched device`);
+        log.debug(
+          `The 'deviceName' capability value is empty. ` +
+          `Selecting the first matching device '${device.name}' having the ` +
+          `'platformVersion' set to ${platformVersion}`
+        );
       }
       return await selectSim(device);
     }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import log from './logger';
 import { util } from 'appium/support';
 import { PLATFORM_NAME_IOS } from './desired-caps';
+import { UDID_AUTO } from './utils';
 
 
 const APPIUM_SIM_PREFIX = 'appiumTest';
@@ -85,7 +86,7 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
 
   const simctl = new Simctl({devicesSetPath});
   let devicesMap;
-  if (udid) {
+  if (udid && _.toLower(udid) !== UDID_AUTO) {
     log.debug(`Selecting the requested Simulator with UDID '${udid}'`);
     devicesMap = await simctl.getDevices(null, platformName);
     for (const device of _.flatMap(_.values(devicesMap))) {

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -56,10 +56,11 @@ async function createSim (caps, platform = PLATFORM_NAME_IOS) {
  * @property {string} [deviceName] - The name of the device to lookup
  * @property {string} platformVersion - The platform version string
  * @property {string} [simulatorDevicesSetPath] - The full path to the simulator devices set
+ * @property {string} [udid] - Simulator udid
  */
 
 /**
- * Get a simulator which is already running.
+ * Get an existing simulator matching the provided capabilities.
  *
  * @param {SimulatorLookupOptions} opts
  * @returns {Promise<any|null>} The matched Simulator instance or `null` if no matching  device is found.
@@ -68,38 +69,43 @@ async function getExistingSim (opts = /** @type {SimulatorLookupOptions} */({}))
   const {
     platformVersion,
     deviceName,
+    udid,
     simulatorDevicesSetPath: devicesSetPath,
   } = opts;
 
-  let appiumTestDevice;
-  const simctl = new Simctl({devicesSetPath});
-  for (const device of _.values(await simctl.getDevices(platformVersion))) {
-    if ((deviceName && device.name === deviceName) || !deviceName) {
-      return await getSimulator(device.udid, {
-        platform: device.platform,
-        checkExistence: false,
-        devicesSetPath,
-      });
-    }
-
-    if (device.name.startsWith(APPIUM_SIM_PREFIX)
-      && ((deviceName && device.name.endsWith(deviceName)) || !deviceName)) {
-      appiumTestDevice = device;
-      // choose the first booted simulator
-      if (device.state === 'Booted') {
-        break;
-      }
-    }
-  }
-
-  if (appiumTestDevice) {
-    log.warn(`Unable to find device '${deviceName}'. ` +
-      `Found '${appiumTestDevice.name}' (udid: '${appiumTestDevice.udid}') instead`);
-    return await getSimulator(appiumTestDevice.udid, {
-      platform: appiumTestDevice.platform,
+  const selectSim = async (/** @type {{ udid: string; platform: string; }} */ dev) => await getSimulator(
+    dev.udid, {
+      platform: dev.platform,
       checkExistence: false,
       devicesSetPath,
-    });
+    }
+  );
+
+  const simctl = new Simctl({devicesSetPath});
+  let devicesMap;
+  if (udid) {
+    log.debug(`Selecting the requested Simulator with UDID '${udid}'`);
+    devicesMap = await simctl.getDevices();
+    for (const device of _.flatMap(_.values(devicesMap))) {
+      if (device.udid === udid) {
+        return await selectSim(device);
+      }
+    }
+    return null;
+  }
+
+  if (!platformVersion) {
+    log.debug(`Provide 'platformVersion' capability if you prefer an existing Simulator to be selected`);
+    return null;
+  }
+
+  for (const device of (devicesMap?.[platformVersion] ?? await simctl.getDevices(platformVersion))) {
+    if ((deviceName && device.name === deviceName) || !deviceName) {
+      if (!deviceName) {
+        log.debug(`The 'deviceName' capability value is empty. Selecting the first matched device`);
+      }
+      return await selectSim(device);
+    }
   }
   return null;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@ import {exec} from 'teen_process';
 import iosGenericSimulators from './ios-generic-simulators';
 import log from './logger';
 
+export const UDID_AUTO = 'auto';
 const DEFAULT_TIMEOUT_KEY = 'default';
 const XCTEST_LOG_FILES_PATTERNS = [
   /^Session-WebDriverAgentRunner.*\.log$/i,


### PR DESCRIPTION
So the logic there is the following:

- If udid is provided and no real device has been matched then we try to match a simulator with the given udid. If no match is found then an error is thrown
- If platformVersion is provided then we try to match the first available device with the given version or a particular device if deviceName has been provided
- If a new simulator device has been created by the driver then it must also be destroyed on session cleanup

Related to https://github.com/appium/appium/issues/18814