### PR TITLE
fix: uncaughtException: maxObjectCount exceeded in listApplications

### DIFF
--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -200,8 +200,7 @@ class RealDevice {
     try {
       installProxyService = await services.startInstallationProxyService(this.udid);
       const apps = await installProxyService.listApplications({
-        // to prevent getting large plist
-        returnAttributes: ['CFBundleIdentifier', 'CFBundleVersion']
+        returnAttributes: ['CFBundleExecutable']
       });
       if (!apps[bundleId]) {
         log.info(`The bundle id '${bundleId}' did not exist`);

--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -200,7 +200,7 @@ class RealDevice {
     try {
       installProxyService = await services.startInstallationProxyService(this.udid);
       const apps = await installProxyService.listApplications({
-        returnAttributes: ['CFBundleExecutable']
+        returnAttributes: ['CFBundleIdentifier', 'CFBundleExecutable']
       });
       if (!apps[bundleId]) {
         log.info(`The bundle id '${bundleId}' did not exist`);
@@ -262,7 +262,9 @@ class RealDevice {
   async getUserInstalledBundleIdsByBundleName(bundleName) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
-      const applications = await service.listApplications({applicationType: 'User', returnAttributes: ['CFBundleName']});
+      const applications = await service.listApplications({
+        applicationType: 'User', returnAttributes: ['CFBundleIdentifier', 'CFBundleName']
+      });
       return _.reduce(
         applications,
         (acc, {CFBundleName}, key) => {

--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -199,7 +199,10 @@ class RealDevice {
     let installProxyService;
     try {
       installProxyService = await services.startInstallationProxyService(this.udid);
-      const apps = await installProxyService.listApplications();
+      const apps = await installProxyService.listApplications({
+        // to prevent getting large plist
+        returnAttributes: ['CFBundleIdentifier', 'CFBundleVersion']
+      });
       if (!apps[bundleId]) {
         log.info(`The bundle id '${bundleId}' did not exist`);
         return false;
@@ -260,7 +263,7 @@ class RealDevice {
   async getUserInstalledBundleIdsByBundleName(bundleName) {
     const service = await services.startInstallationProxyService(this.udid);
     try {
-      const applications = await service.listApplications({applicationType: 'User'});
+      const applications = await service.listApplications({applicationType: 'User', returnAttributes: ['CFBundleName']});
       return _.reduce(
         applications,
         (acc, {CFBundleName}, key) => {


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/19834 that is similar to https://github.com/appium/appium/issues/18753
```
[XCUITestDriver@c3fa (a8298d6e)] Event 'wdaStartAttempted' logged at 1711345142607 (13:39:02 GMT+0800 (Singapore Standard Time))
uncaughtException: maxObjectCount exceeded
Error: maxObjectCount exceeded
    at Object.exports.parseBuffer (/Users/saikrishna/Downloads/git/appium-device-farm/node_modules/appium-xcuitest-driver/node_modules/bplist-parser/bplistParser.js:92:11)
    at parseBinaryPlist (/Users/saikrishna/Downloads/git/appium-device-farm/node_modules/appium-xcuitest-driver/node_modules/@appium/support/lib/plist.js:111:22)
    at Object.parsePlist (/Users/saikrishna/Downloads/git/appium-device-farm/node_modules/appium-xcuitest-driver/node_modules/@appium/support/lib/plist.js:169:12)
    at PlistServiceDecoder._decode (/Users/saikrishna/Downloads/git/appium-device-farm/node_modules/appium-xcuitest-driver/node_modules/appium-ios-device/lib/plist-service/transformer/plist-service-decoder.js:23:26)
    at PlistServiceDecoder._transform (/Users/saikrishna/Downloads/git/appium-device-farm/node_modules/appium-xcuitest-driver/node_modules/appium-ios-device/lib/plist-service/transformer/plist-service-decoder.js:14:10)
    at PlistServiceDecoder.Transform._write (node:internal/streams/transform:205:23)
    at writeOrBuffer (node:internal/streams/writable:391:12)
```

https://github.com/appium/appium-xcuitest-driver/pull/2356 is required to fix the build.


Tested this won't break existing relevant behavior for real devices.