### PR TITLE
fix: stream end after write in a file push

### DIFF
--- a/lib/ios-fs-helpers.js
+++ b/lib/ios-fs-helpers.js
@@ -198,6 +198,7 @@ export async function pushFile (afcService, localPathOrPayload, remotePath, opts
   });
   if (Buffer.isBuffer(source)) {
     writeStream.write(source);
+    writeStream.end();
   } else {
     source.pipe(writeStream);
   }


### PR DESCRIPTION
I found a regression in https://github.com/appium/appium-xcuitest-driver/pull/2388/files#diff-22d12fc5b181e17350b50e15778689447222790c00e7e8303e8973bcdd91a8fbR204

When I test a file upload (e.g. `d.push_file '@com.apple.Keynote:documents/sample.png', (File.read '/Users/kazu/github/ruby_lib_core/sample.png')`), I observed no-response behavior as below:

```
[HTTP] --> POST /session/d57aaa4f-5f82-45e8-a55f-0f7f093c7aa5/appium/device/push_file
...
[XCUITestDriver@61a8 (d57aaa4f)] Executing command 'pushFile'
[XCUITest] Parsed container type: documents

# waited for await filePushPromise.timeout(Math.max(timeoutMs, 60000)); timeout
```

Maybe... in buffer case, should the write stream call `end` after `write`....?


With this change:

```
[XCUITestDriver@601b (fe85e621)] Executing command 'pushFile'
[XCUITest] Parsed container type: documents
[XCUITest] Successfully pushed the file payload (271.08 KB) to the remote location 'Documents/sample.png' in 57ms
[XCUITestDriver@601b (fe85e621)] Responding to client with driver.pushFile() result: null
[HTTP] <-- POST /session/fe85e621-451f-4eb1-becd-a95b783e73ff/appium/device/push_file 200 1276 ms - 14
```