### PR TITLE
feat: Switch size retrieval to use the W3C window/rect endpoint

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -36,24 +36,6 @@ const commands = {
   async toggleEnrollTouchId(isEnabled = true) {
     await this.mobileEnrollBiometric(isEnabled);
   },
-  /**
-   * Get the window size
-   * @this {XCUITestDriver}
-   * @deprecated Use {@linkcode XCUITestDriver.getWindowRect} instead.
-   */
-  async getWindowSize(windowHandle = 'current') {
-    if (windowHandle !== 'current') {
-      throw new errors.NotYetImplementedError(
-        'Currently only getting current window size is supported.',
-      );
-    }
-
-    if (!this.isWebContext()) {
-      return await this.getWindowSizeNative();
-    } else {
-      return await this.getWindowSizeWeb();
-    }
-  },
 
   /**
    * Retrieves the actual device time.
@@ -118,13 +100,14 @@ const commands = {
    * @this {XCUITestDriver}
    */
   async getWindowRect() {
-    const {width, height} = await this.getWindowSize();
-    return {
-      width,
-      height,
-      x: 0,
-      y: 0,
-    };
+    if (this.isWebContext()) {
+      const script = 'return {x: 0, y: 0, width: window.innerWidth, height: window.innerHeight}';
+      return await this.executeAtom('execute_script', [script]);
+    }
+
+    return /** @type {import('@appium/types').Rect} */ (
+      await this.proxyCommand('/window/rect', 'GET')
+    );
   },
   /**
    * @this {XCUITestDriver}
@@ -181,7 +164,7 @@ const commands = {
     const scale = await this.getDevicePixelRatio();
     // status bar height comes in unscaled, so scale it
     const statusBarHeight = Math.round((await this.getStatusBarHeight()) * scale);
-    const windowSize = await this.getWindowSize();
+    const windowSize = await this.getWindowRect();
 
     // ios returns coordinates/dimensions in logical pixels, not device pixels,
     // so scale up to device pixels. status bar height is already scaled.
@@ -260,23 +243,7 @@ const commands = {
   },
 };
 
-const helpers = {
-  /**
-   * @this {XCUITestDriver}
-   */
-  async getWindowSizeWeb() {
-    const script = 'return {width: window.innerWidth, height: window.innerHeight}';
-    return await this.executeAtom('execute_script', [script]);
-  },
-  /**
-   * @this {XCUITestDriver}
-   */
-  async getWindowSizeNative() {
-    return await this.proxyCommand(`/window/size`, 'GET');
-  },
-};
-
-export default {...helpers, ...commands};
+export default commands;
 
 /**
  * @typedef {Object} PressButtonOptions

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -110,7 +110,12 @@ const commands = {
    */
   async getWindowRect() {
     if (this.isWebContext()) {
-      const script = 'return {x: 0, y: 0, width: window.innerWidth, height: window.innerHeight}';
+      const script = 'return {' +
+        'x: window.screenX || 0,' +
+        'y: window.screenY || 0,' +
+        'width: window.innerWidth,' +
+        'height: window.innerHeight' +
+      '}';
       return await this.executeAtom('execute_script', [script]);
     }
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -36,7 +36,15 @@ const commands = {
   async toggleEnrollTouchId(isEnabled = true) {
     await this.mobileEnrollBiometric(isEnabled);
   },
-
+  /**
+   * Get the window size
+   * @this {XCUITestDriver}
+   * @returns {Promise<import('@appium/types').Size>}
+   */
+  async getWindowSize() {
+    const {width, height} = await this.getWindowRect();
+    return {width, height};
+  },
   /**
    * Retrieves the actual device time.
    *
@@ -98,6 +106,7 @@ const commands = {
   /**
    * For W3C
    * @this {XCUITestDriver}
+   * @return {Promise<import('@appium/types').Rect>}
    */
   async getWindowRect() {
     if (this.isWebContext()) {

--- a/lib/commands/proxy-helper.js
+++ b/lib/commands/proxy-helper.js
@@ -43,9 +43,6 @@ const WDA_ROUTES = /** @type {const} */ ({
   '/wda/locked': {
     GET: 'isLocked',
   },
-  '/window/size': {
-    GET: 'getWindowSize',
-  },
 });
 
 /**

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -97,33 +97,24 @@ export default {
   },
   /**
    * @this {XCUITestDriver}
+   * @returns {Promise<string>}
    */
   async getViewportScreenshot() {
     if (this.isWebContext()) {
       return await (/** @type {import('appium-remote-debugger').RemoteDebugger} */ (this.remote)).captureScreenshot();
     }
 
-    let statusBarHeight = await this.getStatusBarHeight();
     const screenshot = await this.getScreenshot();
-
     // if we don't have a status bar, there's nothing to crop, so we can avoid
     // extra calls and return straightaway
-    if (statusBarHeight === 0) {
+    if ((await this.getStatusBarHeight()) === 0) {
       return screenshot;
     }
 
-    const scale = await this.getDevicePixelRatio();
-    // status bar height comes in unscaled, so scale it
-    statusBarHeight = Math.round(statusBarHeight * scale);
-    const windowSize = await this.getWindowRect();
-    let rect = {
-      left: 0,
-      top: statusBarHeight,
-      width: windowSize.width * scale,
-      height: windowSize.height * scale - statusBarHeight,
-    };
-    let newScreenshot = await imageUtil.cropBase64Image(screenshot, rect);
-    return newScreenshot;
+    return await imageUtil.cropBase64Image(
+      screenshot,
+      await this.getViewportRect()
+    );
   },
 };
 

--- a/lib/commands/screenshots.js
+++ b/lib/commands/screenshots.js
@@ -115,7 +115,7 @@ export default {
     const scale = await this.getDevicePixelRatio();
     // status bar height comes in unscaled, so scale it
     statusBarHeight = Math.round(statusBarHeight * scale);
-    const windowSize = await this.getWindowSize();
+    const windowSize = await this.getWindowRect();
     let rect = {
       left: 0,
       top: statusBarHeight,

--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -897,7 +897,9 @@ const extensions = {
 
     const currentUrl = await this.getUrl();
     await this.setUrl(`${this.getWdaLocalhostRoot()}/calibrate`);
-    const {width, height} = /** @type {import('@appium/types').Size} */(await this.proxyCommand(`/window/size`, 'GET'));
+    const {width, height} = /** @type {import('@appium/types').Rect} */(
+      await this.proxyCommand('/window/rect', 'GET')
+    );
     const [centerX, centerY] = [width / 2, height / 2];
     const errorPrefix = 'Cannot determine web view coordinates offset. Are you in Safari context?';
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1985,6 +1985,7 @@ export class XCUITestDriver extends BaseDriver {
   background = commands.appManagementExtensions.background;
   touchId = commands.generalExtensions.touchId;
   toggleEnrollTouchId = commands.generalExtensions.toggleEnrollTouchId;
+  getWindowSize = commands.generalExtensions.getWindowSize;
   getDeviceTime = commands.generalExtensions.getDeviceTime;
   mobileGetDeviceTime = commands.generalExtensions.mobileGetDeviceTime;
   getWindowRect = commands.generalExtensions.getWindowRect;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1985,7 +1985,6 @@ export class XCUITestDriver extends BaseDriver {
   background = commands.appManagementExtensions.background;
   touchId = commands.generalExtensions.touchId;
   toggleEnrollTouchId = commands.generalExtensions.toggleEnrollTouchId;
-  getWindowSize = commands.generalExtensions.getWindowSize;
   getDeviceTime = commands.generalExtensions.getDeviceTime;
   mobileGetDeviceTime = commands.generalExtensions.mobileGetDeviceTime;
   getWindowRect = commands.generalExtensions.getWindowRect;
@@ -2000,8 +1999,6 @@ export class XCUITestDriver extends BaseDriver {
   getDevicePixelRatio = commands.generalExtensions.getDevicePixelRatio;
   mobilePressButton = commands.generalExtensions.mobilePressButton;
   mobileSiriCommand = commands.generalExtensions.mobileSiriCommand;
-  getWindowSizeWeb = commands.generalExtensions.getWindowSizeWeb;
-  getWindowSizeNative = commands.generalExtensions.getWindowSizeNative;
 
   /*-------------+
    | GEOLOCATION |

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "appium-ios-device": "^2.8.0",
     "appium-ios-simulator": "^6.2.0",
     "appium-remote-debugger": "^12.2.0",
-    "appium-webdriveragent": "^9.2.0",
+    "appium-webdriveragent": "^9.3.0",
     "appium-xcode": "^5.1.4",
     "async-lock": "^1.4.0",
     "asyncbox": "^3.0.0",

--- a/test/functional/basic/basic-e2e-specs.js
+++ b/test/functional/basic/basic-e2e-specs.js
@@ -195,7 +195,7 @@ describe('XCUITestDriver - basics -', function () {
 
   describe('window size -', function () {
     it('should be able to get the current window size', async function () {
-      let size = await driver.getWindowSize();
+      let size = await driver.getWindowRect();
       size.width.should.be.a('number');
       size.height.should.be.a('number');
     });

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -259,7 +259,7 @@ describe('Safari - basics -', function () {
         await a.getTagName().should.eventually.equal('a');
       });
       it('should retrieve a window size', async function () {
-        const size = await driver.getWindowSize();
+        const size = await driver.getWindowRect();
         size.height.should.be.above(0);
         size.width.should.be.above(0);
       });

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -115,13 +115,6 @@ describe('general commands', function () {
     });
   });
 
-  describe('window size', function () {
-    it('should be able to get the current window size with Rect', async function () {
-      mockDriver.expects('proxyCommand').once().withExactArgs('/window/size', 'GET').returns({width: 100, height: 20});
-      await driver.getWindowRect();
-    });
-  });
-
   describe('nativeWebTap as a setting', function () {
     // create new driver with no opts
     let driver, startStub;


### PR DESCRIPTION
BREAKING CHANGE: The following deprecated driver methods were removed:
- getWindowSizeWeb
- getWindowSizeNative