### PR TITLE
fix: add TypeScript declarations to npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lib",
     "scripts",
     "build/index.js",
+    "build/index.d.ts",
     "build/lib",
     "!.DS_Store",
     "CHANGELOG.md",


### PR DESCRIPTION
Hi everybody!

when I used this library in a TypeScript project, I found that the type hints were missing because index.d.ts was not included in the npm package build, so I submitted this PR.