### PR TITLE
docs: add remote debugger disconnection in troubleshooting

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -181,4 +181,4 @@ Please try out iOS 17.6 or a newer version which includes [a possible fix by App
 
 Frequent Web Inspector debugger disconnection started since iOS 17.2 (or iOS 17.0), that eventually caused `Disconnecting from remote debugger` error.
 It could be improved since iOS 17.6.
-Please check [a PR](https://github.com/appium/appium-xcuitest-driver/pull/2334) for more details.
+Please check [the corresponding pull request](https://github.com/appium/appium-xcuitest-driver/pull/2334) for more details.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -175,10 +175,10 @@ $HOME/Library/Logs/CoreSimulator/*
 $HOME/Library/Developer/Xcode/DerivedData/*
 ```
 
-## Frequent `Disconnecting from remote debugger` error in iOS 17.0 - 17.5
+## Frequent `Disconnecting from remote debugger` error in iOS 17
 
-Please try out iOS 17.6 which includes [a possible fix by Apple](https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes#Web-Inspector).
+Please try out iOS 17.6 or a newer version which includes [a possible fix by Apple](https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes#Web-Inspector).
 
-Frequent Web Inspector debugger disconnection started since iOS 17, that eventually caused `Disconnecting from remote debugger` error.
+Frequent Web Inspector debugger disconnection started since iOS 17.2 (or iOS 17.0), that eventually caused `Disconnecting from remote debugger` error.
 It could be improved since iOS 17.6.
 Please check [a PR](https://github.com/appium/appium-xcuitest-driver/pull/2334) for more details.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -177,9 +177,8 @@ $HOME/Library/Developer/Xcode/DerivedData/*
 
 ## Frequent `Disconnecting from remote debugger` error in iOS 17.0 - 17.5
 
-Please try out iOS 17.6 which includes [a possible fix by Apple](https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes#Web-Inspector)
+Please try out iOS 17.6 which includes [a possible fix by Apple](https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes#Web-Inspector).
 
-Frequent Web Inspector debugger disconnection started since iOS 17.
-It eventually caused `Disconnecting from remote debugger` error.
+Frequent Web Inspector debugger disconnection started since iOS 17, that eventually caused `Disconnecting from remote debugger` error.
 It could be improved since iOS 17.6.
-Please check [a PR](https://github.com/appium/appium-xcuitest-driver/pull/2334) about details.
+Please check [a PR](https://github.com/appium/appium-xcuitest-driver/pull/2334) for more details.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -174,3 +174,12 @@ usually found in the following locations, should they need to be deleted:
 $HOME/Library/Logs/CoreSimulator/*
 $HOME/Library/Developer/Xcode/DerivedData/*
 ```
+
+## Frequent `Disconnecting from remote debugger` error in iOS 17.0 - 17.5
+
+Please try out iOS 17.6 which includes [a possible fix by Apple](https://developer.apple.com/documentation/safari-release-notes/safari-17_6-release-notes#Web-Inspector)
+
+Frequent Web Inspector debugger disconnection started since iOS 17.
+It eventually caused `Disconnecting from remote debugger` error.
+It could be improved since iOS 17.6.
+Please check [a PR](https://github.com/appium/appium-xcuitest-driver/pull/2334) about details.


### PR DESCRIPTION
Address https://github.com/appium/appium-xcuitest-driver/pull/2334 in the troubleshooting that iOS 17.6+ could have a fix.
I haven't observed the issue in iOS 18 so far, so addressing here and maybe can close the PR as Apple side issue.