### PR TITLE
chore: skip connected device check if the caps had webDriverAgentUrl

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1210,7 +1210,7 @@ class XCUITestDriver extends BaseDriver {
         // If the session specified this.opts.webDriverAgentUrl with a real device,
         // we can assume the user prepared the device properly already.
         if (this.opts.webDriverAgentUrl) {
-          this.logs.debug('Skip checking the device availability since the session specifies appium:webDriverAgentUrl');
+          this.logs.debug('Skipping checking of the device availability since the session specifies appium:webDriverAgentUrl');
         } else {
           // make sure it is a connected device. If not, the udid passed in is invalid
           const devices = await getConnectedDevices();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1210,7 +1210,7 @@ class XCUITestDriver extends BaseDriver {
         // If the session specified this.opts.webDriverAgentUrl with a real device,
         // we can assume the user prepared the device properly already.
         if (this.isRealDevice() && this.opts.webDriverAgentUrl) {
-          this.logs.debug(`Skip checking the device availability since the session specifies appium:webDriverAgentUrl`)
+          this.logs.debug('Skip checking the device availability since the session specifies appium:webDriverAgentUrl');
         } else {
           // make sure it is a connected device. If not, the udid passed in is invalid
           const devices = await getConnectedDevices();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1207,19 +1207,25 @@ class XCUITestDriver extends BaseDriver {
           return {device, realDevice: false, udid: device.udid};
         }
       } else {
-        // make sure it is a connected device. If not, the udid passed in is invalid
-        const devices = await getConnectedDevices();
-        this.log.debug(`Available devices: ${devices.join(', ')}`);
-        if (!devices.includes(this.opts.udid)) {
-          // check for a particular simulator
-          this.log.debug(`No real device with udid '${this.opts.udid}'. Looking for a simulator`);
-          try {
-            const device = await getSimulator(this.opts.udid, {
-              devicesSetPath: this.opts.simulatorDevicesSetPath,
-            });
-            return {device, realDevice: false, udid: this.opts.udid};
-          } catch (ign) {
-            throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+        // If the session specified this.opts.webDriverAgentUrl with a real device,
+        // we can assume the user prepared the device properly already.
+        if (this.isRealDevice() && this.opts.webDriverAgentUrl) {
+          this.logs.debug(`Skip checking the device availability since the session specifies appium:webDriverAgentUrl`)
+        } else {
+          // make sure it is a connected device. If not, the udid passed in is invalid
+          const devices = await getConnectedDevices();
+          this.log.debug(`Available devices: ${devices.join(', ')}`);
+          if (!devices.includes(this.opts.udid)) {
+            // check for a particular simulator
+            this.log.debug(`No real device with udid '${this.opts.udid}'. Looking for a simulator`);
+            try {
+              const device = await getSimulator(this.opts.udid, {
+                devicesSetPath: this.opts.simulatorDevicesSetPath,
+              });
+              return {device, realDevice: false, udid: this.opts.udid};
+            } catch (ign) {
+              throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+            }
           }
         }
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1209,7 +1209,7 @@ class XCUITestDriver extends BaseDriver {
       } else {
         // If the session specified this.opts.webDriverAgentUrl with a real device,
         // we can assume the user prepared the device properly already.
-        if (this.isRealDevice() && this.opts.webDriverAgentUrl) {
+        if (this.opts.webDriverAgentUrl) {
           this.logs.debug('Skip checking the device availability since the session specifies appium:webDriverAgentUrl');
         } else {
           // make sure it is a connected device. If not, the udid passed in is invalid


### PR DESCRIPTION
I wondered if we simply can skip the connected devices check with `webDriverAgentUrl` since `webDriverAgentUrl` usually means the caller prepared the device properly for the session