### PR TITLE
chore: Tune contextUpdated event generation

### DIFF
--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -46,11 +46,23 @@ Events are emitted for both emulator and real devices. Each event contains a sin
 Events are always emitted with the `NATIVE_APP` context.
 Events are only emitted if the `get_server_logs` server security feature is enabled.
 
-## appium.contextUpdate
+## appium:xcuitest.contextUpdate
 
 This event is emitted upon the context change, either explicit or implicit.
 The event is always emitted upon new session initialization.
 See the [GitHub feature ticket](https://github.com/appium/appium/issues/20741) for more details.
+
+### CDDL
+
+```cddl
+appium:xcuitest.contextUpdated = {
+  method: "appium:xcuitest.contextUpdated",
+  params: {
+    name: text,
+    type: "NATIVE" / "WEB",
+  },
+}
+```
 
 The event contains the following params:
 

--- a/lib/commands/bidi/constants.ts
+++ b/lib/commands/bidi/constants.ts
@@ -1,3 +1,6 @@
 export const BIDI_EVENT_NAME = 'bidiEvent';
-export const CONTEXT_UPDATED_EVENT = 'appium.contextUpdated';
+const DOMAIN = 'xcuitest';
+export const CONTEXT_UPDATED_EVENT = `appium:${DOMAIN}.contextUpdated`;
+/** @deprecated Use {@link CONTEXT_UPDATED_EVENT} instead */
+export const CONTEXT_UPDATED_EVENT_OBSOLETE = 'appium.contextUpdated';
 export const LOG_ENTRY_ADDED_EVENT = 'log.entryAdded';

--- a/lib/commands/bidi/models.ts
+++ b/lib/commands/bidi/models.ts
@@ -1,17 +1,28 @@
 import type { LogEntryAddedEvent, ContextUpdatedEvent } from './types';
 import { NATIVE_WIN } from '../../utils';
-import { CONTEXT_UPDATED_EVENT, LOG_ENTRY_ADDED_EVENT } from './constants';
+import { CONTEXT_UPDATED_EVENT, CONTEXT_UPDATED_EVENT_OBSOLETE, LOG_ENTRY_ADDED_EVENT } from './constants';
 import type { LogEntry } from '../types';
 
-export function makeContextUpdatedEvent(contextName: string): ContextUpdatedEvent {
+function toContextUpdatedEvent(method: string, contextName: string): ContextUpdatedEvent {
   return {
-    method: CONTEXT_UPDATED_EVENT,
+    method,
     params: {
       name: contextName,
       type: contextName === NATIVE_WIN ? 'NATIVE' : 'WEB',
     },
   };
 }
+
+export const makeContextUpdatedEvent = (contextName: string) => toContextUpdatedEvent(
+  CONTEXT_UPDATED_EVENT, contextName
+);
+
+/**
+ * @deprecated Use {@link makeContextUpdatedEvent} instead
+ */
+export const makeObsoleteContextUpdatedEvent = (contextName: string) => toContextUpdatedEvent(
+  CONTEXT_UPDATED_EVENT_OBSOLETE, contextName
+);
 
 export function makeLogEntryAddedEvent(entry: LogEntry, context: string, type: string): LogEntryAddedEvent {
   return {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -4,7 +4,10 @@ import {util, timing} from 'appium/support';
 import IOSPerformanceLog from '../device-log/ios-performance-log';
 import _ from 'lodash';
 import { NATIVE_WIN } from '../utils';
-import { makeContextUpdatedEvent } from './bidi/models';
+import {
+  makeContextUpdatedEvent,
+  makeObsoleteContextUpdatedEvent,
+} from './bidi/models';
 import { BIDI_EVENT_NAME } from './bidi/constants';
 import { assignBiDiLogListener } from './log';
 
@@ -715,6 +718,7 @@ function isUrlIgnored(url, safariIgnoreWebHostnames) {
 export async function notifyBiDiContextChange() {
   const name = await this.getCurrentContext();
   this.eventEmitter.emit(BIDI_EVENT_NAME, makeContextUpdatedEvent(name));
+  this.eventEmitter.emit(BIDI_EVENT_NAME, makeObsoleteContextUpdatedEvent(name));
 }
 
 export default {...helpers, ...extensions, ...commands};


### PR DESCRIPTION
After talking to @christian-bromann we have decided to update the event name up to the standard, which required it to have a custom prefix. The old one is still there, has been marked as deprecated, and will be removed after the next driver major bump.