### PR TITLE
feat: export doctor used in xcuitest driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 import {XCUITestDriver} from './lib/driver';
 
 export {XCUITestDriver};
+
+export * as doctorRequired from './lib/doctor/required-checks';
+export * as doctorOptional from './lib/doctor/optional-checks';
+
 export default XCUITestDriver;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import {XCUITestDriver} from './lib/driver';
 
 export {XCUITestDriver};
 
-export * as doctorRequired from './lib/doctor/required-checks';
-export * as doctorOptional from './lib/doctor/optional-checks';
+export * as doctor from './lib/doctor/checks';
 
 export default XCUITestDriver;

--- a/lib/doctor/checks.js
+++ b/lib/doctor/checks.js
@@ -1,0 +1,2 @@
+export * as required from './required-checks';
+export * as optional from './optional-checks';


### PR DESCRIPTION
I'd like to use doctor in xcuitest from Flutter driver to check xcuitest-related env check. In Android, appium-android-driver already has the same one like uia2 driver does.

Example usage:

```
import { doctor } from "appium-xcuitest-driver";

doctor.required.XcodeCheck...
doctor.optional.OptionalFfmpegCheck...
```