### PR TITLE
fix: Revert "feat: always use vendContainer to add files without extra app permissions"

### DIFF
--- a/docs/guides/file-transfer.md
+++ b/docs/guides/file-transfer.md
@@ -27,8 +27,7 @@ possible formats this path can take:
 * `<container-type>` is the container type
     * On simulators, common values are `app`, `data`, `groups`, but a custom one can also be provided
     * On real devices, the only accepted value is `documents`. All others are treated as Format 2
-        * In `xcuitest-driver` versions prior to version `v8.3.0` the following limitation applies:
-        This value can only be specified for apps that have the `UIFileSharingEnabled` flag set to
+        * This value can only be specified for apps that have the `UIFileSharingEnabled` flag set to
           `true`. You can use the [`mobile: listApps`](../reference/execute-methods.md#mobile-listapps)
           extension to identify such apps.
 * `<path-to-file-or-folder>` is the target file or folder

--- a/lib/commands/file-movement.js
+++ b/lib/commands/file-movement.js
@@ -72,14 +72,17 @@ function verifyIsSubPath(originalPath, root) {
  *
  * @param {string} udid
  * @param {string} [bundleId]
+ * @param {string} [containerType]
  * @returns {Promise<any>}
  */
-async function createAfcClient(udid, bundleId) {
+async function createAfcClient(udid, bundleId, containerType) {
   if (!bundleId) {
     return await services.startAfcService(udid);
   }
   const service = await services.startHouseArrestService(udid);
-  return await service.vendContainer(bundleId);
+  return isDocumentsContainer(containerType)
+    ? await service.vendDocuments(bundleId)
+    : await service.vendContainer(bundleId);
 }
 
 /**
@@ -100,7 +103,7 @@ function isDocumentsContainer(containerType) {
 async function createService(remotePath) {
   if (CONTAINER_PATH_PATTERN.test(remotePath)) {
     const {bundleId, pathInContainer, containerType} = await parseContainerPath.bind(this)(remotePath);
-    const service = await createAfcClient(this.device.udid, bundleId);
+    const service = await createAfcClient(this.device.udid, bundleId, containerType);
     const relativePath = isDocumentsContainer(containerType)
       ? path.join(CONTAINER_DOCUMENTS_PATH, pathInContainer)
       : pathInContainer;


### PR DESCRIPTION
Reverts appium/appium-xcuitest-driver#2522

The change got two regression reports for that (I haven't verified that by myself, but it looks like no workaround right now) -> https://github.com/appium/appium-xcuitest-driver/commit/6f3e7b5b30f7f5c438cd0cc0fce1f2aa7a3f4f3b#commitcomment-154341503

so I think it would be nice to revert that for now and apply the change again later with taking care of the reported case.


cc @aluedeke 