### PR TITLE
chore: Align simulator and real device default startup urls

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -468,11 +468,7 @@ class XCUITestDriver extends BaseDriver {
    */
   getDefaultUrl() {
     // Setting this to some external URL slows down Appium startup
-    return this.isRealDevice()
-      ? `http://127.0.0.1:${this.opts.wdaLocalPort || 8100}/health`
-      : `http://${this.opts.address.includes(':') ? `[${this.opts.address}]` : this.opts.address}:${
-          this.opts.port
-        }/welcome`;
+    return `http://127.0.0.1:${this.opts.wdaLocalPort || 8100}/health`;
   }
 
   async start() {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -467,7 +467,7 @@ class XCUITestDriver extends BaseDriver {
    * @returns {string} The default URL
    */
   getDefaultUrl() {
-    // Setting this to some external URL slows down Appium startup
+    // Setting this to some external URL slows down the session init
     return `http://127.0.0.1:${this.opts.wdaLocalPort || 8100}/health`;
   }
 

--- a/test/functional/web/helpers.js
+++ b/test/functional/web/helpers.js
@@ -46,6 +46,16 @@ async function spinTitle (driver) {
   });
 }
 
+async function spinBodyIncludes (driver, expected) {
+  return await retry(10, async function () {
+    const el = await driver.$('//body');
+    const body = await el.getHTML();
+    if (!_.includes(body, expected)) {
+      throw new Error(`Could not find '${expected}' in the page body. Found: '${body}'`);
+    }
+  });
+}
+
 async function spinTitleEquals (driver, expectedTitle, tries = 10, interval = 500) {
   await retryInterval(tries, interval, async function () {
     const title = await spinTitle(driver);
@@ -81,4 +91,5 @@ export {
   GUINEA_PIG_FRAME_PAGE, GUINEA_PIG_IFRAME_PAGE, PHISHING_END_POINT,
   APPIUM_IMAGE, GUINEA_PIG_SCROLLABLE_PAGE, GUINEA_PIG_APP_BANNER_PAGE,
   doesIncludeCookie, doesNotIncludeCookie, newCookie, oldCookie1, oldCookie2,
+  spinBodyIncludes,
 };

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -4,7 +4,7 @@ import B from 'bluebird';
 import { MOCHA_TIMEOUT, initSession, deleteSession, hasDefaultPrebuiltWDA } from '../helpers/session';
 import { SAFARI_CAPS, amendCapabilities } from '../desired';
 import {
-  spinTitle, spinTitleEquals, spinWait, openPage, GUINEA_PIG_PAGE,
+  spinTitle, spinTitleEquals, spinWait, openPage, GUINEA_PIG_PAGE, spinBodyIncludes,
   // GUINEA_PIG_SCROLLABLE_PAGE,
   PHISHING_END_POINT, GUINEA_PIG_IFRAME_PAGE,
   doesIncludeCookie, doesNotIncludeCookie, newCookie, oldCookie1, oldCookie2
@@ -35,13 +35,11 @@ describe('Safari - basics -', function () {
     });
 
     it('should start a session with default init', async function () {
-      const expectedTitle = 'Appium/welcome';
       driver = await initSession(amendCapabilities(SAFARI_CAPS, {
         'appium:noReset': false,
         'appium:usePrebuiltWDA': hasDefaultPrebuiltWDA(),
       }));
-      const title = await spinTitle(driver);
-      title.should.equal(expectedTitle);
+      await spinBodyIncludes(driver, 'I-AM-ALIVE');
     });
 
     it('should start a session with custom init', async function () {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -50,16 +50,14 @@ describe('XCUITestDriver', function () {
 
     it('simulator with ipv4', function () {
       driver.opts.realDevice = false;
-      driver.opts.address = '127.0.0.1';
-      driver.opts.port = '8080';
-      expect(driver.getDefaultUrl()).eq('http://127.0.0.1:8080/welcome');
+      driver.opts.wdaLocalPort = 8111;
+      expect(driver.getDefaultUrl()).eq('http://127.0.0.1:8111/health');
     });
 
     it('simulator with ipv6', function () {
       driver.opts.realDevice = false;
       driver.opts.address = '::1';
-      driver.opts.port = '8080';
-      expect(driver.getDefaultUrl()).eq('http://[::1]:8080/welcome');
+      expect(driver.getDefaultUrl()).eq('http://127.0.0.1:8100/health');
     });
   });
 


### PR DESCRIPTION
We want to load the startup url as fast as possible to reduce the session startup duration. Thus loading the URL available on the device itself would be the fastest.