### PR TITLE
feat: Bump ios-simulator

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -806,6 +806,7 @@ export class XCUITestDriver extends BaseDriver {
       try {
         const idb = new IDB({udid: this.opts.udid});
         await idb.connect();
+        // @ts-ignore This is ok. We are going to ditch idb soon anyway
         device.idb = idb;
       } catch (e) {
         this.log.debug(e.stack);

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@colors/colors": "^1.6.0",
     "appium-idb": "^2.0.0",
     "appium-ios-device": "^3.0.0",
-    "appium-ios-simulator": "^7.0.0",
+    "appium-ios-simulator": "^8.0.0",
     "appium-remote-debugger": "^15.2.0",
     "appium-webdriveragent": "^10.2.1",
     "appium-xcode": "^6.0.2",


### PR DESCRIPTION
This might also be a breaking patch, but since we anyway only target to support only two latest Xcode releases in this driver version 14 perfectly matches there.