### PR TITLE
fix: use lipo -info instead of file for architecture detection

### DIFF
--- a/lib/app-utils.js
+++ b/lib/app-utils.js
@@ -58,7 +58,7 @@ export async function verifyApplicationPlatform() {
 
   const executablePath = path.resolve(this.opts.app, await this.appInfosCache.extractExecutableName(this.opts.app));
   const [resFile, resUname] = await B.all([
-    exec('file', [executablePath]),
+    exec('lipo', ['-info', executablePath]),
     exec('uname', ['-m']),
   ]);
   const bundleExecutableInfo = _.trim(resFile.stdout);
@@ -68,8 +68,8 @@ export async function verifyApplicationPlatform() {
   // We cannot run Simulator builds compiled for arm64 on Intel machines
   // Rosetta allows only to run Intel ones on arm64
   if (
-    !_.includes(bundleExecutableInfo, `executable ${arch}`) &&
-    !(isAppleSilicon && _.includes(bundleExecutableInfo, 'executable x86_64'))
+    !_.includes(bundleExecutableInfo, arch) &&
+    !(isAppleSilicon && _.includes(bundleExecutableInfo, 'x86_64'))
   ) {
     throw new Error(
       `The ${this.opts.bundleId} application does not support the ${arch} Simulator ` +


### PR DESCRIPTION
### Summary:

This PR updates the `verifyApplicationPlatform` function to use `lipo -info` instead of the `file` command for determining the architectures supported by the app’s executable. The change improves accuracy when verifying compatibility on both Intel and Apple Silicon devices by aligning with the consistent output format of lipo.

### Reasoning:

• **Inconsistent file Output:** The file command’s output can vary based on the system, leading to unreliable architecture detection.

• **Consistent lipo Output:** lipo -info provides consistent architecture details, which makes it a better choice for ensuring the correct Simulator architecture is detected.

• **Simplified Logic:** This change also simplifies string matching and error handling, reducing potential issues with cross-architecture setups.

### Example of inconsistent file Output
```
# System version:
/usr/bin/file --version
file-5.41
/usr/bin/file test.app
test.app/test: Mach-O 64-bit executable arm64

# Custom version in PATH:
file --version
file-5.45
file test.app
test.app/test: Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
```

### Example of consistent lipo Output
```
lipo -info test.app
Non-fat file: test.app/test is architecture: arm64
```