### PR TITLE
feat: add more info in the mobile:deviceInfo

### DIFF
--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -1,9 +1,12 @@
-import {utilities} from 'appium-ios-device';
+import {utilities, services, INSTRUMENT_CHANNEL} from 'appium-ios-device';
+import log from './../logger';
 export default {
   /**
    * Returns the miscellaneous information about the device under test.
    *
    * Since XCUITest driver v4.2.0, this includes device information via lockdown in a real device.
+   * Since XCUITEst driver v4.34.0, tis includes device system and network information via
+   * com.apple.instruments.server.services.deviceinfo in a real device if available.
    *
    * @returns {Promise<DeviceInfo | (DeviceInfo & LockdownInfo)>} The response of `/wda/device/info'`
    * @this {import('../driver').XCUITestDriver}
@@ -16,7 +19,33 @@ export default {
     if (this.isRealDevice()) {
       // @ts-expect-error - do not assign arbitrary properties to `this.opts`
       const lockdownInfo = await utilities.getDeviceInfo(this.opts.device.udid);
-      return {...infoByWda, ...{lockdownInfo}};
+
+      let instrumentService;
+      let deviceInfo = {};
+      let networkInfo = {};
+      try {
+        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        instrumentService = await services.startInstrumentService(this.opts.device.udid);
+        deviceInfo = await instrumentService.callChannel(
+          INSTRUMENT_CHANNEL.DEVICE_INFO,
+          'systemInformation',
+        );
+        networkInfo = await instrumentService.callChannel(
+          INSTRUMENT_CHANNEL.DEVICE_INFO,
+          'networkInformation',
+        );
+      } catch (err) {
+        log.warn(
+          `Failed to get device information via '${
+            INSTRUMENT_CHANNEL.DEVICE_INFO
+          }'. Original error: ${err.stderr || err.message}`,
+        );
+      } finally {
+        if (instrumentService) {
+          instrumentService.close();
+        }
+      }
+      return {...infoByWda, ...{lockdownInfo}, ...{deviceInfo}, ...{networkInfo}};
     }
 
     return infoByWda;

--- a/lib/commands/deviceInfo.js
+++ b/lib/commands/deviceInfo.js
@@ -21,16 +21,17 @@ export default {
       const lockdownInfo = await utilities.getDeviceInfo(this.opts.device.udid);
 
       let instrumentService;
-      let deviceInfo = {};
-      let networkInfo = {};
+      let systemInformation = {};
+      let networkInformation = {};
       try {
         // @ts-expect-error - do not assign arbitrary properties to `this.opts`
         instrumentService = await services.startInstrumentService(this.opts.device.udid);
-        deviceInfo = await instrumentService.callChannel(
+        // Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Do not know how to serialize a BigInt
+        systemInformation = await instrumentService.callChannel(
           INSTRUMENT_CHANNEL.DEVICE_INFO,
           'systemInformation',
         );
-        networkInfo = await instrumentService.callChannel(
+        networkInformation = await instrumentService.callChannel(
           INSTRUMENT_CHANNEL.DEVICE_INFO,
           'networkInformation',
         );
@@ -45,7 +46,7 @@ export default {
           instrumentService.close();
         }
       }
-      return {...infoByWda, ...{lockdownInfo}, ...{deviceInfo}, ...{networkInfo}};
+      return {...infoByWda, ...{lockdownInfo}, ...{systemInformation}, ...{networkInformation}};
     }
 
     return infoByWda;


### PR DESCRIPTION
This is WIP yet.

I wondered if some information via instrument may help.

I saw the blow exception so need to check something before this pr.
```
[debug] [XCUITestDriver@202f (78cb04d6)] Proxying [GET /wda/device/info] to [GET http://192.168.4.30:8100/session/357A6C76-5A33-4489-9568-AF543E466294/wda/device/info] with no body
[debug] [XCUITestDriver@202f (78cb04d6)] Got response with status 200: {"value":{"timeZone":"GMT-0700","currentLocale":"ja_JP","model":"iPhone","uuid":"8E8D97F0-2893-46EB-9680-C04E988098E9","thermalState":0,"userInterfaceIdiom":0,"userInterfaceStyle":"light","name":"🦉kazu","isSimulator":false},"sessionId":"357A6C76-5A33-4489-9568-AF543E466294"}
[debug] [XCUITestDriver@202f (78cb04d6)] Encountered internal error running command: TypeError: Do not know how to serialize a BigInt
[debug] [XCUITestDriver@202f (78cb04d6)]     at JSON.stringify (<anonymous>)
[debug] [XCUITestDriver@202f (78cb04d6)]     at asyncHandler (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/@appium/base-driver/lib/protocol/protocol.js:456:78)
[HTTP] <-- POST /session/78cb04d6-90f2-4b9a-8186-e21f63b9a0c0/execute/sync 500 1332 ms - 632
```