### PR TITLE
docs: update prebuilt page

### DIFF
--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -94,7 +94,7 @@ Then, starting a new session with capabilities below:
 }
 ```
 
-The new session starts wihtout `xcodebuild` run.
+The new session starts without `xcodebuild` run.
 
 ### Capabilities for Prebuilt WDA with `appium:useXctestrunFile`, `appium:usePrebuiltWDA` or `appium:prebuildWDA`
 

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -60,7 +60,7 @@ xcodebuild test-without-building \
 
 ### Download Prebuilt WDA and run them with `appium:prebuiltWDAPath` and `appium:usePreinstalledWDA`
 
-This approach lets the XCUITest driver start WDA without running `xcodebuild` by using prebuilt WDA packages.
+This approach allows the XCUITest driver to start WDA without running `xcodebuild` by using prebuilt WDA packages.
 We recommend this method if you don't need to modify the WDA source code.
 
 [The Appium WebDriverAgent GitHub page](https://github.com/appium/WebDriverAgent/releases) provides

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -75,7 +75,7 @@ workflows may help with validating the build script.
 
 [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md) provides `appium:prebuiltWDAPath`
 and `appium:usePreinstalledWDA` capabilities.
-These capabilities combination allows XCUITest driver installing prebuilt WDA specified with
+These capabilities combination allows the XCUITest driver to install prebuilt WDA specified with
 `appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
 
 `download-wda-sim` command helps to download proper version of WDA for your XCUITest driver version

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -76,7 +76,7 @@ workflows may help with validating the build script.
 [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md) provides `appium:prebuiltWDAPath`
 and `appium:usePreinstalledWDA` capabilities.
 These capabilities combination allows the XCUITest driver to install prebuilt WDA specified with
-`appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
+`appium:prebuiltWDAPath` and start it **without** `xcodebuild`.
 
 The `download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
 for simulator use.

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -94,7 +94,7 @@ Then, starting a new session with capabilities below:
 }
 ```
 
-The new session starts without `xcodebuild` run.
+The new session starts without an `xcodebuild` run.
 
 ### Capabilities for Prebuilt WDA with `appium:useXctestrunFile`, `appium:usePrebuiltWDA` or `appium:prebuildWDA`
 

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -3,16 +3,17 @@ title: Run Prebuilt WebDriverAgentRunner
 ---
 
 The XCUITest driver runs `xcodebuild` to build and install the WebDriverAgentRunner (WDA) app on the
-target device. You can manually run a modified version of this command in order to prebuild the WDA.
+target device. Running the command every time could slow down the new session creation performance.
+You can manually run a modified version of this command in order to prebuild the WDA.
 
-## How `xcodebuild` Works
+## Understanding How `xcodebuild` Works
 
 By default, `xcodebuild` is run with two commands: `build-for-testing` and `test-without-building`.
-`build-for-testing` builds a test bundle package, whereas `test-without-building` actually runs it.
+`build-for-testing` is to build a test bundle package, whereas `test-without-building` is to run it.
 
 For instance, XCUITest driver issues an `xcodebuild` command like so:
 
-```
+```bash
 xcodebuild build-for-testing test-without-building \
   -project WebDriverAgent.xcodeproj \
   -derivedDataPath wda_build \
@@ -22,11 +23,11 @@ xcodebuild build-for-testing test-without-building \
 ```
 
 This translates to `xcodebuild` building `WebDriverAgent.xcodeproj` and running the resulting
-package on the specified device.
+package on the specified device. `wda_build` path will have the built package.
 
 The command can be split into `build-for-testing` and `test-without-building` parts as follows:
 
-```
+```bash
 xcodebuild build-for-testing \
   -project WebDriverAgent.xcodeproj \
   -derivedDataPath wda_build \
@@ -35,7 +36,7 @@ xcodebuild build-for-testing \
   CODE_SIGNING_ALLOWED=NO
 ```
 
-```
+```bash
 xcodebuild test-without-building \
   -xctestrun wda_build/Build/Products/WebDriverAgentRunner_iphonesimulator16.2-arm64.xctestrun \
   -destination "platform=iOS Simulator,name=iPhone 14 Pro"
@@ -55,7 +56,47 @@ xcodebuild test-without-building \
   provided `.xctestrun` file. Once this is done, `http://localhost:8100` will be able to receive
   commands for the target device.
 
