### PR TITLE
fix: Do not try to set the default URL using the remote debugger on iOS 17+

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -650,22 +650,41 @@ export class XCUITestDriver extends BaseDriver {
       this.logEvent('orientationSet');
     }
 
+    await this.prepareWebSession();
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async prepareWebSession() {
     if (this.isSafari() || this.opts.autoWebview) {
       await this.activateRecentWebview();
     }
-    if (this.isSafari()) {
-      if (shouldSetInitialSafariUrl(this.opts)) {
+    if (!this.isSafari()) {
+      return;
+    }
+
+    if (shouldSetInitialSafariUrl(this.opts)) {
+      if (this.getCurrentUrl() === this.getDefaultUrl()
+        // On iOS 17+ we try to set the default URL via WDA using deeplinking
+        && !!this.opts.platformVersion && util.compareVersions(this.opts.platformVersion, '>=', '17.0')
+      ) {
+        this.log.info(
+          `Assuming the default URL '${this.getDefaultUrl()}' has been set at the browser startup`
+        );
+      } else {
         this.log.info(
           `About to set the initial Safari URL to '${this.getCurrentUrl()}'.` +
             `Use 'safariInitialUrl' capability in order to customize it`,
         );
         await this.setUrl(this.getCurrentUrl());
-      } else {
-        const currentUrl = await this.getUrl();
-        this.log.info(`Current URL: ${currentUrl}`);
-        this.setCurrentUrl(currentUrl);
+        return;
       }
     }
+
+    const currentUrl = await this.getUrl();
+    this.log.info(`Current URL: ${currentUrl}`);
+    this.setCurrentUrl(currentUrl);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.5.4",
     "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^12.0.1",
-    "appium-webdriveragent": "^8.7.8",
+    "appium-webdriveragent": "^8.8.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
Based on https://github.com/appium/WebDriverAgent/pull/929