### PR TITLE
chore: tvOS 17 workaround

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -387,7 +387,8 @@ class XCUITestDriver extends BaseDriver {
   }
 
   skipDeviceCheck() {
-    return isTvOs(this.opts.platformName);
+    return true;
+    // return isTvOs(this.opts.platformName);
   }
 
   async createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData) {
@@ -1253,7 +1254,7 @@ class XCUITestDriver extends BaseDriver {
           return {device, realDevice: false, udid: device.udid};
         }
       } else {
-        if (!this.skipDeviceCheck()) {
+        if (this.skipDeviceCheck()) {
           this.log.info(`Skipping connected device check. Using the given udid ${this.opts.udid}.`);
         } else {
           // make sure it is a connected device. If not, the udid passed in is invalid

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -386,6 +386,10 @@ class XCUITestDriver extends BaseDriver {
     return !(this.opts.webDriverAgentUrl || this.opts.usePreinstalledWDA);
   }
 
+  skipDeviceCheck() {
+    return isTvOs(this.opts.platformName);
+  }
+
   async createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData) {
     try {
       let [sessionId, caps] = await super.createSession(w3cCaps1, w3cCaps2, w3cCaps3, driverData);
@@ -1249,19 +1253,23 @@ class XCUITestDriver extends BaseDriver {
           return {device, realDevice: false, udid: device.udid};
         }
       } else {
-        // make sure it is a connected device. If not, the udid passed in is invalid
-        const devices = await getConnectedDevices();
-        this.log.debug(`Available devices: ${devices.join(', ')}`);
-        if (!devices.includes(this.opts.udid)) {
-          // check for a particular simulator
-          this.log.debug(`No real device with udid '${this.opts.udid}'. Looking for a simulator`);
-          try {
-            const device = await getSimulator(this.opts.udid, {
-              devicesSetPath: this.opts.simulatorDevicesSetPath,
-            });
-            return {device, realDevice: false, udid: this.opts.udid};
-          } catch (ign) {
-            throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+        if (!this.skipDeviceCheck()) {
+          this.log.info(`Skipping connected device check. Using the given udid ${this.opts.udid}.`);
+        } else {
+          // make sure it is a connected device. If not, the udid passed in is invalid
+          const devices = await getConnectedDevices();
+          this.log.debug(`Available devices: ${devices.join(', ')}`);
+          if (!devices.includes(this.opts.udid)) {
+            // check for a particular simulator
+            this.log.debug(`No real device with udid '${this.opts.udid}'. Looking for a simulator`);
+            try {
+              const device = await getSimulator(this.opts.udid, {
+                devicesSetPath: this.opts.simulatorDevicesSetPath,
+              });
+              return {device, realDevice: false, udid: this.opts.udid};
+            } catch (ign) {
+              throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+            }
           }
         }
       }
@@ -1674,6 +1682,11 @@ class XCUITestDriver extends BaseDriver {
       isSimulator: this.isSimulator(),
       isTvOS: isTvOs(this.opts.platformName),
     });
+
+    if (this.opts.bundleId && this.skipDeviceCheck()) {
+      // TODO: remove if tvOS iOS 17 has no issue with this installation device check state.
+      this.log.info('Skip the bundle id installation check');
+    }
 
     const {install, skipUninstall} = await this.checkAutInstallationState();
     if (install) {


### PR DESCRIPTION
Do not merge this yet. I'll modify the error message etc if this works for tvOS iOS 17.


This PR aims to add a workaround for https://github.com/appium/appium/issues/19343

TvOS 17 changes the device paring method to use IP v6 first according to https://github.com/appium/appium/issues/19343. I need more time to investigate the change, but as a workaround, we can allow a session to start by skipping device detection logic in a new session request.

On my network-connected device (iPad tho), with this change, with `webDriverAgentUrl` or starting WDA from `xcodebuild` succeeded in starting a new session request and issuing commands that worked via WDA as appium XCUITest session.


The given `udid` will be used for xcodebuild, so the `id` should be the existing udid style (not IP address), but xcuitest driver won't verify that.