### PR TITLE
fix: get bundleId for other apps before calling installation

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1724,12 +1724,13 @@ class XCUITestDriver extends BaseDriver {
       /** @type {string[]} */ (appsList).map((app) => this.helpers.configureApp(app, '.app')),
     );
     for (const otherApp of appPaths) {
+      const otherAppBundleId = await extractBundleId.bind(this)(otherApp);
       if (this.isRealDevice()) {
         await installToRealDevice(
           // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           this.opts.device,
           otherApp,
-          undefined,
+          otherAppBundleId,
           {
             skipUninstall: true, // to make the behavior as same as UIA2
             timeout: this.opts.appPushTimeout,
@@ -1741,7 +1742,7 @@ class XCUITestDriver extends BaseDriver {
           // @ts-expect-error - do not assign arbitrary properties to `this.opts`
           this.opts.device,
           otherApp,
-          undefined,
+          otherAppBundleId,
           {
             newSimulator: this.lifecycleData.createSim,
           },

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -275,6 +275,7 @@ describe('XCUITestDriver', function () {
       sandbox.stub(RealDeviceManagementModule, 'installToRealDevice');
       sandbox.stub(driver, 'isRealDevice').returns(true);
       sandbox.stub(driver.helpers, 'configureApp').resolves('/path/to/iosApp.app');
+      sandbox.stub(appUtils, 'extractBundleId').resolves('bundle-id');
       // @ts-expect-error random stuff on opts
       driver.opts.device = 'some-device';
       driver.lifecycleData = {createSim: false};
@@ -296,6 +297,9 @@ describe('XCUITestDriver', function () {
       const configureAppStub = sandbox.stub(driver.helpers, 'configureApp');
       configureAppStub.onCall(0).resolves('/path/to/iosApp1.app');
       configureAppStub.onCall(1).resolves('/path/to/iosApp2.app');
+      sandbox.stub(appUtils, 'extractBundleId')
+        .onCall(0).resolves('bundle-id')
+        .onCall(1).resolves('bundle-id2');
       // @ts-expect-error random stuff on opts
       driver.opts.device = 'some-device';
       driver.lifecycleData = {createSim: false};
@@ -321,6 +325,7 @@ describe('XCUITestDriver', function () {
       sandbox.stub(SimulatorManagementModule, 'installToSimulator');
       sandbox.stub(driver, 'isRealDevice').returns(false);
       sandbox.stub(driver.helpers, 'configureApp').resolves('/path/to/iosApp.app');
+      sandbox.stub(appUtils, 'extractBundleId').resolves('bundle-id');
       driver.opts.noReset = false;
       // @ts-expect-error random stuff on opts
       driver.opts.device = 'some-device';
@@ -343,6 +348,9 @@ describe('XCUITestDriver', function () {
       const configureAppStub = sandbox.stub(driver.helpers, 'configureApp');
       configureAppStub.onCall(0).resolves('/path/to/iosApp1.app');
       configureAppStub.onCall(1).resolves('/path/to/iosApp2.app');
+      sandbox.stub(appUtils, 'extractBundleId')
+        .onCall(0).resolves('bundle-id')
+        .onCall(1).resolves('bundle-id2');
       driver.opts.noReset = false;
       // @ts-expect-error random stuff on opts
       driver.opts.device = 'some-device';

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -284,7 +284,7 @@ describe('XCUITestDriver', function () {
       expect(RealDeviceManagementModule.installToRealDevice).to.have.been.calledOnceWith(
         'some-device',
         '/path/to/iosApp.app',
-        undefined,
+        'bundle-id',
         {skipUninstall: true, timeout: undefined, strategy: undefined},
       );
     });
@@ -305,13 +305,13 @@ describe('XCUITestDriver', function () {
       expect(RealDeviceManagementModule.installToRealDevice).to.have.been.calledWith(
         'some-device',
         '/path/to/iosApp1.app',
-        undefined,
+        'bundle-id',
         {skipUninstall: true, timeout: undefined, strategy: undefined},
       );
       expect(RealDeviceManagementModule.installToRealDevice).to.have.been.calledWith(
         'some-device',
         '/path/to/iosApp2.app',
-        undefined,
+        'bundle-id2',
         {skipUninstall: true, timeout: undefined, strategy: undefined},
       );
     });
@@ -331,7 +331,7 @@ describe('XCUITestDriver', function () {
       expect(SimulatorManagementModule.installToSimulator).to.have.been.calledOnceWith(
         'some-device',
         '/path/to/iosApp.app',
-        undefined,
+        'bundle-id',
         {newSimulator: false},
       );
     });
@@ -353,13 +353,13 @@ describe('XCUITestDriver', function () {
       expect(SimulatorManagementModule.installToSimulator).to.have.been.calledWith(
         'some-device',
         '/path/to/iosApp1.app',
-        undefined,
+        'bundle-id',
         {newSimulator: false},
       );
       expect(SimulatorManagementModule.installToSimulator).to.have.been.calledWith(
         'some-device',
         '/path/to/iosApp2.app',
-        undefined,
+        'bundle-id2',
         {newSimulator: false},
       );
     });


### PR DESCRIPTION
Extract https://github.com/appium/appium-xcuitest-driver/commit/00ed99fdd75d54d74ab1971f5998ed2173b8b94d from https://github.com/appium/appium-xcuitest-driver/pull/2050 to here to make diff small.

This PR will remove `undefined` usage for `installToRealDevice` and `installToSimulator`