### PR TITLE
fix: safari process management will be done by WDA

### DIFF
--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -314,14 +314,15 @@ export class RealDevice {
    * @param {import('./driver').XCUITestDriverOpts} opts
    * @returns {Promise<void>}
    */
-  async reset({bundleId, fullReset, platformVersion}) {
+  async reset({bundleId, fullReset}) {
     if (!bundleId) {
       return;
     }
 
     if (bundleId === SAFARI_BUNDLE_ID) {
-      this.log.debug('Reset requested. About to terminate Safari');
-      await this.terminateApp(bundleId, String(platformVersion));
+      // Safari cannot be removed as system app.
+      // Safari process handling will be managed by WDA
+      // with noReset, forceAppLaunch or shouldTerminateApp capabilities.
       return;
     }
 

--- a/lib/real-device.js
+++ b/lib/real-device.js
@@ -315,18 +315,10 @@ export class RealDevice {
    * @returns {Promise<void>}
    */
   async reset({bundleId, fullReset}) {
-    if (!bundleId) {
-      return;
-    }
-
-    if (bundleId === SAFARI_BUNDLE_ID) {
+    if (!bundleId || !fullReset || bundleId === SAFARI_BUNDLE_ID) {
       // Safari cannot be removed as system app.
       // Safari process handling will be managed by WDA
       // with noReset, forceAppLaunch or shouldTerminateApp capabilities.
-      return;
-    }
-
-    if (!fullReset) {
       return;
     }
 


### PR DESCRIPTION
I observed that `xcrun devicectl` could take a few mins some cases.

This PR's `reset` in real-devices.js is called before starting WDA etc.

Safari process will be killed by the WDA in the WDA's new session creation, so this `this.terminateApp(bundleId, String(platformVersion));` here for real device is completely redundant AND it calls `xcrun devicectl` which could make the session preparation long unexpectedly for iOS 17+ as the `xcrun devicectl` behavior.

So, it makes sense to not call it for real devices.


I have tested this does not change existing behavior with noReset, shouldTerminateApp and forceAppLaunch combinations. forceAppLaunch is default `true` so even with this PR, a new session's Safari process is a new one.