### PR TITLE
fix: bump WDA to fix transient overlay windows handling when respectSystemAlerts is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.7.23",
     "appium-ios-simulator": "^6.1.7",
     "appium-remote-debugger": "^12.1.1",
-    "appium-webdriveragent": "^8.9.1",
+    "appium-webdriveragent": "^8.9.4",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
related to https://github.com/appium/WebDriverAgent/pull/946