### PR TITLE
docs: update Java executeScript example

### DIFF
--- a/docs/execute-methods.md
+++ b/docs/execute-methods.md
@@ -6,9 +6,9 @@ Beside of standard W3C APIs the driver provides the below custom command extensi
 
 ```java
 // Java 11+
-var result = driver.executeScript("mobile: <methodName>", Map.of(
-    "arg1", "value1",
-    "arg2", "value2"
+var result = driver.executeScript("mobile: <methodName>", Map.ofEntries(
+    Map.entry("arg1", "value1"),
+    Map.entry("arg2", "value2")
     // you may add more pairs if needed or skip providing the map completely
     // if all arguments are defined as optional
 ));


### PR DESCRIPTION
* Update Java `executeScript` code example to use `Map.ofEntries` instead of `Map.of`
  * Unlike `Map.ofEntries`, `Map.of` is limited to 10 key-value pairs, however, unlike `uiautomator2`, `xcuitest` does not have any extension methods that support more than 10 parameters. Still, this may not be the case in the future, so it is safer to use common terminology across both drivers.