### PR TITLE
chore: Streamline logging helpers

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -8,6 +8,7 @@ import log from '../logger';
 import WebSocket from 'ws';
 import SafariConsoleLog from '../device-log/safari-console-log';
 import SafariNetworkLog from '../device-log/safari-network-log';
+import { toLogEntry } from '../device-log/helpers';
 
 /**
  * Determines the websocket endpoint based on the `sessionId`
@@ -225,20 +226,6 @@ export default {
     await /** @type {AppiumServer} */ (this.server).removeWebSocketHandler(pathname);
   },
 };
-
-/**
- *
- * @param {string} message
- * @param {number} timestamp
- * @returns {import('./types').LogEntry}
- */
-export function toLogEntry(message, timestamp) {
-  return {
-    timestamp,
-    level: 'ALL',
-    message,
-  };
-}
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -47,26 +47,17 @@ const SUPPORTED_LOG_TYPES = {
   server: {
     description: 'Appium server logs',
     /**
-     * @returns {AppiumServerLogEntry[]}
+     * @returns {import('./types').LogEntry[]}
      */
     getter: (self) => {
       self.assertFeatureEnabled(GET_SERVER_LOGS_FEATURE);
-      return log.unwrap().record.map((x) => ({
-        timestamp: /** @type {any} */ (x).timestamp ?? Date.now(),
-        level: 'ALL',
-        message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
-      }));
+      return log.unwrap().record.map((x) => toLogEntry(
+        _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
+        /** @type {any} */ (x).timestamp ?? Date.now()
+      ));
     },
   },
 };
-
-/**
- * Log entry in the array returned by `getLogs('server')`
- * @typedef AppiumServerLogEntry
- * @property {number} timestamp
- * @property {'ALL'} level
- * @property {string} message
- */
 
 export default {
   supportedLogTypes: SUPPORTED_LOG_TYPES,
@@ -234,6 +225,20 @@ export default {
     await /** @type {AppiumServer} */ (this.server).removeWebSocketHandler(pathname);
   },
 };
+
+/**
+ *
+ * @param {string} message
+ * @param {number} timestamp
+ * @returns {import('./types').LogEntry}
+ */
+export function toLogEntry(message, timestamp) {
+  return {
+    timestamp,
+    level: 'ALL',
+    message,
+  };
+}
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -566,3 +566,9 @@ export interface KeyboardKey {
    */
   modifierFlags?: number;
 }
+
+export interface LogEntry {
+  timestamp: number;
+  level: string,
+  message: string;
+}

--- a/lib/device-log/helpers.ts
+++ b/lib/device-log/helpers.ts
@@ -1,0 +1,9 @@
+import type { LogEntry } from '../commands/types';
+
+export function toLogEntry(message: string, timestamp: number): LogEntry {
+  return {
+    timestamp,
+    level: 'ALL',
+    message,
+  };
+}

--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -11,13 +11,6 @@ const MAGIC_SEP = '/';
 // The file format has been changed from '.crash' to '.ips' since Monterey.
 const CRASH_REPORTS_GLOB_PATTERN = '**/*.@(crash|ips)';
 
