### PR TITLE
fix: Add accessible attribute to the xml tree in case of useJSONSource

### DIFF
--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -60,6 +60,7 @@ const helpers = {
  *     children:
  *      [ { isEnabled: '1',
  *          isVisible: '1',
+ *          isAccessible: '1',
  *          frame: '{{0, 0}, {375, 667}}',
  *          children: [],
  *          rect: { x: 0, y: 0, width: 375, height: 667 },
@@ -89,6 +90,7 @@ function getTreeForXML(srcTree) {
         type: `XCUIElementType${element.type}`,
         enabled: parseInt(element.isEnabled, 10) === 1,
         visible: parseInt(element.isVisible, 10) === 1,
+        accessible: parseInt(element.isAccessible, 10) === 1,
         x: rect.x,
         y: rect.y,
         width: rect.width,

--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -56,6 +56,7 @@ const helpers = {
  * ```js
  *   { isEnabled: '1',
  *     isVisible: '1',
+ *     isAccessible: '1',
  *     frame: '{{0, 0}, {375, 667}}',
  *     children:
  *      [ { isEnabled: '1',


### PR DESCRIPTION
- With useJSONSource as false, source contains accessible attribute 
- With useJSONSource as true, it bypasses the attribute.