### PR TITLE
fix: Add proper timestamps to server logs

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -52,8 +52,8 @@ const SUPPORTED_LOG_TYPES = {
     getter: (self) => {
       self.assertFeatureEnabled(GET_SERVER_LOGS_FEATURE);
       return log.unwrap().record.map((x) => ({
-        timestamp: Date.now(),
-        level: 'ALL',
+        timestamp: /** @type {any} */ (x).timestamp ?? Date.now(),
+        level: x.level,
         message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
       }));
     },
@@ -64,7 +64,7 @@ const SUPPORTED_LOG_TYPES = {
  * Log entry in the array returned by `getLogs('server')`
  * @typedef AppiumServerLogEntry
  * @property {number} timestamp
- * @property {'ALL'} level
+ * @property {string} level
  * @property {string} message
  */
 

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -53,7 +53,7 @@ const SUPPORTED_LOG_TYPES = {
       self.assertFeatureEnabled(GET_SERVER_LOGS_FEATURE);
       return log.unwrap().record.map((x) => ({
         timestamp: /** @type {any} */ (x).timestamp ?? Date.now(),
-        level: x.level,
+        level: 'ALL',
         message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
       }));
     },
@@ -64,7 +64,7 @@ const SUPPORTED_LOG_TYPES = {
  * Log entry in the array returned by `getLogs('server')`
  * @typedef AppiumServerLogEntry
  * @property {number} timestamp
- * @property {string} level
+ * @property {'ALL'} level
  * @property {string} message
  */
 


### PR DESCRIPTION
After the npmlog has been replaced with the custom fork we have proper timestamps available there