### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "mocha-multi-reporters": "^1.5.1",
     "pem": "^1.14.8",
     "prettier": "^3.0.0",
-    "rimraf": "^5.0.1",
     "semantic-release": "^24.0.0",
     "sharp": "^0.x",
     "sinon": "^21.0.0",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
CHANGELOG.md:* Bump rimraf from 3.0.2 to 4.4.1 ([#1536](https://github.com/appium/appium-xcuitest-driver/issues/1536)) ([8dd4515](https://github.com/appium/appium-xcuitest-driver/commit/8dd4515a3f10a090cd49881217fb98903339a786))
lib/app-infos-cache.js:          await fs.rimraf(tmpRoot);
lib/app-utils.js:      await fs.rimraf(tmpRoot);
lib/app-utils.js:    await fs.rimraf(tmpRoot);
lib/app-utils.js:    await fs.rimraf(tmpRoot);
lib/app-utils.js:      await fs.rimraf(rootDir);
lib/app-utils.js:    await fs.rimraf(ipaPath);
lib/app-utils.js:    await fs.rimraf(rootDir);
lib/commands/app-management.js:    await B.all(items.map((item) => fs.rimraf(path.join(dataRoot, item))));
lib/commands/certificate.js:    await fs.rimraf(tempCert.path);
lib/commands/certificate.js:      await fs.rimraf(tmpRoot);
lib/commands/file-movement.js:    await fs.rimraf(dstFolder);
lib/commands/file-movement.js:  await fs.rimraf(pathOnServer);
lib/commands/pcap.js:      await fs.rimraf(this.resultPath);
lib/commands/performance.js:        await fs.rimraf(path.dirname(this._reportPath));
lib/commands/performance.js:            .map((x) => fs.rimraf(x)),
lib/commands/performance.js:    await fs.rimraf(resultPath);
lib/commands/record-audio.js:      await fs.rimraf(this.audioPath);
lib/commands/recordscreen.js:      await fs.rimraf(this.videoPath);
lib/commands/xctest-record-screen.js:      await fs.rimraf(videoPath);
lib/device-log/ios-crash-log.ts:      await fs.rimraf(tmpRoot);
lib/ios-fs-helpers.js:    await fs.rimraf(tmpFolder);
lib/real-device-clients/py-ios-device-client.ts:        await fs.rimraf(tmpRoot);
lib/utils.js:          await fs.rimraf(location);
lib/utils.js:              fs.rimraf(itemPath);
package.json:    "rimraf": "^5.0.1",
test/functional/device/file-movement-e2e-specs.js:          await fs.rimraf(tmpRoot);
test/unit/app-infos-cache-specs.js:        await fs.rimraf(tmpDir);
test/unit/app-infos-cache-specs.js:        await fs.rimraf(ipaPath);
test/unit/app-utils-specs.js:        await fs.rimraf(tmpDir);
test/unit/app-utils-specs.js:          await fs.rimraf(appRoot);
test/unit/app-utils-specs.js:        await fs.rimraf(tmpDir);
test/unit/app-utils-specs.js:        await fs.rimraf(tmpDir);
test/unit/app-utils-specs.js:          await fs.rimraf(appRoot);
test/unit/app-utils-specs.js:        await fs.rimraf(tmpDir);
test/unit/logs-helpers-specs.js:      await fs.rimraf(tmpRoot);
```

instead of https://github.com/appium/appium-xcuitest-driver/pull/2426