### PR TITLE
chore: make  appium-ios-remotexpc optional deps

### DIFF
--- a/lib/commands/battery.js
+++ b/lib/commands/battery.js
@@ -13,9 +13,9 @@ export default {
   async mobileGetBatteryInfo() {
     let batteryInfoFromShimService;
     if (isIos18OrNewer(this.opts) && this.isRealDevice()) {
-      const {Services} = await import('appium-ios-remotexpc');
       let remoteXPCConnection;
       try {
+        const {Services} = await import('appium-ios-remotexpc');
         let { diagnosticsService, remoteXPC } = await Services.startDiagnosticsService(this.device.udid);
         remoteXPCConnection = remoteXPC;
         batteryInfoFromShimService = await diagnosticsService.ioregistry({

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "appium-idb": "^1.6.13",
     "appium-ios-device": "^2.8.0",
     "appium-ios-simulator": "^6.2.2",
-    "appium-ios-remotexpc": "^0.x",
     "appium-remote-debugger": "^13.1.0",
     "appium-webdriveragent": "^9.11.0",
     "appium-xcode": "^5.1.4",
@@ -105,6 +104,9 @@
     "winston": "3.17.0",
     "ws": "^8.13.0"
   },
+  "optionalDependencies": {
+    "appium-ios-remotexpc": "^0.x"
+  }
   "scripts": {
     "build": "tsc -b",
     "clean": "npm run build -- --clean",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "optionalDependencies": {
     "appium-ios-remotexpc": "^0.x"
-  }
+  },
   "scripts": {
     "build": "tsc -b",
     "clean": "npm run build -- --clean",


### PR DESCRIPTION
Then, at least this module-related installation failure would not block the xcuitest driver installation itself.

https://github.com/appium/appium-ios-tuntap/issues/15