### PR TITLE
fix: Properly match simulator udid if webDriverAgentUrl is provided

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1204,11 +1204,8 @@ export class XCUITestDriver extends BaseDriver {
         // If the session specified this.opts.webDriverAgentUrl with a real device,
         // we can assume the user prepared the device properly already.
         let isRealDeviceUdid = false;
-        if (!this.opts.webDriverAgentUrl) {
-          this.log.debug(
-            'Skipping checking of the real devices availability since the session specifies appium:webDriverAgentUrl'
-          );
-        } else {
+        const shouldCheckAvailableRealDevices = !this.opts.webDriverAgentUrl;
+        if (!shouldCheckAvailableRealDevices) {
           const devices = await getConnectedDevices();
           this.log.debug(`Available real devices: ${devices.join(', ')}`);
           isRealDeviceUdid = devices.includes(this.opts.udid);
@@ -1220,8 +1217,13 @@ export class XCUITestDriver extends BaseDriver {
               logger: this.log,
             });
             return {device, realDevice: false, udid: this.opts.udid};
-          } catch (ign) {
-            throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+          } catch {
+            if (shouldCheckAvailableRealDevices) {
+              throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
+            }
+            this.log.debug(
+              'Skipping checking of the real devices availability since the session specifies appium:webDriverAgentUrl'
+            );
           }
         }
       }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -33,6 +33,7 @@ import {
   installToRealDevice,
   runRealDeviceReset,
   applySafariStartupArgs,
+  detectUdid,
 } from './real-device-management';
 import {
   RealDevice,
@@ -53,7 +54,6 @@ import {
   UDID_AUTO,
   checkAppPresent,
   clearSystemFiles,
-  detectUdid,
   getAndCheckIosSdkVersion,
   getAndCheckXcodeVersion,
   getDriverInfo,
@@ -1165,7 +1165,7 @@ export class XCUITestDriver extends BaseDriver {
     this.lifecycleData.createSim = false;
 
     // if we get generic names, translate them
-    this.opts.deviceName = translateDeviceName(this.opts.platformVersion, this.opts.deviceName);
+    this.opts.deviceName = translateDeviceName(this.opts.platformVersion ?? '', this.opts.deviceName);
 
     const setupVersionCaps = async () => {
       this._iosSdkVersion = await getAndCheckIosSdkVersion();
@@ -1182,7 +1182,7 @@ export class XCUITestDriver extends BaseDriver {
     if (this.opts.udid) {
       if (this.opts.udid.toLowerCase() === UDID_AUTO) {
         try {
-          this.opts.udid = await detectUdid();
+          this.opts.udid = await detectUdid.bind(this)();
         } catch (err) {
           // Trying to find matching UDID for Simulator
           this.log.warn(
@@ -1203,24 +1203,25 @@ export class XCUITestDriver extends BaseDriver {
       } else {
         // If the session specified this.opts.webDriverAgentUrl with a real device,
         // we can assume the user prepared the device properly already.
-        if (this.opts.webDriverAgentUrl) {
-          this.log.debug('Skipping checking of the device availability since the session specifies appium:webDriverAgentUrl');
+        let isRealDeviceUdid = false;
+        if (!this.opts.webDriverAgentUrl) {
+          this.log.debug(
+            'Skipping checking of the real devices availability since the session specifies appium:webDriverAgentUrl'
+          );
         } else {
-          // make sure it is a connected device. If not, the udid passed in is invalid
           const devices = await getConnectedDevices();
-          this.log.debug(`Available devices: ${devices.join(', ')}`);
-          if (!devices.includes(this.opts.udid)) {
-            // check for a particular simulator
-            this.log.debug(`No real device with udid '${this.opts.udid}'. Looking for a simulator`);
-            try {
-              const device = await getSimulator(this.opts.udid, {
-                devicesSetPath: this.opts.simulatorDevicesSetPath,
-                logger: this.log,
-              });
-              return {device, realDevice: false, udid: this.opts.udid};
-            } catch (ign) {
-              throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
-            }
+          this.log.debug(`Available real devices: ${devices.join(', ')}`);
+          isRealDeviceUdid = devices.includes(this.opts.udid);
+        }
+        if (!isRealDeviceUdid) {
+          try {
+            const device = await getSimulator(this.opts.udid, {
+              devicesSetPath: this.opts.simulatorDevicesSetPath,
+              logger: this.log,
+            });
+            return {device, realDevice: false, udid: this.opts.udid};
+          } catch (ign) {
+            throw new Error(`Unknown device or simulator UDID: '${this.opts.udid}'`);
           }
         }
       }

--- a/lib/real-device-management.js
+++ b/lib/real-device-management.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {buildSafariPreferences} from './app-utils';
+import {utilities} from 'appium-ios-device';
 
 /**
  * @typedef {Object} InstallOptions
@@ -100,5 +101,25 @@ export function applySafariStartupArgs() {
 }
 
 /**
+ * @this {XCUITestDriver}
+ * @returns {Promise<string>}
+ */
+export async function detectUdid() {
+  this.log.debug('Auto-detecting real device udid...');
+  const udids = await utilities.getConnectedDevices();
+  if (_.isEmpty(udids)) {
+    throw new Error('No real devices are connected to the host');
+  }
+  const udid = _.last(udids);
+  if (udids.length > 1) {
+    this.log.info(`Multiple devices found: ${udids.join(', ')}`);
+    this.log.info(`Choosing '${udid}'. Consider settings the 'udid' capability if another device must be selected`);
+  }
+  this.log.debug(`Detected real device udid: '${udid}'`);
+  return udid;
+}
+
+/**
  * @typedef {import('./real-device').RealDevice} RealDevice}
+ * @typedef {import('./driver').XCUITestDriver} XCUITestDriver
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-import {utilities} from 'appium-ios-device';
 import xcode from 'appium-xcode';
 import {errors} from 'appium/driver';
 import {fs, net, util} from 'appium/support';
@@ -21,21 +20,6 @@ const XCTEST_LOG_FILES_PATTERNS = [
   /^StandardOutputAndStandardError\.txt$/i,
 ];
 const XCTEST_LOGS_CACHE_FOLDER_PREFIX = 'com.apple.dt.XCTest';
-
-async function detectUdid() {
-  log.debug('Auto-detecting real device udid...');
-  const udids = await utilities.getConnectedDevices();
-  if (_.isEmpty(udids)) {
-    throw new Error('No device is connected to the host');
-  }
-  const udid = _.last(udids);
-  if (udids.length > 1) {
-    log.warn(`Multiple devices found: ${udids.join(', ')}`);
-    log.warn(`Choosing '${udid}'. If this is wrong, manually set with 'udid' desired capability`);
-  }
-  log.debug(`Detected real device udid: '${udid}'`);
-  return udid;
-}
 
 /**
  * @privateRemarks Is the minimum version really Xcode 7.3?
@@ -98,6 +82,12 @@ function getGenericSimulatorForIosVersion(platformVersion, deviceName) {
   return result;
 }
 
+/**
+ *
+ * @param {string} platformVersion
+ * @param {string} [deviceName]
+ * @returns {string|undefined}
+ */
 function translateDeviceName(platformVersion, deviceName) {
   if (!deviceName) {
     return deviceName;
@@ -114,6 +104,10 @@ function translateDeviceName(platformVersion, deviceName) {
   return deviceNameTranslated;
 }
 
+/**
+ * @param {string[]} locations
+ * @returns {Promise<void>}
+ */
 async function clearLogs(locations) {
   log.debug('Clearing log files');
   const cleanupPromises = [];
@@ -503,7 +497,6 @@ export function normalizePlatformName(platformName) {
 }
 
 export {
-  detectUdid,
   getAndCheckXcodeVersion,
   getAndCheckIosSdkVersion,
   checkAppPresent,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,8 +85,8 @@ function getGenericSimulatorForIosVersion(platformVersion, deviceName) {
 /**
  *
  * @param {string} platformVersion
- * @param {string} [deviceName]
- * @returns {string|undefined}
+ * @param {string} deviceName
+ * @returns {string}
  */
 function translateDeviceName(platformVersion, deviceName) {
   if (!deviceName) {

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -89,11 +89,11 @@ describe('utils', function () {
       deviceName.should.equal('iPad Retina');
     });
     it('should set the correct iPad simulator generic device for iOS >= 10.3', function () {
-      let deviceName = translateDeviceName(10.103, ipadDeviceName);
+      let deviceName = translateDeviceName('10.103', ipadDeviceName);
       deviceName.should.equal('iPad Air');
       deviceName = translateDeviceName('10.3', ipadDeviceName);
       deviceName.should.equal('iPad Air');
-      deviceName = translateDeviceName(10.3, ipadDeviceName);
+      deviceName = translateDeviceName('10.3', ipadDeviceName);
       deviceName.should.equal('iPad Air');
     });
     it('should set the correct iPhone simulator generic device', function () {


### PR DESCRIPTION
We may skip listing of real devices if webDriverAgentUrl is set, but we cannot skip listing of simulators, because we don't know if the given udid belongs to a real device or to a simulator. So we must verify the list of simulators does not contain the given udid to make sure a real device is requested.