-/**
- * @typedef {Object} LogRecord
- * @property {number} timestamp
- * @property {string} level
- * @property {string} message
- */
-
 class IOSCrashLog {
   constructor(opts = {}) {
     this.udid = opts.udid;
@@ -103,7 +96,7 @@ class IOSCrashLog {
   }
 
   /**
-   * @returns {Promise<LogRecord[]>}
+   * @returns {Promise<import('../commands/types').LogEntry[]>}
    */
   async getLogs() {
     let crashFiles = await this.getCrashes();
@@ -113,7 +106,7 @@ class IOSCrashLog {
   }
 
   /**
-   * @returns {Promise<LogRecord[]>}
+   * @returns {Promise<import('../commands/types').LogEntry[]>}
    */
   async getAllLogs() {
     let crashFiles = await this.getCrashes();
@@ -123,12 +116,12 @@ class IOSCrashLog {
 
   /**
    * @param {string[]} paths
-   * @returns {Promise<LogRecord[]>}
+   * @returns {Promise<import('../commands/types').LogEntry[]>}
    */
   async filesToJSON(paths) {
     const tmpRoot = await tempDir.openDir();
     try {
-      return /** @type {LogRecord[]} */ ((
+      return /** @type {import('../commands/types').LogEntry[]} */ ((
         await B.map(paths, async (fullPath) => {
           if (_.includes(fullPath, REAL_DEVICE_MAGIC)) {
             const fileName = /** @type {string} */ (_.last(fullPath.split(MAGIC_SEP)));

--- a/lib/device-log/ios-device-log.js
+++ b/lib/device-log/ios-device-log.js
@@ -22,6 +22,9 @@ class IOSDeviceLog extends IOSLog {
     this.service.start(this.onLog.bind(this));
   }
 
+  /**
+   * @param {string} logLine
+   */
   onLog(logLine) {
     this.broadcast(logLine);
     if (this.showLogs) {

--- a/lib/device-log/ios-device-log.js
+++ b/lib/device-log/ios-device-log.js
@@ -4,7 +4,7 @@ import {services} from 'appium-ios-device';
 
 const log = logger.getLogger('IOSDeviceLog');
 
-class IOSDeviceLog extends IOSLog {
+export class IOSDeviceLog extends IOSLog {
   constructor(opts) {
     super();
     this.udid = opts.udid;
@@ -53,5 +53,4 @@ class IOSDeviceLog extends IOSLog {
   }
 }
 
-export {IOSDeviceLog};
 export default IOSDeviceLog;

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,14 +1,22 @@
 import {EventEmitter} from 'events';
+import { LRUCache } from 'lru-cache';
+import { toLogEntry } from '../commands/log';
 
 // We keep only the most recent log entries to avoid out of memory error
 const MAX_LOG_ENTRIES_COUNT = 10000;
 
+// TODO: Rewrite this class to typescript for better generic typing
+
 class IOSLog extends EventEmitter {
-  constructor() {
+  constructor(maxBufferSize = MAX_LOG_ENTRIES_COUNT) {
     super();
-    this.logs = [];
-    this.logIdxSinceLastRequest = -1;
-    this.maxBufferSize = MAX_LOG_ENTRIES_COUNT;
+    this.maxBufferSize = maxBufferSize;
+    /** @type {LRUCache<bigint, any>} */
+    this.logs = new LRUCache({
+      max: this.maxBufferSize,
+    });
+    /** @type {bigint?} */
+    this.logHrTimeSinceLastRequest = null;
   }
 
   /** @returns {Promise<void>} */
@@ -28,36 +36,80 @@ class IOSLog extends EventEmitter {
     throw new Error(`Sub-classes need to implement a 'isCapturing' function`);
   }
 
-  broadcast(logLine) {
-    const logObj = {
-      timestamp: Date.now(),
-      level: 'ALL',
-      message: logLine,
-    };
-    this.logs.push(logObj);
-    this.emit('output', logObj);
-    if (this.logs.length > this.maxBufferSize) {
-      this.logs.shift();
-      if (this.logIdxSinceLastRequest > 0) {
-        --this.logIdxSinceLastRequest;
-      }
+  /**
+   *
+   * @param {any} entry
+   * @returns {void}
+   */
+  broadcast(entry) {
+    const hrTime = process.hrtime.bigint();
+    const serializedEntry = this._serializeEntry(entry);
+    this.logs.set(hrTime, serializedEntry);
+    if (this.listenerCount('output')) {
+      this.emit('output', this._deserializeEntry(serializedEntry));
     }
   }
 
+  /**
+   *
+   * @returns {import('../commands/types').LogEntry[]}
+   */
   getLogs() {
-    if (this.logs.length && this.logIdxSinceLastRequest < this.logs.length) {
-      let result = this.logs;
-      if (this.logIdxSinceLastRequest > 0) {
-        result = result.slice(this.logIdxSinceLastRequest);
-      }
-      this.logIdxSinceLastRequest = this.logs.length;
-      return result;
+    if (!this.logs.size) {
+      return [];
     }
-    return [];
+
+    /** @type {import('../commands/types').LogEntry[]} */
+    const result = [];
+    /** @type {bigint?} */
+    let recentLogHrTime = null;
+    for (const [hrTime, value] of this.logs.entries()) {
+      if (this.logHrTimeSinceLastRequest && hrTime > this.logHrTimeSinceLastRequest
+          || !this.logHrTimeSinceLastRequest) {
+        recentLogHrTime = hrTime;
+        result.push(this._deserializeEntry(value));
+      }
+    }
+    if (recentLogHrTime) {
+      this.logHrTimeSinceLastRequest = recentLogHrTime;
+    }
+    return result;
   }
 
+  /**
+   *
+   * @returns {import('../commands/types').LogEntry[]}
+   */
   getAllLogs() {
-    return this.logs;
+    /** @type {import('../commands/types').LogEntry[]} */
+    const result = [];
+    for (const value of this.logs.values()) {
+      result.push(this._deserializeEntry(value));
+    }
+    return result;
+  }
+
+  /**
+   *
+   * @param {any} value
+   * @returns {any}
+   */
+  _serializeEntry(value) {
+    return [value, Date.now()];
+  }
+
+  /**
+   *
+   * @param {any} value
+   * @returns {any}
+   */
+  _deserializeEntry(value) {
+    const [message, timestamp] = value;
+    return toLogEntry(message, timestamp);
+  }
+
+  _clearEntries() {
+    this.logs.clear();
   }
 }
 

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -11,12 +11,12 @@ export class IOSLog extends EventEmitter {
   constructor(maxBufferSize = MAX_LOG_ENTRIES_COUNT) {
     super();
     this.maxBufferSize = maxBufferSize;
-    /** @type {LRUCache<bigint, any>} */
+    /** @type {LRUCache<number, any>} */
     this.logs = new LRUCache({
       max: this.maxBufferSize,
     });
-    /** @type {bigint?} */
-    this.logHrTimeSinceLastRequest = null;
+    /** @type {number?} */
+    this.logIndexSinceLastRequest = null;
   }
 
   /** @returns {Promise<void>} */
@@ -42,9 +42,13 @@ export class IOSLog extends EventEmitter {
    * @returns {void}
    */
   broadcast(entry) {
-    const hrTime = process.hrtime.bigint();
+    let recentIndex = -1;
+    for (const key of this.logs.rkeys()) {
+      recentIndex = key;
+      break;
+    }
     const serializedEntry = this._serializeEntry(entry);
-    this.logs.set(hrTime, serializedEntry);
+    this.logs.set(++recentIndex, serializedEntry);
     if (this.listenerCount('output')) {
       this.emit('output', this._deserializeEntry(serializedEntry));
     }
@@ -55,23 +59,19 @@ export class IOSLog extends EventEmitter {
    * @returns {import('../commands/types').LogEntry[]}
    */
   getLogs() {
-    if (!this.logs.size) {
-      return [];
-    }
-
     /** @type {import('../commands/types').LogEntry[]} */
     const result = [];
-    /** @type {bigint?} */
-    let recentLogHrTime = null;
-    for (const [hrTime, value] of this.logs.entries()) {
-      if (this.logHrTimeSinceLastRequest && hrTime > this.logHrTimeSinceLastRequest
-          || !this.logHrTimeSinceLastRequest) {
-        recentLogHrTime = hrTime;
+    /** @type {number?} */
+    let recentLogIndex = null;
+    for (const [index, value] of this.logs.entries()) {
+      if (this.logIndexSinceLastRequest && index > this.logIndexSinceLastRequest
+          || !this.logIndexSinceLastRequest) {
+        recentLogIndex = index;
         result.push(this._deserializeEntry(value));
       }
     }
-    if (recentLogHrTime) {
-      this.logHrTimeSinceLastRequest = recentLogHrTime;
+    if (recentLogIndex !== null) {
+      this.logIndexSinceLastRequest = recentLogIndex;
     }
     return result;
   }

--- a/lib/device-log/ios-log.js
+++ b/lib/device-log/ios-log.js
@@ -1,13 +1,13 @@
 import {EventEmitter} from 'events';
 import { LRUCache } from 'lru-cache';
-import { toLogEntry } from '../commands/log';
+import { toLogEntry } from './helpers';
 
 // We keep only the most recent log entries to avoid out of memory error
 const MAX_LOG_ENTRIES_COUNT = 10000;
 
 // TODO: Rewrite this class to typescript for better generic typing
 
-class IOSLog extends EventEmitter {
+export class IOSLog extends EventEmitter {
   constructor(maxBufferSize = MAX_LOG_ENTRIES_COUNT) {
     super();
     this.maxBufferSize = maxBufferSize;
@@ -113,5 +113,4 @@ class IOSLog extends EventEmitter {
   }
 }
 
-export {IOSLog};
 export default IOSLog;

--- a/lib/device-log/ios-performance-log.js
+++ b/lib/device-log/ios-performance-log.js
@@ -1,55 +1,67 @@
 import {logger} from 'appium/support';
 import _ from 'lodash';
+import IOSLog from './ios-log';
 
 const log = logger.getLogger('IOSPerformanceLog');
 const MAX_EVENTS = 5000;
 
-class IOSPerformanceLog {
+class IOSPerformanceLog extends IOSLog {
   constructor(remoteDebugger, maxEvents = MAX_EVENTS) {
+    super(maxEvents);
     this.remoteDebugger = remoteDebugger;
     this.maxEvents = parseInt(String(maxEvents), 10);
-
-    this.timelineEvents = [];
+    this._started = false;
   }
 
+  /**
+   * @override
+   */
   async startCapture() {
     log.debug('Starting performance (Timeline) log capture');
-    this.timelineEvents = [];
-    return await this.remoteDebugger.startTimeline(this.onTimelineEvent.bind(this));
+    this._clearEntries();
+    const result = await this.remoteDebugger.startTimeline(this.onTimelineEvent.bind(this));
+    this._started = true;
+    return result;
   }
 
+  /**
+   * @override
+   */
   async stopCapture() {
     log.debug('Stopping performance (Timeline) log capture');
-    return await this.remoteDebugger.stopTimeline();
+    const result = await this.remoteDebugger.stopTimeline();
+    this._started = false;
+    return result;
   }
 
+  /**
+   * @override
+   */
+  get isCapturing() {
+    return this._started;
+  }
+
+  /**
+   * @override
+   */
+  _serializeEntry(value) {
+    return value;
+  }
+
+  /**
+   * @override
+   */
+  _deserializeEntry(value) {
+    return value;
+  }
+
+  /**
+   *
+   * @param {import('../commands/types').LogEntry} event
+   */
   onTimelineEvent(event) {
     log.debug(`Received Timeline event: ${_.truncate(JSON.stringify(event))}`);
-    this.timelineEvents.push(event);
-
-    // if we have too many, get rid of the oldest log line
-    if (this.timelineEvents.length > this.maxEvents) {
-      let removedEvent = this.timelineEvents.shift();
-      log.warn(
-        `Too many Timeline events, removing earliest: ${_.truncate(JSON.stringify(removedEvent))}`,
-      );
-    }
-  }
-
-  // eslint-disable-next-line require-await
-  async getLogs() {
-    let events = this.timelineEvents;
-
-    // flush events
-    log.debug('Flushing Timeline events');
-    this.timelineEvents = [];
-
-    return events;
-  }
-
-  // eslint-disable-next-line require-await
-  async getAllLogs() {
-    return this.getLogs();
+    this.broadcast(event);
   }
 }
 

--- a/lib/device-log/ios-performance-log.js
+++ b/lib/device-log/ios-performance-log.js
@@ -1,11 +1,11 @@
 import {logger} from 'appium/support';
 import _ from 'lodash';
-import IOSLog from './ios-log';
+import { IOSLog } from './ios-log';
 
 const log = logger.getLogger('IOSPerformanceLog');
 const MAX_EVENTS = 5000;
 
-class IOSPerformanceLog extends IOSLog {
+export class IOSPerformanceLog extends IOSLog {
   constructor(remoteDebugger, maxEvents = MAX_EVENTS) {
     super(maxEvents);
     this.remoteDebugger = remoteDebugger;
@@ -65,5 +65,4 @@ class IOSPerformanceLog extends IOSLog {
   }
 }
 
-export {IOSPerformanceLog};
 export default IOSPerformanceLog;

--- a/lib/device-log/ios-simulator-log.js
+++ b/lib/device-log/ios-simulator-log.js
@@ -17,6 +17,9 @@ class IOSSimulatorLog extends IOSLog {
     this.proc = null;
   }
 
+  /**
+   * @override
+   */
   async startCapture() {
     if (_.isUndefined(this.sim.udid)) {
       throw new Error(`Log capture requires a sim udid`);
@@ -44,47 +47,34 @@ class IOSSimulatorLog extends IOSLog {
     }
   }
 
-  async finishStartingLogCapture() {
-    if (!this.proc) {
-      log.errorAndThrow('Could not capture simulator log');
-    }
-    let firstLine = true;
-    let logRow = '';
-    this.proc.on('output', (stdout, stderr) => {
-      if (stdout) {
-        if (firstLine) {
-          if (stdout.endsWith('\n')) {
-            // don't store the first line of the log because it came before the sim was launched
-            firstLine = false;
-          }
-        } else {
-          logRow += stdout;
-          if (stdout.endsWith('\n')) {
-            this.onOutput(logRow);
-            logRow = '';
-          }
-        }
-      }
-      if (stderr) {
-        this.onOutput(logRow, 'STDERR');
-      }
-    });
-
-    let sd = (stdout, stderr) => {
-      if (/execvp\(\)/.test(stderr)) {
-        throw new Error('iOS log capture process failed to start');
-      }
-      return stdout || stderr;
-    };
-    await this.proc.start(sd, START_TIMEOUT);
-  }
-
+  /**
+   * @override
+   */
   async stopCapture() {
     if (!this.proc) {
       return;
     }
     await this.killLogSubProcess();
     this.proc = null;
+  }
+
+  /**
+   * @override
+   */
+  get isCapturing() {
+    return this.proc && this.proc.isRunning;
+  }
+
+  /**
+   * @param {string} logRow
+   * @param {string} [prefix='']
+   */
+  onOutput(logRow, prefix = '') {
+    this.broadcast(logRow);
+    if (this.showLogs) {
+      const space = prefix.length > 0 ? ' ' : '';
+      log.info(`[IOS_SYSLOG_ROW${space}${prefix}] ${logRow}`);
+    }
   }
 
   async killLogSubProcess() {
@@ -103,20 +93,26 @@ class IOSSimulatorLog extends IOSLog {
     }
   }
 
-  get isCapturing() {
-    return this.proc && this.proc.isRunning;
-  }
-
-  onOutput(logRow, prefix = '') {
-    const logs = _.cloneDeep(logRow.split('\n'));
-    for (const logLine of logs) {
-      if (!logLine) continue; // eslint-disable-line curly
-      this.broadcast(logLine);
-      if (this.showLogs) {
-        const space = prefix.length > 0 ? ' ' : '';
-        log.info(`[IOS_SYSLOG_ROW${space}${prefix}] ${logLine}`);
-      }
+  async finishStartingLogCapture() {
+    if (!this.proc) {
+      log.errorAndThrow('Could not capture simulator log');
     }
+
+    for (const streamName of ['stdout', 'stderr']) {
+      this.proc.on(`lines-${streamName}`, (/** @type {string[]} */ lines) => {
+        for (const line of lines) {
+          this.onOutput(line, ...(streamName === 'stderr' ? ['STDERR'] : []));
+        }
+      });
+    }
+
+    const startDetector = (/** @type {string} */ stdout, /** @type {string} */ stderr) => {
+      if (/execvp\(\)/.test(stderr)) {
+        throw new Error('iOS log capture process failed to start');
+      }
+      return stdout || stderr;
+    };
+    await this.proc.start(startDetector, START_TIMEOUT);
   }
 }
 

--- a/lib/device-log/ios-simulator-log.js
+++ b/lib/device-log/ios-simulator-log.js
@@ -7,7 +7,7 @@ const log = logger.getLogger('IOSSimulatorLog');
 
 const START_TIMEOUT = 10000;
 
-class IOSSimulatorLog extends IOSLog {
+export class IOSSimulatorLog extends IOSLog {
   constructor({sim, showLogs, xcodeVersion, iosSimulatorLogsPredicate}) {
     super();
     this.sim = sim;
@@ -116,5 +116,4 @@ class IOSSimulatorLog extends IOSLog {
   }
 }
 
-export {IOSSimulatorLog};
 export default IOSSimulatorLog;

--- a/lib/device-log/ios-simulator-log.js
+++ b/lib/device-log/ios-simulator-log.js
@@ -4,6 +4,7 @@ import {logger} from 'appium/support';
 import {exec} from 'teen_process';
 
 const log = logger.getLogger('IOSSimulatorLog');
+const EXECVP_ERROR_PATTERN = /execvp\(\)/;
 
 const START_TIMEOUT = 10000;
 
@@ -107,7 +108,7 @@ export class IOSSimulatorLog extends IOSLog {
     }
 
     const startDetector = (/** @type {string} */ stdout, /** @type {string} */ stderr) => {
-      if (/execvp\(\)/.test(stderr)) {
+      if (EXECVP_ERROR_PATTERN.test(stderr)) {
         throw new Error('iOS log capture process failed to start');
       }
       return stdout || stderr;

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "portscanner": "^2.2.0",
     "semver": "^7.5.4",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.60",
+    "teen_process": "^2.1.10",
     "ws": "^8.13.0"
   },
   "scripts": {


### PR DESCRIPTION
This is probably the first PR  out of many. I would like to streamline all logging-related classes to:
- Avoid code duplication
- Reduce CPU and memory usage as logs are written fairly often
- Make it typed, so it would be easier to work with this hierarchy