### PR TITLE
chore: add a guide for the simulated location

### DIFF
--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -31,10 +31,13 @@ export default {
     // '3' is 'Always' in the privacy
     // https://developer.apple.com/documentation/corelocation/clauthorizationstatus
     if (authorizationStatus !== AuthorizationStatus.authorizedAlways) {
-      this.log.errorAndThrow(
+      throw this.log.errorWithException(
         `Location service must be set to 'Always' in order to ` +
           `retrive the current geolocation data. Please set it up manually via ` +
-          `'Settings > Privacy > Location Services -> WebDriverAgentRunner-Runner'`,
+          `'Settings > Privacy > Location Services -> WebDriverAgentRunner-Runner'. ` +
+          `Newer simulator environment does not have the settings item. Please use ` +
+          `'mobile:getSimulatedLocation'/'mobile:setSimulatedLocation' commands to ` +
+          `simulate locations instead.`,
       );
     }
 
@@ -71,7 +74,7 @@ export default {
       try {
         service.setLocation(latitude, longitude);
       } catch (e) {
-        this.log.errorAndThrow(
+        throw this.log.errorWithException(
           `Can't set the location on device '${this.opts.udid}'. Original error: ${e.message}`,
         );
         throw new Error(); // unreachable
@@ -98,7 +101,7 @@ export default {
     try {
       service.resetLocation();
     } catch (err) {
-      this.log.errorAndThrow(
+      throw this.log.errorWithException(
         `Failed to reset the location on the device on device '${this.opts.udid}'. ` +
           `Origianl error: ${err.message}`,
       );

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -35,9 +35,8 @@ export default {
         `Location service must be set to 'Always' in order to ` +
           `retrieve the current geolocation data. Please set it up manually via ` +
           `'Settings > Privacy > Location Services -> WebDriverAgentRunner-Runner'. ` +
-          `Newer simulator environment may not have the settings item. Please use ` +
-          `'mobile:getSimulatedLocation'/'mobile:setSimulatedLocation' commands to ` +
-          `simulate locations instead.`,
+          `Or please use 'mobile:getSimulatedLocation'/'mobile:setSimulatedLocation' commands ` +
+          `to simulate locations instead.`,
       );
     }
 

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -33,9 +33,9 @@ export default {
     if (authorizationStatus !== AuthorizationStatus.authorizedAlways) {
       throw this.log.errorWithException(
         `Location service must be set to 'Always' in order to ` +
-          `retrive the current geolocation data. Please set it up manually via ` +
+          `retrieve the current geolocation data. Please set it up manually via ` +
           `'Settings > Privacy > Location Services -> WebDriverAgentRunner-Runner'. ` +
-          `Newer simulator environment does not have the settings item. Please use ` +
+          `Newer simulator environment may not have the settings item. Please use ` +
           `'mobile:getSimulatedLocation'/'mobile:setSimulatedLocation' commands to ` +
           `simulate locations instead.`,
       );

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -77,7 +77,6 @@ export default {
         throw this.log.errorWithException(
           `Can't set the location on device '${this.opts.udid}'. Original error: ${e.message}`,
         );
-        throw new Error(); // unreachable
       } finally {
         service.close();
       }


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/19761

It looks like simulators need to use simulated locations right now. I'm not sure this is for all simulators nowadays, so lets me update the error message right now instead of returning an error for all simulator cases