### PR TITLE
fix: relax the max of recording limitation to 4200 sec as timeLimit

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -7,7 +7,12 @@ import {WDA_BASE_URL} from 'appium-webdriveragent';
 import {waitForCondition} from 'asyncbox';
 import url from 'url';
 
-const MAX_RECORDING_TIME_SEC = 60 * 30;
+/** 
+ * Set max timeout for 'reconnect_delay_max' ffmpeg argument usage.
+ * It could have [0 - 4294] range limitation thus this value should be less than that right now
+ * to return a better error message.
+ */
+const MAX_RECORDING_TIME_SEC = 4200;
 const DEFAULT_RECORDING_TIME_SEC = 60 * 3;
 const DEFAULT_MJPEG_SERVER_PORT = 9100;
 const DEFAULT_FPS = 10;

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -7,7 +7,7 @@ import {WDA_BASE_URL} from 'appium-webdriveragent';
 import {waitForCondition} from 'asyncbox';
 import url from 'url';
 
-/** 
+/**
  * Set max timeout for 'reconnect_delay_max' ffmpeg argument usage.
  * It could have [0 - 4294] range limitation thus this value should be less than that right now
  * to return a better error message.


### PR DESCRIPTION
This is not "fix" but we intentionally put the max limit as 1800 right now.
According to https://github.com/appium/appium/issues/20265#issuecomment-2176518291 , it could be `4293` as ffmpeg.

So, we probably could put the max as `4200` instead. I also wondered if we could remove the max limitation, but this would give a better error response than printing error message in the appium server log only.