### PR TITLE
fix: tune shrinkwrap for a release

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -24,7 +24,6 @@ jobs:
     - run: |
         npm prune --omit=dev --omit=peer
         rm -rf package-lock.json
-        rm -rf node_modules/appium
       name: Remove dev dependencies and appium peer dependencies
     - run: npm shrinkwrap
       name: Create shrinkwrap

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -21,9 +21,7 @@ jobs:
       name: Install dependencies
     - run: npm run test
       name: Run NPM Test
-    - run: |
-        npm prune --omit=dev --omit=peer
-        rm -rf package-lock.json
+    - run: npm prune --omit=dev --omit=peer
       name: Remove dev dependencies and appium peer dependencies
     - run: npm shrinkwrap
       name: Create shrinkwrap

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -22,8 +22,8 @@ jobs:
     - run: npm run test
       name: Run NPM Test
     - run: |
-        rm -rf package-lock.json
         npm prune --omit=dev --omit=peer
+        rm -rf package-lock.json
         rm -rf node_modules/appium
       name: Remove dev dependencies and appium peer dependencies
     - run: npm shrinkwrap

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+packge-lock=false


### PR DESCRIPTION
### Intent

Exclude dev and peer dependencies from npm-shrinkwrap.json upon release. This PR tries to avoid the following behavior.

1. `npm prune ...` creates `package-lock.json` and the lock file contains dev/peer dependencies
2. As `npm shrinkwrap` creates `npm-shrinkwrap.json` based on `package-lock.json`, dev/peer dependencies are included in the published `npm-shrinkwrap.json`

refs. https://github.com/appium/appium-xcuitest-driver/pull/2189

### Confirmed

By following the updated workflow manually, confirmed no dev/peer dependencies are included in npm-shrinkwrap.json. (17581 lines at [v5.11.0](https://www.npmjs.com/package/appium-xcuitest-driver/v/5.11.0?activeTab=code) with many `"dev": true` -> 3924 lines without `"dev": true`)