### PR TITLE
ci: run CI only for master branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Build Docs
 
 on:
   pull_request:
+    branches: [ master ]
     paths:
       - 'typedoc.json'
       - 'tsconfig.json'
@@ -14,6 +15,7 @@ on:
       - '!ci-jobs/**'
       - '!**/test/**'
   push:
+    branches: [ master ]
     paths:
       - 'typedoc.json'
       - 'tsconfig.json'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,9 @@
 name: Unit Tests
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
 
 jobs:
   # https://thekevinwang.com/2021/09/19/github-actions-dynamic-matrix/


### PR DESCRIPTION
Currently there are a lot of dependency PRs from dependabot. Any new commits on master cause dependabot to force-push them onto its dependency update branches. This triggers both the `push` and `pull_request` workflows for docs and unit tests, creating unnecessary work.
With this change, such force-pushes should only trigger the `pull_request` workflows.