### PR TITLE
fix: no actions in w3c actions case

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -118,7 +118,7 @@ jobs:
           failures=$(cat "$RESULTS_XML" | xq --xpath '//testsuite/@failures')
           threshold=$(( (failures + errors) * 100 / (tests - skipped) ))
           cat "$RESULTS_XML"
-          if [[ $threshold -gt 7 ]]; then
+          if [[ $threshold -gt 8 ]]; then
             echo "${threshold}% of tests failed"
             exit 1
           else

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -118,7 +118,7 @@ jobs:
           failures=$(cat "$RESULTS_XML" | xq --xpath '//testsuite/@failures')
           threshold=$(( (failures + errors) * 100 / (tests - skipped) ))
           cat "$RESULTS_XML"
-          if [[ $threshold -gt 10 ]]; then
+          if [[ $threshold -gt 7 ]]; then
             echo "${threshold}% of tests failed"
             exit 1
           else

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,6 +27,7 @@ jobs:
     needs:
     - prepare_matrix
     strategy:
+      fail-fast: false
       matrix:
         node-version: ${{ fromJSON(needs.prepare_matrix.outputs.versions) }}
     steps:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^11.3.0",
-    "appium-webdriveragent": "^8.7.8",
+    "appium-webdriveragent": "8.7.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^11.3.0",
-    "appium-webdriveragent": "8.7.0",
+    "appium-webdriveragent": "^8.7.8",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^11.3.0",
-    "appium-webdriveragent": "^8.7.0",
+    "appium-webdriveragent": "^8.7.8",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -327,6 +327,9 @@ describe('XCUITestDriver - elements -', function () {
               actions: [
                 {type: 'pause', duration: 0},
                 {type: 'pause', duration: 0},
+                {type: 'pause', duration: 0},
+                {type: 'pause', duration: 0},
+                {type: 'pause', duration: 0},
                 {type: 'pause', duration: 0}
               ]
             },

--- a/test/functional/basic/element-e2e-specs.js
+++ b/test/functional/basic/element-e2e-specs.js
@@ -320,6 +320,16 @@ describe('XCUITestDriver - elements -', function () {
           await el.click();
 
           const actions = [
+            // Selenium clients generate below code for `driver.action.send_keys('a').perform`.
+            {
+              type: 'pointer',
+              id: 'touch',
+              actions: [
+                {type: 'pause', duration: 0},
+                {type: 'pause', duration: 0},
+                {type: 'pause', duration: 0}
+              ]
+            },
             {
               type: 'key',
               id: 'keyboard',


### PR DESCRIPTION
Let's update existing e2e for send_keys with w3c action in selenium client way.
For now, this test should fail without https://github.com/appium/WebDriverAgent/pull/919.