### PR TITLE
fix: assign deeply cloned processArguments for starting a WDA session

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -892,7 +892,7 @@ class XCUITestDriver extends BaseDriver {
             try {
               this.cachedWdaStatus =
                 this.cachedWdaStatus || (await this.proxyCommand('/status', 'GET'));
-              await this.startWdaSession(this.opts.bundleId, _.cloneDeep(this.opts.processArguments));
+              await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
             } catch (err) {
               originalStacktrace = err.stack;
               this.log.debug(`Failed to create WDA session (${err.message}). Retrying...`);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -892,7 +892,7 @@ class XCUITestDriver extends BaseDriver {
             try {
               this.cachedWdaStatus =
                 this.cachedWdaStatus || (await this.proxyCommand('/status', 'GET'));
-              await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
+              await this.startWdaSession(this.opts.bundleId, _.cloneDeep(this.opts.processArguments));
             } catch (err) {
               originalStacktrace = err.stack;
               this.log.debug(`Failed to create WDA session (${err.message}). Retrying...`);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1343,14 +1343,14 @@ class XCUITestDriver extends BaseDriver {
   }
 
   async startWdaSession(bundleId, processArguments) {
-    const args = processArguments ? processArguments.args || [] : [];
+    const args = processArguments ? _.cloneDeep(processArguments.args) || [] : [];
     if (!_.isArray(args)) {
       throw new Error(
         `processArguments.args capability is expected to be an array. ` +
           `${JSON.stringify(args)} is given instead`,
       );
     }
-    const env = processArguments ? processArguments.env || {} : {};
+    const env = processArguments ? _.cloneDeep(processArguments.env) || {} : {};
     if (!_.isPlainObject(env)) {
       throw new Error(
         `processArguments.env capability is expected to be a dictionary. ` +

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import chai from 'chai';
+import _ from 'lodash';
 import XCUITestDriver from '../../lib/driver';
 
 chai.should();
@@ -87,6 +88,7 @@ describe('language and locale', function () {
         env: processArguments.env,
       };
 
+      const expectedProcessArguments = _.cloneDeep(processArguments);
       const expectedWDACapabilities = {
         capabilities: {
           firstMatch: [
@@ -121,6 +123,7 @@ describe('language and locale', function () {
       proxySpy.calledOnce.should.be.true;
       proxySpy.firstCall.args[0].should.eql('/session');
       proxySpy.firstCall.args[1].should.eql('POST');
+      desiredCapabilities.processArguments.should.eql(expectedProcessArguments);
       /** @type {any} */ (proxySpy.firstCall.args[2]).should.eql(expectedWDACapabilities);
     });
   });


### PR DESCRIPTION
I observed the following appium server log which appium-xcuitest-driver pushes language and locale arguments when retrying `/session` api call to WDA. 

```
07:24:34:138 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Sending createSession command to WDA
07:24:34:139 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Matched '/session' to command name 'createSession'
07:24:34:140 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Proxying [POST /session] to [POST http://127.0.0.1:50201/session] with body: {"capabilities":{"firstMatch":[{"bundleId":"com.trident-qa.ScrollSleuth","arguments":["-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US"],"environment":{},"eventloopIdleDelaySec":0,"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":60,"shouldUseSingletonTestManager":true,"shouldTerminateApp":true,"forceAppLaunch":true,"useNativeCachingStrategy":true,"forceSimulatorSoftwareKeyboardPresence":true}],"alwaysMatch":{}}}
07:24:34:592 i [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m socket hang up
07:24:34:910 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to the remote server. Original error: socket hang up). Retrying...
07:24:35:913 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Event 'wdaSessionAttempted' logged at 1699914275912 (07:24:35 GMT+0900 (Japan Standard Time))
07:24:35:914 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Sending createSession command to WDA
07:24:35:915 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Matched '/session' to command name 'createSession'
07:24:35:917 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Proxying [POST /session] to [POST http://127.0.0.1:50201/session] with body: {"capabilities":{"firstMatch":[{"bundleId":"com.trident-qa.ScrollSleuth","arguments":["-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US","-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US"],"environment":{},"eventloopIdleDelaySec":0,"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":60,"shouldUseSingletonTestManager":true,"shouldTerminateApp":true,"forceAppLaunch":true,"useNativeCachingStrategy":true,"forceSimulatorSoftwareKeyboardPresence":true}],"alwaysMatch":{}}}
07:24:35:921 i [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m connect ECONNREFUSED 127.0.0.1:50201
07:24:35:924 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to the remote server. Original error: connect ECONNREFUSED 127.0.0.1:50201). Retrying...
07:24:36:926 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Event 'wdaSessionAttempted' logged at 1699914276925 (07:24:36 GMT+0900 (Japan Standard Time))
07:24:36:927 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Sending createSession command to WDA
07:24:36:928 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Matched '/session' to command name 'createSession'
07:24:36:930 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Proxying [POST /session] to [POST http://127.0.0.1:50201/session] with body: {"capabilities":{"firstMatch":[{"bundleId":"com.trident-qa.ScrollSleuth","arguments":["-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US","-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US","-AppleLanguages","(en)","-NSLanguages","(en)","-AppleLocale","en_US"],"environment":{},"eventloopIdleDelaySec":0,"shouldWaitForQuiescence":true,"shouldUseTestManagerForVisibilityDetection":false,"maxTypingFrequency":60,"shouldUseSingletonTestManager":true,"shouldTerminateApp":true,"forceAppLaunch":true,"useNativeCachingStrategy":true,"forceSimulatorSoftwareKeyboardPresence":true}],"alwaysMatch":{}}}
07:24:36:934 i [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m connect ECONNREFUSED 127.0.0.1:50201
07:24:36:937 d [38;5;64m[XCUITestDriver@68b6 (5cc2d54a)][0m Failed to create WDA session (An unknown server-side error occurred while processing the command. Original error: Could not proxy command to the remote server. Original error: connect ECONNREFUSED 127.0.0.1:50201). Retrying...
```