### PR TITLE
docs: add additional unnecessary module removal in run-preinstalled-wda

### DIFF
--- a/docs/guides/run-preinstalled-wda.md
+++ b/docs/guides/run-preinstalled-wda.md
@@ -65,6 +65,12 @@ Then you can remove `Frameworks/XC**` in `WebDriverAgentRunner-Runner.app` like 
 
 Configuring `appium:prebuiltWDAPath` to the `/Users/<user>/Library/Developer/Xcode/DerivedData/WebDriverAgent-ezumztihszjoxgacuhatrhxoklbh/Build/Products/Debug-appletvos/WebDriverAgentRunner-Runner.app` would install the `WebDriverAgentRunner-Runner.app`, which has no `Frameworks/XC**` to the target device and launch it with `devicectl` command as part of `appium:usePreinstalledWDA` functionality.
 
+!!! note
+
+    You can also remove `Frameworks/Testing.framework` and `Frameworks/libXCTestSwiftSupport.dylib` to reduce the package size
+    because WebDriverAgent doesn't need both. Then, the total size of the WebDriverAgent runner app can be 3MB or less.
+    `Testing.framework` is almost 6MB and `libXCTestSwiftSupport.dylib` is 2.6MB with Xcode 16 build.
+    
 
 ## Launch the Session
 


### PR DESCRIPTION
To address a small tips to reduce the amount of WDA.app for real device use.