### PR TITLE
fix: Update the default timeout for the recent webview detection

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -58,7 +58,7 @@ const extensions = {
   async activateRecentWebview() {
     this.log.debug('Activating a recent webview');
     const timer = new timing.Timer().start();
-    const waitMs = RECENT_WEBVIEW_DETECTION_TIMEOUT_MS;
+    const waitMs = this.opts.webviewConnectTimeout || RECENT_WEBVIEW_DETECTION_TIMEOUT_MS;
     /** @type {Error|null} */
     let lastError = null;
     try {
@@ -87,12 +87,15 @@ const extensions = {
       });
     } catch (e) {
       const elapsedMs = timer.getDuration().asMilliSeconds;
-      if (elapsedMs >= RECENT_WEBVIEW_DETECTION_TIMEOUT_MS) {
+      if (elapsedMs >= waitMs) {
         if (lastError) {
           this.log.debug((/** @type {Error} */ (lastError)).stack);
         }
         // no webview was found
-        throw new Error(`No webview has been detected after ${elapsedMs.toFixed(0)}ms`);
+        throw new Error(
+          `No webview has been detected after ${elapsedMs.toFixed(0)}ms. ` +
+          `You may try to change the 'webviewConnectTimeout' capability value to modify the timeout.`
+        );
       } else {
         throw e;
       }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -1,14 +1,14 @@
 import {createRemoteDebugger, RemoteDebugger} from 'appium-remote-debugger';
 import {errors, isErrorType} from 'appium/driver';
 import {util, timing} from 'appium/support';
-import B from 'bluebird';
+import { waitForCondition } from 'asyncbox';
 import IOSPerformanceLog from '../device-log/ios-performance-log';
 import _ from 'lodash';
 
 const NATIVE_WIN = 'NATIVE_APP';
 const WEBVIEW_WIN = 'WEBVIEW';
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
-const RECENT_WEBVIEW_DETECTION_TIMEOUT_MS = 90000;
+const RECENT_WEBVIEW_DETECTION_TIMEOUT_MS = 7000;
 
 /**
  * Type guard for a non-empty array.
@@ -58,60 +58,45 @@ const extensions = {
   async activateRecentWebview() {
     this.log.debug('Activating a recent webview');
     const timer = new timing.Timer().start();
-    const spinTimeMs = 500;
-    const spinHandles = async () => {
-      /** @type {string|undefined} */
-      let contextId;
-      try {
-        contextId = await this.getRecentWebviewContextId(/.*/, /.*/);
-      } catch (err) {
-        if (!err.message.includes('Could not connect to a valid app after')) {
-          const error = new Error(`Could not navigate to webview! Err: ${err.message}`);
-          error.stack += `\nCaused by: ${err.stack}`;
-          throw error;
+    const waitMs = RECENT_WEBVIEW_DETECTION_TIMEOUT_MS;
+    /** @type {Error|null} */
+    let lastError = null;
+    try {
+      await waitForCondition(async () => {
+        /** @type {string|undefined} */
+        let contextId;
+        try {
+          contextId = await this.getRecentWebviewContextId(/.*/, /.*/);
+        } catch (err) {
+          lastError = err;
+          this.log.debug(err.message);
+          return false;
         }
-        this.log.debug('Could not navigate to webview. Retrying if possible.');
-      }
-      if (contextId) {
-        this.log.debug(`Picking webview '${contextId}'`);
-        await this.setContext(contextId);
-        await this.remote.cancelPageLoad();
-        return;
-      }
+        if (contextId) {
+          this.log.info(`Picking webview '${contextId}' after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+          await this.setContext(contextId);
+          await this.remote.cancelPageLoad();
+          return true;
+        }
 
-      // no webview was found
-      if (timer.getDuration().asMilliSeconds >= RECENT_WEBVIEW_DETECTION_TIMEOUT_MS) {
-        // too slow, get out
-        throw new Error('Could not navigate to webview; there are none!');
+        this.log.info('Could not find any webviews yet, retrying');
+        return false;
+      }, {
+        waitMs,
+        intervalMs: 500,
+      });
+    } catch (e) {
+      const elapsedMs = timer.getDuration().asMilliSeconds;
+      if (elapsedMs >= RECENT_WEBVIEW_DETECTION_TIMEOUT_MS) {
+        if (lastError) {
+          this.log.debug((/** @type {Error} */ (lastError)).stack);
+        }
+        // no webview was found
+        throw new Error(`No webview has been detected after ${elapsedMs.toFixed(0)}ms`);
+      } else {
+        throw e;
       }
-
-      this.log.warn('Could not find any webviews yet, refreshing/retrying');
-      // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-      if (this.isRealDevice() || !this.opts.safari) {
-        // on a real device, when not using Safari, we just want to try again
-        await B.delay(spinTimeMs);
-        return await spinHandles();
-      }
-
-      // find the reload button and tap it, if possible
-      /** @type {import('@appium/types').Element} */
-      let element;
-      try {
-        this.log.debug('Finding and tapping reload button');
-        element = /** @type {import('@appium/types').Element} */ (
-          await this.findNativeElementOrElements('accessibility id', 'ReloadButton', '', false)
-        );
-        await this.nativeClick(element);
-      } catch (err) {
-        this.log.warn(`Error finding and tapping reload button: ${err.message}`);
-        this.log.warn('Retrying.');
-        await B.delay(spinTimeMs);
-      }
-
-      // try it all again
-      return await spinHandles();
-    };
-    await spinHandles();
+    }
   },
   /**
    * @this {XCUITestDriver}


### PR DESCRIPTION
90 seconds is definitely too much for that by default.
