### PR TITLE
chore: include devicectl in IOSDeploy object

### DIFF
--- a/lib/commands/memory.js
+++ b/lib/commands/memory.js
@@ -19,8 +19,7 @@ export default {
     const device = this.opts.device;
 
     /** @type {import('../devicectl').AppInfo[]} */
-    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    const appInfos = await this.opts.device.devicectl.listApps(bundleId);
+    const appInfos = await device.devicectl.listApps(bundleId);
     if (_.isEmpty(appInfos)) {
       throw new errors.InvalidArgumentError(
         `The application identified by ${bundleId} cannot be found on the device. Is it installed?`

--- a/lib/commands/memory.js
+++ b/lib/commands/memory.js
@@ -16,6 +16,7 @@ export default {
     }
 
     /** @type {import('../devicectl').AppInfo[]} */
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const appInfos = await this.opts.device.devicectl.listApps(bundleId);
     if (_.isEmpty(appInfos)) {
       throw new errors.InvalidArgumentError(
@@ -34,6 +35,7 @@ export default {
     // allow to connect a bundle id to a process id.
     const pattern = new RegExp(`^${_.escapeRegExp(appInfos[0].url)}[^/]+$`);
     /** @type {number[]} */
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const pids = (await this.opts.device.devicectl.listProcesses())
       .filter(({executable}) => pattern.test(executable))
       .map(({processIdentifier}) => processIdentifier);
@@ -43,6 +45,7 @@ export default {
       );
     }
     this.log.info(`Emulating Low Memory warning for the process id ${pids[0]}, bundle id ${bundleId}`);
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     await this.opts.device.devicectl.sendMemoryWarning(pids[0]);
   }
 };

--- a/lib/commands/memory.js
+++ b/lib/commands/memory.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { Devicectl } from '../devicectl';
 import { errors } from 'appium/driver';
 
 export default {
@@ -16,9 +15,8 @@ export default {
       throw new Error('Memory warning simulation is only supported on real devices');
     }
 
-    const devicectl = new Devicectl(this.opts.udid, this.log);
     /** @type {import('../devicectl').AppInfo[]} */
-    const appInfos = await devicectl.listApps(bundleId);
+    const appInfos = await this.opts.device.devicectl.listApps(bundleId);
     if (_.isEmpty(appInfos)) {
       throw new errors.InvalidArgumentError(
         `The application identified by ${bundleId} cannot be found on the device. Is it installed?`
@@ -36,7 +34,7 @@ export default {
     // allow to connect a bundle id to a process id.
     const pattern = new RegExp(`^${_.escapeRegExp(appInfos[0].url)}[^/]+$`);
     /** @type {number[]} */
-    const pids = (await devicectl.listProcesses())
+    const pids = (await this.opts.device.devicectl.listProcesses())
       .filter(({executable}) => pattern.test(executable))
       .map(({processIdentifier}) => processIdentifier);
     if (_.isEmpty(pids)) {
@@ -45,7 +43,7 @@ export default {
       );
     }
     this.log.info(`Emulating Low Memory warning for the process id ${pids[0]}, bundle id ${bundleId}`);
-    await devicectl.sendMemoryWarning(pids[0]);
+    await this.opts.device.devicectl.sendMemoryWarning(pids[0]);
   }
 };
 

--- a/lib/commands/memory.js
+++ b/lib/commands/memory.js
@@ -15,6 +15,9 @@ export default {
       throw new Error('Memory warning simulation is only supported on real devices');
     }
 
+    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
+    const device = this.opts.device;
+
     /** @type {import('../devicectl').AppInfo[]} */
     // @ts-expect-error - do not assign arbitrary properties to `this.opts`
     const appInfos = await this.opts.device.devicectl.listApps(bundleId);
@@ -35,8 +38,7 @@ export default {
     // allow to connect a bundle id to a process id.
     const pattern = new RegExp(`^${_.escapeRegExp(appInfos[0].url)}[^/]+$`);
     /** @type {number[]} */
-    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    const pids = (await this.opts.device.devicectl.listProcesses())
+    const pids = (await device.devicectl.listProcesses())
       .filter(({executable}) => pattern.test(executable))
       .map(({processIdentifier}) => processIdentifier);
     if (_.isEmpty(pids)) {
@@ -45,8 +47,7 @@ export default {
       );
     }
     this.log.info(`Emulating Low Memory warning for the process id ${pids[0]}, bundle id ${bundleId}`);
-    // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-    await this.opts.device.devicectl.sendMemoryWarning(pids[0]);
+    await device.devicectl.sendMemoryWarning(pids[0]);
   }
 };
 

--- a/lib/commands/xctest-record-screen.js
+++ b/lib/commands/xctest-record-screen.js
@@ -60,7 +60,9 @@ async function retrieveRecodingFromSimulator(uuid) {
  */
 async function retrieveRecodingFromRealDevice(uuid) {
   // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-  const fileNames = await this.opts.device.devicectl.listFiles(DOMAIN_TYPE, DOMAIN_IDENTIFIER, {
+  const device = this.opts.device;
+
+  const fileNames = await device.devicectl.listFiles(DOMAIN_TYPE, DOMAIN_IDENTIFIER, {
     username: USERNAME,
     subdirectory: SUBDIRECTORY,
   });
@@ -70,8 +72,7 @@ async function retrieveRecodingFromRealDevice(uuid) {
     );
   }
   const videoPath = path.join(/** @type {string} */ (this.opts.tmpDir), `${uuid}${MOV_EXT}`);
-  // @ts-expect-error - do not assign arbitrary properties to `this.opts`
-  await this.opts.device.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
+  await device.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
     username: USERNAME,
     domainIdentifier: DOMAIN_IDENTIFIER,
     domainType: DOMAIN_TYPE,

--- a/lib/commands/xctest-record-screen.js
+++ b/lib/commands/xctest-record-screen.js
@@ -72,7 +72,7 @@ async function retrieveRecodingFromRealDevice(uuid) {
     );
   }
   const videoPath = path.join(/** @type {string} */ (this.opts.tmpDir), `${uuid}${MOV_EXT}`);
-  await device.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
+  await device.devicectl.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
     username: USERNAME,
     domainIdentifier: DOMAIN_IDENTIFIER,
     domainType: DOMAIN_TYPE,

--- a/lib/commands/xctest-record-screen.js
+++ b/lib/commands/xctest-record-screen.js
@@ -59,6 +59,7 @@ async function retrieveRecodingFromSimulator(uuid) {
  * @returns {Promise<string>} The full path to the screen recording movie
  */
 async function retrieveRecodingFromRealDevice(uuid) {
+  // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   const fileNames = await this.opts.device.devicectl.listFiles(DOMAIN_TYPE, DOMAIN_IDENTIFIER, {
     username: USERNAME,
     subdirectory: SUBDIRECTORY,
@@ -69,6 +70,7 @@ async function retrieveRecodingFromRealDevice(uuid) {
     );
   }
   const videoPath = path.join(/** @type {string} */ (this.opts.tmpDir), `${uuid}${MOV_EXT}`);
+  // @ts-expect-error - do not assign arbitrary properties to `this.opts`
   await this.opts.device.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
     username: USERNAME,
     domainIdentifier: DOMAIN_IDENTIFIER,

--- a/lib/commands/xctest-record-screen.js
+++ b/lib/commands/xctest-record-screen.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import {fs, util} from 'appium/support';
 import {encodeBase64OrUpload} from '../utils';
 import path from 'node:path';
-import {Devicectl} from '../devicectl';
 
 const MOV_EXT = '.mov';
 const FEATURE_NAME = 'xctest_screen_record';
@@ -60,8 +59,7 @@ async function retrieveRecodingFromSimulator(uuid) {
  * @returns {Promise<string>} The full path to the screen recording movie
  */
 async function retrieveRecodingFromRealDevice(uuid) {
-  const devicectl = new Devicectl(this.opts.udid, this.log);
-  const fileNames = await devicectl.listFiles(DOMAIN_TYPE, DOMAIN_IDENTIFIER, {
+  const fileNames = await this.opts.device.devicectl.listFiles(DOMAIN_TYPE, DOMAIN_IDENTIFIER, {
     username: USERNAME,
     subdirectory: SUBDIRECTORY,
   });
@@ -71,7 +69,7 @@ async function retrieveRecodingFromRealDevice(uuid) {
     );
   }
   const videoPath = path.join(/** @type {string} */ (this.opts.tmpDir), `${uuid}${MOV_EXT}`);
-  await devicectl.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
+  await this.opts.device.pullFile(`${SUBDIRECTORY}/${uuid}`, videoPath, {
     username: USERNAME,
     domainIdentifier: DOMAIN_IDENTIFIER,
     domainType: DOMAIN_TYPE,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1224,7 +1224,7 @@ class XCUITestDriver extends BaseDriver {
         }
       }
 
-      const device = getRealDeviceObj(this.opts.udid);
+      const device = getRealDeviceObj(this.opts.udid, this.log);
       return {device, realDevice: true, udid: this.opts.udid};
     }
 

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -21,9 +21,9 @@ const APP_INSTALL_STRATEGY = Object.freeze({
 });
 
 class IOSDeploy {
-  constructor(udid) {
+  constructor(udid, logger) {
     this.udid = udid;
-    this.devicectl = new Devicectl(this.udid, log);
+    this.devicectl = new Devicectl(this.udid, logger);
   }
 
   async remove(bundleId) {

--- a/lib/ios-deploy.js
+++ b/lib/ios-deploy.js
@@ -23,6 +23,7 @@ const APP_INSTALL_STRATEGY = Object.freeze({
 class IOSDeploy {
   constructor(udid) {
     this.udid = udid;
+    this.devicectl = new Devicectl(this.udid, log);
   }
 
   async remove(bundleId) {
@@ -211,15 +212,14 @@ class IOSDeploy {
       if (util.compareVersions(platformVersion, '>=', '17.0')) {
         log.debug(`Calling devicectl to kill the process`);
 
-        const devicectl = new Devicectl(this.udid, log);
-        const pids = (await devicectl.listProcesses())
+        const pids = (await this.devicectl.listProcesses())
           .filter(({executable}) => executable.endsWith(`/${executableName}`))
           .map(({processIdentifier}) => processIdentifier);
         if (_.isEmpty(pids)) {
           log.info(`The process of the bundle id '${bundleId}' was not running`);
           return false;
         }
-        await devicectl.sendSignalToProcess(pids[0], 2);
+        await this.devicectl.sendSignalToProcess(pids[0], 2);
       } else {
         instrumentService = await services.startInstrumentService(this.udid);
         const processes = await instrumentService.callChannel(

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -124,11 +124,12 @@ async function installToRealDevice(device, app, bundleId, opts) {
 
 /**
  * @param {string} udid
+ * @param {import('@appium/types').AppiumLogger} logger
  * @returns {IOSDeploy}
  */
-function getRealDeviceObj(udid) {
+function getRealDeviceObj(udid, logger) {
   log.debug(`Creating iDevice object with udid '${udid}'`);
-  return new IOSDeploy(udid);
+  return new IOSDeploy(udid, logger);
 }
 
 export {


### PR DESCRIPTION
the command itself failed but below example was this pr's test. The `lib/commands/memory.js`'s instance called the devicectl command properly

```
[HTTP] --> POST /session/882dfb56-d64d-4124-a74e-f1056e9c7200/execute/sync
[HTTP] {"script":"mobile: sendMemoryWarning","args":[{"bundleId":"com.apple.Maps"}]}
[XCUITestDriver@36d5 (882dfb56)] Calling AppiumDriver.execute() with args: ["mobile: sendMemoryWarning",[{"bundleId":"com.apple.Maps"}],"882dfb56-d64d-4124-a74e-f1056e9c7200"]
[XCUITestDriver@36d5 (882dfb56)] Executing command 'execute'
[XCUITest] Executing xcrun devicectl device info apps --device 00008020-000E5CDA0A23002E --include-all-apps --bundle-id com.apple.Maps --quiet --json-output -
[XCUITest] Executing xcrun devicectl device info processes --device 00008020-000E5CDA0A23002E --quiet --json-output -
[XCUITestDriver@36d5 (882dfb56)] Emulating Low Memory warning for the process id 3745, bundle id com.apple.Maps
[XCUITest] Executing xcrun devicectl device process sendMemoryWarning --device 00008020-000E5CDA0A23002E --pid 3745 --quiet --json-output -
[XCUITestDriver@36d5 (882dfb56)] Encountered internal error running command: Error: 'xcrun devicectl device process sendMemoryWarning --device 00008020-000E5CDA0A23002E --pid 3745 --quiet --json-output -' failed. Original error: ERROR: The operation couldn’t be completed. No such file or directory (NSPOSIXErrorDomain error 2.)
[XCUITestDriver@36d5 (882dfb56)]
[XCUITestDriver@36d5 (882dfb56)]     at Devicectl.execute (/Users/kazu/GitHub/appium-xcuitest-driver/lib/devicectl.js:138:13)
[XCUITestDriver@36d5 (882dfb56)]     at Devicectl.sendMemoryWarning (/Users/kazu/GitHub/appium-xcuitest-driver/lib/devicectl.js:149:5)
[XCUITestDriver@36d5 (882dfb56)]     at XCUITestDriver.mobileSendMemoryWarning (/Users/kazu/GitHub/appium-xcuitest-driver/lib/commands/memory.js:49:5)
[XCUITestDriver@36d5 (882dfb56)]     at XCUITestDriver.executeMethod (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/basedriver/commands/execute.ts:36:12)
[XCUITestDriver@36d5 (882dfb56)]     at XCUITestDriver.execute (/Users/kazu/GitHub/appium-xcuitest-driver/lib/commands/execute.js:118:14)
[HTTP] <-- POST /session/882dfb56-d64d-4124-a74e-f1056e9c7200/execute/sync 500 4357 ms - 1054
```