### PR TITLE
feat: Unify gesture extensions

### DIFF
--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -1134,8 +1134,8 @@ Sends one or more taps with one or more touch points since Appium 1.17.1.
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
 elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to perform one or more taps. The active application element will be used instead if this parameter is not provided.| fe50b60b-916d-420b-8728-ee2072ec53eb
-numberOfTaps | number | yes | The number of taps | 2
-numberOfTouches | number | yes | The number of touch points | 2
+numberOfTaps | number | no | The number of taps. 1 by default | 2
+numberOfTouches | number | no | The number of touch points. 1 by default | 2
 
 #### Examples
 
@@ -1145,6 +1145,11 @@ e = @driver.find_element :id, 'target element'
 # Taps the element with a single touch point twice
 @driver.execute_script 'mobile: tapWithNumberOfTaps', {elementId: e.ref, numberOfTaps: 2, numberOfTouches: 1}
 ```
+
+- numberOfTaps=1, numberOfTouches=1 -> "vanilla" single tap
+- numberOfTaps=2, numberOfTouches=1 -> double tap
+- numberOfTaps=3, numberOfTouches=1 -> tripple tap
+- numberOfTaps=2, numberOfTouches=2 -> double tap with two fingers
 
 #### Reference
 [tapWithNumberOfTaps:numberOfTouches:](https://developer.apple.com/documentation/xctest/xcuielement/1618671-tapwithnumberoftaps)

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -920,7 +920,7 @@ _Important_: The implemntation of this extension relies on several undocumented 
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to scroll on (e.g. the container). Application element will be used if this argument is not set | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to scroll on (e.g. the container). The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
 name | string | no | The accessibility id of the child element, to which scrolling is performed. The same result can be achieved by setting _predicateString_ argument to 'name == accessibilityId'. Has no effect if _elementId_ is not a container | cell12
 direction | Either 'up', 'down', 'left' or 'right' | yes | The main difference from [swipe](#mobile-swipe) call with the same argument is that _scroll_ will try to move the current viewport exactly to the next/previous page (the term "page" means the content, which fits into a single device screen) | down
 predicateString | string | no | The NSPredicate locator of the child element, to which the scrolling should be performed. Has no effect if _elementId_ is not a container | label == "foo"
@@ -941,7 +941,7 @@ Performs pinch gesture on the given element or on the application element.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to pinch on. Application element will be used instead if this parameter is not provided | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to pinch on. The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
 scale | number | yes | Pinch scale of type float. Use a scale between 0 and 1 to "pinch close" or zoom out and a scale greater than 1 to "pinch open" or zoom in. | 0.5
 velocity | number | yes | The velocity of the pinch in scale factor per second (float value) | 2.2
 
@@ -964,9 +964,9 @@ Performs double tap gesture on the given element or on the screen.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no if x and y are set | The internal element identifier (as hexadecimal hash string) to double tap on | fe50b60b-916d-420b-8728-ee2072ec53eb
-x | number | no if elementId is set | Screen x tap coordinate of type float. | 100
-y | number | no if elementId is set | Screen y tap coordinate of type float. | 100
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to double tap on. The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
+x | number | no | Horizontal coordinate offset. | 100
+y | number | no | Vertical coordinate offset. | 100
 
 #### Examples
 
@@ -983,17 +983,17 @@ Performs long press gesture on the given element or on the screen.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no if x and y are set | The internal element identifier (as hexadecimal hash string) to long tap on | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to long tap on. The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
 duration | number | yes | The float duration of press action in seconds | 1.5
-x | number | no if elementId is set | Screen x tap coordinate of type float. | 100
-y | number | no if elementId is set | Screen y tap coordinate of type float. | 100
+x | number | no | Horizontal coordinate offset. | 100
+y | number | no | Vertical coordinate offset. | 100
 
 #### Examples
 
 ```csharp
 // c#
 Dictionary<string, object> tfLongTap = new Dictionary<string, object>();
-tfLongTap.Add("element", element.Id);
+tfLongTap.Add("elementId", element.Id);
 tfLongTap.Add("duration", 2.0);
 ((IJavaScriptExecutor)driver).ExecuteScript("mobile: touchAndHold", tfLongTap);
 ```
@@ -1010,14 +1010,14 @@ Performs two finger tap gesture on the given element or on the application eleme
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to tap on. Application element will be used instead if this parameter is not provided | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to tap on. The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
 
 #### Examples
 
 ```csharp
 // c#
 Dictionary<string, object> tfTap = new Dictionary<string, object>();
