### PR TITLE
fix: revert active application detection fix added in 5.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.5.1",
     "appium-remote-debugger": "^10.0.0",
-    "appium-webdriveragent": "^5.15.9",
+    "appium-webdriveragent": "~5.15.9",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.5.1",
     "appium-remote-debugger": "^10.0.0",
-    "appium-webdriveragent": "^5.15.5",
+    "appium-webdriveragent": "^5.15.9",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
This revert will fix https://github.com/appium/appium/issues/19716 for xcuitest driver v5.

The change will be in xcuitest driver v6.

cc @eglitise