### PR TITLE
docs: change method command on doubleTap code examples

### DIFF
--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -1200,7 +1200,7 @@ y | number | no | Vertical coordinate offset. | 100
 
     ```java
     RemoteWebElement e = driver.findElement(AppiumBy.accessibilityId("target element"));
-    driver.executeScript("mobile: pinch", ImmutableMap.of(
+    driver.executeScript("mobile: doubleTap", ImmutableMap.of(
         "elementId", e.getId()
     ));
     ```
@@ -1209,7 +1209,7 @@ y | number | no | Vertical coordinate offset. | 100
 
     ```js
     const e = await $('~target element');
-    await driver.executeScript('mobile: pinch', [{
+    await driver.executeScript('mobile: doubleTap', [{
       elementId: e.elementId
     }]);
 
@@ -1217,7 +1217,7 @@ y | number | no | Vertical coordinate offset. | 100
 
     ```python
     e = driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='target element')
-    driver.execute_script("mobile: pinch", {
+    driver.execute_script("mobile: doubleTap", {
       "elementId": e.id
     })
     ```
@@ -1226,7 +1226,7 @@ y | number | no | Vertical coordinate offset. | 100
 
     ```ruby
     e = driver.find_element :accessibility_id, 'target element'
-    driver.execute_script 'mobile: pinch', {
+    driver.execute_script 'mobile: doubleTap', {
       elementId: e.ref
     }
     ```
@@ -1235,7 +1235,7 @@ y | number | no | Vertical coordinate offset. | 100
 
     ```csharp
     var e = driver.FindElement(By.AccessibilityId("target element"))
-    driver.ExecuteScript("mobile: pinch", new Dictionary<string, object>() {
+    driver.ExecuteScript("mobile: doubleTap", new Dictionary<string, object>() {
         {"elementId", element.Id}
     });
     ```


### PR DESCRIPTION
In the documentation of the mobile: doubleTap command, the mobile: pinch command was being used in the code examples.
![image](https://github.com/user-attachments/assets/a0ebeded-6fde-417d-b6e6-c550faae33d5)
