### PR TITLE
docs: address com.apple.ContactsUI.LimitedAccessPromptView in troubleshooting

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -49,6 +49,25 @@ XCUITest driver offers a couple of approaches to handle them:
 
 [`mobile: activeAppInfo`](../reference/execute-methods.md#mobile-activateappinfo) helps to understand what application (bundleId) is considered as active for the XCUITest driver.
 
+## Interact with dialogs managed by `com.apple.ContactsUI.LimitedAccessPromptView`
+
+iOS 18 introduced a new process, named `com.apple.ContactsUI.LimitedAccessPromptView`. See [this issue](https://github.com/appium/appium/issues/20591) for more details.
+As of XCUITest driver v7.26.4, the only workaround to interact with the view is below method:
+
+- `defaultActiveApplication` setting in [Settings](../reference/settings.md).
+    - e.g. With the [Appium Ruby client](https://github.com/appium/ruby_lib_core)
+        ```ruby
+        # Interacting with the test target
+        driver.settings.update({defaultActiveApplication: "com.apple.ContactsUI.LimitedAccessPromptView"})
+        # to accept the alert
+        driver.find_element("accessibility_id", "Select Contacts").click
+        driver.settings.update({defaultActiveApplication: "auto"})
+        # keep interacting with the test target
+        ```
+
+`com.apple.ContactsUI.LimitedAccessPromptView` looks like can include elements available via `com.apple.springboard` thus you could use `com.apple.ContactsUI.LimitedAccessPromptView` instead of `com.apple.springboard` for iOS 18 for now to interact with dialogs manabed either `com.apple.ContactsUI.LimitedAccessPromptView` or `com.apple.springboard`.
+
+
 ## Leftover Application Data on Real Devices
 
 There might be a situation where application data is present on the real device, even if the

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -65,8 +65,8 @@ As of XCUITest driver v7.26.4, the only workaround to interact with the view is 
         # keep interacting with the test target
         ```
 
-`com.apple.ContactsUI.LimitedAccessPromptView` looks like can include elements available via `com.apple.springboard` thus you could use `com.apple.ContactsUI.LimitedAccessPromptView` instead of `com.apple.springboard` for iOS 18 for now to interact with dialogs manabed either `com.apple.ContactsUI.LimitedAccessPromptView` or `com.apple.springboard`.
-
+The `com.apple.ContactsUI.LimitedAccessPromptView` process can get elements available through `com.apple.springboard`, such as several system permission dialogs.
+iOS 18+ devices may be possible to use `com.apple.ContactsUI.LimitedAccessPromptView` to interact with elements managed either by `com.apple.ContactsUI.LimitedAccessPromptView` or `com.apple.springboard`.
 
 ## Leftover Application Data on Real Devices
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -51,8 +51,8 @@ XCUITest driver offers a couple of approaches to handle them:
 
 ## Interact with dialogs managed by `com.apple.ContactsUI.LimitedAccessPromptView`
 
-iOS 18 introduced a new process, named `com.apple.ContactsUI.LimitedAccessPromptView`. See [this issue](https://github.com/appium/appium/issues/20591) for more details.
-As of XCUITest driver v7.26.4, the only workaround to interact with the view is below method:
+iOS 18 introduced a new process named `com.apple.ContactsUI.LimitedAccessPromptView`. See [this issue](https://github.com/appium/appium/issues/20591) for more details.
+As of XCUITest driver v7.26.4, the only workaround to interact with views available through the process is the below method:
 
 - `defaultActiveApplication` setting in [Settings](../reference/settings.md).
     - e.g. With the [Appium Ruby client](https://github.com/appium/ruby_lib_core)


### PR DESCRIPTION
Adding https://github.com/appium/appium/issues/20591 as troubleshooting.

Maybe users will check `com.apple.springboard` for this dialogs, thus adding this description near place would help so far.

I wondered if we could use `com.apple.ContactsUI.LimitedAccessPromptView` instead of `com.apple.springboard` for iOS 18+ in WDA (since so far, it looks like elements available via `com.apple.springboard` were also available via `com.apple.ContactsUI.LimitedAccessPromptView` as well).

I haven't investigated this `com.apple.ContactsUI.LimitedAccessPromptView` behavior well yet.