### PR TITLE
fix: remove empty action

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -122,12 +122,15 @@ const commands = {
       )
       .map((action) => {
         const modifiedAction = _.clone(action) || {};
-        // Selenium API unexpectedly inserts zero pauses, which are not supported by WDA
+        // Zero pauses are not supported by WDA yet.
         modifiedAction.actions = (action.actions || []).filter(
           (innerAction) => !(innerAction.type === 'pause' && innerAction.duration === 0),
         );
         return modifiedAction;
-      });
+      })
+      // If included actions are empty due to the above operation,
+      // they should be removed because they are also not supported by WDA.
+      .filter((action) => !_.isEmpty(action.actions));
     this.log.debug(`Preprocessed actions: ${JSON.stringify(preprocessedActions, null, '  ')}`);
     await this.proxyCommand('/actions', 'POST', {actions: preprocessedActions});
   },


### PR DESCRIPTION
```python
from selenium.webdriver.common.action_chains import ActionChains

action = ActionChains(driver)
action.send_keys('abcde').perform()
```

When performing the above operation, the pointer action(mouse) is filled with zero pauses(according to the W3C specification for isolating time slices between action types). The driver's operation to remove the zero pauses creates an empty action, resulting in the following error from WDA.

```log
Error Domain=com.facebook.WebDriverAgent Code=1 "It is mandatory to have at least one gesture item defined for each action. Action with id 'mouse' contains none" UserInfo={NSLocalizedDescription=It is mandatory to have at least one gesture item defined for each action. Action with id 'mouse' contains none}
```

Until WDA fully supports W3C ActionChains, this exception handling might be necessary.

I am unsure how to execute the e2e test code, so I am providing a rough version of the test code here.
```javascript
it('should send keys', async () => {
  const pointer = driver
    .action('pointer', {id: 'mouse'})
    .pause(0)
    .pause(0)
    .pause(0)
    .pause(0)
    .pause(0)
    .pause(0);
  const key = driver
    .action('key', {id: 'key'})
    .down('a')
    .up('a')
    .down('b')
    .up('b')
    .down('c')
    .up('c');

  await driver.actions([pointer, key]);
});
```