### PR TITLE
fix: Pyidevice ctor invocations with options object

### DIFF
--- a/lib/commands/certificate.js
+++ b/lib/commands/certificate.js
@@ -317,7 +317,10 @@ export default {
         );
       }
     } else {
-      const client = new Pyidevice(this.opts.udid);
+      const client = new Pyidevice({
+        udid: this.opts.udid,
+        log: this.log,
+      });
       if (await client.assertExists(false)) {
         await client.installProfile({payload: Buffer.from(content, 'base64')});
         return;
@@ -447,7 +450,10 @@ export default {
     if (!this.isRealDevice()) {
       throw new errors.NotImplementedError('This extension is only supported on real devices');
     }
-    const client = new Pyidevice(this.opts.udid);
+    const client = new Pyidevice({
+      udid: this.opts.udid,
+      log: this.log,
+    });
     await client.assertExists(true);
     return await client.removeProfile(name);
   },
@@ -466,7 +472,10 @@ export default {
     if (!this.isRealDevice()) {
       throw new errors.NotImplementedError('This extension is only supported on real devices');
     }
-    const client = new Pyidevice(this.opts.udid);
+    const client = new Pyidevice({
+      udid: this.opts.udid,
+      log: this.log,
+    });
     await client.assertExists(true);
     return await client.listProfiles();
   },

--- a/lib/commands/pcap.js
+++ b/lib/commands/pcap.js
@@ -18,7 +18,10 @@ export class TrafficCapture {
 
   async start(timeoutSeconds) {
     this.mainProcess = /** @type {import('teen_process').SubProcess} */ (
-      await new Pyidevice(this.udid).collectPcap(this.resultPath)
+      await new Pyidevice({
+        udid: this.udid,
+        log: this.log,
+      }).collectPcap(this.resultPath)
     );
     this.mainProcess.on('line-stderr', (line) => this.log.info(`[Pcap] ${line}`));
     this.log.info(

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -603,7 +603,10 @@ export class XCUITestDriver extends BaseDriver {
         await startLogCapture();
       }
     } else if (this.opts.customSSLCert) {
-      await new Pyidevice(udid).installProfile({payload: this.opts.customSSLCert});
+      await new Pyidevice({
+        udid,
+        log: this.log,
+      }).installProfile({payload: this.opts.customSSLCert});
       this.logEvent('customCertInstalled');
     }
 


### PR DESCRIPTION
Fix for https://github.com/appium/appium/issues/20427
`Pyidevice` ctor was not invoked properly, hence the command `mobile: installCertificate` is broken.