### PR TITLE
fix: Make sure a proper file names encoding is used while unzipping files from app bundles

### DIFF
--- a/lib/app-utils.js
+++ b/lib/app-utils.js
@@ -265,7 +265,11 @@ export async function unzipFile(archivePath) {
     _.isEmpty(useSystemUnzipEnv) || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
   const tmpRoot = await tempDir.openDir();
   try {
-    await zip.extractAllTo(archivePath, tmpRoot, {useSystemUnzip});
+    await zip.extractAllTo(archivePath, tmpRoot, {
+      useSystemUnzip,
+      // https://github.com/appium/appium/issues/14100
+      fileNamesEncoding: 'utf8',
+    });
   } catch (e) {
     await fs.rimraf(tmpRoot);
     throw e;


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/14100