### PR TITLE
docs: address dialog thing in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## [5.14.1](https://github.com/appium/appium-xcuitest-driver/compare/v5.14.0...v5.14.1) (2024-01-24)
 
 ### Bug Fixes
-* Fixed current active application detection in WebDriverAgent [WebDriverAgent#834](https://github.com/appium/WebDriverAgent/pull/834). It might require an update to interact with system dialogs (managed by `com.apple.springboard`) while current active application is not the springboard. See also [appium#19716](https://github.com/appium/appium/issues/19716).
+* Fixed current active application detection in WebDriverAgent [WebDriverAgent#834](https://github.com/appium/WebDriverAgent/pull/834). It might require switching the active application to `com.apple.springboard` in order to interact with system dialogs, such as permission dialogs, while the current active application is not the springboard. Using `mobile:alert` or `acceptAlertButtonSelector`/`dismissAlertButtonSelector` also should help. See also [appium#19716](https://github.com/appium/appium/issues/19716).
 
 ### Miscellaneous Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## [5.14.1](https://github.com/appium/appium-xcuitest-driver/compare/v5.14.0...v5.14.1) (2024-01-24)
 
+### Bug Fixes
+* Fixed current active application detection in WebDriverAgent [WebDriverAgent#834](https://github.com/appium/WebDriverAgent/pull/834). It might require an update to interact with system dialogs (managed by `com.apple.springboard`) while current active application is not the springboard. See also [appium#19716](https://github.com/appium/appium/issues/19716).
 
 ### Miscellaneous Chores
 


### PR DESCRIPTION
semantics release appends new content on the top, so we can add more information for the past sections.
Maybe it is nice to address  https://github.com/appium/appium/issues/19716 in the changelog.