### PR TITLE
feat: Remove obsolete MJSONWP touch actions

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -305,30 +305,6 @@ Return the language-specific strings for an app
 
 A record of localized keys to localized text
 
-### `click`
-
-!!! warning "Deprecated"
-
-    This method is deprecated. Please use the [`mobile: tap`](./execute-methods.md#mobile-tap) extension instead
-
-`POST` **`/session/:sessionId/touch/click`**
-
-Click/tap an element
-
-**`See`**
-
-[https://w3c.github.io/webdriver/#element-click](https://w3c.github.io/webdriver/#element-click)
-
-#### Arguments
-
-| Name | Type |
-| :------ | :------ |
-| `element` | `any` |
-
-#### Returned Result
-
-`any`
-
 ### `setValueImmediate`
 
 !!! warning "Deprecated"
@@ -492,44 +468,3 @@ Get the window size
 #### Returned Result
 
 `any`
-
-### `performMultiAction`
-
-!!! warning "Deprecated"
-
-    This method is deprecated. Please use `performActions` instead
-
-`POST` **`/session/:sessionId/touch/multi/perform`**
-
-Perform a set of touch actions
-
-#### Arguments
-
-| Name | Type |
-| :------ | :------ |
-| `actions` | `any` |
-| `elementId?` | `any` |
-
-#### Returned Result
-
-`unknown`
-
-### `performTouch`
-
-!!! warning "Deprecated"
-
-    This method is deprecated. Please use `performActions` instead
-
-`POST` **`/session/:sessionId/touch/perform`**
-
-Perform a set of touch actions
-
-#### Arguments
-
-| Name | Type |
-| :------ | :------ |
-| `actions` | `any` |
-
-#### Returned Result
-
-`unknown`

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -133,54 +133,6 @@ const commands = {
     await this.proxyCommand('/actions', 'POST', {actions: preprocessedActions});
   },
   /**
-   * Perform a set of touch actions
-   *
-   * @param {any[]} gestures - the old MJSONWP style touch action objects
-   * @this {XCUITestDriver}
-   * @deprecated Use {@linkcode XCUITestDriver.performActions} instead
-   */
-  async performTouch(gestures) {
-    this.log.debug(`Received the following touch action: ${gesturesChainToString(gestures)}`);
-    try {
-      return await this.proxyCommand('/wda/touch/perform', 'POST', {actions: gestures});
-    } catch (e) {
-      if (!this.isWebContext()) {
-        throw e;
-      }
-      this.log.errorAndThrow(
-        'The Touch API is aimed for usage in NATIVE context. ' +
-          'Consider using "execute" API with custom events trigger script ' +
-          `to emulate touch events being in WEBVIEW context. Original error: ${e.message}`,
-      );
-    }
-  },
-  /**
-   * Perform a set of touch actions
-   *
-   * @param {any[]} actions - the old MJSONWP style touch action objects
-   * @this {XCUITestDriver}
-   * @deprecated Use {@linkcode XCUITestDriver.performActions} instead
-   * @group Native Only
-   */
-  async performMultiAction(actions) {
-    this.log.debug(`Received the following multi touch action:`);
-    for (let i in actions) {
-      this.log.debug(`    ${parseInt(i, 10) + 1}: ${_.map(actions[i], 'action').join('-')}`);
-    }
-    try {
-      return await this.proxyCommand('/wda/touch/multi/perform', 'POST', {actions});
-    } catch (e) {
-      if (!this.isWebContext()) {
-        throw e;
-      }
-      this.log.errorAndThrow(
-        'The MultiTouch API is aimed for usage in NATIVE context. ' +
-          'Consider using "execute" API with custom events trigger script ' +
-          `to emulate multitouch events being in WEBVIEW context. Original error: ${e.message}`,
-      );
-    }
-  },
-  /**
    * @param {import('@appium/types').Element|string} el
    * @this {XCUITestDriver}
    * @group Native Only

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -7,12 +7,6 @@ const DELETE = 'DELETE';
 const SUPPORTED_METHODS = Object.freeze(new Set(/** @type {const} */ ([GET, POST, DELETE])));
 
 const WDA_ROUTES = /** @type {const} */ ({
-  '/wda/touch/perform': {
-    POST: 'performTouch',
-  },
-  '/wda/touch/multi/perform': {
-    POST: 'performMultiAction',
-  },
   '/wda/screen': {
     GET: 'getScreenInfo',
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -145,7 +145,6 @@ const NO_PROXY_NATIVE_LIST = [
   ['POST', /session\/[^\/]+\/location/], // geo location, but not element location
   ['POST', /shake/],
   ['POST', /timeouts/],
-  ['POST', /touch/],
   ['POST', /url/],
   ['POST', /value/],
   ['POST', /window/],

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2025,8 +2025,6 @@ class XCUITestDriver extends BaseDriver {
   click = commands.gestureExtensions.click;
   releaseActions = commands.gestureExtensions.releaseActions;
   performActions = commands.gestureExtensions.performActions;
-  performTouch = commands.gestureExtensions.performTouch;
-  performMultiAction = commands.gestureExtensions.performMultiAction;
   nativeClick = commands.gestureExtensions.nativeClick;
   mobileScrollToElement = commands.gestureExtensions.mobileScrollToElement;
   mobileScroll = commands.gestureExtensions.mobileScroll;

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -16,21 +16,6 @@ export const newMethodMap = /** @type {const} */ ({
   '/session/:sessionId/element/:elementId/location': {GET: {command: 'getLocation'}},
   '/session/:sessionId/element/:elementId/location_in_view': {GET: {command: 'getLocationInView'}},
   '/session/:sessionId/element/:elementId/size': {GET: {command: 'getSize'}},
-  '/session/:sessionId/touch/click': {
-    POST: {command: 'click', payloadParams: {required: ['element']}},
-  },
-  '/session/:sessionId/touch/perform': {
-    POST: {
-      command: 'performTouch',
-      payloadParams: {wrap: 'actions', required: ['actions']},
-    },
-  },
-  '/session/:sessionId/touch/multi/perform': {
-    POST: {
-      command: 'performMultiAction',
-      payloadParams: {required: ['actions'], optional: ['elementId']},
-    },
-  },
   '/session/:sessionId/appium/device/shake': {POST: {command: 'mobileShake'}},
   '/session/:sessionId/appium/device/lock': {
     POST: {command: 'lock', payloadParams: {optional: ['seconds']}},

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^5.5.1",
     "appium-remote-debugger": "^10.0.0",
-    "appium-webdriveragent": "^6.1.0",
+    "appium-webdriveragent": "^7.0.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/test/unit/commands/gesture-specs.js
+++ b/test/unit/commands/gesture-specs.js
@@ -41,28 +41,6 @@ describe('gesture commands', function () {
     });
   });
 
-  describe('tap', function () {
-    it('should send POST request to /tap on WDA when no element is given', async function () {
-      const actions = [{action: 'tap'}];
-      await driver.performTouch(actions);
-      proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/wda/touch/perform');
-      proxySpy.firstCall.args[1].should.eql('POST');
-    });
-    it('should send POST request to /tap/element on WDA', async function () {
-      const actions = [{action: 'tap', options: {element: 42}}];
-      await driver.performTouch(actions);
-      proxySpy.calledOnce.should.be.true;
-      proxySpy.firstCall.args[0].should.eql('/wda/touch/perform');
-      proxySpy.firstCall.args[1].should.eql('POST');
-    });
-    it('should send POST request to /tap/element with offset on WDA', async function () {
-      const actions = [{action: 'tap', options: {element: 42, x: 1, y: 2}}];
-      await driver.performTouch(actions);
-      proxySpy.should.have.been.calledOnceWith('/wda/touch/perform', 'POST', {actions});
-    });
-  });
-
   describe('mobile methods', function () {
     describe('anything other than scroll', function () {
       it('should throw an error', async function () {


### PR DESCRIPTION
BREAKING CHANGE: Removed the following obsolete APIs:
- performTouch
- performMultiAction

Based on https://github.com/appium/WebDriverAgent/pull/847
