### PR TITLE
fix: system prompt for Apple ID sign translation for simulators

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@colors/colors": "^1.6.0",
     "appium-idb": "^1.6.13",
     "appium-ios-device": "^2.5.4",
-    "appium-ios-simulator": "^6.1.2",
+    "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^11.1.0",
     "appium-webdriveragent": "^8.7.0",
     "appium-xcode": "^5.1.4",


### PR DESCRIPTION
To include https://github.com/appium/appium-ios-simulator/pull/431