### PR TITLE
chore: bump webdriveragent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,9 +4060,9 @@
       }
     },
     "node_modules/appium-webdriveragent": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-5.14.0.tgz",
-      "integrity": "sha512-TNPsCmhbiFpEE1jtV+o+raqZIxoDyBxwAQ23JLFe/O15PTdt63SJncp9Z8M9Gl60OJypmPp0LBiVhXSMYfz29g==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-5.15.1.tgz",
+      "integrity": "sha512-Elj+y9sjmKYq5jFfXd5z18TDfFff8/bF8HdHE7E+xYGRVX5sZOhmkbDeKubcZmN8LhFpYPZu8C0NXUbD1xWa0w==",
       "dependencies": {
         "@appium/base-driver": "^9.0.0",
         "@appium/strongbox": "^0.x",


### PR DESCRIPTION
Just to check if the latest package is available https://www.npmjs.com/package/appium-webdriveragent?activeTab=versions