### PR TITLE
fix: set bundle id at the end to make arguments work properly in Devicectl#launchApp

### DIFF
--- a/lib/devicectl.js
+++ b/lib/devicectl.js
@@ -280,7 +280,7 @@ export class Devicectl {
     };
     // The bundle id should be the last to apply arguments properly.
     // devicectl command might not raise exception while the order is wrong.
-    subcommandOptions.push(bundleId)
+    subcommandOptions.push(bundleId);
 
     await this.execute(['device', 'process', 'launch'], { subcommandOptions, asJson: false});
   }

--- a/lib/devicectl.js
+++ b/lib/devicectl.js
@@ -271,13 +271,16 @@ export class Devicectl {
       terminateExisting = false
     } = opts;
 
-    const subcommandOptions = [bundleId];
+    const subcommandOptions = [];
     if (terminateExisting) {
       subcommandOptions.push('--terminate-existing');
     };
     if (!_.isEmpty(env)) {
       subcommandOptions.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))));
     };
+    // The bundle id should be the last to apply arguments properly.
+    // devicectl command might not raise exception while the order is wrong.
+    subcommandOptions.push(bundleId)
 
     await this.execute(['device', 'process', 'launch'], { subcommandOptions, asJson: false});
   }


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/19926

It looks like:

> xcrun devicectl device process launch --device 00008020-000E5CDA0A23002E com.trident.WebDriverAgentRunner.xctrunner --terminate-existing --environment-variables '{"USE_PORT":"9900","WDA_PRODUCT_BUNDLE_IDENTIFIER":"com.trident.WebDriverAgentRunner.xctrunner"}'

does not apply arguments properly while it does not raise any errors. It should be:

> xcrun devicectl device process launch --device 00008020-000E5CDA0A23002E --terminate-existing --environment-variables '{"USE_PORT":"9900","WDA_PRODUCT_BUNDLE_IDENTIFIER":"com.trident.WebDriverAgentRunner.xctrunner"}' com.trident.WebDriverAgentRunner.xctrunner

I tested this case before but as part of refactoring in the pr, changed the order. I thought it worked but did not in the fact...


I'll merge this after CI passes since this is just order modification