### PR TITLE
feat: use new selenium atoms from remote debugger

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -44,7 +44,7 @@ const commands = {
   async getWindowSize(windowHandle = 'current') {
     if (windowHandle !== 'current') {
       throw new errors.NotYetImplementedError(
-        'Currently only getting current window size is supported.'
+        'Currently only getting current window size is supported.',
       );
     }
 
@@ -74,7 +74,7 @@ const commands = {
       const parsedTimestamp = moment.utc(stdout, inputFormat);
       if (!parsedTimestamp.isValid()) {
         this.log.warn(
-          `Cannot parse the timestamp '${stdout}' returned by '${cmd}' command. Returning it as is`
+          `Cannot parse the timestamp '${stdout}' returned by '${cmd}' command. Returning it as is`,
         );
         return stdout;
       }
@@ -141,7 +141,7 @@ const commands = {
   async launchApp() {
     this.log.warn(
       'launchApp is deprecated. Please use activateApp, ' +
-        'mobile:launchApp or create a new session instead.'
+        'mobile:launchApp or create a new session instead.',
     );
     const appName = this.opts.app || this.opts.bundleId;
     try {
@@ -160,7 +160,7 @@ const commands = {
   async closeApp() {
     this.log.warn(
       'closeApp is deprecated. Please use terminateApp, ' +
-        'mobile:terminateApp, mobile:killApp or quit the session instead.'
+        'mobile:terminateApp, mobile:killApp or quit the session instead.',
     );
     const appName = this.opts.app || this.opts.bundleId;
     try {
@@ -287,7 +287,8 @@ const helpers = {
    * @this {XCUITestDriver}
    */
   async getWindowSizeWeb() {
-    return await this.executeAtom('get_window_size', []);
+    const script = 'return {width: window.innerWidth, height: window.innerHeight}';
+    return await this.executeAtom('execute_script', [script]);
   },
   /**
    * @this {XCUITestDriver}

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -31,7 +31,7 @@ async function toElementOrApplicationId(driver, elementId) {
     return util.unwrapElement(elementId);
   }
   return util.unwrapElement(
-    await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false)
+    await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false),
   );
 }
 
@@ -47,7 +47,7 @@ function asFloat(value, paramName) {
   const num = parseFloat(String(value));
   if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter should be a valid number. "${value}" is given instead`
+      `"${paramName}" parameter should be a valid number. "${value}" is given instead`,
     );
   }
   return num;
@@ -65,7 +65,7 @@ function asInt(value, paramName) {
   const num = parseInt(String(value), 10);
   if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter should be a valid integer. "${value}" is given instead`
+      `"${paramName}" parameter should be a valid integer. "${value}" is given instead`,
     );
   }
   return num;
@@ -87,7 +87,7 @@ export function gesturesChainToString(gestures, keysToInclude = ['options']) {
           `${item.action}` +
           `(${_.map(
             otherKeys,
-            (x) => x + '=' + (_.isPlainObject(item[x]) ? JSON.stringify(item[x]) : item[x])
+            (x) => x + '=' + (_.isPlainObject(item[x]) ? JSON.stringify(item[x]) : item[x]),
           ).join(', ')})`
         );
       }
@@ -110,20 +110,15 @@ const commands = {
     el = util.unwrapElement(el);
 
     if (this.isWebContext()) {
-      let {x, y} = await this.getLocation(el);
-      let coords = {
-        x: x + xoffset,
-        y: y + yoffset,
-      };
-      this.curWebCoords = coords;
-      let atomsElement = this.getAtomsElement(el);
-      let relCoords = {x: xoffset, y: yoffset};
-      await this.executeAtom('move_mouse', [atomsElement, relCoords]);
+      throw new errors.UnknownMethodError(
+        'The moveTo command is not available in the web context. Use the Actions API in the ' +
+          'native context instead',
+      );
     } else {
       if (_.isNil(el)) {
         if (!this.curCoords) {
           throw new errors.UnknownError(
-            'Current cursor position unknown, please use moveTo with an element the first time.'
+            'Current cursor position unknown, please use moveTo with an element the first time.',
           );
         }
         this.curCoords = {
@@ -167,7 +162,19 @@ const commands = {
       await this.nativeWebTap(el);
     } else {
       const atomsElement = this.getAtomsElement(el);
-      return await this.executeAtom('click', [atomsElement]);
+      // clicking can cause an alert to pop up and freeze the event loop, meaning the click atom
+      // itself never returns. we have alert handling in `waitForAtom` but with click, we create
+      // a special case where if a click results in an unexpected alert error, we just return
+      // control to the client. they will encounter the error on their next command, which mirrors
+      // the behaviour of selenium.
+      try {
+        return await this.executeAtom('click', [atomsElement]);
+      } catch (err) {
+        if (err.error === errors.UnexpectedAlertOpenError.error()) {
+          return;
+        }
+        throw err;
+      }
     }
   },
   /**
@@ -197,14 +204,14 @@ const commands = {
                   pointerType: 'touch',
                 },
               }
-            : {}
-        )
+            : {},
+        ),
       )
       .map((action) => {
         const modifiedAction = _.clone(action) || {};
         // Selenium API unexpectedly inserts zero pauses, which are not supported by WDA
         modifiedAction.actions = (action.actions || []).filter(
-          (innerAction) => !(innerAction.type === 'pause' && innerAction.duration === 0)
+          (innerAction) => !(innerAction.type === 'pause' && innerAction.duration === 0),
         );
         return modifiedAction;
       });
@@ -229,7 +236,7 @@ const commands = {
       this.log.errorAndThrow(
         'The Touch API is aimed for usage in NATIVE context. ' +
           'Consider using "execute" API with custom events trigger script ' +
-          `to emulate touch events being in WEBVIEW context. Original error: ${e.message}`
+          `to emulate touch events being in WEBVIEW context. Original error: ${e.message}`,
       );
     }
   },
@@ -255,7 +262,7 @@ const commands = {
       this.log.errorAndThrow(
         'The MultiTouch API is aimed for usage in NATIVE context. ' +
           'Consider using "execute" API with custom events trigger script ' +
-          `to emulate multitouch events being in WEBVIEW context. Original error: ${e.message}`
+          `to emulate multitouch events being in WEBVIEW context. Original error: ${e.message}`,
       );
     }
   },
@@ -338,7 +345,7 @@ const helpers = {
     } else if (direction) {
       if (!SUPPORTED_GESTURE_DIRECTIONS.includes(_.toLower(direction))) {
         throw new errors.InvalidArgumentError(
-          `'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`
+          `'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`,
         );
       }
       params.direction = direction;
@@ -349,7 +356,7 @@ const helpers = {
     } else {
       throw new errors.InvalidArgumentError(
         'Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. ' +
-          'Specify one of these'
+          'Specify one of these',
       );
     }
     // we can also optionally pass a distance which appears to be a ratio of
@@ -369,7 +376,7 @@ const helpers = {
   async mobileSwipe(direction, velocity, elementId) {
     if (!SUPPORTED_GESTURE_DIRECTIONS.includes(_.toLower(direction))) {
       throw new errors.InvalidArgumentError(
-        `'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`
+        `'direction' must be one of: ${SUPPORTED_GESTURE_DIRECTIONS}`,
       );
     }
     const params = {direction};
@@ -558,7 +565,7 @@ const helpers = {
     fromX,
     fromY,
     toX,
-    toY
+    toY,
   ) {
     const params = {
       pressDuration: asFloat(pressDuration, 'pressDuration'),
@@ -570,14 +577,14 @@ const helpers = {
       toElementId = toElementId ? util.unwrapElement(toElementId) : undefined;
       if (!toElementId) {
         throw new errors.InvalidArgumentError(
-          `"toElementId" parameter is mandatory for "dragFromToWithVelocity" call`
+          `"toElementId" parameter is mandatory for "dragFromToWithVelocity" call`,
         );
       }
       params.toElement = toElementId;
       return await this.proxyCommand(
         `/wda/element/${fromElementId}/pressAndDragWithVelocity`,
         'POST',
-        params
+        params,
       );
     }
     params.fromX = asFloat(fromX, 'fromX');
@@ -606,7 +613,7 @@ const helpers = {
   async mobileTapWithNumberOfTaps(elementId, numberOfTouches, numberOfTaps) {
     if (!elementId) {
       throw new errors.InvalidArgumentError(
-        'Element id is expected to be set for tapWithNumberOfTaps method'
+        'Element id is expected to be set for tapWithNumberOfTaps method',
       );
     }
     const params = {
@@ -658,13 +665,13 @@ const helpers = {
     elementId = /** @type {string} */ (toElementId(elementId));
     if (!elementId) {
       throw new errors.InvalidArgumentError(
-        'elementId is expected to be set for selectPickerWheelValue method'
+        'elementId is expected to be set for selectPickerWheelValue method',
       );
     }
     if (!_.isString(order) || !['next', 'previous'].includes(order.toLowerCase())) {
       throw new errors.InvalidArgumentError(
         `The mandatory 'order' parameter is expected to be equal either to 'next' or 'previous'. ` +
-          `'${order}' is given instead`
+          `'${order}' is given instead`,
       );
     }
     const params = {order};
@@ -704,7 +711,7 @@ const helpers = {
     elementId = /** @type {string} */ (toElementId(elementId));
     if (!elementId) {
       throw new errors.InvalidArgumentError(
-        'Element id is expected to be set for rotateElement method'
+        'Element id is expected to be set for rotateElement method',
       );
     }
     const params = {

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -69,7 +69,7 @@ async function tapWebElementNatively(driver, atomsElement) {
           const el2 = els[1];
           const rect2 = await driver.proxyCommand(
             `/element/${util.unwrapElement(el2)}/rect`,
-            'GET'
+            'GET',
           );
 
           if (
@@ -178,7 +178,7 @@ const commands = {
       throw new errors.NotImplementedError();
     }
 
-    await this.executeAtom('refresh', []);
+    await this.remote.execute('window.location.reload()');
   },
   /**
    * @this {XCUITestDriver}
@@ -200,7 +200,7 @@ const commands = {
       throw new errors.NotImplementedError();
     }
 
-    return await this.executeAtom('title', [], true);
+    return await this.remote.execute('window.document.title');
   },
   /**
    * @this {XCUITestDriver}
@@ -212,7 +212,7 @@ const commands = {
     }
 
     // get the cookies from the remote debugger, or an empty object
-    const { cookies } = await this.remote.getCookies();
+    const {cookies} = await this.remote.getCookies();
 
     // the value is URI encoded, so decode it safely
     return cookies.map((cookie) => {
@@ -221,7 +221,7 @@ const commands = {
           cookie.value = decodeURI(cookie.value);
         } catch (error) {
           this.log.debug(
-            `Cookie ${cookie.name} was not decoded successfully. Cookie value: ${cookie.value}`
+            `Cookie ${cookie.name} was not decoded successfully. Cookie value: ${cookie.value}`,
           );
           this.log.warn(error);
           // Keep the original value
@@ -324,11 +324,11 @@ const helpers = {
     if (_.isArray(response)) {
       return response.map(toCached);
     } else if (_.isPlainObject(response)) {
-        const result = {...response, ...this.cacheWebElement(response)};
-        return _.toPairs(result).reduce((acc, [key, value]) => {
-          acc[key] = toCached(value);
-          return acc;
-        }, {});
+      const result = {...response, ...this.cacheWebElement(response)};
+      return _.toPairs(result).reduce((acc, [key, value]) => {
+        acc[key] = toCached(value);
+        return acc;
+      }, {});
     }
     return response;
   },
@@ -363,7 +363,7 @@ const helpers = {
    */
   getAtomsElement(elOrId) {
     const elId = util.unwrapElement(elOrId);
-      if (!this.webElementsCache?.has(elId)) {
+    if (!this.webElementsCache?.has(elId)) {
       throw new errors.StaleElementReferenceError();
     }
     return {ELEMENT: this.webElementsCache.get(elId)};
@@ -408,13 +408,10 @@ const extensions = {
    */
   async findWebElementOrElements(strategy, selector, many, ctx) {
     const contextElement = _.isNil(ctx) ? null : this.getAtomsElement(ctx);
+    const atomName = many ? 'find_elements' : 'find_element_fragment';
     let element;
     let doFind = async () => {
-      element = await this.executeAtom(`find_element${many ? 's' : ''}`, [
-        strategy,
-        selector,
-        contextElement,
-      ]);
+      element = await this.executeAtom(atomName, [strategy, selector, contextElement]);
       return !_.isNull(element);
     };
     try {
@@ -491,7 +488,7 @@ const extensions = {
       }
     } catch (err) {
       this.log.warn(
-        `Unable to find device type from dimensions. Assuming the device is not notched`
+        `Unable to find device type from dimensions. Assuming the device is not notched`,
       );
       this.log.debug(`Error: ${err.message}`);
     }
@@ -511,15 +508,15 @@ const extensions = {
     const {
       nativeWebTapTabBarVisibility,
       nativeWebTapSmartAppBannerVisibility,
-        // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-        safariTabBarPosition = util.compareVersions(this.opts.platformVersion, '>=', '15.0') &&
-        isIphone
-          ? TAB_BAR_POSITION_BOTTOM
-          : TAB_BAR_POSITION_TOP,
-      } = this.settings.getSettings();
-      let tabBarVisibility = _.lowerCase(String(nativeWebTapTabBarVisibility));
-      let bannerVisibility = _.lowerCase(String(nativeWebTapSmartAppBannerVisibility));
-      const tabBarPosition = _.lowerCase(String(safariTabBarPosition));
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+      safariTabBarPosition = util.compareVersions(this.opts.platformVersion, '>=', '15.0') &&
+      isIphone
+        ? TAB_BAR_POSITION_BOTTOM
+        : TAB_BAR_POSITION_TOP,
+    } = this.settings.getSettings();
+    let tabBarVisibility = _.lowerCase(String(nativeWebTapTabBarVisibility));
+    let bannerVisibility = _.lowerCase(String(nativeWebTapSmartAppBannerVisibility));
+    const tabBarPosition = _.lowerCase(String(safariTabBarPosition));
 
     if (!VISIBILITIES.includes(tabBarVisibility)) {
       tabBarVisibility = DETECT;
@@ -530,7 +527,7 @@ const extensions = {
 
     if (!TAB_BAR_POSSITIONS.includes(tabBarPosition)) {
       throw new errors.InvalidArgumentError(
-        `${safariTabBarPosition} is invalid as Safari tab bar position. Available positions are ${TAB_BAR_POSSITIONS}.`
+        `${safariTabBarPosition} is invalid as Safari tab bar position. Available positions are ${TAB_BAR_POSSITIONS}.`,
       );
     }
 
@@ -539,8 +536,8 @@ const extensions = {
     const orientation = realDims.h > realDims.w ? 'PORTRAIT' : 'LANDSCAPE';
 
     const notchOffset = isNotched
-        ? // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-          util.compareVersions(this.opts.platformVersion, '=', '13.0')
+      ? // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+        util.compareVersions(this.opts.platformVersion, '=', '13.0')
         ? IPHONE_X_NOTCH_OFFSET_IOS_13
         : IPHONE_X_NOTCH_OFFSET_IOS
       : 0;
@@ -678,10 +675,10 @@ const extensions = {
     try {
       webview = /** @type {import('@appium/types').Element|undefined} */ (
         await retryInterval(
-        5,
-        100,
-        async () =>
-          await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false)
+          5,
+          100,
+          async () =>
+            await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false),
         )
       );
     } catch (ign) {}
@@ -728,7 +725,9 @@ const extensions = {
       this.log.debug(`    yRatio: ${JSON.stringify(yRatio)}`);
 
       this.log.debug(
-        `Converted web coords ${JSON.stringify(coords)} into real coords ${JSON.stringify(newCoords)}`
+        `Converted web coords ${JSON.stringify(coords)} into real coords ${JSON.stringify(
+          newCoords,
+        )}`,
       );
       return newCoords;
     }
@@ -759,7 +758,7 @@ const extensions = {
         if (originalError instanceof B.TimeoutError) {
           throw new errors.TimeoutError(
             `Did not get any response for atom execution after ` +
-              `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`
+              `${timer.getDuration().asMilliSeconds.toFixed(0)}ms`,
           );
         }
         throw originalError;
@@ -794,7 +793,7 @@ const extensions = {
               }
               await B.delay(OBSTRUCTING_ALERT_PRESENCE_CHECK_INTERVAL_MS);
             }
-          })()
+          })(),
         );
       }
 
@@ -812,7 +811,7 @@ const extensions = {
       if (onAlertCallback) {
         this._waitingAtoms.alertNotifier.removeListener(
           ON_OBSTRUCTING_ALERT_EVENT,
-          onAlertCallback
+          onAlertCallback,
         );
       }
       if (onAppCrashCallback) {
@@ -835,19 +834,19 @@ const extensions = {
     }
   },
 
-/**
- * @typedef {Object} SafariOpts
- * @property {object} preferences An object containing Safari settings to be updated.
- * The list of available setting names and their values could be retrieved by
- * changing the corresponding Safari settings in the UI and then inspecting
- * 'Library/Preferences/com.apple.mobilesafari.plist' file inside of
- * com.apple.mobilesafari app container.
- * The full path to the Mobile Safari's container could be retrieved from
- * `xcrun simctl get_app_container <sim_udid> com.apple.mobilesafari data`
- * command output.
- * Use the `xcrun simctl spawn <sim_udid> defaults read <path_to_plist>` command
- * to print the plist content to the Terminal.
- */
+  /**
+   * @typedef {Object} SafariOpts
+   * @property {object} preferences An object containing Safari settings to be updated.
+   * The list of available setting names and their values could be retrieved by
+   * changing the corresponding Safari settings in the UI and then inspecting
+   * 'Library/Preferences/com.apple.mobilesafari.plist' file inside of
+   * com.apple.mobilesafari app container.
+   * The full path to the Mobile Safari's container could be retrieved from
+   * `xcrun simctl get_app_container <sim_udid> com.apple.mobilesafari data`
+   * command output.
+   * Use the `xcrun simctl spawn <sim_udid> defaults read <path_to_plist>` command
+   * to print the plist content to the Terminal.
+   */
 
   /**
    * Updates Mobile Safari preferences on an iOS Simulator

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "appium-idb": "^1.6.13",
         "appium-ios-device": "^2.5.4",
         "appium-ios-simulator": "^5.1.3",
-        "appium-remote-debugger": "^9.1.17",
+        "appium-remote-debugger": "^10.0.0-beta.2",
         "appium-webdriveragent": "^5.6.0",
         "appium-xcode": "^5.1.4",
         "async-lock": "^1.4.0",
@@ -6213,9 +6213,9 @@
       }
     },
     "node_modules/appium-remote-debugger": {
-      "version": "9.1.17",
-      "resolved": "https://registry.npmjs.org/appium-remote-debugger/-/appium-remote-debugger-9.1.17.tgz",
-      "integrity": "sha512-1mkE5pHluP+MgYF3o7AwxMjEWFlmARygAtRF/Ni6Op2mbzNPSpi6QI1Y4z4UM8kk8i2E4SePKs5+91QEE6ojEw==",
+      "version": "10.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/appium-remote-debugger/-/appium-remote-debugger-10.0.0-beta.2.tgz",
+      "integrity": "sha512-1KY6OeKJhWmVw+a6YYUCoWWYDuduKzeBXD5JhDmQbnJTq5P9/QuKKpHX/9ahIFjkz7LDxoA2SXMLRk4HOcKjKw==",
       "dependencies": {
         "@appium/base-driver": "^9.0.0",
         "@appium/support": "^4.0.0",
@@ -6225,7 +6225,7 @@
         "asyncbox": "^2.6.0",
         "bluebird": "^3.4.7",
         "fancy-log": "^2.0.0",
-        "glob": "^8.0.3",
+        "glob": "^10.3.3",
         "lodash": "^4.17.11",
         "source-map-support": "^0.x",
         "teen_process": "^2.0.0"
@@ -6233,43 +6233,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=8"
-      }
-    },
-    "node_modules/appium-remote-debugger/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/appium-remote-debugger/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-remote-debugger/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/appium-webdriveragent": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "appium-idb": "^1.6.13",
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.1.3",
-    "appium-remote-debugger": "^9.1.17",
+    "appium-remote-debugger": "^10.0.0",
     "appium-webdriveragent": "^5.6.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",

--- a/test/functional/web/safari-alerts-e2e-specs.js
+++ b/test/functional/web/safari-alerts-e2e-specs.js
@@ -1,10 +1,9 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { retryInterval } from 'asyncbox';
-import { SAFARI_CAPS, amendCapabilities } from '../desired';
-import { initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT } from '../helpers/session';
-import { GUINEA_PIG_PAGE } from './helpers';
-
+import {retryInterval} from 'asyncbox';
+import {SAFARI_CAPS, amendCapabilities} from '../desired';
+import {initSession, deleteSession, hasDefaultPrebuiltWDA, MOCHA_TIMEOUT} from '../helpers/session';
+import {GUINEA_PIG_PAGE} from './helpers';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -25,44 +24,47 @@ describe('safari - alerts', function () {
     await deleteSession();
   });
 
-  async function acceptAlert (driver) {
+  async function acceptAlert(driver) {
     await retryInterval(5, 500, driver.acceptAlert.bind(driver));
   }
 
-  async function dismissAlert (driver) {
+  async function dismissAlert(driver) {
     await retryInterval(5, 500, driver.dismissAlert.bind(driver));
   }
 
   // All tests below are skipped until https://github.com/appium/appium/issues/17013 is resolved
 
-  it.skip('should accept alert', async function () {
+  it('should accept alert', async function () {
     const alert = await driver.$('#alert1');
     await alert.click();
     await acceptAlert(driver);
     (await driver.getTitle()).should.include('I am a page title');
   });
 
-  it.skip('should dismiss alert', async function () {
+  it('should dismiss alert', async function () {
     const alert = await driver.$('#alert1');
     await alert.click();
     await dismissAlert(driver);
     (await driver.getTitle()).should.include('I am a page title');
   });
 
-  it.skip('should get text of alert', async function () {
+  it('should get text of alert', async function () {
     const alert = await driver.$('#alert1');
     await alert.click();
     (await driver.getAlertText()).should.include('I am an alert');
     await dismissAlert(driver);
   });
-  it.skip('should not get text of alert that closed', async function () {
+  it('should not get text of alert that closed', async function () {
     const alert = await driver.$('#alert1');
     await alert.click();
     await acceptAlert(driver);
-    await driver.getAlertText()
-      .should.be.rejectedWith(/An attempt was made to operate on a modal dialog when one was not open/);
+    await driver
+      .getAlertText()
+      .should.be.rejectedWith(
+        /An attempt was made to operate on a modal dialog when one was not open/,
+      );
   });
-  it.skip('should set text of prompt', async function () {
+  it('should set text of prompt', async function () {
     const alert = await driver.$('#prompt1');
     await alert.click();
     await driver.sendAlertText('of course!');
@@ -71,10 +73,10 @@ describe('safari - alerts', function () {
     const el = await driver.$('#promptVal');
     (await el.getAttribute('value')).should.eql('of course!');
   });
-  it.skip('should fail to set text of alert', async function () {
+  it('should fail to set text of alert', async function () {
     const alert = await driver.$('#alert1');
     await alert.click();
-    await driver.sendAlertText('yes I do!')
-      .should.be.rejectedWith(/no input fields/);
+    await driver.sendAlertText('yes I do!').should.be.rejectedWith(/no input fields/);
+    await acceptAlert(driver);
   });
 });

--- a/test/functional/web/safari-nativewebtap-e2e-specs.js
+++ b/test/functional/web/safari-nativewebtap-e2e-specs.js
@@ -36,6 +36,7 @@ const SPIN_RETRIES = 25;
 
 const PAGE_3_LINK = 'i am a link to page 3';
 const PAGE_3_TITLE = 'Another Page: page 3';
+const SCROLL_AMT = 1400;
 
 describe('Safari - coordinate conversion -', function () {
   this.timeout(MOCHA_TIMEOUT * 2);
@@ -71,10 +72,12 @@ describe('Safari - coordinate conversion -', function () {
         util.compareVersions(
           extractCapabilityValue(localSettingsCaps, 'appium:platformVersion'),
           '>=',
-          '17.0'
+          '17.0',
         )
       ) {
-        await driver.$(`-ios predicate string:type='XCUIElementTypeSwitch' AND label='Close All Tabs'`).click();
+        await driver
+          .$(`-ios predicate string:type='XCUIElementTypeSwitch' AND label='Close All Tabs'`)
+          .click();
         await driver.$$('~Clear History')[1].click();
       } else {
         if ((await driver.$$('~Clear').length) > 0) {
@@ -88,7 +91,7 @@ describe('Safari - coordinate conversion -', function () {
           util.compareVersions(
             extractCapabilityValue(localSettingsCaps, 'appium:platformVersion'),
             '>=',
-            '16.0'
+            '16.0',
           )
         ) {
           await driver
@@ -169,7 +172,10 @@ describe('Safari - coordinate conversion -', function () {
 
         it('should be able to tap on an element after scrolling', async function () {
           await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
-          await driver.execute('mobile: scroll', {direction: 'down'});
+          // FIXME mobile: scroll is broken in safari; it selects text instead of scrolling
+          // for now we'll just use JS to scroll
+          //await driver.execute('mobile: scroll', {direction: 'down'});
+          await driver.execute(`window.scrollBy(0, ${SCROLL_AMT})`);
 
           await driver.$(`=${PAGE_3_LINK}`).click();
 
@@ -247,7 +253,10 @@ describe('Safari - coordinate conversion -', function () {
 
           it('should be able to tap on an element after scrolling', async function () {
             await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
-            await driver.execute('mobile: scroll', {direction: 'down'});
+            // FIXME mobile: scroll is broken in safari; it selects text instead of scrolling
+            // for now we'll just use JS to scroll
+            //await driver.execute('mobile: scroll', {direction: 'down'});
+            await driver.execute(`window.scrollBy(0, ${SCROLL_AMT})`);
 
             await driver.$(`=${PAGE_3_LINK}`).click();
 
@@ -256,7 +265,10 @@ describe('Safari - coordinate conversion -', function () {
 
           it('should be able to tap on an element after scrolling, when the url bar is present', async function () {
             await loadPage(driver, GUINEA_PIG_SCROLLABLE_PAGE);
-            await driver.execute('mobile: scroll', {direction: 'down'});
+            // FIXME mobile: scroll is broken in safari; it selects text instead of scrolling
+            // for now we'll just use JS to scroll
+            //await driver.execute('mobile: scroll', {direction: 'down'});
+            await driver.execute(`window.scrollBy(0, ${SCROLL_AMT})`);
 
             // to get the url bar, click on the URL bar
             const ctx = await driver.getContext();


### PR DESCRIPTION
this is technically a breaking change since we're removing a deprecated method (`moveTo`). not sure how much we care.

fixes appium/appium#17013
fixes appium/appium#18951