### PR TITLE
fix: keep backward compatibility for the value of set location command via xcrun simctl privacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "appium-idb": "^1.6.13",
     "appium-ios-device": "^2.5.4",
-    "appium-ios-simulator": "^5.5.0",
+    "appium-ios-simulator": "^5.5.1",
     "appium-remote-debugger": "^10.0.0",
     "appium-webdriveragent": "^5.15.2",
     "appium-xcode": "^5.1.4",


### PR DESCRIPTION
To release a version with https://github.com/appium/appium-ios-simulator/pull/407 explicitly