### PR TITLE
fix: terminateApp with devicectl for iOS 17

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -139,7 +139,7 @@ export default {
     }
 
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    return await this.opts.device.terminateApp(bundleId);
+    return await this.opts.device.terminateApp(bundleId, this.opts.platformVersion);
   },
 
   /**

--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -3,6 +3,7 @@ import path from 'path';
 import {fs, zip, logger, util, tempDir} from 'appium/support';
 import {SubProcess, exec} from 'teen_process';
 import {encodeBase64OrUpload} from '../utils';
+import { XCRUN, requireXcrun } from '../xcrun';
 import {waitForCondition} from 'asyncbox';
 import B from 'bluebird';
 
@@ -18,19 +19,10 @@ const DEFAULT_PROFILE_NAME = 'Activity Monitor';
 const DEFAULT_EXT = '.trace';
 const DEFAULT_PID = 'current';
 const INSTRUMENTS = 'instruments';
-const XCRUN = 'xcrun';
 const XCTRACE = 'xctrace';
 
 async function requireXctrace() {
-  let xcrunPath;
-  try {
-    xcrunPath = await fs.which(XCRUN);
-  } catch (e) {
-    throw new Error(
-      `${XCRUN} has not been found in PATH. ` +
-        `Please make sure XCode development tools are installed`,
-    );
-  }
+  const xcrunPath = await requireXcrun();
   try {
     await exec(xcrunPath, [XCTRACE, 'help']);
   } catch (e) {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import {exec} from 'teen_process';
 import {extractBundleId} from './app-utils';
 import {pushFolder} from './ios-fs-helpers';
+import { requireXcrun } from './xcrun';
 
 const APPLICATION_INSTALLED_NOTIFICATION = 'com.apple.mobile.application_installed';
 const INSTALLATION_STAGING_DIR = 'PublicStaging';
@@ -192,7 +193,7 @@ class IOSDeploy {
     }
   }
 
-  async terminateApp(bundleId) {
+  async terminateApp(bundleId, platformVersion) {
     let instrumentService;
     let installProxyService;
     try {
@@ -204,22 +205,51 @@ class IOSDeploy {
       }
       const executableName = apps[bundleId].CFBundleExecutable;
       log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
-      instrumentService = await services.startInstrumentService(this.udid);
-      const processes = await instrumentService.callChannel(
-        INSTRUMENT_CHANNEL.DEVICE_INFO,
-        'runningProcesses',
-      );
-      const process = processes.selector.find((process) => process.name === executableName);
-      if (!process) {
-        log.info(`The process of the bundle id '${bundleId}' was not running`);
-        return false;
+
+      log.info(`platformVersion: '${platformVersion}'`);
+
+      // TODO: use version comparison
+      if (platformVersion === '17.0') {
+        const xcrunBinnaryPath = await requireXcrun();
+        let args = [];
+        args.push(
+          'devicectl',
+          'device',
+          'info',
+          'processes',
+          `--device`, this.udid
+        );
+        const {stdout} = await exec(xcrunBinnaryPath, args, { timeout: 60 * 1000 });
+        const executableLine = stdout.split('\n').find((line) => line.trim().endsWith(executableName));
+        args = [];
+        args.push(
+          'devicectl',
+          'device',
+          'process',
+          'signal',
+          '-s', `2`,
+          '-p', `${executableLine?.split(/\s+/)[0]}`,
+          `--device`, this.udid
+        );
+        await exec(xcrunBinnaryPath, args, { timeout: 60 * 1000 });
+      } else {
+        instrumentService = await services.startInstrumentService(this.udid);
+        const processes = await instrumentService.callChannel(
+          INSTRUMENT_CHANNEL.DEVICE_INFO,
+          'runningProcesses',
+        );
+        const process = processes.selector.find((process) => process.name === executableName);
+        if (!process) {
+          log.info(`The process of the bundle id '${bundleId}' was not running`);
+          return false;
+        }
+          await instrumentService.callChannel(
+          INSTRUMENT_CHANNEL.PROCESS_CONTROL,
+          'killPid:',
+          `${process.pid}`,
+        );
+        return true;
       }
-      await instrumentService.callChannel(
-        INSTRUMENT_CHANNEL.PROCESS_CONTROL,
-        'killPid:',
-        `${process.pid}`,
-      );
-      return true;
     } catch (err) {
       log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
       return false;

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -1,4 +1,4 @@
-import {fs, timing} from 'appium/support';
+import {fs, timing, util} from 'appium/support';
 import path from 'path';
 import {services, utilities, INSTRUMENT_CHANNEL} from 'appium-ios-device';
 import B from 'bluebird';
@@ -206,10 +206,13 @@ class IOSDeploy {
       const executableName = apps[bundleId].CFBundleExecutable;
       log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
 
-      log.info(`platformVersion: '${platformVersion}'`);
+      // 'devicectl' has overhead than the instrument service via appium-ios-device,
+      // so hre uses the 'devicectl' only for iOS 17+.
+      if (util.compareVersions(platformVersion, '>', '17.0')) {
+        log.debug(`Calling devicectl to kill the process`);
 
-      // TODO: use version comparison
-      if (platformVersion === '17.0') {
+        // FIXME: replace `devicectl` command with a wrapper later
+
         const xcrunBinnaryPath = await requireXcrun();
         let args = [];
         args.push(
@@ -219,8 +222,10 @@ class IOSDeploy {
           'processes',
           `--device`, this.udid
         );
-        const {stdout} = await exec(xcrunBinnaryPath, args, { timeout: 60 * 1000 });
-        // e.g.
+        const {stdout} = await exec(xcrunBinnaryPath, args);
+        // Each line has spaces. devicectl has JSON output option, but it writes it to a file only.
+        // Here parse the standard output directly.
+        // e.g.:
         // 823   /private/var/containers/Bundle/Application/8E748312-8CBE-4C13-8295-C2EF3ED2C0C1/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner
         // 824   /Applications/MobileSafari.app/MobileSafari
         // 825   /usr/libexec/debugserver
@@ -236,7 +241,7 @@ class IOSDeploy {
           '-p', `${executableLine?.split(/\s+/)[0]}`,
           `--device`, this.udid
         );
-        await exec(xcrunBinnaryPath, args, { timeout: 60 * 1000 });
+        await exec(xcrunBinnaryPath, args);
       } else {
         instrumentService = await services.startInstrumentService(this.udid);
         const processes = await instrumentService.callChannel(

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -220,6 +220,10 @@ class IOSDeploy {
           `--device`, this.udid
         );
         const {stdout} = await exec(xcrunBinnaryPath, args, { timeout: 60 * 1000 });
+        // e.g.
+        // 823   /private/var/containers/Bundle/Application/8E748312-8CBE-4C13-8295-C2EF3ED2C0C1/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner
+        // 824   /Applications/MobileSafari.app/MobileSafari
+        // 825   /usr/libexec/debugserver
         const executableLine = stdout.split('\n').find((line) => line.trim().endsWith(executableName));
         args = [];
         args.push(
@@ -228,6 +232,7 @@ class IOSDeploy {
           'process',
           'signal',
           '-s', `2`,
+          // e.g. '824   /Applications/MobileSafari.app/MobileSafari              '
           '-p', `${executableLine?.split(/\s+/)[0]}`,
           `--device`, this.udid
         );

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -242,7 +242,7 @@ class IOSDeploy {
           // e.g.
           // '824   /Applications/MobileSafari.app/MobileSafari              '
           // ' 999   /Applications/MobileSafari.app/MobileSafari              '  (can include spaces in the top)
-          '-p', `${executableLine?.trim().split(/\s+/)[0]}`,
+          '-p', `${executableLine.trim().split(/\s+/)[0]}`,
           `--device`, this.udid
         ]);
       } else {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -206,7 +206,7 @@ class IOSDeploy {
       const executableName = apps[bundleId].CFBundleExecutable;
       log.debug(`The executable name for the bundle id '${bundleId}' was '${executableName}'`);
 
-      // 'devicectl' has overhead than the instrument service via appium-ios-device,
+      // 'devicectl' has overhead (generally?) than the instrument service via appium-ios-device,
       // so hre uses the 'devicectl' only for iOS 17+.
       if (util.compareVersions(platformVersion, '>=', '17.0')) {
         log.debug(`Calling devicectl to kill the process`);

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -208,7 +208,7 @@ class IOSDeploy {
 
       // 'devicectl' has overhead than the instrument service via appium-ios-device,
       // so hre uses the 'devicectl' only for iOS 17+.
-      if (util.compareVersions(platformVersion, '>', '17.0')) {
+      if (util.compareVersions(platformVersion, '>=', '17.0')) {
         log.debug(`Calling devicectl to kill the process`);
 
         // FIXME: replace `devicectl` command with a wrapper later
@@ -231,6 +231,10 @@ class IOSDeploy {
         // 824   /Applications/MobileSafari.app/MobileSafari
         // 825   /usr/libexec/debugserver
         const executableLine = stdout.split('\n').find((line) => line.trim().endsWith(executableName));
+        if (!executableLine) {
+          log.info(`The process of the bundle id '${bundleId}' was not running`);
+          return false;
+        }
         args = [];
         args.push(
           'devicectl',
@@ -259,7 +263,6 @@ class IOSDeploy {
           'killPid:',
           `${process.pid}`,
         );
-        return true;
       }
     } catch (err) {
       log.warn(`Failed to kill '${bundleId}'. Original error: ${err.stderr || err.message}`);
@@ -272,6 +275,7 @@ class IOSDeploy {
         instrumentService.close();
       }
     }
+    return true;
   }
 
   /**

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -212,6 +212,7 @@ class IOSDeploy {
         log.debug(`Calling devicectl to kill the process`);
 
         // FIXME: replace `devicectl` command with a wrapper later
+        // or remove after implementing appium-ios-device for iOS 17+.
 
         const xcrunBinnaryPath = await requireXcrun();
         let args = [];

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -215,15 +215,13 @@ class IOSDeploy {
         // or remove after implementing appium-ios-device for iOS 17+.
 
         const xcrunBinnaryPath = await requireXcrun();
-        let args = [];
-        args.push(
+        const {stdout} = await exec(xcrunBinnaryPath, [
           'devicectl',
           'device',
           'info',
           'processes',
           `--device`, this.udid
-        );
-        const {stdout} = await exec(xcrunBinnaryPath, args);
+        ]);
         // Each line has spaces. devicectl has JSON output option, but it writes it to a file only.
         // Here parse the standard output directly.
         // e.g.:
@@ -235,8 +233,7 @@ class IOSDeploy {
           log.info(`The process of the bundle id '${bundleId}' was not running`);
           return false;
         }
-        args = [];
-        args.push(
+        await exec(xcrunBinnaryPath, [
           'devicectl',
           'device',
           'process',
@@ -247,8 +244,7 @@ class IOSDeploy {
           // ' 999   /Applications/MobileSafari.app/MobileSafari              '  (can include spaces in the top)
           '-p', `${executableLine?.trim().split(/\s+/)[0]}`,
           `--device`, this.udid
-        );
-        await exec(xcrunBinnaryPath, args);
+        ]);
       } else {
         instrumentService = await services.startInstrumentService(this.udid);
         const processes = await instrumentService.callChannel(

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -242,8 +242,10 @@ class IOSDeploy {
           'process',
           'signal',
           '-s', `2`,
-          // e.g. '824   /Applications/MobileSafari.app/MobileSafari              '
-          '-p', `${executableLine?.split(/\s+/)[0]}`,
+          // e.g.
+          // '824   /Applications/MobileSafari.app/MobileSafari              '
+          // ' 999   /Applications/MobileSafari.app/MobileSafari              '  (can include spaces in the top)
+          '-p', `${executableLine?.trim().split(/\s+/)[0]}`,
           `--device`, this.udid
         );
         await exec(xcrunBinnaryPath, args);

--- a/lib/xcrun.js
+++ b/lib/xcrun.js
@@ -1,0 +1,16 @@
+import {fs} from 'appium/support';
+
+const XCRUN = 'xcrun';
+
+async function requireXcrun() {
+  try {
+    return await fs.which(XCRUN);
+  } catch (e) {
+    throw new Error(
+      `${XCRUN} has not been found in PATH. ` +
+        `Please make sure XCode development tools are installed`,
+    );
+  }
+}
+
+export {requireXcrun, XCRUN};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appium-xcuitest-driver",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appium-xcuitest-driver",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "appium-idb": "^1.6.13",


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/18749

This PR kills the process directly against iOS 17 devices via `devicectl` command without appium-ios-device side modifications.

```
driver.execute_script 'mobile:killApp', {bundleId: "com.apple.mobilesafari"}
```


terminateApp via XCTest (WDA) works without any issues, but instrument service gets an issue in iOS 17 with current appium-ios-device implementation. This could have small overhead than existing implementation (because of `devicectl`), but should not be a big issue for this usage

---

**Note**
Maybe we need to build a wrapper module for `devicectl` to use it widely for our use. This PR should refer to it later.