### PR TITLE
ci: use angular as the preset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,7 @@
 {
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "conventionalcommits"
+      "preset": "angular"
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits",


### PR DESCRIPTION
seems weird... but `npx semantic-release --dry-run --debug` also ended below:

```
n' + '\n' + 'Bumps [@types/lodash](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/lodash) from 4.14.197 to 4.14.198.\n' + '- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)\n' + '- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/lodash)\n' + '\n' + '---\n' + 'updated-dependencies:\n' + '- dependency-name: "@types/lodash"\n' + '  dependency-type: direct:development\n' + '  update-type: version-update:semver-patch\n' + '...\n' + '\n' + 'Signed-off-by: dependabot[bot] <support@github.com>', gitTags: '' }, { commit: { long: '91584c910f2f800bc741bb205a71e69dadfe9d42', short: '91584c91' }, tree: { long: 'a25c104566ed3c896cdc8042aeb38fbeda2dca6e', short: 'a25c1045' }, author: { name: 'Kazuaki Matsuo', email: 'fly.49.89.over@gmail.com', date: 2023-09-06T03:43:39.000Z }, committer: { name: 'GitHub', email: 'noreply@github.com', date: 2023-09-06T03:43:39.000Z }, subject: 'docs: update CHANGELOG.md', body: '', hash: '91584c910f2f800bc741bb205a71e69dadfe9d42', committerDate: 2023-09-06T03:43:39.000Z, message: 'docs: update CHANGELOG.md', gitTags: '' } ] +37ms
[12:27:15 AM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
```

So the release command did not proceed further after `analyzeCommits`. After the command, the release command generate packages etc.

After changing to angular, it would be:

```
[12:29:54 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: dummy feat commit to run the auto release (#1983)
  semantic-release:commit-analyzer Analyzing with default rules +0ms
  semantic-release:commit-analyzer The rule { type: 'feat', release: 'minor' } match commit with release type 'minor' +0ms
[12:29:54 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[12:29:54 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add autoFillPasswords capability (#1972)
  semantic-release:commit-analyzer Analyzing with default rules +1ms
  semantic-release:commit-analyzer The rule { type: 'feat', release: 'minor' } match commit with release type 'minor' +1ms
[12:29:54 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[12:29:54 AM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore(deps-dev): bump @types/teen_process from 2.0.0 to 2.0.1

Bumps [@types/teen_process](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/teen_process) from 2.0.0 to 2.0.1.
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/teen_process)

...
marked(): mangle parameter is enabled by default, but is deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install https://www.npmjs.com/package/marked-mangle, or disable by setting `{mangle: false}`.
marked(): headerIds and headerPrefix parameters enabled by default, but are deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install  https://www.npmjs.com/package/marked-gfm-heading-id, or disable by setting `{headerIds: false}`.
## 5.1.0 (2023-09-14)

### Features

    * add autoFillPasswords capability (#1972) (85aaa7f)
    * dummy feat commit to run the auto release (#1983) (5916712)

```

So I think this command will work again

Basically other drivers use `angular` like https://github.com/appium/appium-uiautomator2-driver/blob/master/.releaserc so this rule itself is consistent across our repositories so far.