### PR TITLE
fix: Streamline page selection

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -183,40 +183,19 @@ const extensions = {
       this.log.debug('We are in the middle of selecting a page, ignoring');
       return;
     }
-    if (!this.remote || !this.remote.isConnected) {
+    if (!this.remote?.isConnected) {
       this.log.debug('We have not yet connected, ignoring');
       return;
     }
 
     const {appIdKey, pageArray} = pageChangeNotification;
 
-    let newIds = [];
-    let newPages = [];
+    /** @type {string[]} */
+    const newIds = [];
+    /** @type {string[]} */
+    const newPages = [];
+    /** @type {string|null} */
     let keyId = null;
-
-    // Checks if a URL is blacklisted in the 'safariIgnoreWebHostnames' capability
-    function isUrlIgnored(url, safariIgnoreWebHostnames) {
-      const ignoredHosts = (safariIgnoreWebHostnames || '')
-        .split(',')
-        .map((b) => b.trim())
-        .filter((b) => !_.isEmpty(b));
-      for (const ignoredHost of ignoredHosts) {
-        if (ignoredHost === 'about:blank' && url === 'about:blank') {
-          return true;
-        } else {
-          try {
-            const hostname = new URL(url).hostname;
-            if (hostname === ignoredHost) {
-              return true;
-            }
-          } catch (ign) {
-            // do nothing if invalid URL
-          }
-        }
-      }
-      return false;
-    }
-
     for (const page of pageArray) {
       const id = page.id.toString();
       newIds.push(id);
@@ -250,17 +229,16 @@ const extensions = {
       this.log.debug('We do not appear to have window set yet, ignoring');
       return;
     }
-
     const [curAppIdKey, curPageIdKey] = this.curContext.split('.');
-
     if (curAppIdKey !== appIdKey) {
       this.log.debug('Page change not referring to currently selected app, ignoring.');
       return;
     }
 
+    /** @type {string|null} */
     let newPage = null;
     if (newPages.length) {
-      newPage = _.last(newPages);
+      newPage = /** @type {string} */ (_.last(newPages));
       this.log.debug(`We have new pages, selecting page '${newPage}'`);
     } else if (!_.includes(newIds, curPageIdKey)) {
       this.log.debug(
@@ -318,12 +296,16 @@ const extensions = {
       const oldContext = this.curContext;
       this.curContext = `${appIdKey}.${newPage}`;
       // do not wait, as this can take a long time, and the response is not necessary
-      // eslint-disable-next-line promise/prefer-await-to-callbacks, promise/prefer-await-to-then
-      this.remote.selectPage(appIdKey, parseInt(newPage, 10)).catch((err) => {
-        this.log.warn(`Failed to select page: ${err.message}`);
-        this.curContext = oldContext;
-      });
-      this.selectingNewPage = false;
+      (async () => {
+        try {
+          await /** @type {RemoteDebugger} */ (this.remote).selectPage(appIdKey, parseInt(newPage, 10));
+        } catch (e) {
+          this.log.warn(`Failed to select page: ${e.message}`);
+          this.curContext = oldContext;
+        } finally {
+          this.selectingNewPage = false;
+        }
+      })();
     }
     this.windowHandleCache = pageArray;
   },
@@ -626,6 +608,39 @@ const commands = {
     );
   },
 };
+
+/**
+ * Checks if a URL is blacklisted in the 'safariIgnoreWebHostnames' capability
+ *
+ * @param {string} url
+ * @param {string} [safariIgnoreWebHostnames]
+ * @returns {boolean}
+ */
+function isUrlIgnored(url, safariIgnoreWebHostnames) {
+  if (!safariIgnoreWebHostnames || _.isEmpty(safariIgnoreWebHostnames)) {
+    return false;
+  }
+
+  const ignoredHosts = safariIgnoreWebHostnames
+    .split(',')
+    .map((b) => b.trim())
+    .filter((b) => !_.isEmpty(b));
+  for (const ignoredHost of ignoredHosts) {
+    if (ignoredHost === 'about:blank' && url === 'about:blank') {
+      return true;
+    } else {
+      try {
+        const hostname = new URL(url).hostname;
+        if (hostname === ignoredHost) {
+          return true;
+        }
+      } catch (ign) {
+        // do nothing if invalid URL
+      }
+    }
+  }
+  return false;
+}
 
 export default {...helpers, ...extensions, ...commands};
 


### PR DESCRIPTION
Fixed the async call to selectPage to avoid linter errors and to properly assign the value of `this.selectingNewPage`.

Also refactored the `isUrlIgnored` call to make the method more readable