-tfTap.Add("element", element.Id);
+tfTap.Add("elementId", element.Id);
 ((IJavaScriptExecutor)driver).ExecuteScript("mobile: twoFingerTap", tfTap);
 ```
 
@@ -1033,9 +1033,9 @@ Performs tap gesture by coordinates on the given element or on the screen.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to tap on. _x_ and _y_ tap coordinates will be calulated relatively to the current element position on the screen if this argument is provided. Otherwise they should be calculated relatively to the active application element. | fe50b60b-916d-420b-8728-ee2072ec53eb
-x | number | yes | Screen x tap coordinate of type float. | 100
-y | number | yes | Screen y tap coordinate of type float. | 100
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to tap on. _x_ and _y_ tap coordinates will be calculated relatively to the current element position on the screen if this argument is provided. Otherwise they should be calculated relatively to the active application element. | fe50b60b-916d-420b-8728-ee2072ec53eb
+x | number | yes | Horizontal coordinate offset. | 100
+y | number | yes | Vertical coordinate offset. | 100
 
 ### mobile: dragFromToForDuration
 
@@ -1064,7 +1064,7 @@ params.put("fromX", 100);
 params.put("fromY", 100);
 params.put("toX", 200);
 params.put("toY", 200);
-params.put("element", ((RemoteWebElement) element).getId());
+params.put("elementId", ((RemoteWebElement) element).getId());
 js.executeScript("mobile: dragFromToForDuration", params);
 ```
 
