### PR TITLE
chore: rename IosDeploy obhect to RealDevice to make the object meaning actual usage

### DIFF
--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -1,5 +1,5 @@
 import {utilities} from 'appium-ios-device';
-import IOSDeploy from './ios-deploy';
+import RealDevice from './real-device';
 import log from './logger';
 import {SAFARI_BUNDLE_ID} from './app-utils';
 
@@ -16,7 +16,7 @@ async function getOSVersion(udid) {
 }
 
 /**
- * @param {IOSDeploy} device
+ * @param {RealDevice} device
  * @param {import('./driver').XCUITestDriverOpts} opts
  * @returns {Promise<void>}
  */
@@ -51,7 +51,7 @@ async function resetRealDevice(device, opts) {
 }
 
 /**
- * @param {IOSDeploy} device
+ * @param {RealDevice} device
  * @param {import('./driver').XCUITestDriverOpts} opts
  * @returns {Promise<void>}
  */
@@ -76,7 +76,7 @@ async function runRealDeviceReset(device, opts) {
  */
 
 /**
- * @param {IOSDeploy} device The device instance
+ * @param {RealDevice} device The device instance
  * @param {string} [app] The app to the path
  * @param {string} [bundleId] The bundle id to ensure it is already installed and uninstall it
  * @param {InstallOptions} [opts]
@@ -124,11 +124,11 @@ async function installToRealDevice(device, app, bundleId, opts) {
 
 /**
  * @param {string} udid
- * @returns {IOSDeploy}
+ * @returns {RealDevice}
  */
 function getRealDeviceObj(udid) {
   log.debug(`Creating iDevice object with udid '${udid}'`);
-  return new IOSDeploy(udid);
+  return new RealDevice(udid);
 }
 
 export {

--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -20,7 +20,7 @@ const APP_INSTALL_STRATEGY = Object.freeze({
   IOS_DEPLOY,
 });
 
-class IOSDeploy {
+class RealDevice {
   constructor(udid) {
     this.udid = udid;
   }
@@ -281,4 +281,4 @@ class IOSDeploy {
   }
 }
 
-export default IOSDeploy;
+export default RealDevice;

--- a/test/unit/real-device-management-specs.js
+++ b/test/unit/real-device-management-specs.js
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import {createSandbox} from 'sinon';
 import sinonChai from 'sinon-chai';
 import { installToRealDevice } from '../../lib/real-device-management';
-import IOSDeploy from '../../lib/ios-deploy';
+import RealDevice from '../../lib/real-device';
 
 chai.should();
 chai.use(sinonChai).use(chaiAsPromised);
@@ -26,7 +26,7 @@ describe('installToRealDevice', function () {
   });
 
   it('nothing happen without app', async function () {
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').resolves();
 
@@ -36,7 +36,7 @@ describe('installToRealDevice', function () {
   });
 
   it('nothing happen without bundle id', async function () {
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').resolves();
 
@@ -49,7 +49,7 @@ describe('installToRealDevice', function () {
     const opts = {
       skipUninstall: true
     };
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').resolves();
 
@@ -63,7 +63,7 @@ describe('installToRealDevice', function () {
     const opts = {
       skipUninstall: false
     };
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').resolves();
 
@@ -78,7 +78,7 @@ describe('installToRealDevice', function () {
       skipUninstall: false
     };
     const err_msg = `{"Error":"ApplicationVerificationFailed","ErrorDetail":-402620395,"ErrorDescription":"Failed to verify code signature of /path/to.app : 0xe8008015 (A valid provisioning profile for this executable was not found.)"}`;
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').throws(err_msg);
 
@@ -93,7 +93,7 @@ describe('installToRealDevice', function () {
     const opts = {
       skipUninstall: true
     };
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install')
       .onCall(0).throws(`{"Error":"MismatchedApplicationIdentifierEntitlement","ErrorDescription":"Upgrade's application-identifier entitlement string (TEAM_ID.com.kazucocoa.example) does not match installed application's application-identifier string (ANOTHER_TEAM_ID.com.kazucocoa.example); rejecting upgrade."}`)
@@ -110,7 +110,7 @@ describe('installToRealDevice', function () {
       skipUninstall: true
     };
     const err_msg = `{"Error":"ApplicationVerificationFailed","ErrorDetail":-402620395,"ErrorDescription":"Failed to verify code signature of /path/to.app : 0xe8008015 (A valid provisioning profile for this executable was not found.)"}`;
-    const iosDeploy = new IOSDeploy(udid);
+    const iosDeploy = new RealDevice(udid);
     sandbox.stub(iosDeploy, 'remove').resolves();
     sandbox.stub(iosDeploy, 'install').throws(err_msg);
     sandbox.stub(iosDeploy, 'isAppInstalled').resolves(true);

--- a/test/unit/real-device-management-specs.js
+++ b/test/unit/real-device-management-specs.js
@@ -26,51 +26,51 @@ describe('installToRealDevice', function () {
   });
 
   it('nothing happen without app', async function () {
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').resolves();
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').resolves();
 
-    await installToRealDevice(iosDeploy, undefined, bundleId, {});
-    expect(iosDeploy.remove).to.not.have.been.called;
-    expect(iosDeploy.install).to.not.have.been.called;
+    await installToRealDevice(realDevice, undefined, bundleId, {});
+    expect(realDevice.remove).to.not.have.been.called;
+    expect(realDevice.install).to.not.have.been.called;
   });
 
   it('nothing happen without bundle id', async function () {
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').resolves();
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').resolves();
 
-    await installToRealDevice(iosDeploy, app, undefined, {});
-    expect(iosDeploy.remove).to.not.have.been.called;
-    expect(iosDeploy.install).to.not.have.been.called;
+    await installToRealDevice(realDevice, app, undefined, {});
+    expect(realDevice.remove).to.not.have.been.called;
+    expect(realDevice.install).to.not.have.been.called;
   });
 
   it('should install without remove', async function () {
     const opts = {
       skipUninstall: true
     };
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').resolves();
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').resolves();
 
-    await installToRealDevice(iosDeploy, app, bundleId, opts);
+    await installToRealDevice(realDevice, app, bundleId, opts);
 
-    expect(iosDeploy.remove).to.not.have.been.called;
-    expect(iosDeploy.install).to.have.been.calledOnce;
+    expect(realDevice.remove).to.not.have.been.called;
+    expect(realDevice.install).to.have.been.calledOnce;
   });
 
   it('should install after remove', async function () {
     const opts = {
       skipUninstall: false
     };
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').resolves();
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').resolves();
 
-    await installToRealDevice(iosDeploy, app, bundleId, opts);
+    await installToRealDevice(realDevice, app, bundleId, opts);
 
-    expect(iosDeploy.remove).to.have.been.calledOnce;
-    expect(iosDeploy.install).to.have.been.calledOnce;
+    expect(realDevice.remove).to.have.been.calledOnce;
+    expect(realDevice.install).to.have.been.calledOnce;
   });
 
   it('should raise an error for invalid verification error after uninstall', async function () {
@@ -78,13 +78,13 @@ describe('installToRealDevice', function () {
       skipUninstall: false
     };
     const err_msg = `{"Error":"ApplicationVerificationFailed","ErrorDetail":-402620395,"ErrorDescription":"Failed to verify code signature of /path/to.app : 0xe8008015 (A valid provisioning profile for this executable was not found.)"}`;
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').throws(err_msg);
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').throws(err_msg);
 
-    await installToRealDevice(iosDeploy, app, bundleId, opts).should.be.rejectedWith('ApplicationVerificationFailed');
-    expect(iosDeploy.remove).to.have.been.calledOnce;
-    expect(iosDeploy.install).to.have.been.calledOnce;
+    await installToRealDevice(realDevice, app, bundleId, opts).should.be.rejectedWith('ApplicationVerificationFailed');
+    expect(realDevice.remove).to.have.been.calledOnce;
+    expect(realDevice.install).to.have.been.calledOnce;
   });
 
   it('should install after removal once because of MismatchedApplicationIdentifierEntitlement error', async function () {
@@ -93,16 +93,16 @@ describe('installToRealDevice', function () {
     const opts = {
       skipUninstall: true
     };
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install')
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install')
       .onCall(0).throws(`{"Error":"MismatchedApplicationIdentifierEntitlement","ErrorDescription":"Upgrade's application-identifier entitlement string (TEAM_ID.com.kazucocoa.example) does not match installed application's application-identifier string (ANOTHER_TEAM_ID.com.kazucocoa.example); rejecting upgrade."}`)
       .onCall(1).resolves();
 
-    await installToRealDevice(iosDeploy, app, bundleId, opts);
+    await installToRealDevice(realDevice, app, bundleId, opts);
 
-    expect(iosDeploy.remove).to.have.been.calledOnce;
-    expect(iosDeploy.install).to.have.been.calledTwice;
+    expect(realDevice.remove).to.have.been.calledOnce;
+    expect(realDevice.install).to.have.been.calledTwice;
   });
 
   it('should raise an error in the install ApplicationVerificationFailed error because it is not recoverable', async function () {
@@ -110,13 +110,13 @@ describe('installToRealDevice', function () {
       skipUninstall: true
     };
     const err_msg = `{"Error":"ApplicationVerificationFailed","ErrorDetail":-402620395,"ErrorDescription":"Failed to verify code signature of /path/to.app : 0xe8008015 (A valid provisioning profile for this executable was not found.)"}`;
-    const iosDeploy = new RealDevice(udid);
-    sandbox.stub(iosDeploy, 'remove').resolves();
-    sandbox.stub(iosDeploy, 'install').throws(err_msg);
-    sandbox.stub(iosDeploy, 'isAppInstalled').resolves(true);
+    const realDevice = new RealDevice(udid);
+    sandbox.stub(realDevice, 'remove').resolves();
+    sandbox.stub(realDevice, 'install').throws(err_msg);
+    sandbox.stub(realDevice, 'isAppInstalled').resolves(true);
 
-    await installToRealDevice(iosDeploy, app, bundleId, opts).should.be.rejectedWith('ApplicationVerificationFailed');
-    expect(iosDeploy.remove).to.not.have.been.called;
-    expect(iosDeploy.install).to.have.been.calledOnce;
+    await installToRealDevice(realDevice, app, bundleId, opts).should.be.rejectedWith('ApplicationVerificationFailed');
+    expect(realDevice.remove).to.not.have.been.called;
+    expect(realDevice.install).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
`ios-deploy` method usage keeps as-is. This changes `IOSDeploy` object names and the file name.

I have tested with a real device locally