### PR TITLE
feat: always use vendContainer to add files without extra app permissions

### DIFF
--- a/docs/guides/file-transfer.md
+++ b/docs/guides/file-transfer.md
@@ -27,7 +27,7 @@ possible formats this path can take:
 * `<container-type>` is the container type
     * On simulators, common values are `app`, `data`, `groups`, but a custom one can also be provided
     * On real devices, the only accepted value is `documents`. All others are treated as Format 2
-        * In `xcuitest-driver` versions prior to version `v8.1.0` the following limitation applies:
+        * In `xcuitest-driver` versions prior to version `v8.3.0` the following limitation applies:
         This value can only be specified for apps that have the `UIFileSharingEnabled` flag set to
           `true`. You can use the [`mobile: listApps`](../reference/execute-methods.md#mobile-listapps)
           extension to identify such apps.

--- a/docs/guides/file-transfer.md
+++ b/docs/guides/file-transfer.md
@@ -27,7 +27,8 @@ possible formats this path can take:
 * `<container-type>` is the container type
     * On simulators, common values are `app`, `data`, `groups`, but a custom one can also be provided
     * On real devices, the only accepted value is `documents`. All others are treated as Format 2
-        * This value can only be specified for apps that have the `UIFileSharingEnabled` flag set to
+        * In `xcuitest-driver` versions prior to version `v8.1.0` the following limitation applies:
+        This value can only be specified for apps that have the `UIFileSharingEnabled` flag set to
           `true`. You can use the [`mobile: listApps`](../reference/execute-methods.md#mobile-listapps)
           extension to identify such apps.
 * `<path-to-file-or-folder>` is the target file or folder

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -72,17 +72,14 @@ function verifyIsSubPath(originalPath, root) {
  *
  * @param {string} udid
  * @param {string} [bundleId]
- * @param {string} [containerType]
  * @returns {Promise<any>}
  */
-async function createAfcClient(udid, bundleId, containerType) {
+async function createAfcClient(udid, bundleId) {
   if (!bundleId) {
     return await services.startAfcService(udid);
   }
   const service = await services.startHouseArrestService(udid);
-  return isDocumentsContainer(containerType)
-    ? await service.vendDocuments(bundleId)
-    : await service.vendContainer(bundleId);
+  return await service.vendContainer(bundleId);
 }
 
 /**
@@ -103,7 +100,7 @@ function isDocumentsContainer(containerType) {
 async function createService(remotePath) {
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
     const {bundleId, pathInContainer, containerType} = await parseContainerPath.bind(this)(remotePath);
-    const service = await createAfcClient(this.device.udid, bundleId, containerType);
+    const service = await createAfcClient(this.device.udid, bundleId);
     const relativePath = isDocumentsContainer(containerType)
       ? path.join(CONTAINER_DOCUMENTS_PATH, pathInContainer)
       : pathInContainer;


### PR DESCRIPTION
- always use vendContainer to add files without extra app permissions
- adjust docs accordingly

as discussed in https://github.com/appium/appium-xcuitest-driver/issues/2521

I tested this on ios 18 and ios 16 so i its safe to assume it works on 17 as well (i unfortunately don't have an ios 17 device)
