### PR TITLE
fix: build by type error

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1119,6 +1119,7 @@ export class XCUITestDriver extends BaseDriver {
           try {
             const device = await getSimulator(this.opts.udid, {
               devicesSetPath: this.opts.simulatorDevicesSetPath,
+              // @ts-ignore AppiumLogger from @appium/types in XCUITest driver vs the same type imported in the appium-ios-simulator
               logger: this.log,
             });
             return {device, realDevice: false, udid: this.opts.udid};

--- a/lib/simulator-management.js
+++ b/lib/simulator-management.js
@@ -42,6 +42,7 @@ export async function createSim() {
     platform,
     checkExistence: false,
     devicesSetPath,
+    // @ts-ignore AppiumLogger from @appium/types in XCUITest driver vs the same type imported in the appium-ios-simulator
     logger: this.log,
   });
 }
@@ -76,6 +77,7 @@ export async function getExistingSim() {
       platform,
       checkExistence: false,
       devicesSetPath,
+      // @ts-ignore AppiumLogger from @appium/types in XCUITest driver vs the same type imported in the appium-ios-simulator
       logger: this.log,
     });
 


### PR DESCRIPTION
Just a workaround for build error below.
Maybe we need to coordinate AppiumLogger type import? in simulator and this repo. I haven't checked deeper well yet.

```
lib/simulator-management.js:45:5 - error TS2322: Type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/types/build/lib/logger").AppiumLogger' is not assignable to type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/appium-ios-simulator/node_modules/@appium/types/build/lib/logger").AppiumLogger'.
  The types returned by 'unwrap()' are incompatible between these types.
    Type 'Logger' is missing the following properties from type 'Logger': debug, loadSecureValuesPreprocessingRules, asyncStorage

45     logger: this.log,
       ~~~~~~

lib/simulator-management.js:79:7 - error TS2322: Type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/types/build/lib/logger").AppiumLogger' is not assignable to type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/appium-ios-simulator/node_modules/@appium/types/build/lib/logger").AppiumLogger'.

79       logger: this.log,
         ~~~~~~

lib/driver.js:1122:15 - error TS2322: Type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/types/build/lib/logger").AppiumLogger' is not assignable to type 'import("/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/appium-ios-simulator/node_modules/@appium/types/build/lib/logger").AppiumLogger'.
```