### PR TITLE
fix: Properly handle WDA session startup errors

### DIFF
--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -104,19 +104,19 @@ export default {
     }
 
     this.log.debug(`Setting custom timeout to ${timeout} ms for '${cmdName}' command`);
-    let isCommandExpired = false;
-    const res = await B.resolve(proxy.command(url, method, body))
-      .timeout(timeout)
-      .catch(B.Promise.TimeoutError, () => {
-        isCommandExpired = true;
-      });
-    if (isCommandExpired) {
+    try {
+      return /** @type {TRes} */ (await B.resolve(proxy.command(url, method, body)).timeout(timeout));
+    } catch (e) {
+      if (!(e instanceof B.Promise.TimeoutError)) {
+        throw e;
+      }
       proxy.cancelActiveRequests();
-      const errMsg = `Appium did not get any response from '${cmdName}' command in ${timeout} ms`;
-      await this.startUnexpectedShutdown(new errors.TimeoutError(errMsg));
-      this.log.errorAndThrow(errMsg);
+      const error = new errors.TimeoutError(
+        `Appium did not get any response from '${cmdName}' command in ${timeout} ms`
+      );
+      await this.startUnexpectedShutdown(error);
+      throw error;
     }
-    return /** @type {TRes} */ (res);
   },
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,7 +1,7 @@
 import IDB from 'appium-idb';
 import {getSimulator} from 'appium-ios-simulator';
 import {WebDriverAgent} from 'appium-webdriveragent';
-import {BaseDriver, DeviceSettings} from 'appium/driver';
+import {BaseDriver, DeviceSettings, errors} from 'appium/driver';
 import {fs, mjpeg, util, timing} from 'appium/support';
 import AsyncLock from 'async-lock';
 import {retry, retryInterval} from 'asyncbox';
@@ -773,14 +773,11 @@ class XCUITestDriver extends BaseDriver {
       // local helper for the two places we need to uninstall wda and re-start it
       const quitAndUninstall = async (msg) => {
         this.log.debug(msg);
-        if (this.opts.webDriverAgentUrl) {
+        const noUninstallCap = ['webDriverAgentUrl', 'usePreinstalledWDA']
+          .find((x) => Boolean(this.opts[x]));
+        if (noUninstallCap) {
           this.log.debug(
-            'Not quitting/uninstalling WebDriverAgent since webDriverAgentUrl capability is provided',
-          );
-          throw new Error(msg);
-        } else if (this.opts.usePreinstalledWDA) {
-          this.log.debug(
-            'Not uninstalling WebDriverAgent since this.opts.usePreinstalledWDA capability is provided',
+            `Not quitting/uninstalling WebDriverAgent since ${noUninstallCap} capability is provided`,
           );
           throw new Error(msg);
         }
@@ -810,8 +807,10 @@ class XCUITestDriver extends BaseDriver {
           `These values can be customized by changing wdaStartupRetries/wdaStartupRetryInterval capabilities`,
         );
       }
-      let retryCount = 0;
 
+      /** @type {Error|null} */
+      let shortCircuitError = null;
+      let retryCount = 0;
       await retryInterval(startupRetries, startupRetryInterval, async () => {
         this.logEvent('wdaStartAttempted');
         if (retryCount > 0) {
@@ -880,34 +879,25 @@ class XCUITestDriver extends BaseDriver {
         this.proxyReqRes = this.wda.proxyReqRes.bind(this.wda);
         this.jwpProxyActive = true;
 
-        let originalStacktrace = null;
         try {
-          await retryInterval(15, 1000, async () => {
-            this.logEvent('wdaSessionAttempted');
-            this.log.debug('Sending createSession command to WDA');
-            try {
-              this.cachedWdaStatus =
-                this.cachedWdaStatus || (await this.proxyCommand('/status', 'GET'));
-              await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
-            } catch (err) {
-              originalStacktrace = err.stack;
-              this.log.debug(`Failed to create WDA session (${err.message}). Retrying...`);
-              throw err;
-            }
-          });
+          this.logEvent('wdaSessionAttempted');
+          this.log.debug('Sending createSession command to WDA');
+          this.cachedWdaStatus = this.cachedWdaStatus || (await this.proxyCommand('/status', 'GET'));
+          await this.startWdaSession(this.opts.bundleId, this.opts.processArguments);
           this.logEvent('wdaSessionStarted');
         } catch (err) {
-          if (originalStacktrace) {
-            this.log.debug(originalStacktrace);
+          this.logEvent('wdaSessionFailed');
+          this.log.debug(err.stack);
+          if (err instanceof errors.TimeoutError) {
+            // Session startup timed out. There is no point to retry
+            shortCircuitError = err;
+            return;
           }
-          let errorMsg = `Unable to start WebDriverAgent session because of xcodebuild failure: ${err.message}`;
-          if (this.isRealDevice()) {
-            errorMsg +=
-              ` Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}. ` +
-              `Try to remove the WebDriverAgentRunner application from the device if it is installed ` +
-              `and reboot the device.`;
+          let errorMsg = `Unable to start WebDriverAgent session because of an unexpected failure: ${err.message}`;
+          if (this.isRealDevice() && _.includes(err.message, 'xcodebuild')) {
+            errorMsg += ` Make sure you follow the tutorial at ${WDA_REAL_DEV_TUTORIAL_URL}.`;
           }
-          await quitAndUninstall(errorMsg);
+          throw new Error(errorMsg);
         }
 
         if (this.opts.clearSystemFiles && this.isXcodebuildNeeded()) {
@@ -919,6 +909,10 @@ class XCUITestDriver extends BaseDriver {
         this.wda.fullyStarted = true;
         this.logEvent('wdaStarted');
       });
+
+      if (shortCircuitError) {
+        throw shortCircuitError;
+      }
     });
   }
 


### PR DESCRIPTION
- It does not make sense to uninstall WDA when session startup fails, because that means WDA has actually started successfully
- We must short-circuit (e.g. no more reties) if the session startup times out
- Hardcoded repeats for WDA session startup are useless. They only prolong the time to fail.