### PR TITLE
docs: address ios 17 for setSimulatedLocation

### DIFF
--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -1240,7 +1240,7 @@ Sets simulated geolocation value.
 This functionality is only available since xcuitest driver version 4.18.
 Xcode must be at version 14.3+ and iOS must be at version 16.4+.
 
-iOS 17+ requires this command to simulate the location.
+It is recommended for iOS 17+ real devices to simulate the device location.
 
 #### Arguments
 

--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -1240,6 +1240,8 @@ Sets simulated geolocation value.
 This functionality is only available since xcuitest driver version 4.18.
 Xcode must be at version 14.3+ and iOS must be at version 16.4+.
 
+iOS 17+ requires this command to simulate the location.
+
 #### Arguments
 
 Name | Type | Required | Description | Example
@@ -1255,7 +1257,7 @@ Xcode must be at version 14.3+ and iOS must be at version 16.4+.
 
 > **Warning**
 > Do not forget to reset the simulated geolocation value after your automated test is finished.
-> If the value is not reset explcitly then the simulated one will remain until the next device restart.
+> If the value is not reset explicitly then the simulated one will remain until the next device restart.
 
 ### mobile: getAppStrings
 

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -52,10 +52,6 @@ export default {
       return /** @type {Location} */ ({latitude, longitude, altitude: 0});
     }
 
-    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.warn(`Please use "mobile:setSimulatedLocation" to simulate the device location.`);
-    }
-
     const service = await services.startSimulateLocationService(this.opts.udid);
     try {
       service.setLocation(latitude, longitude);

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -52,6 +52,10 @@ export default {
       return /** @type {Location} */ ({latitude, longitude, altitude: 0});
     }
 
+    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
+      this.log.warn(`Please use "mobile:setSimulatedLocation" to simulate the device location.`);
+    }
+
     const service = await services.startSimulateLocationService(this.opts.udid);
     try {
       service.setLocation(latitude, longitude);


### PR DESCRIPTION
https://github.com/appium/appium/issues/18749 clarified iOS 17 requires `mobile:setSimulatedLocation` to simulate the location. We could explicitly address the fact in the documentation