### PR TITLE
chore: generate shrinkwrap without including dev and peer deps

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -23,13 +23,22 @@ jobs:
     - run: npm run test
       name: Run test
     - run: |
-        npm prune --production
-        rm -rf node_modules/appium
-      name: Remove dev dependencies and appium peer dependencies
-    - run: npm shrinkwrap # this command removes package-lock.json...
-      name: Create shrinkwrap
-    - run: npm ci --only=dev
-      name: Install dev dependencies for the release
+        # Remove dev and peer dependencies from node_modules
+        npm prune --omit=dev --omit=peer
+
+        # Generate shrinkwrap from the content of node_modules
+        mv package-lock.json package-lock.json.bak
+        npm shrinkwrap
+        mv package-lock.json.bak package-lock.json
+
+        # Restore dev dependencies for the release
+        mv npm-shrinkwrap.json npm-shrinkwrap.json.bak
+        npm ci --only=dev
+        mv npm-shrinkwrap.json.bak npm-shrinkwrap.json
+
+        # Remove unnecessary package-lock.json
+        rm -f package-lock.json
+      name: Generate shrinkwrap without including dev/peer dependencies
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Intent

Exclude dev and peer dependencies from `npm-shrinkwrap.json` which are included [in npm releases](https://www.npmjs.com/package/appium-xcuitest-driver/v/5.8.1?activeTab=code).

### Confirmed

By following the workflow manually, confirmed no dev/peer dependencies are included in `npm-shrinkwrap.json`.