### PR TITLE
feat: Add a possibility to record screen video via IDB

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -133,6 +133,15 @@ Capability | Description
 |`appium:enablePerformanceLogging`| Enable Safari's performance logging (default `false`)| `true`, `false`|
 |`appium:autoWebview`| Move directly into Webview context if available. Default `false`|`true`, `false`|
 
+### iOS Device Bridge (IDB)
+
+Providing these capabilities assumes you have the most recent version of [Facebook IDB](https://fbidb.io/) installed on the same machine where Appium server is running and the `idb` executable is available in PATH.
+
+|Capability|Description|Values|
+|----------|-----------|------|
+|`appium:launchWithIDB`| Launch WebDriverAgentRunner with [idb](https://github.com/facebook/idb) instead of xcodebuild. This could save a significant amout of time by skiping the xcodebuild process, although the idb might not be very reliable, especially with fresh Xcode SDKs. Check the [idb repository](https://github.com/facebook/idb/issues) for more details on possible compatibility issues. Defaults to `false` |`true` or `false`|
+|`appium:idbVideo`| Starts background screen recording of the device under test using [IDB video-stream](https://fbidb.io/docs/video/) feature. The recording continues until either the session is stopped or the [mobile: stopIdbVideoRecording](./execute-methods.md#mobile-stopidbvideorecording) extension is invoked. The capability value must be a valid map with the following entries: `fps` - desirable FPS count. The value should be in range [1, 60]. It is highly recommended to explicitly provide this value to avoid unexpected video artifacts; `startupTimeoutMs` - for how long to wait until the video recording starts. 30000ms by default; `compressionQuality` - 1.0 represents the quality level used for encoded frames, this is a value between 0.0 and 1.0. 1.0 by default; `scaleFactor` - The scale factor for the source video (between 0 and 1.0) for the stream. 1.0 by default. |{fps: 15, compressionQuality: 0.75, scaleFactor: 0.5}|
+
 ### Other
 
 |Capability|Description|Values|
@@ -141,7 +150,6 @@ Capability | Description
 |`appium:commandTimeouts`|Custom timeout(s) in milliseconds for WDA backend commands execution. This might be useful if WDA backend freezes unexpectedly or requires too much time to fail and blocks automated test execution. The value is expected to be of type string and can either contain max milliseconds to wait for each WDA command to be executed before terminating the session forcefully or a valid JSON string, where keys are internal Appium command names (you can find these in logs, look for "Executing command 'command_name'" records) and values are timeouts in milliseconds. You can also set the 'default' key to assign the timeout for all other commands not explicitly enumerated as JSON keys.|`'120000'`, `'{"findElement": 40000, "findElements": 40000, "setValue": 20000, "default": 120000}'`|
 |`appium:useJSONSource`|Get JSON source from WDA and transform it to XML on the Appium server side. Defaults to `false`.|e.g., `true`|
 |`appium:skipLogCapture`|Skips to start capturing logs such as crash, system, safari console and safari network. It might improve performance such as network. Log related commands will not work. Defaults to `false`. |`true` or `false`|
-|`appium:launchWithIDB`| Launch WebDriverAgentRunner with [idb](https://github.com/facebook/idb) instead of xcodebuild. This could save a significant amout of time by skiping the xcodebuild process, although the idb might not be very reliable, especially with fresh Xcode SDKs. Check the [idb repository](https://github.com/facebook/idb/issues) for more details on possible compatibility issues. Defaults to `false` |`true` or `false`|
 |`appium:showIOSLog`| Whether to show any logs captured from a device in the appium logs. Default `false`|`true` or `false`|
 |`appium:clearSystemFiles`|Whether to clean temporary XCTest files (for example logs) when a testing session is closed. `false` by default| `true` or `false`
 |`appium:newCommandTimeout`|How long (in seconds) the driver should wait for a new command from the client before assuming the client has stopped sending requests. After the timeout the session is going to be deleted. `60` seconds by default. Setting it to zero disables the timer. |e.g. `100`|

--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -1320,3 +1320,25 @@ detailedDescription | string | The detailed description of the found accessbilit
 compactDescription | string | The compact description of the found accessbility issue. | Some compact issue description
 auditType | string or number | The name of the audit type this issue belongs to. Could be a number if the type name is unknown. | 'XCUIAccessibilityAuditTypeContrast'
 element | string | The description of the element this issue was found for. | 'Yes' button
+
+### mobile: stopIdbVideoRecording
+
+Stops the video recording initiated by the `idbVideo` capability and either returns the resulting file as base64-encoded string or uploads it to a remote server. The resulting video file is encoded by [h264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) codec and has .mp4 extension.
+An exception is thrown if the above capability has not been provided or there was a failure while recording/storing the video.
+Multiple calls to this method in scope of a single session will return the same video that the very first call has returned.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+remotePath | string | no | The path to the remote location, where the resulting video should be uploaded. The following protocols are supported: `http`, `https`, `ftp`. Null or empty string value (the default setting) means the content of resulting file should be encoded as Base64 and passed as the endpoint response value. An exception will be thrown if the generated media file is too big to fit into the available process memory. | http://my.server.com/upload
+user | string | no | The name of the user for the remote authentication. Only works if `remotePath` is provided. | admin
+pass | string | no | The password for the remote authentication. Only works if `remotePath` is provided. | pas$$w0rd
+headers | map | no | Additional headers mapping for multipart http(s) uploads | {'X-Yolo': 'yolo'}
+fileFieldName | string | no | The name of the form field where the file content BLOB should be stored for http(s) uploads | payload
+formFields | map or array of pairs | no | Additional form fields for multipart http(s) uploads | {'Field': 'value'}
+method | 'PUT' \| 'POST' \| 'PATCH' | no | The http multipart upload method name. Only works if `remotePath` is provided. 'PUT' by default. | POST
+
+#### Returned Result
+
+Base64-encoded content of the recorded media file if `remotePath` parameter is empty or an empty string.

--- a/lib/commands/idb-video.js
+++ b/lib/commands/idb-video.js
@@ -1,0 +1,152 @@
+import _ from 'lodash';
+import { tempDir, fs } from 'appium/support';
+import path from 'path';
+import {encodeBase64OrUpload} from '../utils';
+import {waitForCondition} from 'asyncbox';
+import {exec} from 'teen_process';
+
+const commands = {};
+
+/**
+ *
+ * @param {string} fpath
+ * @param {number} [timeoutMs=60000]
+ */
+async function waitUntilIdbUnlocksFile(fpath, timeoutMs = 60000) {
+  await waitForCondition(
+    async () => {
+      try {
+        const {stdout} = await exec('lsof', [fpath]);
+        return !_.includes(stdout, 'idb');
+      } catch (ign) {
+        return true;
+      }
+    },
+    {
+      waitMs: timeoutMs,
+      intervalMs: 100,
+    }
+  );
+}
+
+/**
+ * @this {import('../driver').XCUITestDriver}
+ */
+commands.startIdbVideoRecording = async function startIdbVideoRecording () {
+  if (!_.isPlainObject(this.opts.idbVideo)) {
+    throw new TypeError('The idbVideo capability is expected to be a valid object');
+  }
+  /** @type {import('appium-idb').IDB?} */
+  // @ts-ignore This property should exist
+  const idb = this.opts.device.idb;
+  if (!idb) {
+    throw new Error(`IDB must be initialized in order to start the video recording`);
+  }
+
+  // no hacks allowed
+  delete this.opts.idbVideo.outputFile;
+
+  const {
+    fps = 30,
+    startupTimeoutMs,
+    compressionQuality,
+    scaleFactor,
+  } = this.opts.idbVideo;
+
+  // Make sure we don't run any obsolete streaming processes
+  await idb.stopVideoStream();
+
+  const tmpRoot = await tempDir.openDir();
+  const name = `${new Date().toISOString().replace(/[:.]/g, '-')}.mp4`;
+  const outputFile = path.join(tmpRoot, name);
+  try {
+    await idb.startVideoStream({
+      fps,
+      format: 'h264',
+      timeoutMs: startupTimeoutMs,
+      compressionQuality,
+      scaleFactor,
+      outputFile,
+    });
+  } catch (e) {
+    await fs.rimraf(tmpRoot);
+    throw e;
+  }
+  this.log.info(`Recording the device screen into '${outputFile}'`);
+  this.opts.idbVideo.outputFile = outputFile;
+};
+
+/**
+ * @typedef {Object} StopVideoRecordingOptions
+ * @property {string} [remotePath] The path to the remote location, where the resulting video should be
+ * uploaded.
+ * The following protocols are supported: `http`, `https`, `ftp`. Null or empty
+ * string value (the default setting) means the content of resulting file
+ * should be encoded as Base64 and passed as the endpoint response value. An
+ * exception will be thrown if the generated media file is too big to fit into
+ * the available process memory.
+ * @property {string} [user] The name of the user for the remote authentication.
+ * Only works if `remotePath` is provided.
+ * @property {string} [pass] The password for the remote authentication.
+ * Only works if `remotePath` is provided.
+ * @property {import('@appium/types').HTTPHeaders} [headers] Additional headers
+ * mapping for multipart http(s) uploads
+ * @property {string} [fileFieldName] The name of the form field where the file
+ * content BLOB should be stored for http(s) uploads
+ * @property {Record<string, any> | [string, any][]} [formFields] Additional form
+ * fields for multipart http(s) uploads
+ * @property {'PUT' | 'POST' | 'PATCH'} [method='PUT'] The http multipart upload method name.
+ * Only works if `remotePath` is provided.
+ */
+
+/**
+ * @this {import('../driver').XCUITestDriver}
+ * @param {StopVideoRecordingOptions} opts
+ * @returns {Promise<string>} Base64-encoded content of the recorded media
+ * file if `remotePath` parameter is empty or null or an empty string.
+ */
+commands.mobileStopIdbVideoRecording = async function mobileStopIdbVideoRecording (opts) {
+  const videoPath = this.opts.idbVideo?.outputFile;
+  if (!videoPath) {
+    this.log.info('The IDB screen recording is not running. There is nothing to stop.');
+    return '';
+  }
+
+  // @ts-ignore This property should exist
+  await this.opts.device.idb.stopVideoStream();
+  if (!(await fs.exists(videoPath))) {
+    throw new Error(
+      `The IDB screen recording has failed to store the actual screen recording at '${videoPath}'`
+    );
+  }
+  await waitUntilIdbUnlocksFile(videoPath);
+  return await encodeBase64OrUpload(videoPath, opts.remotePath, opts);
+};
+
+/**
+ * @this {import('../driver').XCUITestDriver}
+ * @returns {Promise<void>}
+ */
+commands.cleanupIdbVideoRecording = async function cleanupIdbVideoRecording () {
+  // @ts-ignore This property should exist
+  const idb = this.opts.device?.idb;
+  if (!idb) {
+    return;
+  }
+  const videoPath = this.opts.idbVideo?.outputFile;
+  if (!videoPath) {
+    return;
+  }
+  await idb.stopVideoStream();
+  if (!await fs.exists(videoPath)) {
+    return;
+  }
+  try {
+    await waitUntilIdbUnlocksFile(videoPath);
+  } catch (ign) {
+  } finally {
+    await fs.rimraf(videoPath);
+  }
+};
+
+export default commands;

--- a/lib/commands/idb-video.js
+++ b/lib/commands/idb-video.js
@@ -77,50 +77,64 @@ commands.startIdbVideoRecording = async function startIdbVideoRecording () {
 };
 
 /**
- * @typedef {Object} StopVideoRecordingOptions
- * @property {string} [remotePath] The path to the remote location, where the resulting video should be
+ * @this {import('../driver').XCUITestDriver}
+ * @param {string} [remotePath] The path to the remote location, where the resulting video should be
  * uploaded.
  * The following protocols are supported: `http`, `https`, `ftp`. Null or empty
  * string value (the default setting) means the content of resulting file
  * should be encoded as Base64 and passed as the endpoint response value. An
  * exception will be thrown if the generated media file is too big to fit into
  * the available process memory.
- * @property {string} [user] The name of the user for the remote authentication.
+ * @param {string} [user] The name of the user for the remote authentication.
  * Only works if `remotePath` is provided.
- * @property {string} [pass] The password for the remote authentication.
+ * @param {string} [pass] The password for the remote authentication.
  * Only works if `remotePath` is provided.
- * @property {import('@appium/types').HTTPHeaders} [headers] Additional headers
+ * @param {import('@appium/types').HTTPHeaders} [headers] Additional headers
  * mapping for multipart http(s) uploads
- * @property {string} [fileFieldName] The name of the form field where the file
+ * @param {string} [fileFieldName] The name of the form field where the file
  * content BLOB should be stored for http(s) uploads
- * @property {Record<string, any> | [string, any][]} [formFields] Additional form
+ * @param {Record<string, any> | [string, any][]} [formFields] Additional form
  * fields for multipart http(s) uploads
- * @property {'PUT' | 'POST' | 'PATCH'} [method='PUT'] The http multipart upload method name.
+ * @param {'PUT' | 'POST' | 'PATCH'} [method='PUT'] The http multipart upload method name.
  * Only works if `remotePath` is provided.
- */
-
-/**
- * @this {import('../driver').XCUITestDriver}
- * @param {StopVideoRecordingOptions} opts
  * @returns {Promise<string>} Base64-encoded content of the recorded media
  * file if `remotePath` parameter is empty or null or an empty string.
  */
-commands.mobileStopIdbVideoRecording = async function mobileStopIdbVideoRecording (opts) {
+commands.mobileStopIdbVideoRecording = async function mobileStopIdbVideoRecording (
+  remotePath, user, pass, headers, fileFieldName, formFields, method
+) {
+  // @ts-ignore This property should exist
+  const idb = this.opts.device?.idb;
+  if (!idb) {
+    throw new Error(
+      `IDB has not been initialized. Have you provided the 'idbVideo' capability value?`
+    );
+  }
   const videoPath = this.opts.idbVideo?.outputFile;
   if (!videoPath) {
-    this.log.info('The IDB screen recording is not running. There is nothing to stop.');
-    return '';
+    throw new Error(
+      `No video has been recorded by IDB. Have you provided the 'idbVideo' capability value?`
+    );
   }
 
   // @ts-ignore This property should exist
-  await this.opts.device.idb.stopVideoStream();
+  await idb.stopVideoStream();
   if (!(await fs.exists(videoPath))) {
     throw new Error(
       `The IDB screen recording has failed to store the actual screen recording at '${videoPath}'`
     );
   }
-  await waitUntilIdbUnlocksFile(videoPath);
-  return await encodeBase64OrUpload(videoPath, opts.remotePath, opts);
+  try {
+    await waitUntilIdbUnlocksFile(videoPath);
+  } catch (e) {
+    this.log.warn(
+      `The resulting video file '${videoPath}' is still not fully unlocked ` +
+      `before being prepared for the response: ${e.message}`
+    );
+  }
+  return await encodeBase64OrUpload(videoPath, remotePath, {
+    user, pass, headers, fileFieldName, formFields, method
+  });
 };
 
 /**
@@ -141,12 +155,15 @@ commands.cleanupIdbVideoRecording = async function cleanupIdbVideoRecording () {
   if (!await fs.exists(videoPath)) {
     return;
   }
-  try {
-    await waitUntilIdbUnlocksFile(videoPath);
-  } catch (ign) {
-  } finally {
-    await fs.rimraf(videoPath);
-  }
+  // We don't want it to block
+  (async () => {
+    try {
+      await waitUntilIdbUnlocksFile(videoPath);
+    } catch (ign) {
+    } finally {
+      await fs.rimraf(videoPath);
+    }
+  })();
 };
 
 export default commands;

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -39,6 +39,7 @@ import sourceExtensions from './source';
 import timeoutExtensions from './timeouts';
 import webExtensions from './web';
 import xctestExtensions from './xctest';
+import idbVideoExtensions from './idb-video';
 
 export default {
   activeAppInfoExtensions,
@@ -81,5 +82,6 @@ export default {
   sourceExtensions,
   timeoutExtensions,
   webExtensions,
-  xctestExtensions
+  xctestExtensions,
+  idbVideoExtensions,
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -341,6 +341,9 @@ const desiredCapConstraints = /** @type {const} */({
   },
   enforceAppInstall: {
     isBoolean: true,
+  },
+  idbVideo: {
+    isObject: true,
   }
 });
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -471,6 +471,26 @@ class XCUITestDriver extends BaseDriver {
     return `http://127.0.0.1:${this.opts.wdaLocalPort || 8100}/health`;
   }
 
+  async initIdb() {
+    if (!this.opts.launchWithIDB && !this.opts.idbVideo) {
+      return;
+    }
+
+    try {
+      const idb = new IDB({udid: this.opts.udid});
+      await idb.connect();
+      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+      this.opts.device.idb = idb;
+    } catch (e) {
+      this.log.debug(e.stack);
+      if (!this.opts.idbVideo) {
+        this.log.warn(`idb will not be used. Original error: ${e.message}`);
+        return;
+      }
+      throw new Error(`idb cannot be used for video recording. Original error: ${e.message}`);
+    }
+  }
+
   async start() {
     this.opts.noReset = !!this.opts.noReset;
     this.opts.fullReset = !!this.opts.fullReset;
@@ -622,18 +642,9 @@ class XCUITestDriver extends BaseDriver {
         await this.opts.device.setReduceTransparency(this.opts.reduceTransparency);
       }
 
-      if (this.opts.launchWithIDB) {
-        try {
-          const idb = new IDB({udid});
-          await idb.connect();
-          // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-          this.opts.device.idb = idb;
-        } catch (e) {
-          this.log.debug(e.stack);
-          this.log.warn(
-            `idb will not be used for Simulator interaction. Original error: ${e.message}`
-          );
-        }
+      await this.initIdb();
+      if (!_.isNil(this.opts.idbVideo)) {
+        await this.startIdbVideoRecording();
       }
 
       this.logEvent('simStarted');
@@ -1021,6 +1032,8 @@ class XCUITestDriver extends BaseDriver {
       this.log.info('Closing MJPEG stream');
       this.mjpegStream.stop();
     }
+
+    await this.cleanupIdbVideoRecording();
 
     this.resetIos();
 
@@ -2013,6 +2026,13 @@ class XCUITestDriver extends BaseDriver {
   mobileRotateElement = commands.gestureExtensions.mobileRotateElement;
   getCoordinates = commands.gestureExtensions.getCoordinates;
   applyMoveToOffset = commands.gestureExtensions.applyMoveToOffset;
+
+  /*-----------+
+   | IDB VIDEO |
+   +----------+*/
+  startIdbVideoRecording = commands.idbVideoExtensions.startIdbVideoRecording;
+  mobileStopIdbVideoRecording = commands.idbVideoExtensions.mobileStopIdbVideoRecording;
+  cleanupIdbVideoRecording = commands.idbVideoExtensions.cleanupIdbVideoRecording;
 
   /*-------+
    | IOHID |

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -320,6 +320,12 @@ export const executeMethodMap = {
       required: ['style'],
     },
   },
+  'mobile: stopIdbVideoRecording': {
+    command: 'mobileStopIdbVideoRecording',
+    params: {
+      optional: ['remotePath', 'user', 'pass', 'headers', 'fileFieldName', 'formFields', 'method'],
+    },
+  },
   'mobile: siriCommand': {
     command: 'mobileSiriCommand',
     params: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.x",
-        "appium-idb": "^1.6.13",
+        "appium-idb": "^1.8.2",
         "appium-ios-device": "^2.5.4",
         "appium-ios-simulator": "^5.1.3",
         "appium-remote-debugger": "^10.0.0",
@@ -4115,9 +4115,9 @@
       }
     },
     "node_modules/appium-idb": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/appium-idb/-/appium-idb-1.7.0.tgz",
-      "integrity": "sha512-D/r0D8D69TO9rha5zak+9544ZweceglzncZc/UuEyfjRS/IjH4AbGmww3/ntA5MjEjj35u+X66EtVU1mHEW+SA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/appium-idb/-/appium-idb-1.8.2.tgz",
+      "integrity": "sha512-G/mCkEAdE9SHGNaWclOb4D0tFQwfGPZF32U3XVIKgA5c/jm2p0A8STPv6SEDY0KEbBHKbZI5YeY+8CH7kQ8MOg==",
       "dependencies": {
         "@appium/support": "^4.0.0",
         "asyncbox": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "types": "./build/index.d.ts",
   "dependencies": {
     "@xmldom/xmldom": "^0.x",
-    "appium-idb": "^1.6.13",
+    "appium-idb": "^1.8.1",
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.1.3",
     "appium-remote-debugger": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "types": "./build/index.d.ts",
   "dependencies": {
     "@xmldom/xmldom": "^0.x",
-    "appium-idb": "^1.8.1",
+    "appium-idb": "^1.8.2",
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.1.3",
     "appium-remote-debugger": "^10.0.0",


### PR DESCRIPTION
Based on https://fbidb.io/docs/video/

Obviously, in order to switch the device under test to the video broadcasting mode idb needs to reset the existing connection to it, which terminates xcodebuild or any other proxy instances to it. That is why we cannot make the corresponding CLI call being in a test session, but rather before it starts. That is why I have made it to a capability, so the video recording always starts in advance (the usual user scenario would be anyway to just record the whole test execution) and the method to stop the recording might be called at any time while the session runs (This is also something that needs verification with real devices, because if it also resets the connection then we would need to move the stuff into the capability as well).