### PR TITLE
feat: return the result of getGeoLocation if available for ios 17+

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -63,6 +63,10 @@ Returns the location of the device under test. Location Services for WebDriverAg
 The 'latitude', 'longitude' and 'altitude' could be zero even if the Location Services are set to
 'Always', because the device may need some time to update the location data.
 
+For iOS 17+ simulators and real devices, this method will return the result of
+[`mobile: getSimulatedLocation`](./execute-methods.md#mobile-getsimulatedlocation) extension
+if they were set by [`mobile: setSimulatedLocation`](./execute-methods.md#mobile-setsimulatedlocation).
+
 **`Throws`**
 
 If the device under test returns an error message. i.e.: tvOS returns unsupported error

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,7 +65,7 @@ The 'latitude', 'longitude' and 'altitude' could be zero even if the Location Se
 
 For iOS 17+ simulators and real devices, this method will return the result of
 [`mobile: getSimulatedLocation`](./execute-methods.md#mobile-getsimulatedlocation) extension
-if they were set by [`mobile: setSimulatedLocation`](./execute-methods.md#mobile-setsimulatedlocation).
+if the simulated location was previously set by [`mobile: setSimulatedLocation`](./execute-methods.md#mobile-setsimulatedlocation).
 
 **`Throws`**
 

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -13,6 +13,10 @@ export default {
    * if the Location Services are set to 'Always', because the device
    * needs some time to update the location data.
    *
+   * For iOS 17, the return value could be the result of
+   * "mobile:getSimulatedLocation" if the value was set by
+   * "mobile:setSimulatedLocation" already.
+   *
    * @returns {Promise<import('./types').LocationWithAltitude>}
    * @throws {Error} If the device under test returns an error message.
    *                 i.e.: tvOS returns unsupported error
@@ -21,8 +25,13 @@ export default {
   async getGeoLocation() {
     // Currently we proxy the setGeoLocation to mobile:setSimulatedLocation for iOS 17+.
     // It would be helpful to address to use "mobile:getSimulatedLocation" for iOS 17+.
-    if (this.isRealDevice() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.info(`Location set by mobile:setSimulatedLocation method should be retrieved via mobile:getSimulatedLocation method.`);
+    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
+      const {latitude, longitude} = await this.mobileGetSimulatedLocation();
+      if (latitude && longitude) {
+        return {latitude, longitude, altitude: 0};
+      }
+
+      this.log.warn(`No location was set by mobile:setSimulatedLocation. Trying to return the location from the device.`);
     }
 
     // Please do not change the way to get the location here with '/wda/simulatedLocation'

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -14,7 +14,7 @@ export default {
    * needs some time to update the location data.
    *
    * For iOS 17, the return value could be the result of
-   * "mobile:getSimulatedLocation" if the value was set by
+   * "mobile:getSimulatedLocation" if the simulated location has been previously set
    * "mobile:setSimulatedLocation" already.
    *
    * @returns {Promise<import('./types').LocationWithAltitude>}
@@ -28,7 +28,7 @@ export default {
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
       const {latitude, longitude} = await this.mobileGetSimulatedLocation();
       if (latitude && longitude) {
-        this.log.debug('Current location is set by mobile:setSimulatedLocation. ' +
+        this.log.debug('Returning the geolocation that has been previously set by mobile:setSimulatedLocation. ' +
           'mobile:resetSimulatedLocation can reset the location configuration.');
         return {latitude, longitude, altitude: 0};
       }
@@ -83,7 +83,7 @@ export default {
     }
 
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.info(`Proxy to mobile:setSimulatedLocation method for iOS 17+ platform version`);
+      this.log.info(`Proxying to mobile:setSimulatedLocation method for iOS 17+ platform version`);
       await this.mobileSetSimulatedLocation(latitude, longitude);
     } else {
       const service = await services.startSimulateLocationService(this.opts.udid);

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -22,7 +22,7 @@ export default {
     // Currently we proxy the setGeoLocation to simulate location for iOS 17+.
     // This endpoint can return actual device location, thus we won't return
     // mobile:getSimulatedLocation right now.
-    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
+    if (this.isRealDevice() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
       this.log.info(`Location set by mobile:setSimulatedLocation method should get via mobile:getSimulatedLocation method.`);
     }
 

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -73,7 +73,7 @@ export default {
     }
 
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.debug(`Proxy mobile:setSimulatedLocation method as iOS 17+ platform version`);
+      this.log.info(`Proxy mobile:setSimulatedLocation method as iOS 17+ platform version`);
       await this.mobileSetSimulatedLocation(latitude, longitude);
     } else {
       const service = await services.startSimulateLocationService(this.opts.udid);

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -28,6 +28,8 @@ export default {
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
       const {latitude, longitude} = await this.mobileGetSimulatedLocation();
       if (latitude && longitude) {
+        this.log.debug('Current location is set by mobile:setSimulatedLocation. ' +
+          'mobile:resetSimulatedLocation can reset the location configuration.');
         return {latitude, longitude, altitude: 0};
       }
 

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -19,6 +19,13 @@ export default {
    * @this {XCUITestDriver}
    */
   async getGeoLocation() {
+    // Currently we proxy the setGeoLocation to simulate location for iOS 17+.
+    // This endpoint can return actual device location, thus we won't return
+    // mobile:getSimulatedLocation right now.
+    if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
+      this.log.info(`Location set by mobile:setSimulatedLocation method should get via mobile:getSimulatedLocation method.`);
+    }
+
     // Please do not change the way to get the location here with '/wda/simulatedLocation'
     // endpoint because they could return different value before setting the simulated location.
     // '/wda/device/location' returns current device location information,

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -19,9 +19,8 @@ export default {
    * @this {XCUITestDriver}
    */
   async getGeoLocation() {
-    // Currently we proxy the setGeoLocation to simulate location for iOS 17+.
-    // This endpoint can return actual device location, thus we won't return
-    // mobile:getSimulatedLocation right now.
+    // Currently we proxy the setGeoLocation to mobile:setSimulatedLocation for iOS 17+.
+    // It would be helpful to address to use "mobile:getSimulatedLocation" for iOS 17+.
     if (this.isRealDevice() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
       this.log.info(`Location set by mobile:setSimulatedLocation method should get via mobile:getSimulatedLocation method.`);
     }

--- a/lib/commands/location.js
+++ b/lib/commands/location.js
@@ -22,7 +22,7 @@ export default {
     // Currently we proxy the setGeoLocation to mobile:setSimulatedLocation for iOS 17+.
     // It would be helpful to address to use "mobile:getSimulatedLocation" for iOS 17+.
     if (this.isRealDevice() && this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.info(`Location set by mobile:setSimulatedLocation method should get via mobile:getSimulatedLocation method.`);
+      this.log.info(`Location set by mobile:setSimulatedLocation method should be retrieved via mobile:getSimulatedLocation method.`);
     }
 
     // Please do not change the way to get the location here with '/wda/simulatedLocation'
@@ -72,7 +72,7 @@ export default {
     }
 
     if (this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')) {
-      this.log.info(`Proxy mobile:setSimulatedLocation method as iOS 17+ platform version`);
+      this.log.info(`Proxy to mobile:setSimulatedLocation method for iOS 17+ platform version`);
       await this.mobileSetSimulatedLocation(latitude, longitude);
     } else {
       const service = await services.startSimulateLocationService(this.opts.udid);


### PR DESCRIPTION
[update]
Let's return the result of getSimulatedLocation first if available for ios 17+.


---

For iOS 17+, our primary method for setting location is setSimulatedLocation. It would make sense to show log to use `mobile:getSimulatedLocation`. The existing method can get actual device location info, so we don't need to forcefully proxy the request to the mobile:getSimulatedLocation