### PR TITLE
feat: add launchApp via devicectl

### DIFF
--- a/lib/devicectl.js
+++ b/lib/devicectl.js
@@ -246,4 +246,46 @@ export class Devicectl {
     });
     return JSON.parse(stdout).result.apps;
   }
+
+
+  /**
+   * @typedef {Object} LaunchWdaViaDeviceCtlOptions
+   * @property {Record<string, string|number>} [env] environment variables for the launching WDA process
+   * @property {boolean} [terminateExisting] if terminating the already running app
+   * @property {string} [bundleId] if terminating the already running app
+   */
+
+  /**
+   * Launch the given bundle id application with the given environment variable.
+   *
+   * @param {LaunchWdaViaDeviceCtlOptions} [opts={}] launching WDA with devicectl command options.
+   * @returns {Promise<void>}
+   * @throws {Error} If the launching app command fails. For example, the given bundle id did not exist.
+   */
+  async launchApp(opts = {}) {
+
+    const {
+      bundleId,
+      env,
+      terminateExisting = false
+    } = opts;
+
+    if (!_.isString(bundleId)) {
+      throw new Error('bundleId option is required');
+    }
+
+    const subcommandOptions = []
+
+    if (terminateExisting) {
+      subcommandOptions.push('--terminate-existing');
+    }
+    if (!_.isEmpty(env)) {
+      subcommandOptions.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))));
+    };
+
+    // should be the last of command
+    subcommandOptions.push(bundleId);
+
+    await this.execute(['device', 'process', 'launch'], { subcommandOptions, logStdout: true});
+  }
 }

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -36,8 +36,8 @@ async function createSim(caps) {
   if (!deviceName) {
     let deviceNames = 'none';
     try {
-      deviceNames = await simctl
-        .getDevices(platformVersion, platform)
+      deviceNames = (await simctl
+        .getDevices(platformVersion, platform))
         .map(({deviceName}) => deviceName);
     } catch (ign) {}
     throw new Error(
@@ -45,6 +45,12 @@ async function createSim(caps) {
         `Currently available device names: ${deviceNames}`,
     );
   }
+  if (!platformVersion) {
+    throw new Error(
+      `'platformVersion' is required.`
+    );
+  }
+
   const simName = `${APPIUM_SIM_PREFIX}-${util.uuidV4().toUpperCase()}-${deviceName}`;
   log.debug(`Creating a temporary Simulator device '${simName}'`);
   const udid = await simctl.createDevice(simName, deviceName, platformVersion, {platform});


### PR DESCRIPTION
The expected usage is https://github.com/appium/WebDriverAgent/pull/870 .
This PR should include updating the wda package major version.



Also, according to https://github.com/appium/appium-xcuitest-driver/actions/runs/8413083261/job/23034781606 , we need to modify type a bit.

```
Error: lib/simulator-management.js(41,10): error TS2339: Property 'map' does not exist on type 'Promise<any>'.
Error: lib/simulator-management.js(50,63): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
npm ERR! code 1
npm ERR! path /home/runner/work/appium-xcuitest-driver/appium-xcuitest-driver
npm ERR! command failed
npm ERR! command sh -c npm run rebuild

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2024-03-25T00_07_44_898Z-debug-0.log
Error: Process completed with exit code 1.
```