### PR TITLE
docs: remove emoji flag from `mobile: getDeviceTime` Example

### DIFF
--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -518,7 +518,7 @@ Returns the actual device time.
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-format | string | no | The format specifier string. Read [MomentJS documentation](https://momentjs.com/docs/) to get the full list of supported datetime format specifiers. The default format is `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601 | YYYY-MM-DD HH:mm:ss
+format | string | no | The format specifier string. Read [MomentJS documentation](https://momentjs.com/docs/) to get the full list of supported datetime format specifiers. The default format is `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601 | `YYYY-MM-DD HH:mm:ss`
 
 #### Returned Result
 


### PR DESCRIPTION
Currently the :mm: combo creates an emoji flag in the Example section for the `mobile: getDeviceTime' command
![image](https://github.com/user-attachments/assets/6a669be7-f9d1-4736-8f66-57f802906103)
