### PR TITLE
fix: (dummy) releaserc update

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -30,7 +30,7 @@ jobs:
       name: Create shrinkwrap
     - run: npm ci --only=dev
       name: Install dev dependencies for the release
-    - run: npx semantic-release
+    - run: npx semantic-release --dry-run
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -21,10 +21,10 @@
         ]
       }
     }],
+    "@semantic-release/npm",
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/npm",
     ["@semantic-release/git", {
       "assets": ["docs", "package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
I wonder current unexpected `npm-shrinkwrap.json` removal from npm push was by this order diff. Let me check if this helps.

Expected behavior is `npm-shrinkwrap.json` present in the npm package:

current (npm-shrinkwrap.json does not exist)
```
2023-09-23T23:25:31.9799760Z npm notice 17.4kB  lib/utils.js                                     
2023-09-23T23:25:31.9800160Z npm notice 329B    lib/xcrun.js                                     
2023-09-23T23:25:31.9800570Z npm notice 6.0kB   package.json                                     
2023-09-23T23:25:31.9801090Z npm notice 1.9kB   scripts/build-docs.js                            
2023-09-23T23:25:31.9801630Z npm notice 1.2kB   scripts/build-wda.js                             
2023-09-23T23:25:31.9802170Z npm notice 411B    scripts/open-wda.js                              
2023-09-23T23:25:31.9802510Z npm notice === Tarball Details === 
2023-09-23T23:25:31.9803040Z npm notice name:          appium-xcuitest-driver                  
2023-09-23T23:25:31.9803460Z npm notice version:       5.3.1                                   
2023-09-23T23:25:31.9804000Z npm notice filename:      appium-xcuitest-driver-5.3.1.tgz        
2023-09-23T23:25:31.9804600Z npm notice package size:  473.2 kB                                
2023-09-23T23:25:31.9805030Z npm notice unpacked size: 2.8 MB                                  
2023-09-23T23:25:31.9805480Z npm notice shasum:        c0cf3322dacf25e6cecf2acab82d096bfc6f4fda
2023-09-23T23:25:31.9806060Z npm notice integrity:     sha512-tYcLTPtIILdD5[...]DhNBs80GwVRCA==
2023-09-23T23:25:31.9806500Z npm notice total files:   369                                     
2023-09-23T23:25:31.9806740Z npm notice 
```