### PR TITLE
chore: remove shrinkwrap

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -26,8 +26,6 @@ jobs:
         npm prune --production
         rm -rf node_modules/appium
       name: Remove dev dependencies and appium peer dependencies
-    - run: npm shrinkwrap # this command removes package-lock.json...
-      name: Create shrinkwrap
     - run: npm ci --only=dev
       name: Install dev dependencies for the release
     - run: npx semantic-release


### PR DESCRIPTION
Noticed current uia2, xcuitest and probably other drivers also no longer include `npm-shrinkwrap.json` in the published packages. 

So maybe every install installs the latest dependencies in the package.json even when am installation command specifies an older version. (This is not good)

This repository already has lock file, so maybe we can remove `npm shrinkwrap`, then can expect the lock file will be part of npm install module to lock dependencies...? The npm command converts package-lock.json to npm-shrinkwrap.json so just removing it will keep package-lock.json I assume...

If this works, we may be able to add package-lock.json file in each driver's top directory as same as this xcuitest to lock dependencies for each package versions


e.g.
<img width="245" alt="Screenshot 2023-09-14 at 1 35 46 AM" src="https://github.com/appium/appium-xcuitest-driver/assets/5511591/8e7c74a4-e669-4a9f-a5a7-9630f5cf0ea1">



5.0.0 no longer had. 4.32.0 still had, but 4.32.23 did not.

So I guess typescript update affected this...? Then, other drivers started recently???