### PR TITLE
fix: build error

### DIFF
--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -47,9 +47,7 @@ async function createSim(caps) {
   }
 
   if (!platformVersion) {
-    throw new Error(
-      `'platformVersion' is required.`
-    );
+    throw new Error(`'platformVersion' is required.`);
   }
 
   const simName = `${APPIUM_SIM_PREFIX}-${util.uuidV4().toUpperCase()}-${deviceName}`;

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -36,8 +36,8 @@ async function createSim(caps) {
   if (!deviceName) {
     let deviceNames = 'none';
     try {
-      deviceNames = await simctl
-        .getDevices(platformVersion, platform)
+      deviceNames = (await simctl
+        .getDevices(platformVersion, platform))
         .map(({deviceName}) => deviceName);
     } catch (ign) {}
     throw new Error(
@@ -45,6 +45,13 @@ async function createSim(caps) {
         `Currently available device names: ${deviceNames}`,
     );
   }
+
+  if (!platformVersion) {
+    throw new Error(
+      `'platformVersion' is required.`
+    );
+  }
+
   const simName = `${APPIUM_SIM_PREFIX}-${util.uuidV4().toUpperCase()}-${deviceName}`;
   log.debug(`Creating a temporary Simulator device '${simName}'`);
   const udid = await simctl.createDevice(simName, deviceName, platformVersion, {platform});


### PR DESCRIPTION
```
Error: lib/simulator-management.js(41,10): error TS2339: Property 'map' does not exist on type 'Promise<any>'.
Error: lib/simulator-management.js(50,63): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
npm ERR! code 1
npm ERR! path /home/runner/work/appium-xcuitest-driver/appium-xcuitest-driver
npm ERR! command failed
npm ERR! command sh -c npm run rebuild

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2024-03-25T00_07_44_898Z-debug-0.log
Error: Process completed with exit code 1.
```

https://github.com/appium/appium-xcuitest-driver/actions/runs/8413083261/job/23034781606