### PR TITLE
feat: use Menu button for tvOS in driver.back

### DIFF
--- a/lib/commands/navigation.js
+++ b/lib/commands/navigation.js
@@ -1,6 +1,7 @@
 import {errors} from 'appium/driver';
 import _ from 'lodash';
 import {waitForCondition} from 'asyncbox';
+import { isTvOs } from '../utils';
 
 // these two constitute the wait after closing a window
 const CLOSE_WINDOW_TIMEOUT = 5000;
@@ -78,6 +79,11 @@ const helpers = {
    * @this {XCUITestDriver}
    */
   async nativeBack() {
+    if (isTvOs(this.opts.platformName)) {
+      this.log.debug(`Sending Menu button as back behavior in tvOS`);
+      return await this.mobilePressButton('Menu');
+    }
+
     try {
       let navBar = await this.findNativeElementOrElements(
         'class name',


### PR DESCRIPTION
It looks like sending `Menu` button in tvOS behaves "back" behavior.

A button below is the menu in the recent remote control.
![Screenshot 2024-01-12 at 5 36 15 PM](https://github.com/appium/appium-xcuitest-driver/assets/5511591/1fdb5f24-1338-4c2f-bb03-c80df89362c4)