-## Capabilities for Prebuilt WDA with `appium:useXctestrunFile`, `appium:usePrebuiltWDA` or `appium:prebuildWDA`
+## Preparation performance improvement ideas
+
+### Download Prebuilt WDA and run them with `appium:prebuiltWDAPath` and `appium:usePreinstalledWDA`
+
+This approach lets the XCUITest driver start WDA without running `xcodebuild` by using prebuilt WDA packages.
+We recommend this method if you don't need to modify the WDA source code.
+
+[The Appium WebDriverAgent GitHub page](https://github.com/appium/WebDriverAgent/releases) provides
+downloads for WebDriverAgent packages for real devices and simulators.
+WebDriverAgent packages for real devices do not have embedded XCTest frameworks so that
+they can run on iOS 17+ devices. Please read [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md)
+for more details. Understanding app signing is also important for real devices.
+Simulators need everything, so WDA package sizes for simulators are greater than for real devices.
+The [Release](https://github.com/appium/appium-xcuitest-driver/actions/workflows/publish.js.yml) and
+[Building WebDriverAgent](https://github.com/appium/WebDriverAgent/actions/workflows/wda-package.yml)
+workflows may help with validating the build script.
+
+[Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md) provides `appium:prebuiltWDAPath`
+and `appium:usePreinstalledWDA` capabilities.
+These capabilities combination allows XCUITest driver installing prebuilt WDA specified with
+`appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
+
+`download-wda-sim` command helps to download proper version of WDA for your XCUITest driver version
+in simulator use.
+
+```bash
+appium driver run xcuitest download-wda-sim --outdir=/path/to/target/directory
+```
+
+Then, starting a new session with capabilities below:
+
+```json
+{
+  "appium:usePreinstalledWDA": true,
+  "appium:prebuiltWDAPath": "/path/to/target/directory/WebDriverAgentRunner-Runner.app"
+}
+```
+
+The new session starts wihtout `xcodebuild` run.
+
+### Capabilities for Prebuilt WDA with `appium:useXctestrunFile`, `appium:usePrebuiltWDA` or `appium:prebuildWDA`
 
 The XCUITest driver provides two capabilities that allow skipping the `build-for-testing` command,
 and executing only the `test-without-building` command: __`appium:useXctestrunFile`__ and
@@ -68,7 +109,6 @@ __`appium:bootstrapPath`__ (see [Capabilities](../reference/capabilities.md#webd
 
 This method can be used on both real devices and simulators, but real devices requires proper
 signing as described in [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md).
-We recommend using this method for real devices.
 
 The capabilities can be used as follows:
 
@@ -76,8 +116,8 @@ The capabilities can be used as follows:
 {
   "platformName": "ios",
   "appium:automationName": "xcuitest",
-  "appium:platformVersion": "15.5",
-  "appium:deviceName": "iPhone 12",
+  "appium:platformVersion": "18.4",
+  "appium:deviceName": "iPhone 16",
   "appium:useXctestrunFile": true,
   "appium:bootstrapPath": "/path/to/wda_build/Build/Products"
 }
@@ -93,24 +133,3 @@ __`appium:prebuildWDA`__ lets the XCUITest driver build the WDA before running i
 will be handled with `appium:usePrebuiltWDA`.
 It might have additional building steps than with `appium:derivedDataPath` and `appium:usePrebuiltWDA`
 combination, but it could help `appium:usePrebuiltWDA` to not manage the WDA project.
-
-## Capabilities for Prebuilt WDA with `appium:prebuiltWDAPath` and `appium:usePreinstalledWDA`
-
-[Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md) provides `appium:prebuiltWDAPath`
-and `appium:usePreinstalledWDA` capabilities.
-It also achieves the same thing, but the `appium:prebuiltWDAPath` does not use `xcodebuild`.
-The method will help to avoid `xcodebuild` related slowness.
-
-## Download Prebuilt WDA
-
-[The Appium WebDriverAgent GitHub page](https://github.com/appium/WebDriverAgent/releases) provides
-downloads for WebDriverAgent packages for real devices and simulators.
-WebDriverAgent packages for real devices do not have embedded XCTest frameworks so that
-they can run on iOS 17+ devices.
-Simulators need everything, so package sizes for simulators are greater than for real devices.
-
-The [Release](https://github.com/appium/appium-xcuitest-driver/actions/workflows/publish.js.yml) and
-[Building WebDriverAgent](https://github.com/appium/WebDriverAgent/actions/workflows/wda-package.yml)
-workflows may help with validating the build script.
-
-`appium driver run xcuitest download-wda-sim` command helps to download the prebuilt WDA.

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -9,7 +9,7 @@ You can manually run a modified version of this command in order to prebuild the
 ## Understanding How `xcodebuild` Works
 
 By default, `xcodebuild` is run with two commands: `build-for-testing` and `test-without-building`.
-`build-for-testing` builds a test bundle package, whereas `test-without-building` runs it.
+`build-for-testing` builds a test bundle package, whereas `test-without-building` actually runs it.
 
 For instance, XCUITest driver issues an `xcodebuild` command like so:
 

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -3,7 +3,7 @@ title: Run Prebuilt WebDriverAgentRunner
 ---
 
 The XCUITest driver runs `xcodebuild` to build and install the WebDriverAgentRunner (WDA) app on the
-target device. Running the command every time could slow down the new session creation performance.
+target device. Running the command every time could slow down new session creation.
 You can manually run a modified version of this command in order to prebuild the WDA.
 
 ## Understanding How `xcodebuild` Works

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -23,7 +23,7 @@ xcodebuild build-for-testing test-without-building \
 ```
 
 This translates to `xcodebuild` building `WebDriverAgent.xcodeproj` and running the resulting
-package on the specified device. `wda_build` path will have the built package.
+package on the specified device. The built package will be located in the `wda_build` path.
 
 The command can be split into `build-for-testing` and `test-without-building` parts as follows:
 

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -78,7 +78,7 @@ and `appium:usePreinstalledWDA` capabilities.
 These capabilities combination allows the XCUITest driver to install prebuilt WDA specified with
 `appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
 
-`download-wda-sim` command helps to download proper version of WDA for your XCUITest driver version
+`download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
 in simulator use.
 
 ```bash

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -78,7 +78,7 @@ and `appium:usePreinstalledWDA` capabilities.
 These capabilities combination allows the XCUITest driver to install prebuilt WDA specified with
 `appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
 
-`download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
+The `download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
 in simulator use.
 
 ```bash

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -9,7 +9,7 @@ You can manually run a modified version of this command in order to prebuild the
 ## Understanding How `xcodebuild` Works
 
 By default, `xcodebuild` is run with two commands: `build-for-testing` and `test-without-building`.
-`build-for-testing` is to build a test bundle package, whereas `test-without-building` is to run it.
+`build-for-testing` builds a test bundle package, whereas `test-without-building` runs it.
 
 For instance, XCUITest driver issues an `xcodebuild` command like so:
 

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -67,7 +67,7 @@ We recommend this method if you don't need to modify the WDA source code.
 downloads for WebDriverAgent packages for real devices and simulators.
 WebDriverAgent packages for real devices do not have embedded XCTest frameworks so that
 they can run on iOS 17+ devices. Please read [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md)
-for more details. Understanding app signing is also important for real devices.
+for more details about running on real devices. Understanding app signing is also important when working with real devices.
 Simulators need everything, so WDA package sizes for simulators are greater than for real devices.
 The [Release](https://github.com/appium/appium-xcuitest-driver/actions/workflows/publish.js.yml) and
 [Building WebDriverAgent](https://github.com/appium/WebDriverAgent/actions/workflows/wda-package.yml)

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -79,7 +79,7 @@ These capabilities combination allows the XCUITest driver to install prebuilt WD
 `appium:prebuiltWDAPath` and starting it **without** `xcodebuild`.
 
 The `download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
-in simulator use.
+for simulator use.
 
 ```bash
 appium driver run xcuitest download-wda-sim --outdir=/path/to/target/directory

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -75,8 +75,8 @@ workflows may help with validating the build script.
 
 [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md) provides `appium:prebuiltWDAPath`
 and `appium:usePreinstalledWDA` capabilities.
-These capabilities combination allows the XCUITest driver to install prebuilt WDA specified with
-`appium:prebuiltWDAPath` and start it **without** `xcodebuild`.
+These capabilities allow the XCUITest driver to install prebuilt WDA specified with
+`appium:prebuiltWDAPath` and start it **without** running `xcodebuild`.
 
 The `download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
 for simulator use.

--- a/docs/guides/run-preinstalled-wda.md
+++ b/docs/guides/run-preinstalled-wda.md
@@ -105,6 +105,15 @@ bundle ID, the session will launch the WebDriverAgent process without `xcodebuil
     For example, check whether the provisioning profile is trusted.
 
 
+!!! note
+
+    Please make sure the device under test has the developer disk image mounted.
+    This is necessary to start an XCTest session and load the required XCTest libraries from the device.
+    For example, starting Xcode after connecting the device to the host machine will mount the developer disk image automatically.
+    Using third-party tools can also help to mount the developer disk image service.
+    Please check the documentation for each tool to understand how to mount the developer disk image.
+
+
 ```ruby
 # Ruby
 capabilities: {


### PR DESCRIPTION
I think now `download-wda-sim` and using `usePreinstalledWDA` and `prebuiltWDAPath` can be a recommended way to improve the new session creation performance for simulators.

So... maybe it's nice to move the idea before the `useXctestrunFile` one