### PR TITLE
chore: add deprecated marks in lib/method-map.js

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -18,7 +18,7 @@ Please note that most of the driver-specific functionality is available using
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: getClipboard`](./execute-methods.md#mobile-getclipboard) extension instead
+    This method is deprecated. Please use the [`mobile: getClipboard`](./execute-methods.md#mobile-getclipboard) extension instead
 
 `POST` **`/session/:sessionId/appium/device/get_clipboard`**
 
@@ -42,7 +42,7 @@ clipboard contains no data.
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: setClipboard`](./execute-methods.md#mobile-setclipboard) extension instead
+    This method is deprecated. Please use the [`mobile: setClipboard`](./execute-methods.md#mobile-setclipboard) extension instead
 
 `POST` **`/session/:sessionId/appium/device/set_clipboard`**
 
@@ -187,9 +187,9 @@ Submit the form an element is in
 
 ### `background`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: backgroundApp`](./execute-methods.md#mobile-backgroundapp) extension instead
+    This method is deprecated. Please use the [`mobile: backgroundApp`](./execute-methods.md#mobile-backgroundapp) extension instead
 
 `POST` **`/session/:sessionId/appium/app/background`**
 
@@ -210,7 +210,7 @@ the app after the timeout or keep it minimized based on the parameter value.
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: queryAppState`](./execute-methods.md#mobile-queryappstate) extension instead
+    This method is deprecated. Please use the [`mobile: queryAppState`](./execute-methods.md#mobile-queryappstate) extension instead
 
 `POST` **`/session/:sessionId/appium/device/app_state`**
 
@@ -228,7 +228,7 @@ running in the foreground
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: isLocked`](./execute-methods.md#mobile-islocked) extension instead
+    This method is deprecated. Please use the [`mobile: isLocked`](./execute-methods.md#mobile-islocked) extension instead
 
 `POST` **`/session/:sessionId/appium/device/is_locked`**
 
@@ -244,7 +244,7 @@ Determine whether the device is locked
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: lock`](./execute-methods.md#mobile-lock) extension instead
+    This method is deprecated. Please use the [`mobile: lock`](./execute-methods.md#mobile-lock) extension instead
 
 `POST` **`/session/:sessionId/appium/device/lock`**
 
@@ -268,7 +268,7 @@ Lock the device (and optionally unlock the device after a certain amount of time
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: unlock`](./execute-methods.md#mobile-unlock) extension instead
+    This method is deprecated. Please use the [`mobile: unlock`](./execute-methods.md#mobile-unlock) extension instead
 
 `POST` **`/session/:sessionId/appium/device/unlock`**
 
@@ -284,7 +284,7 @@ Unlock the device
 
 !!! warning "Deprecated"
 
-    This method is deprecated. Please use [`mobile: shake`](./execute-methods.md#mobile-shake) extension instead
+    This method is deprecated. Please use the [`mobile: shake`](./execute-methods.md#mobile-shake) extension instead
 
 `POST` **`/session/:sessionId/appium/device/shake`**
 
@@ -296,9 +296,9 @@ Shake the device
 
 ### `getStrings`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: getAppStrings`](./execute-methods.md#mobile-getappstrings) extension instead
+    This method is deprecated. Please use the  [`mobile: getAppStrings`](./execute-methods.md#mobile-getappstrings) extension instead
 
 `POST` **`/session/:sessionId/appium/app/strings`**
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -16,6 +16,10 @@ Please note that most of the driver-specific functionality is available using
 
 ### `getClipboard`
 
+!!! warning "Deprecated"
+
+    This method is deprecated. Please use [`mobile: getClipboard`](./execute-methods.md#mobile-getclipboard) extension instead
+
 `POST` **`/session/:sessionId/appium/device/get_clipboard`**
 
 Gets the content of the primary clipboard on the device under test.
@@ -35,6 +39,10 @@ The actual clipboard content encoded into base64 string. An empty string is retu
 clipboard contains no data.
 
 ### `setClipboard`
+
+!!! warning "Deprecated"
+
+    This method is deprecated. Please use [`mobile: setClipboard`](./execute-methods.md#mobile-setclipboard) extension instead
 
 `POST` **`/session/:sessionId/appium/device/set_clipboard`**
 
@@ -200,9 +208,9 @@ the app after the timeout or keep it minimized based on the parameter value.
 
 ### `queryAppState`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: queryAppState`](./execute-methods.md#mobile-queryappstate) extension instead
+    This method is deprecated. Please use [`mobile: queryAppState`](./execute-methods.md#mobile-queryappstate) extension instead
 
 `POST` **`/session/:sessionId/appium/device/app_state`**
 
@@ -218,9 +226,9 @@ running in the foreground
 
 ### `isLocked`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: isLocked`](./execute-methods.md#mobile-islocked) extension instead
+    This method is deprecated. Please use [`mobile: isLocked`](./execute-methods.md#mobile-islocked) extension instead
 
 `POST` **`/session/:sessionId/appium/device/is_locked`**
 
@@ -234,9 +242,9 @@ Determine whether the device is locked
 
 ### `lock`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: lock`](./execute-methods.md#mobile-lock) extension instead
+    This method is deprecated. Please use [`mobile: lock`](./execute-methods.md#mobile-lock) extension instead
 
 `POST` **`/session/:sessionId/appium/device/lock`**
 
@@ -258,9 +266,9 @@ Lock the device (and optionally unlock the device after a certain amount of time
 
 ### `unlock`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: unlock`](./execute-methods.md#mobile-unlock) extension instead
+    This method is deprecated. Please use [`mobile: unlock`](./execute-methods.md#mobile-unlock) extension instead
 
 `POST` **`/session/:sessionId/appium/device/unlock`**
 
@@ -274,9 +282,9 @@ Unlock the device
 
 ### `mobileShake`
 
-!!! note
+!!! warning "Deprecated"
 
-    We recommend using the [`mobile: shake`](./execute-methods.md#mobile-shake) extension instead
+    This method is deprecated. Please use [`mobile: shake`](./execute-methods.md#mobile-shake) extension instead
 
 `POST` **`/session/:sessionId/appium/device/shake`**
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -165,6 +165,10 @@ or an empty string.
 
 ### `getSize`
 
+!!! warning "Deprecated"
+
+    This method is deprecated. Please refer to the [Get Element Rect][https://www.w3.org/TR/webdriver1/#dfn-get-element-rect] instead
+
 `GET` **`/session/:sessionId/element/:elementId/size`**
 
 Get the size of an element
@@ -176,6 +180,10 @@ Get the size of an element
 The positions of the element
 
 ### `submit`
+
+!!! warning "Deprecated"
+
+    This method is deprecated. Please click the submit button instead
 
 `POST` **`/session/:sessionId/element/:elementId/submit`**
 
@@ -359,7 +367,7 @@ Send keys to the app
 
 !!! warning "Deprecated"
 
-    This method is deprecated
+    This method is deprecated. Please use the [Execute Async Script](https://www.w3.org/TR/webdriver1/#dfn-execute-async-script) instead
 
 `POST` **`/session/:sessionId/appium/receive_async_response`**
 

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -3,25 +3,78 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'asyncScriptTimeout',
       payloadParams: {required: ['ms']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/timeouts/implicit_wait': {
-    POST: {command: 'implicitWait', payloadParams: {required: ['ms']}},
+    POST: {
+      command: 'implicitWait',
+      payloadParams: {required: ['ms']},
+      deprecated: true
+    },
   },
-  '/session/:sessionId/window/:windowhandle/size': {GET: {command: 'getWindowSize'}},
-  '/session/:sessionId/element/:elementId/submit': {POST: {command: 'submit'}},
+  '/session/:sessionId/window/:windowhandle/size': {
+    GET: {
+      command: 'getWindowSize',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/element/:elementId/submit': {
+    POST: {
+      command: 'submit',
+      deprecated: true
+    }
+  },
   '/session/:sessionId/keys': {
-    POST: {command: 'keys', payloadParams: {required: ['value']}},
+    POST: {
+      command: 'keys',
+      payloadParams: {required: ['value']},
+      deprecated: true
+    },
   },
-  '/session/:sessionId/element/:elementId/location': {GET: {command: 'getLocation'}},
-  '/session/:sessionId/element/:elementId/location_in_view': {GET: {command: 'getLocationInView'}},
-  '/session/:sessionId/element/:elementId/size': {GET: {command: 'getSize'}},
-  '/session/:sessionId/appium/device/shake': {POST: {command: 'mobileShake'}},
+  '/session/:sessionId/element/:elementId/location': {
+    GET: {
+      command: 'getLocation',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/element/:elementId/location_in_view': {
+    GET: {
+      command: 'getLocationInView',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/element/:elementId/size': {
+    GET: {
+      command: 'getSize',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/appium/device/shake': {
+    POST: {
+      command: 'mobileShake',
+      deprecated: true
+    }
+  },
   '/session/:sessionId/appium/device/lock': {
-    POST: {command: 'lock', payloadParams: {optional: ['seconds']}},
+    POST: {
+      command: 'lock',
+      payloadParams: {optional: ['seconds']},
+      deprecated: true
+    },
   },
-  '/session/:sessionId/appium/device/unlock': {POST: {command: 'unlock'}},
-  '/session/:sessionId/appium/device/is_locked': {POST: {command: 'isLocked'}},
+  '/session/:sessionId/appium/device/unlock': {
+    POST: {
+      command: 'unlock',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/appium/device/is_locked': {
+    POST: {
+      command: 'isLocked',
+      deprecated: true
+    }
+  },
   '/session/:sessionId/appium/start_recording_screen': {
     POST: {
       command: 'startRecordingScreen',
@@ -41,33 +94,56 @@ export const newMethodMap = /** @type {const} */ ({
     },
   },
   '/session/:sessionId/appium/simulator/touch_id': {
-    POST: {command: 'touchId', payloadParams: {required: ['match']}},
+    POST: {
+      command: 'touchId',
+      payloadParams: {required: ['match']},
+      deprecated: true
+    },
   },
   '/session/:sessionId/appium/simulator/toggle_touch_id_enrollment': {
     POST: {
       command: 'toggleEnrollTouchId',
       payloadParams: {optional: ['enabled']},
+      deprecated: true,
     },
   },
-  '/session/:sessionId/appium/app/launch': {POST: {command: 'launchApp'}},
-  '/session/:sessionId/appium/app/close': {POST: {command: 'closeApp'}},
-  '/session/:sessionId/appium/app/reset': {POST: {command: 'reset'}},
+  '/session/:sessionId/appium/app/launch': {
+    POST: {
+      command: 'launchApp',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/appium/app/close': {
+    POST: {
+      command: 'closeApp',
+      deprecated: true
+    }
+  },
+  '/session/:sessionId/appium/app/reset': {
+    POST: {
+      command: 'reset',
+      deprecated: true
+    }
+  },
   '/session/:sessionId/appium/app/background': {
     POST: {
       command: 'background',
       payloadParams: {required: ['seconds']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/appium/app/strings': {
     POST: {
       command: 'getStrings',
       payloadParams: {optional: ['language', 'stringFile']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/appium/element/:elementId/value': {
     POST: {
       command: 'setValueImmediate',
       payloadParams: {required: ['text']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/appium/receive_async_response': {
@@ -80,6 +156,7 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'getClipboard',
       payloadParams: {optional: ['contentType']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/appium/device/set_clipboard': {
@@ -89,6 +166,7 @@ export const newMethodMap = /** @type {const} */ ({
         required: ['content'],
         optional: ['contentType', 'label'],
       },
+      deprecated: true,
     },
   },
 });

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -19,12 +19,7 @@ export const newMethodMap = /** @type {const} */ ({
       deprecated: true
     }
   },
-  '/session/:sessionId/element/:elementId/submit': {
-    POST: {
-      command: 'submit',
-      deprecated: true
-    }
-  },
+  '/session/:sessionId/element/:elementId/submit': {POST: {command: 'submit'}},
   '/session/:sessionId/keys': {
     POST: {
       command: 'keys',
@@ -45,10 +40,7 @@ export const newMethodMap = /** @type {const} */ ({
     }
   },
   '/session/:sessionId/element/:elementId/size': {
-    GET: {
-      command: 'getSize',
-      deprecated: true
-    }
+    GET: {command: 'getSize'}
   },
   '/session/:sessionId/appium/device/shake': {
     POST: {

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -19,7 +19,12 @@ export const newMethodMap = /** @type {const} */ ({
       deprecated: true
     }
   },
-  '/session/:sessionId/element/:elementId/submit': {POST: {command: 'submit'}},
+  '/session/:sessionId/element/:elementId/submit': {
+    POST: {
+      command: 'submit',
+      deprecated: true
+    }
+  },
   '/session/:sessionId/keys': {
     POST: {
       command: 'keys',
@@ -40,7 +45,10 @@ export const newMethodMap = /** @type {const} */ ({
     }
   },
   '/session/:sessionId/element/:elementId/size': {
-    GET: {command: 'getSize'}
+    GET: {
+      command: 'getSize',
+      deprecated: true
+    }
   },
   '/session/:sessionId/appium/device/shake': {
     POST: {
@@ -142,6 +150,7 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'receiveAsyncResponse',
       payloadParams: {required: ['response']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/appium/device/get_clipboard': {

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -91,6 +91,7 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'queryAppState',
       payloadParams: {required: [['appId'], ['bundleId']]},
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/simulator/touch_id': {
@@ -104,7 +105,7 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'toggleEnrollTouchId',
       payloadParams: {optional: ['enabled']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/app/launch': {
@@ -129,35 +130,35 @@ export const newMethodMap = /** @type {const} */ ({
     POST: {
       command: 'background',
       payloadParams: {required: ['seconds']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/app/strings': {
     POST: {
       command: 'getStrings',
       payloadParams: {optional: ['language', 'stringFile']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/element/:elementId/value': {
     POST: {
       command: 'setValueImmediate',
       payloadParams: {required: ['text']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/receive_async_response': {
     POST: {
       command: 'receiveAsyncResponse',
       payloadParams: {required: ['response']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/device/get_clipboard': {
     POST: {
       command: 'getClipboard',
       payloadParams: {optional: ['contentType']},
-      deprecated: true,
+      deprecated: true
     },
   },
   '/session/:sessionId/appium/device/set_clipboard': {
@@ -167,7 +168,7 @@ export const newMethodMap = /** @type {const} */ ({
         required: ['content'],
         optional: ['contentType', 'label'],
       },
-      deprecated: true,
+      deprecated: true
     },
   },
 });


### PR DESCRIPTION
This PR adds deprecated marks in lib/method-map.js. Some are already mentioned as deprecated in our doc (and current appium master), some will be removed in appium 3 branch. They already have alternatives like extensions.

- https://appium.github.io/appium-xcuitest-driver/latest/reference/commands/ already addressed deprecated
    - `/session/:sessionId/appium/element/:elementId/value`
    - `/session/:sessionId/keys`
    - `/session/:sessionId/appium/receive_async_response`
    - `/session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
    - `/session/:sessionId/appium/simulator/touch_id`
    - `/session/:sessionId/element/:elementId/location`
    - `/session/:sessionId/element/:elementId/location_in_view`
    - `/session/:sessionId/window/:windowhandle/size`
- `/session/:sessionId/timeouts/async_script`
- `/session/:sessionId/timeouts/implicit_wait`
    - -> timeout in w3c
- `/session/:sessionId/appium/device/shake`
    - `mobile: shake`
- `/session/:sessionId/appium/device/lock`
    - `mobile: lock`
- `/session/:sessionId/appium/device/unlock`
    - `mobile: unlock`
- `/session/:sessionId/appium/device/is_locked`
    - `mobile: isLocked`
- `/session/:sessionId/appium/device/app_state`
    - `mobile: queryAppState`
- `/session/:sessionId/appium/element/:elementId/value`
    - Already marked as deprecated. click the element -> send keys etc...
- `/session/:sessionId/appium/device/get_clipboard`
    - `mobile: getClipboard`
- `/session/:sessionId/appium/device/set_clipboard`
    - `mobile: setClipboard`
- `/session/:sessionId/appium/app/launch`
    - already deprecated. `mobile: launchApp`
- `/session/:sessionId/appium/app/reset`
    - already deprecated. combination of terminate an launch etc
- `/session/:sessionId/appium/app/close`
    - already deprecated. `mobile: terminateApp`
- `/session/:sessionId/appium/app/background`
    - `mobile: backgroundApp`
- `/session/:sessionId/appium/app/strings`
    - `mobile: getAppStrings`
- `/session/:sessionId/element/:elementId/submit`
    - click the submit button
- `/session/:sessionId/element/:elementId/size`
    - get element rect