### PR TITLE
fix: tune to minimize release module

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -20,23 +20,21 @@ jobs:
         check-latest: true
     - run: npm install
       name: Install dependencies
-    - run: ls -all
     - run: npm run test
       name: Run NPM Test
-    - run: ls -all
     - run: |
+        # GH env weirdly generates lock file, so here needs to remove the node_modules
+        # and lock file once before doing omit dev and peer env for the npm shrinkwrap
         rm -rf node_modules
         rm -rf package-lock.json
         npm prune --omit=dev --omit=peer
       name: Remove dev dependencies and appium peer dependencies
-    - run: ls -all      
     - run: npm shrinkwrap
       name: Create shrinkwrap
-    - run: ls -all
     - run: npm install --only=dev
       name: Install dev dependencies for the release
-    # - run: npx semantic-release
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    #   name: Release
+    - run: npx semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      name: Release

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -24,7 +24,7 @@ jobs:
     - run: npm run test
       name: Run NPM Test
     - run: ls -all
-    - run: 
+    - run: |
         rm -rf node_modules
         rm -rf package-lock.json
         npm prune --omit=dev --omit=peer

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -20,10 +20,14 @@ jobs:
         check-latest: true
     - run: npm install
       name: Install dependencies
+    - run: ls -all
     - run: npm run test
       name: Run NPM Test
     - run: ls -all
-    - run: npm prune --omit=dev --omit=peer
+    - run: 
+        rm -rf node_modules
+        rm -rf package-lock.json
+        npm prune --omit=dev --omit=peer
       name: Remove dev dependencies and appium peer dependencies
     - run: ls -all      
     - run: npm shrinkwrap


### PR DESCRIPTION
Ok, I think this is better.

`npm install` to run tests

![Screenshot 2023-12-01 at 10 32 19 PM](https://github.com/appium/appium-xcuitest-driver/assets/5511591/757e71d0-0f8b-4587-8c4f-2b3f5c82c97c)

Then, clear them and run prune:

![Screenshot 2023-12-01 at 10 32 28 PM](https://github.com/appium/appium-xcuitest-driver/assets/5511591/28b5c3e8-5b2a-4837-8fda-665a5e2c611e)