@@ -1103,7 +1103,7 @@ Performs [rotate](https://developer.apple.com/documentation/xctest/xcuielement/1
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | yes | Internal element id (as hexadecimal hash string) to perform rotation on | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | Internal element id (as hexadecimal hash string) to perform rotation on. The active application element will be used instead if this parameter is not provided. | fe50b60b-916d-420b-8728-ee2072ec53eb
 rotation | number | yes | The rotation of the gesture in radians | Math.PI
 velocity | number | yes | The velocity of the rotation gesture in radians per second | Math.PI / 4
 
@@ -1117,7 +1117,7 @@ js.executeScript("mobile: rotateElement", ImmutableMap.of(
     "rotation", -Math.PI / 2,
     // in approximately two seconds
     "velocity", Math.PI / 4,
-    "element", ((RemoteWebElement) element).getId()
+    "elementId", ((RemoteWebElement) element).getId()
 ));
 ```
 
@@ -1133,7 +1133,7 @@ Sends one or more taps with one or more touch points since Appium 1.17.1.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-elementId ("element" prior to Appium v 1.22) | string | yes | The internal element identifier (as hexadecimal hash string) to perform one or more taps. | fe50b60b-916d-420b-8728-ee2072ec53eb
+elementId ("element" prior to Appium v 1.22) | string | no | The internal element identifier (as hexadecimal hash string) to perform one or more taps. The active application element will be used instead if this parameter is not provided.| fe50b60b-916d-420b-8728-ee2072ec53eb
 numberOfTaps | number | yes | The number of taps | 2
 numberOfTouches | number | yes | The number of touch points | 2
 
@@ -1143,7 +1143,7 @@ numberOfTouches | number | yes | The number of touch points | 2
 # Ruby
 e = @driver.find_element :id, 'target element'
 # Taps the element with a single touch point twice
-@driver.execute_script 'mobile: tapWithNumberOfTaps', {element: e.ref, numberOfTaps: 2, numberOfTouches: 1}
+@driver.execute_script 'mobile: tapWithNumberOfTaps', {elementId: e.ref, numberOfTaps: 2, numberOfTouches: 1}
 ```
 
 #### Reference

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -30,7 +30,7 @@ function requireFloat(value, paramName) {
  * @param {string} paramName
  * @returns {number}
  */
-function asInt(value, paramName) {
+function requireInt(value, paramName) {
   const num = parseInt(String(value), 10);
   if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
@@ -511,8 +511,8 @@ const helpers = {
    * Sends one or more taps with one or more touch points.
    *
    * @since 1.17.1
-   * @param {number} numberOfTaps - Number of taps to perform.
-   * @param {number} numberOfTouches - Number of touch points to use.
+   * @param {number} [numberOfTaps=1] - Number of taps to perform.
+   * @param {number} [numberOfTouches=1] - Number of touch points to use.
    * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform one or more taps.
    * The Application element will be used if this parameter is not provided.
    * @returns {Promise<void>}
@@ -525,13 +525,13 @@ const helpers = {
    * @driver.execute_script 'mobile: tapWithNumberOfTaps', {element: e.ref, numberOfTaps: 2, numberOfTouches: 1}
    * ```
    */
-  async mobileTapWithNumberOfTaps(numberOfTouches, numberOfTaps, elementId) {
+  async mobileTapWithNumberOfTaps(numberOfTouches = 1, numberOfTaps = 1, elementId = undefined) {
     const endpoint = elementId
       ? `/wda/element/${util.unwrapElement(elementId)}/tapWithNumberOfTaps`
       : '/wda/tapWithNumberOfTaps';
     return await this.proxyCommand(endpoint, 'POST', {
-      numberOfTaps: asInt(numberOfTaps, 'numberOfTaps'),
-      numberOfTouches: asInt(numberOfTouches, 'numberOfTouches'),
+      numberOfTaps,
+      numberOfTouches,
     });
   },
   /**

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -5,37 +5,6 @@ import _ from 'lodash';
 const SUPPORTED_GESTURE_DIRECTIONS = ['up', 'down', 'left', 'right'];
 
 /**
- * @param {any} [opts]
- * @returns {string|undefined}
- */
-function toElementId(opts) {
-  if (_.isUndefined(opts)) {
-    return;
-  }
-  if (_.isString(opts) || _.isNumber(opts)) {
-    return String(opts);
-  }
-  if ('elementId' in opts || 'element' in opts) {
-    return util.unwrapElement(opts);
-  }
-}
-
-/**
- *
- * @param {XCUITestDriver} driver
- * @param {Element|string} [elementId]
- * @returns {Promise<string>}
- */
-async function toElementOrApplicationId(driver, elementId) {
-  if (!_.isUndefined(elementId)) {
-    return util.unwrapElement(elementId);
-  }
-  return util.unwrapElement(
-    await driver.findNativeElementOrElements(`class name`, `XCUIElementTypeApplication`, false),
-  );
-}
-
-/**
  * Converts the given value to a float number.
  *
  * @throws If `value` is `NaN`
@@ -43,7 +12,7 @@ async function toElementOrApplicationId(driver, elementId) {
  * @param {string} paramName
  * @returns {number}
  */
-function asFloat(value, paramName) {
+function requireFloat(value, paramName) {
   const num = parseFloat(String(value));
   if (Number.isNaN(num)) {
     throw new errors.InvalidArgumentError(
@@ -327,8 +296,8 @@ const helpers = {
     if (!_.isNil(distance)) {
       params.distance = distance;
     }
-    elementId = await toElementOrApplicationId(this, elementId);
-    return await this.proxyCommand(`/wda/element/${elementId}/scroll`, 'POST', params);
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/scroll` : '/wda/scroll';
+    return await this.proxyCommand(endpoint, 'POST', params);
   },
   /**
    * @param {import('./types').Direction} direction
@@ -346,8 +315,8 @@ const helpers = {
     if (!_.isNil(velocity)) {
       params.velocity = velocity;
     }
-    elementId = await toElementOrApplicationId(this, elementId);
-    return await this.proxyCommand(`/wda/element/${elementId}/swipe`, 'POST', params);
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/swipe` : '/wda/swipe';
+    await this.proxyCommand(endpoint, 'POST', params);
   },
   /**
    * Performs a pinch gesture on the given element or on the Application element.
@@ -366,18 +335,18 @@ const helpers = {
    */
   async mobilePinch(scale, velocity, elementId) {
     const params = {
-      scale: asFloat(scale, 'scale'),
-      velocity: asFloat(velocity, 'velocity'),
+      scale: requireFloat(scale, 'scale'),
+      velocity: requireFloat(velocity, 'velocity'),
     };
-    elementId = await toElementOrApplicationId(this, elementId);
-    return await this.proxyCommand(`/wda/element/${elementId}/pinch`, 'POST', params);
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/pinch` : '/wda/pinch';
+    await this.proxyCommand(endpoint, 'POST', params);
   },
   /**
    * Performs double tap gesture on the given element or on the screen.
    *
-   * @param {Element|string} [elementId] - The internal element identifier (as hexadecimal hash string) to double tap on. This is required if `x` and `y` are not provided.
-   * @param {number} [x] - The _x_ coordinate (float value) to double tap on. This is required if `elementId` is not provided.
-   * @param {number} [y] - The _y_ coordinate (float value) to double tap on. This is required if `elementId` is not provided.
+   * @param {Element|string} [elementId] - The internal element identifier (as hexadecimal hash string) to double tap on. The Application element will be used if this parameter is not provided.
+   * @param {number} [x] - The _x_ coordinate (float value) to double tap on.
+   * @param {number} [y] - The _y_ coordinate (float value) to double tap on.
    * @returns {Promise<void>}
    * @this {XCUITestDriver}
    * @example
@@ -387,16 +356,8 @@ const helpers = {
    * ```
    */
   async mobileDoubleTap(elementId, x, y) {
-    if (elementId) {
-      // Double tap element
-      return await this.proxyCommand(`/wda/element/${elementId}/doubleTap`, 'POST');
-    }
-    // Double tap coordinates
-    const params = {
-      x: asFloat(x, 'x'),
-      y: asFloat(y, 'y'),
-    };
-    return await this.proxyCommand('/wda/doubleTap', 'POST', params);
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/doubleTap` : '/wda/doubleTap';
+    await this.proxyCommand(endpoint, 'POST', {x, y});
   },
   /**
    * Performs two finger tap gesture on the given element or on the application element.
@@ -413,16 +374,16 @@ const helpers = {
    * ```
    */
   async mobileTwoFingerTap(elementId) {
-    elementId = await toElementOrApplicationId(this, elementId);
-    return await this.proxyCommand(`/wda/element/${elementId}/twoFingerTap`, 'POST');
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/twoFingerTap` : '/wda/twoFingerTap';
+    await this.proxyCommand(endpoint, 'POST');
   },
   /**
    * Performs a "long press" gesture on the given element or on the screen.
    *
    * @param {number} duration - The duration (in seconds) of the gesture.
-   * @param {number} [y] - The _y_ coordinate (float value) to double tap on. This is required if `elementId` is not provided.
-   * @param {number} [x] - The _x_ coordinate (float value) to double tap on. This is required if `elementId` is not provided.
-   * @param {Element|string} [elementId] - The internal element identifier (as hexadecimal hash string) to double tap on. This is required if `x` and `y` are not provided.
+   * @param {number} [y] - The _y_ coordinate (float value) to hold on.
+   * @param {number} [x] - The _x_ coordinate (float value) to hold on.
+   * @param {Element|string} [elementId] - The internal element identifier (as hexadecimal hash string) to double tap on.  The Application element will be used if this parameter is not provided.
    * @this {XCUITestDriver}
    * @see https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc
    * @example
@@ -434,33 +395,24 @@ const helpers = {
    * ```
    */
   async mobileTouchAndHold(duration, x, y, elementId) {
-    const params = {
-      duration: asFloat(duration, 'duration'),
-    };
-    if (elementId) {
-      // Long tap element
-      return await this.proxyCommand(`/wda/element/${elementId}/touchAndHold`, 'POST', params);
-    }
-    // Long tap coordinates
-    params.x = asFloat(x, 'x');
-    params.y = asFloat(y, 'y');
-    return await this.proxyCommand('/wda/touchAndHold', 'POST', params);
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/touchAndHold` : '/wda/touchAndHold';
+    await this.proxyCommand(endpoint, 'POST', {
+      duration: requireFloat(duration, 'duration'),
+      x, y,
+    });
   },
   /**
    * Performs tap gesture by coordinates on the given element or on the screen.
    *
    * @param {number} x - The _x_ coordinate (float value) to tap on. If `elementId` is provided, this is computed relative to the element; otherwise it is computed relative to the active Application element.
    * @param {number} y - The _y_ coordinate (float value) to tap on. If `elementId` is provided, this is computed relative to the element; otherwise it is computed relative to the active Application element.
-   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to tap on.
+   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to tap on.  The Application element will be used if this parameter is not provided.
    * @this {XCUITestDriver}
    * @returns {Promise<void>}
    */
-  async mobileTap(x, y, elementId = '0') {
-    const params = {
-      x: asFloat(x, 'x'),
-      y: asFloat(y, 'y'),
-    };
-    return await this.proxyCommand(`/wda/tap/${elementId}`, 'POST', params);
+  async mobileTap(x, y, elementId) {
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/tap` : '/wda/tap';
+    await this.proxyCommand(endpoint, 'POST', {x, y});
   },
   /**
    * Performs drag and drop gesture by coordinates on the given element or on the screen.
@@ -489,16 +441,15 @@ const helpers = {
    */
   async mobileDragFromToForDuration(duration, fromX, fromY, toX, toY, elementId) {
     const params = {
-      duration: asFloat(duration, 'duration'),
-      fromX: asFloat(fromX, 'fromX'),
-      fromY: asFloat(fromY, 'fromY'),
-      toX: asFloat(toX, 'toX'),
-      toY: asFloat(toY, 'toY'),
+      duration: requireFloat(duration, 'duration'),
+      fromX: requireFloat(fromX, 'fromX'),
+      fromY: requireFloat(fromY, 'fromY'),
+      toX: requireFloat(toX, 'toX'),
+      toY: requireFloat(toY, 'toY'),
     };
-    elementId = toElementId(elementId);
     return elementId
       ? // Drag element
-        await this.proxyCommand(`/wda/element/${elementId}/dragfromtoforduration`, 'POST', params)
+        await this.proxyCommand(`/wda/element/${util.unwrapElement(elementId)}/dragfromtoforduration`, 'POST', params)
       : // Drag coordinates
         await this.proxyCommand('/wda/dragfromtoforduration', 'POST', params);
   },
@@ -531,9 +482,9 @@ const helpers = {
     toY,
   ) {
     const params = {
-      pressDuration: asFloat(pressDuration, 'pressDuration'),
-      holdDuration: asFloat(holdDuration, 'holdDuration'),
-      velocity: asFloat(velocity, 'velocity'),
+      pressDuration: requireFloat(pressDuration, 'pressDuration'),
+      holdDuration: requireFloat(holdDuration, 'holdDuration'),
+      velocity: requireFloat(velocity, 'velocity'),
     };
     fromElementId = fromElementId ? util.unwrapElement(fromElementId) : undefined;
     if (fromElementId) {
@@ -550,19 +501,20 @@ const helpers = {
         params,
       );
     }
-    params.fromX = asFloat(fromX, 'fromX');
-    params.fromY = asFloat(fromY, 'fromY');
-    params.toX = asFloat(toX, 'toX');
-    params.toY = asFloat(toY, 'toY');
+    params.fromX = requireFloat(fromX, 'fromX');
+    params.fromY = requireFloat(fromY, 'fromY');
+    params.toX = requireFloat(toX, 'toX');
+    params.toY = requireFloat(toY, 'toY');
     return await this.proxyCommand('/wda/pressAndDragWithVelocity', 'POST', params);
   },
   /**
    * Sends one or more taps with one or more touch points.
    *
    * @since 1.17.1
-   * @param {string|Element} elementId - The internal element identifier (as hexadecimal hash string) to perform one or more taps.
    * @param {number} numberOfTaps - Number of taps to perform.
    * @param {number} numberOfTouches - Number of touch points to use.
+   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform one or more taps.
+   * The Application element will be used if this parameter is not provided.
    * @returns {Promise<void>}
    * @this {XCUITestDriver}
    * @see https://developer.apple.com/documentation/xctest/xcuielement/1618671-tapwithnumberoftaps?language=objc
@@ -573,17 +525,14 @@ const helpers = {
    * @driver.execute_script 'mobile: tapWithNumberOfTaps', {element: e.ref, numberOfTaps: 2, numberOfTouches: 1}
    * ```
    */
-  async mobileTapWithNumberOfTaps(elementId, numberOfTouches, numberOfTaps) {
-    if (!elementId) {
-      throw new errors.InvalidArgumentError(
-        'Element id is expected to be set for tapWithNumberOfTaps method',
-      );
-    }
-    const params = {
+  async mobileTapWithNumberOfTaps(numberOfTouches, numberOfTaps, elementId) {
+    const endpoint = elementId
+      ? `/wda/element/${util.unwrapElement(elementId)}/tapWithNumberOfTaps`
+      : '/wda/tapWithNumberOfTaps';
+    return await this.proxyCommand(endpoint, 'POST', {
       numberOfTaps: asInt(numberOfTaps, 'numberOfTaps'),
       numberOfTouches: asInt(numberOfTouches, 'numberOfTouches'),
-    };
-    return await this.proxyCommand(`/wda/element/${elementId}/tapWithNumberOfTaps`, 'POST', params);
+    });
   },
   /**
    * Performs a "force press" on the given element or coordinates.
@@ -593,13 +542,13 @@ const helpers = {
    * @param {number} [y] - The _y_ coordinate of the gesture. If `elementId` is set, this is calculated relative to its position; otherwise it's calculated relative to the active Application.
    * @param {number} [duration] - The duraiton (in seconds) of the force press. If this is provided, `pressure` must also be provided.
    * @param {number} [pressure] - A float value defining the pressure of the force press. If this is provided, `duration` must also be provided.
-   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform one or more taps. If this is _not_ provided, both `x` and `y` must be provided. If this is provided _and_ `x` and `y` are not provided, the actual touch point will be calculated internally.
+   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform one or more taps.
+   * The Application element will be used if this parameter is not provided.
    * @returns {Promise<void>}
    * @this {XCUITestDriver}
    */
   async mobileForcePress(x, y, duration, pressure, elementId) {
-    elementId = toElementId(elementId);
-    const endpoint = elementId ? `/wda/element/${elementId}/forceTouch` : `/wda/forceTouch`;
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/forceTouch` : `/wda/forceTouch`;
     return await this.proxyCommand(endpoint, 'POST', {x, y, duration, pressure});
   },
   /**
@@ -625,7 +574,6 @@ const helpers = {
    * ```
    */
   async mobileSelectPickerWheelValue(elementId, order, offset, value, maxAttempts) {
-    elementId = /** @type {string} */ (toElementId(elementId));
     if (!elementId) {
       throw new errors.InvalidArgumentError(
         'elementId is expected to be set for selectPickerWheelValue method',
@@ -639,7 +587,7 @@ const helpers = {
     }
     const params = {order};
     if (offset) {
-      params.offset = asFloat(offset, 'offset');
+      params.offset = requireFloat(offset, 'offset');
     }
     if (!_.isNil(value)) {
       params.value = value;
@@ -647,15 +595,16 @@ const helpers = {
     if (!_.isNil(maxAttempts)) {
       params.maxAttempts = maxAttempts;
     }
-    return await this.proxyCommand(`/wda/pickerwheel/${elementId}/select`, 'POST', params);
+    return await this.proxyCommand(`/wda/pickerwheel/${util.unwrapElement(elementId)}/select`, 'POST', params);
   },
   /**
    * Performs a rotate gesture on the given element.
    *
    * @see https://developer.apple.com/documentation/xctest/xcuielement/1618665-rotate?language=objc
-   * @param {string|Element} elementId - The internal element identifier (as hexadecimal hash string) to perform the gesture on.
    * @param {number} rotation - The rotation gesture (in radians)
    * @param {number} velocity - The velocity (in radians-per-second) of the gesture.
+   * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform the gesture on.
+   * The Application element will be used if this parameter is not provided.
    * @returns {Promise<void>}
    * @this {XCUITestDriver}
    * @example
@@ -670,65 +619,13 @@ const helpers = {
    * ));
    * ```
    */
-  async mobileRotateElement(elementId, rotation, velocity) {
-    elementId = /** @type {string} */ (toElementId(elementId));
-    if (!elementId) {
-      throw new errors.InvalidArgumentError(
-        'Element id is expected to be set for rotateElement method',
-      );
-    }
+  async mobileRotateElement(rotation, velocity, elementId) {
     const params = {
-      rotation: asFloat(rotation, 'rotation'),
-      velocity: asFloat(velocity, 'velocity'),
+      rotation: requireFloat(rotation, 'rotation'),
+      velocity: requireFloat(velocity, 'velocity'),
     };
-    return await this.proxyCommand(`/wda/element/${elementId}/rotate`, 'POST', params);
-  },
-  /**
-   * @this {XCUITestDriver}
-   */
-  async getCoordinates(gesture) {
-    // defaults
-    let coordinates = {x: 0, y: 0, areOffsets: false};
-
-    let optionX = null;
-    if (gesture.options.x) {
-      optionX = asFloat(gesture.options.x, 'x');
-    }
-    let optionY = null;
-    if (gesture.options.y) {
-      optionY = asFloat(gesture.options.y, 'y');
-    }
-
-    // figure out the element coordinates.
-    const elementId = toElementId(gesture.options);
-    if (elementId) {
-      let rect = await this.getElementRect(elementId);
-      let pos = {x: rect.x, y: rect.y};
-      let size = {w: rect.width, h: rect.height};
-
-      // defaults
-      let offsetX = 0;
-      let offsetY = 0;
-
-      // get the real offsets
-      if (optionX || optionY) {
-        offsetX = optionX || 0;
-        offsetY = optionY || 0;
-      } else {
-        offsetX = size.w / 2;
-        offsetY = size.h / 2;
-      }
-
-      // apply the offsets
-      coordinates.x = pos.x + offsetX;
-      coordinates.y = pos.y + offsetY;
-    } else {
-      // moveTo coordinates are passed in as offsets
-      coordinates.areOffsets = gesture.action === 'moveTo';
-      coordinates.x = optionX || 0;
-      coordinates.y = optionY || 0;
-    }
-    return coordinates;
+    const endpoint = elementId ? `/wda/element/${util.unwrapElement(elementId)}/rotate` : '/wda/rotate';
+    return await this.proxyCommand(endpoint, 'POST', params);
   },
 };
 

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -23,24 +23,6 @@ function requireFloat(value, paramName) {
 }
 
 /**
- * Converts the given value to an integer number.
- *
- * @throws If `value` is `NaN`
- * @param {any} value
- * @param {string} paramName
- * @returns {number}
- */
-function requireInt(value, paramName) {
-  const num = parseInt(String(value), 10);
-  if (Number.isNaN(num)) {
-    throw new errors.InvalidArgumentError(
-      `"${paramName}" parameter should be a valid integer. "${value}" is given instead`,
-    );
-  }
-  return num;
-}
-
-/**
  *
  * @param {any[]} gestures
  * @param {string[]|null} keysToInclude

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2018,7 +2018,6 @@ class XCUITestDriver extends BaseDriver {
   mobileForcePress = commands.gestureExtensions.mobileForcePress;
   mobileSelectPickerWheelValue = commands.gestureExtensions.mobileSelectPickerWheelValue;
   mobileRotateElement = commands.gestureExtensions.mobileRotateElement;
-  getCoordinates = commands.gestureExtensions.getCoordinates;
 
   /*-------+
    | IOHID |

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -61,7 +61,8 @@ export const executeMethodMap = {
   'mobile: tapWithNumberOfTaps': {
     command: 'mobileTapWithNumberOfTaps',
     params: {
-      required: ['elementId', 'numberOfTouches', 'numberOfTaps'],
+      required: ['numberOfTouches', 'numberOfTaps'],
+      optional: ['elementId'],
     },
   },
   // https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc
@@ -84,7 +85,8 @@ export const executeMethodMap = {
   'mobile: rotateElement': {
     command: 'mobileRotateElement',
     params: {
-      required: ['elementId', 'rotation', 'velocity'],
+      required: ['rotation', 'velocity'],
+      optional: ['elementId'],
     },
   },
   // https://developer.apple.com/documentation/xctest/xcuicoordinate/3551692-pressforduration?language=objc

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -61,8 +61,7 @@ export const executeMethodMap = {
   'mobile: tapWithNumberOfTaps': {
     command: 'mobileTapWithNumberOfTaps',
     params: {
-      required: ['numberOfTouches', 'numberOfTaps'],
-      optional: ['elementId'],
+      optional: ['numberOfTouches', 'numberOfTaps', 'elementId'],
     },
   },
   // https://developer.apple.com/documentation/xctest/xcuielement/1618663-pressforduration?language=objc

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.5.1",
     "appium-remote-debugger": "^10.0.0",
-    "appium-webdriveragent": "^5.15.5",
+    "appium-webdriveragent": "^6.0.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xcuitest",
     "xctest"
   ],
-  "version": "5.15.0",
+  "version": "5.15.1",
   "author": "Appium Contributors",
   "license": "Apache-2.0",
   "repository": {

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -165,22 +165,11 @@ describe('gesture commands', function () {
     describe('doubleTap', function () {
       const commandName = 'doubleTap';
 
-      it('should throw an error if no mandatory parameter is specified', async function () {
-        await driver
-          .execute(`mobile: ${commandName}`, {x: 100})
-          .should.be.rejectedWith(/"y" parameter should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {y: 200})
-          .should.be.rejectedWith(/"x" parameter should be a valid number/);
-      });
-
-      it('should throw an error if param is invalid', async function () {
-        await driver
-          .execute(`mobile: ${commandName}`, {x: '', y: 1})
-          .should.be.rejectedWith(/should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {x: 1, y: null})
-          .should.be.rejectedWith(/should be a valid number/);
+      it('should proxy a doubleTap request without element through to WDA', async function () {
+        await driver.execute(`mobile: ${commandName}`);
+        proxySpy.calledOnce.should.be.true;
+        proxySpy.firstCall.args[0].should.eql('/wda/doubleTap');
+        proxySpy.firstCall.args[1].should.eql('POST');
       });
 
       it('should proxy a doubleTap request for an element through to WDA', async function () {
@@ -212,12 +201,6 @@ describe('gesture commands', function () {
       const commandName = 'touchAndHold';
 
       it('should throw an error if no mandatory parameter is specified', async function () {
-        await driver
-          .execute(`mobile: ${commandName}`, {duration: 100, x: 1})
-          .should.be.rejectedWith(/"y" parameter should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {duration: 100, y: 200})
-          .should.be.rejectedWith(/"x" parameter should be a valid number/i);
         await driver.execute(`mobile: ${commandName}`, {x: 100, y: 200}).should.be.rejected;
       });
 
@@ -225,21 +208,33 @@ describe('gesture commands', function () {
         await driver
           .execute(`mobile: ${commandName}`, {duration: '', x: 1, y: 1})
           .should.be.rejectedWith(/should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {duration: 1, x: '', y: 1})
-          .should.be.rejectedWith(/should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {duration: 1, x: 1, y: null})
-          .should.be.rejectedWith(/should be a valid number/);
+      });
+
+      it('should proxy a touchAndHold request without element through to WDA', async function () {
+        const opts = {duration: 100};
+        await driver.execute(`mobile: ${commandName}`, opts);
+        proxySpy.should.have.been.calledOnceWith(
+          '/wda/touchAndHold',
+          'POST',
+          {
+            ...opts,
+            x: undefined,
+            y: undefined,
+          },
+        );
       });
 
       it('should proxy a touchAndHold request for an element through to WDA', async function () {
-        const opts = {element: 4, duration: 100};
+        const opts = {elementId: 4, duration: 100};
         await driver.execute(`mobile: ${commandName}`, opts);
         proxySpy.should.have.been.calledOnceWith(
           '/wda/element/4/touchAndHold',
           'POST',
-          _.omit(opts, 'elementId'), // note elementId here, not element
+          {
+            ..._.omit(opts, 'elementId'),
+            x: undefined,
+            y: undefined,
+          }
         );
       });
 
@@ -253,31 +248,16 @@ describe('gesture commands', function () {
     describe('tap', function () {
       const commandName = 'tap';
 
-      it('should throw an error if no mandatory parameter is specified', async function () {
-        await driver.execute(`mobile: ${commandName}`, {}).should.be.rejected;
-        await driver.execute(`mobile: ${commandName}`, {x: 100}).should.be.rejected;
-        await driver.execute(`mobile: ${commandName}`, {y: 200}).should.be.rejected;
-      });
-
-      it('should throw an error if param is invalid', async function () {
-        await driver
-          .execute(`mobile: ${commandName}`, {x: '', y: 1})
-          .should.be.rejectedWith(/should be a valid number/);
-        await driver
-          .execute(`mobile: ${commandName}`, {x: 1, y: null})
-          .should.be.rejectedWith(/should be a valid number/);
-      });
-
       it('should proxy a tap request for an element through to WDA', async function () {
         const opts = {elementId: 4, x: 100, y: 100};
         await driver.execute(`mobile: ${commandName}`, opts);
-        proxySpy.should.have.been.calledOnceWith('/wda/tap/4', 'POST', _.omit(opts, 'elementId'));
+        proxySpy.should.have.been.calledOnceWith('/wda/element/4/tap', 'POST', _.omit(opts, 'elementId'));
       });
 
       it('should proxy a tap request for a coordinate point through to WDA', async function () {
         const opts = {x: 100, y: 100};
         await driver.execute(`mobile: ${commandName}`, opts);
-        proxySpy.should.have.been.calledOnceWith('/wda/tap/0', 'POST', opts);
+        proxySpy.should.have.been.calledOnceWith('/wda/tap', 'POST', opts);
       });
     });
 

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -411,49 +411,6 @@ describe('gesture commands', function () {
       });
     });
 
-    describe('getCoordinates', function () {
-      it('should properly parse coordinates if they are presented as string values', async function () {
-        const gesture = {
-          action: 'moveTo',
-          options: {
-            x: '100',
-            y: '300',
-          },
-        };
-        const coords = await driver.getCoordinates(gesture);
-        coords.areOffsets.should.be.true;
-        coords.x.should.be.within(100, 101);
-        coords.y.should.be.within(300, 301);
-      });
-      it('should properly parse coordinates if they are presented as numeric values', async function () {
-        const gesture = {
-          action: 'press',
-          options: {
-            x: 100.5,
-            y: 300,
-          },
-        };
-        const coords = await driver.getCoordinates(gesture);
-        coords.areOffsets.should.be.false;
-        coords.x.should.be.within(100, 101);
-        coords.y.should.be.within(300, 301);
-      });
-      it('should throw an exception if coordinates cannot be parsed', async function () {
-        const gesture = {
-          action: 'moveTo',
-          options: {
-            x: 'a',
-            y: 300,
-          },
-        };
-        try {
-          await driver.getCoordinates(gesture);
-          sinon.assert.fail('An exception is expected to be thrown');
-        } catch (e) {
-          // this is expected
-        }
-      });
-    });
   });
 });
 


### PR DESCRIPTION
BREAKING CHANGE: Removed the unused getCoordinates API
BREAKING CHANGE: Changed arguments order for various gesture extensions
BREAKING CHANGE: Bumped WDA to ^6.0.0, which includes fixes for the active application detection

Updated various gesture extensions to align them with recent WDA fixed made in https://github.com/appium/WebDriverAgent/pull/843

This restores https://github.com/appium/appium-xcuitest-driver/pull/2313 erroneously merged without bumping the major driver version