### PR TITLE
ci: add explicit write permission

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This repository is old, so to keep the backward compatibility GitHub automatically added write permission for GITHUB_TOKEN, but this explicit method is expected one for them.

Let's use proper method.