### PR TITLE
ci: use ios 18.5 simulator since 18.2 no longer exists

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -33,9 +33,9 @@ jobs:
         xcodeVersion: ['16.2', '15.4']
         include:
         - xcodeVersion: '16.2'
-          iosVersion: '18.2'
+          iosVersion: '18.5'
           deviceName: 'iPhone 16'
-          tvosVersion: '18.2'
+          tvosVersion: '18.5'
           tvosDeviceName: 'Apple TV'
           platform: macos-15
         - xcodeVersion: '15.4'

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -30,9 +30,9 @@ jobs:
         - driver
         - web
         - long
-        xcodeVersion: ['16.2', '15.4']
+        xcodeVersion: ['16.4', '15.4']
         include:
-        - xcodeVersion: '16.2'
+        - xcodeVersion: '16.4'
           iosVersion: '18.5'
           deviceName: 'iPhone 16'
           tvosVersion: '18.5'


### PR DESCRIPTION
...

https://github.com/appium/appium-xcuitest-driver/actions/runs/17015041298/job/48236195981?pr=2607

Expected result is the func tests pass