### PR TITLE
fix: Apply the default exec timeout if not provided explicitly

### DIFF
--- a/lib/devicectl.js
+++ b/lib/devicectl.js
@@ -136,7 +136,11 @@ export class Devicectl {
         // @ts-ignore TS does not understand it
         return result;
       }
-      const result = await exec(XCRUN, finalArgs, {timeout});
+      const result = await exec(
+        XCRUN,
+        finalArgs,
+        ...(_.isNumber(timeout) ? [{timeout}] : []),
+      );
       if (logStdout) {
         this.log.debug(`Command output: ${result.stdout}`);
       }


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/20290