### PR TITLE
chore: remove old implementation in get page source

### DIFF
--- a/lib/commands/permissions.js
+++ b/lib/commands/permissions.js
@@ -44,7 +44,7 @@ export default {
    *
    * @param {string} bundleId - Bundle identifier of the target application
    * @param {import('./enum').PermissionService} service - Service name
-   * @returns {Promise<PermissionState>} Either 'yes', 'no', 'unset' or 'limited'
+   * @returns {Promise<import('./types').PermissionState>} Either 'yes', 'no', 'unset' or 'limited'
    * @throws {Error} If permission getting fails or the device is not a Simulator.
    * @this {XCUITestDriver}
    * @group Simulator Only
@@ -62,7 +62,7 @@ export default {
   /**
    * Set application permission state on Simulator.
    *
-   * @param {Record<Partial<import('./types').AccessRule>, PermissionState>} access - One or more access rules to set.
+   * @param {Record<Partial<import('./types').AccessRule>, import('./types').PermissionState>} access - One or more access rules to set.
    * @param {string} bundleId - Bundle identifier of the target application
    * @since Xcode SDK 11.4
    * @throws {Error} If permission setting fails or the device is not a Simulator.

--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -12,12 +12,11 @@ const commands = {
       return await this.executeAtom('execute_script', [script, []]);
     }
 
-    const format = (await this.settings.getSettings()).useJSONSource ? 'json' : 'xml';
-    const srcTree = await this.mobileGetSource(format);
-    if (format === 'xml') {
-      return srcTree;
+    if ((await this.settings.getSettings()).useJSONSource) {
+      const srcTree = await this.mobileGetSource('json');
+      return getSourceXml(getTreeForXML(srcTree));
     }
-    return getSourceXml(getTreeForXML(srcTree));
+    return await this.mobileGetSource('xml');
   },
 };
 

--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -1,9 +1,6 @@
-import xmldom from '@xmldom/xmldom';
 import js2xml from 'js2xmlparser2';
 
 const APPIUM_AUT_TAG = 'AppiumAUT';
-const APPIUM_SRC_XML = `<?xml version="1.0" encoding="UTF-8"?><${APPIUM_AUT_TAG}/>`;
-const APPIUM_TAG_PATTERN = new RegExp(`</?${APPIUM_AUT_TAG}/?>`);
 
 const commands = {
   /**
@@ -15,34 +12,16 @@ const commands = {
       return await this.executeAtom('execute_script', [script, []]);
     }
 
-    if ((await this.settings.getSettings()).useJSONSource) {
-      const srcTree = await this.mobileGetSource('json');
-      return getSourceXml(getTreeForXML(srcTree));
+    const format = (await this.settings.getSettings()).useJSONSource ? 'json' : 'xml';
+    const srcTree = await this.mobileGetSource(format);
+    if (format === 'xml') {
+      return srcTree;
     }
-    return await this.getNativePageSource();
+    return getSourceXml(getTreeForXML(srcTree));
   },
 };
 
 const helpers = {
-  /**
-   * @this {XCUITestDriver}
-   */
-  async getNativePageSource() {
-    const srcTree = /** @type {string} */ (
-      await this.proxyCommand(`/source?scope=${APPIUM_AUT_TAG}`, 'GET')
-    );
-    if (APPIUM_TAG_PATTERN.test(srcTree)) {
-      return srcTree;
-    }
-    // This might only happen if the driver is using an older/cached WDA
-    // build (e.g. below 3.16.0)
-    // TODO: remove this block after a while
-    const parser = new xmldom.DOMParser();
-    const tree = parser.parseFromString(srcTree);
-    const doc = parser.parseFromString(APPIUM_SRC_XML);
-    doc.documentElement.appendChild(tree.documentElement);
-    return new xmldom.XMLSerializer().serializeToString(doc);
-  },
   /**
    * Retrieve the source tree of the current page in XML or JSON format.
    *

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2139,7 +2139,6 @@ class XCUITestDriver extends BaseDriver {
    | SOURCE |
    +--------+*/
   getPageSource = commands.sourceExtensions.getPageSource;
-  getNativePageSource = commands.sourceExtensions.getNativePageSource;
   mobileGetSource = commands.sourceExtensions.mobileGetSource;
 
   /*----------+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "^0.x",
         "appium-idb": "^1.6.13",
         "appium-ios-device": "^2.5.4",
         "appium-ios-simulator": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   ],
   "types": "./build/index.d.ts",
   "dependencies": {
-    "@xmldom/xmldom": "^0.x",
     "appium-idb": "^1.6.13",
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.1.3",

--- a/test/unit/commands/source-specs.js
+++ b/test/unit/commands/source-specs.js
@@ -19,14 +19,8 @@ describe('source commands', function () {
     it('should send translated GET request to WDA', async function () {
       await driver.getPageSource();
       proxyStub.calledOnce.should.be.true;
-      proxyStub.firstCall.args[0].should.eql('/source?scope=AppiumAUT');
+      proxyStub.firstCall.args[0].should.eql('/source?format=xml&scope=AppiumAUT');
       proxyStub.firstCall.args[1].should.eql('GET');
-    });
-    it('should insert received xml into AppiumAUT tags', async function () {
-      let src = await driver.getPageSource();
-      src.indexOf(xmlHeader).should.eql(0);
-      src.indexOf(appiumHeadTag).should.eql(xmlHeader.length);
-      src.indexOf(appiumFootTag).should.eql(srcTree.length + appiumHeadTag.length);
     });
   });
 });

--- a/test/unit/commands/source-specs.js
+++ b/test/unit/commands/source-specs.js
@@ -4,8 +4,6 @@ import XCUITestDriver from '../../../lib/driver';
 const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
 const xmlBody = '<some-xml/>';
 const srcTree = `${xmlHeader}${xmlBody}`;
-const appiumHeadTag = '<AppiumAUT>';
-const appiumFootTag = '</AppiumAUT>';
 
 describe('source commands', function () {
   let driver = new XCUITestDriver();


### PR DESCRIPTION
I'm thinking to add a setting like `excludedAttributes` to exclude these attributes for `/source` endpoint. 
I also think of https://github.com/appium/appium-inspector/issues/1062 for lower appium versions, but this is via settings api.

Then, `/source` endpoint will apply the settings always. (This exclude won't apply for `useJSONSource` since it is json format for WDA)

Before that, I found we could remove existing old implementation that we may be able to remove for now. Maybe I think we can drop for now, what do you think?