### PR TITLE
chore: Add geolocation endpoints to the method map

### DIFF
--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -171,4 +171,15 @@ export const newMethodMap = /** @type {const} */ ({
       deprecated: true
     },
   },
+  '/session/:sessionId/location': {
+    GET: {
+      command: 'getGeoLocation',
+      deprecated: true,
+    },
+    POST: {
+      command: 'setGeoLocation',
+      payloadParams: {required: ['location']},
+      deprecated: true,
+    },
+  },
 });


### PR DESCRIPTION
These endpoints are part of the JWP protocol. The expected replacement for them is to use corresponding mobile: execute methods