### PR TITLE
docs: Add source code examples for Execute Methods

### DIFF
--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -2,7 +2,49 @@
 title: Execute Methods
 ---
 
-Beside of standard W3C APIs the driver provides the following custom command extensions to execute platform specific scenarios:
+Beside of standard W3C APIs the driver provides the below custom command extensions to execute platform specific scenarios. Use the following source code example snippets order to invoke them from your client code:
+
+```java
+// Java 11+
+var result = driver.executeScript("mobile: <methodName>", Map.of(
+    "arg1", "value1",
+    "arg2", "value2"
+    // you may add more pairs if needed or skip providing the map completely
+    // if all arguments are defined as optional
+));
+```
+
+```js
+// WebdriverIO
+const result = await driver.executeScript('mobile: <methodName>', [{
+    arg1: "value1",
+    arg2: "value2",
+}]);
+```
+
+```python
+# Python
+result = driver.execute_script('mobile: <methodName>', {
+    'arg1': 'value1',
+    'arg2': 'value2',
+})
+```
+
+```ruby
+# Ruby
+result = @driver.execute_script 'mobile: <methodName>', {
+    arg1: 'value1',
+    arg2: 'value2',
+}
+```
+
+```csharp
+// Dotnet
+object result = driver.ExecuteScript("mobile: <methodName>", new Dictionary<string, object>() {
+    {"arg1", "value1"},
+    {"arg2", "value2"}
+}));
+```
 
 ### mobile: selectPickerWheelValue
 

--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -2,7 +2,7 @@
 title: Execute Methods
 ---
 
-Beside of standard W3C APIs the driver provides the below custom command extensions to execute platform specific scenarios. Use the following source code example snippets order to invoke them from your client code:
+Beside of standard W3C APIs the driver provides the below custom command extensions to execute platform specific scenarios. Use the following source code examples in order to invoke them from your client code:
 
 ```java
 // Java 11+


### PR DESCRIPTION
I can observe users are sometimes confused about how to call Execute methods from their code. This should help them. 