### PR TITLE
chore: Raise more helpful error if a W3C action contains a web element

### DIFF
--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -104,6 +104,7 @@ const commands = {
    */
   async performActions(actions) {
     this.log.debug(`Received the following W3C actions: ${JSON.stringify(actions, null, '  ')}`);
+    assertNoWebElements(actions);
     // This is mandatory, since WDA only supports TOUCH pointer type
     // and Selenium API uses MOUSE as the default one
     const preprocessedActions = actions
@@ -563,6 +564,25 @@ const helpers = {
 };
 
 export default {...helpers, ...commands};
+
+/**
+ * @param {import('@appium/types').ActionSequence[]} actionSeq
+ */
+function assertNoWebElements(actionSeq) {
+  const isOriginWebElement = (gesture) =>
+    _.isPlainObject(gesture) && 'origin' in gesture && JSON.stringify(gesture.origin).includes(':wdc:');
+  const hasWebElements = actionSeq
+    .some((action) => (action?.actions || []).some(isOriginWebElement));
+  if (hasWebElements) {
+    throw new errors.InvalidArgumentError(
+      `The XCUITest driver only supports W3C actions execution in the native context. ` +
+      `Although, your W3C action contains one or more web elements, ` +
+      `which cannot be automatically mapped to the native context. ` +
+      `Consider mapping their absolute web coordinates to the native context coordinates ` +
+      `and pass them to your gesture instead.`
+    );
+  }
+}
 
 /**
  * @typedef {import('../driver').XCUITestDriver} XCUITestDriver

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -579,7 +579,7 @@ function assertNoWebElements(actionSeq) {
       `Although, your W3C action contains one or more web elements, ` +
       `which cannot be automatically mapped to the native context. ` +
       `Consider mapping their absolute web coordinates to the native context coordinates ` +
-      `and pass them to your gesture instead.`
+      `and passing them to your gesture instead.`
     );
   }
 }

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -578,7 +578,7 @@ function assertNoWebElements(actionSeq) {
       `The XCUITest driver only supports W3C actions execution in the native context. ` +
       `Although, your W3C action contains one or more web elements, ` +
       `which cannot be automatically mapped to the native context. ` +
-      `Consider mapping their absolute web coordinates to the native context coordinates ` +
+      `Consider mapping their absolute web coordinates to native context coordinates ` +
       `and passing them to your gesture instead.`
     );
   }


### PR DESCRIPTION
Related to https://discuss.appium.io/t/i-cant-get-click-with-options-working/43095