### PR TITLE
feat: take viewport screenshot using safari remote debugger

### DIFF
--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -72,6 +72,10 @@ export default {
    * @this {XCUITestDriver}
    */
   async getViewportScreenshot() {
+    if (this.isWebContext()) {
+      return await this.remote.captureScreenshot();
+    }
+
     let statusBarHeight = await this.getStatusBarHeight();
     const screenshot = await this.getScreenshot();
 


### PR DESCRIPTION
Starting a discussion @mykola-mokhnach 

- is that a good enough way to take viewport screenshots for web? Do we care that this would (positively) impact customers tests?
- does appium have a way to take full page screenshots?
- do we wanna touch the take element screenshot code?
- TODO: upgrade to latest appium-remote-debugger package once https://github.com/appium/appium-remote-debugger/pull/386 is merged