### PR TITLE
docs: add provisioning profile examples

### DIFF
--- a/docs/preparation/prov-profile-basic-auto.md
+++ b/docs/preparation/prov-profile-basic-auto.md
@@ -12,7 +12,8 @@ to use the automatic configuration strategy. There are two ways to do this:
     ```json
     {
       "appium:xcodeOrgId": "<Team ID>",
-      "appium:xcodeSigningId": "Apple Developer"
+      "appium:xcodeSigningId": "Apple Developer",
+      "appium:updatedWDABundleId": "<budnle id your provisiong profile can accept>"
     }
     ```
 * Create a `.xcconfig` file somewhere on your file system and add the following to it:
@@ -37,6 +38,10 @@ _or_ the combination of `xcodeOrgId` and `xcodeSigningId`.
       section under the team name. You can also find your Team ID listed under the "Organizational
       Unit" field in your iPhone Developer certificate in your keychain.
 * `xcodeSigningId` / `CODE_SIGN_IDENTITY` is usually either `Apple Developer` or `iPhone Developer`.
+* `updatedWDABundleId` is the bundle id you would like to use for the built WebDriverAgent.
+    * Appium replaces the exisitng placeholder of `com.facebook.WebDriverAgentRunner` in `WebDriverAgent.xcodeproj` with the given capability value.
+    * `xcodebuild` adds `.xctrunner` automatically for XCTest package, thus the provisioning profile you're using should have the suffix, or can be `*`.
+    * For instance, the `appium:updatedWDABundleId` is `io.appium.WebDriverAgentRunner`, the given provisioning profile should be for `io.appium.WebDriverAgentRunner.xctrunner`, `io.appium.WebDriverAgentRunner.*` or `*`.
 
 Once this configuration is done, you should specify your real device UDID with the `udid` desired
 capability, after which you should be able to start your test. Proceed with

--- a/docs/preparation/prov-profile-basic-auto.md
+++ b/docs/preparation/prov-profile-basic-auto.md
@@ -40,8 +40,8 @@ _or_ the combination of `xcodeOrgId` and `xcodeSigningId`.
 * `xcodeSigningId` / `CODE_SIGN_IDENTITY` is usually either `Apple Developer` or `iPhone Developer`.
 * `updatedWDABundleId` is the bundle id you would like to use for the built WebDriverAgent.
     * Appium replaces the exisitng placeholder of `com.facebook.WebDriverAgentRunner` in `WebDriverAgent.xcodeproj` with the given capability value.
-    * `xcodebuild` adds `.xctrunner` automatically for XCTest package, thus the provisioning profile you're using should have the suffix, or can be `*`.
-    * For instance, the `appium:updatedWDABundleId` is `io.appium.WebDriverAgentRunner`, the given provisioning profile should be for `io.appium.WebDriverAgentRunner.xctrunner`, `io.appium.WebDriverAgentRunner.*` or `*`.
+    * `xcodebuild` adds `.xctrunner` automatically for XCTest package, thus the provisioning profile you're using should have the suffix explicitly, or it can be for bundle id which has `*`.
+        * For instance, when the `appium:updatedWDABundleId` is `io.appium.WebDriverAgentRunner`, the given provisioning profile should be for `io.appium.WebDriverAgentRunner.xctrunner`, `io.appium.WebDriverAgentRunner.*` or `*`.
 
 Once this configuration is done, you should specify your real device UDID with the `udid` desired
 capability, after which you should be able to start your test. Proceed with

--- a/docs/preparation/prov-profile-generic-manual.md
+++ b/docs/preparation/prov-profile-generic-manual.md
@@ -40,7 +40,10 @@ advanced codesign usage scenarios.
 !!! note
 
     The Appium team distributes generic builds with `CODE_SIGNING_ALLOWED=NO` at
-    <https://github.com/appium/WebDriverAgent/releases>. It is recommended to sign packages with a
-    wildcard (`*`) provisioning profile, although such profiles require a paid Apple Developer
-    account. In case of a free account, you may need to update the bundle id before building the
-    WebDriverAgent package.
+    [WebDriverAgent package releases](https://github.com/appium/WebDriverAgent/releases).
+    It is recommended to sign packages with a wildcard (`*`) provisioning profile,
+    although such profiles require a paid Apple Developer account.
+    For example, if you're preparing such a provisioning profile for `io.appium.WebDriverAgentRunner.xctrunner`, it will be `io.appium.*`, `io.appium.WebDriverAgentRunner.*` or `*`.
+    In case of a free account, you may need to update the bundle id before building
+    the WebDriverAgent package to prepare a properly signed WebDriverAgent package
+    by `xcodebuild`.


### PR DESCRIPTION
- docs/preparation/prov-profile-basic-auto.md is for a paid account thing
- Adds an example in docs/preparation/prov-profile-generic-manual.md