### PR TITLE
feat: add focused attribute to element representation in XML source tree

### DIFF
--- a/lib/commands/source.js
+++ b/lib/commands/source.js
@@ -93,6 +93,7 @@ function getTreeForXML(srcTree) {
         enabled: parseInt(element.isEnabled, 10) === 1,
         visible: parseInt(element.isVisible, 10) === 1,
         accessible: parseInt(element.isAccessible, 10) === 1,
+        focused: parseInt(element.isFocused, 10) === 1,
         x: rect.x,
         y: rect.y,
         width: rect.width,


### PR DESCRIPTION
The **isFocused** attribute is sent by WebDriverAgent, but it is not utilised in this library. As a result, the focused property is not visible in tools like Appium Inspector. This flag should be properly considered and handled to reflect the focus state of elements accurately.

After adding the property
<img width="601" alt="image" src="https://github.com/user-attachments/assets/b4797905-11f3-41f3-80e7-313ca6c318fd" />
