### PR TITLE
refactor: use an object spread instead of Object.assign

### DIFF
--- a/lib/commands/app-strings.js
+++ b/lib/commands/app-strings.js
@@ -17,11 +17,12 @@ export default {
   async getStrings(language, stringFile = null) {
     this.log.debug(`Gettings strings for language '${language}' and string file '${stringFile}'`);
     return await parseLocalizableStrings.bind(this)(
-      Object.assign({}, this.opts, {
+      {
+        ...this.opts,
         language,
         stringFile,
         strictMode: true,
-      }),
+      },
     );
   },
 };

--- a/lib/commands/gesture.js
+++ b/lib/commands/gesture.js
@@ -107,19 +107,16 @@ const commands = {
     // This is mandatory, since WDA only supports TOUCH pointer type
     // and Selenium API uses MOUSE as the default one
     const preprocessedActions = actions
-      .map((action) =>
-        Object.assign(
-          {},
-          action,
-          action.type === 'pointer'
-            ? {
-                parameters: {
-                  pointerType: 'touch',
-                },
-              }
-            : {},
-        ),
-      )
+      .map((action) => ({
+        ...action,
+        ...(action.type === 'pointer'
+          ? {
+              parameters: {
+                pointerType: 'touch',
+              },
+            }
+          : {}),
+      }))
       .map((action) => {
         const modifiedAction = _.clone(action) || {};
         // Selenium API unexpectedly inserts zero pauses, which are not supported by WDA
@@ -473,7 +470,7 @@ const helpers = {
    * @throws If the target device does not support the "force press" gesture.
    * @param {number} [x] - The _x_ coordinate of the gesture. If `elementId` is set, this is calculated relative to its position; otherwise it's calculated relative to the active Application.
    * @param {number} [y] - The _y_ coordinate of the gesture. If `elementId` is set, this is calculated relative to its position; otherwise it's calculated relative to the active Application.
-   * @param {number} [duration] - The duraiton (in seconds) of the force press. If this is provided, `pressure` must also be provided.
+   * @param {number} [duration] - The duration (in seconds) of the force press. If this is provided, `pressure` must also be provided.
    * @param {number} [pressure] - A float value defining the pressure of the force press. If this is provided, `duration` must also be provided.
    * @param {string|Element} [elementId] - The internal element identifier (as hexadecimal hash string) to perform one or more taps.
    * The Application element will be used if this parameter is not provided.

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -429,7 +429,7 @@ export class XCUITestDriver extends BaseDriver {
       await this.start();
 
       // merge server capabilities + desired capabilities
-      caps = Object.assign({}, defaultServerCaps, caps);
+      caps = { ...defaultServerCaps, ...caps };
       // update the udid with what is actually used
       caps.udid = this.opts.udid;
       // ensure we track nativeWebTap capability as a setting as well
@@ -1025,8 +1025,8 @@ export class XCUITestDriver extends BaseDriver {
       await simulatorDevice.delete();
     }
 
-    const shouldResetLocationServivce = this.isRealDevice() && !!this.opts.resetLocationService;
-    if (shouldResetLocationServivce) {
+    const shouldResetLocationService = this.isRealDevice() && !!this.opts.resetLocationService;
+    if (shouldResetLocationService) {
       try {
         await this.mobileResetLocationService();
       } catch {

--- a/test/functional/tv/tvos-e2e-specs.js
+++ b/test/functional/tv/tvos-e2e-specs.js
@@ -42,7 +42,7 @@ describe('tvOS', function () {
   });
 
   beforeEach(function () {
-    baseCaps = Object.assign({}, TVOS_CAPS, {udid});
+    baseCaps = {...TVOS_CAPS, udid};
   });
 
   afterEach(async function () {

--- a/test/functional/web/safari-basic-e2e-specs.js
+++ b/test/functional/web/safari-basic-e2e-specs.js
@@ -408,10 +408,11 @@ describe('Safari - basics -', function () {
           });
 
           it('should be able to set a cookie with expiry', async function () {
-            const expiredCookie = Object.assign({}, newCookie, {
+            const expiredCookie = {
+              ...newCookie,
               expiry: parseInt(String(Date.now() / 1000), 10) - 1000, // set cookie in past
               name: 'expiredcookie',
-            });
+            };
 
             let cookies = await driver.getAllCookies();
             doesNotIncludeCookie(cookies, expiredCookie);

--- a/test/functional/web/safari-ssl-e2e-specs.js
+++ b/test/functional/web/safari-ssl-e2e-specs.js
@@ -80,11 +80,12 @@ describe('Safari SSL', function () {
   });
 
   describe('cookies', function () {
-    const secureCookie = Object.assign({}, newCookie, {
+    const secureCookie = {
+      ...newCookie,
       secure: true,
       name: 'securecookie',
       value: 'this is a secure cookie',
-    });
+    };
 
     before(async function () {
       driver = await initSession(caps);

--- a/test/unit/language-specs.js
+++ b/test/unit/language-specs.js
@@ -48,7 +48,8 @@ describe('language and locale', function () {
       const expectedWDACapabilities = {
         capabilities: {
           firstMatch: [
-            Object.assign({}, DEFAULT_CAPS, {
+            {
+              ...DEFAULT_CAPS,
               bundleId: BUNDLE_ID,
               arguments: [
                 '-AppleLanguages',
@@ -58,7 +59,7 @@ describe('language and locale', function () {
                 '-AppleLocale',
                 LOCALE,
               ],
-            }),
+            },
           ],
           alwaysMatch: {},
         },
@@ -111,11 +112,11 @@ describe('language and locale', function () {
       const expectedWDACapabilities = {
         capabilities: {
           firstMatch: [
-            Object.assign({}, DEFAULT_CAPS, {
+            {...DEFAULT_CAPS,
               bundleId: BUNDLE_ID,
               arguments: augmentedProcessArgumentsWithLanguage.args,
               environment: processArguments.env,
-            }),
+            },
           ],
           alwaysMatch: {},
         },

--- a/test/unit/processargs-specs.js
+++ b/test/unit/processargs-specs.js
@@ -34,11 +34,12 @@ describe('process args', function () {
   let desired = {
     capabilities: {
       firstMatch: [
-        Object.assign({}, DEFAULT_CAPS, {
+        {
+          ...DEFAULT_CAPS,
           bundleId: BUNDLE_ID,
           arguments: PROCESS_ARGS_OBJECT.args,
           environment: PROCESS_ARGS_OBJECT.env,
-        }),
+        },
       ],
       alwaysMatch: {},
     },


### PR DESCRIPTION
use an object spread instead of Object.assign to make it more concise and readable