### PR TITLE
docs: add resigner to help free account as well in docs/getting-started/provisioning-profile/generic-device-config.md

### DIFF
--- a/docs/getting-started/provisioning-profile/generic-device-config.md
+++ b/docs/getting-started/provisioning-profile/generic-device-config.md
@@ -37,13 +37,30 @@ As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOW
 by yourself. This would make the device management more flexible, but you would need to know about
 advanced codesign usage scenarios.
 
-!!! note
+The Appium team distributes generic builds with `CODE_SIGNING_ALLOWED=NO` at
+[WebDriverAgent package releases](https://github.com/appium/WebDriverAgent/releases).
+It is recommended to sign packages with a wildcard (`*`) provisioning profile,
+although such profiles require a paid Apple Developer account.
+For example, if you're preparing such a provisioning profile for `io.appium.WebDriverAgentRunner.xctrunner`, it will be for `io.appium.*`, `io.appium.WebDriverAgentRunner.*` or `*`.
 
-    The Appium team distributes generic builds with `CODE_SIGNING_ALLOWED=NO` at
-    [WebDriverAgent package releases](https://github.com/appium/WebDriverAgent/releases).
-    It is recommended to sign packages with a wildcard (`*`) provisioning profile,
-    although such profiles require a paid Apple Developer account.
-    For example, if you're preparing such a provisioning profile for `io.appium.WebDriverAgentRunner.xctrunner`, it will be for `io.appium.*`, `io.appium.WebDriverAgentRunner.*` or `*`.
-    In case of a free account, you may need to update the bundle id before building
-    the WebDriverAgent package to prepare a properly signed WebDriverAgent package
-    by `xcodebuild`.
+In case of a free account or paid account without `*` provisioning profile,
+you may need to update the bundle id before building so `xcodebuild` can produce
+a properly signed WebDriverAgent package. Another option is to re-sign an existing
+package and remap its bundle ids with 3rd party tools such as [resigner](https://github.com/KazuCocoa/resigner).
+The tool can remap the bundle ids to values allowed by the free provisioning profile and
+then sign the package with that profile.
+
+Please check the tool's readme for details, but in short, you can use the following command to
+re-sign the package with bundle id remapping:
+
+```
+resigner \
+  --p12-file "<path to p12 file>" \
+  --p12-password "<password of p12>" \
+  --profile "<path to provisioning profiles>" \
+  --force \
+  --bundle-id-remap "com.facebook.WebDriverAgentRunner=<valid bundle id for the profile>" \
+  --bundle-id-remap "com.facebook.WebDriverAgentRunner.xctrunner=<valid bundle id for the profile>" \
+  --bundle-id-remap "com.facebook.WebDriverAgentLib=<valid bundle id for the profile>" \
+  /path/to/WebDriverAgentRunner-Runner.app
+```

--- a/docs/guides/run-preinstalled-wda.md
+++ b/docs/guides/run-preinstalled-wda.md
@@ -44,8 +44,7 @@ If using a real device, you may need to change your bundle ID. Please check the
 
 Some 3rd party tools such as [pymobiledevice3](https://github.com/doronz88/pymobiledevice3),
 [ios-deploy](https://github.com/ios-control/ios-deploy), [go-ios](https://github.com/danielpaulus/go-ios) and
-[tidevice](https://github.com/alibaba/taobao-iphone-device), [ios-app-signer](https://github.com/DanTheMan827/ios-app-signer)
-can install the WebDriverAgent package.
+[tidevice](https://github.com/alibaba/taobao-iphone-device) can install the WebDriverAgent package.
 
 Some tools let you set an arbitrary bundle identifier (`CFBundleIdentifier` for the `Info.plist`) and sign it with the bundle identifier.
 It may not have `.xctrunner` as the bundle identifier.
@@ -70,7 +69,6 @@ Configuring `appium:prebuiltWDAPath` to the `/Users/<user>/Library/Developer/Xco
     You can also remove `Frameworks/Testing.framework` and `Frameworks/libXCTestSwiftSupport.dylib` to reduce the package size
     because WebDriverAgent doesn't need both. Then, the total size of the WebDriverAgent runner app can be 3MB or less.
     `Testing.framework` is almost 6MB and `libXCTestSwiftSupport.dylib` is 2.6MB with Xcode 16 build.
-    
 
 ## Launch the Session
 


### PR DESCRIPTION
Recently, I worked to build a resignation tool to help re-map the existing bundle id.

```
./resigner --inspect /Users/kazu/Downloads/WebDriverAgentRunner-Runner.app
Path: WebDriverAgentRunner-Runner.app
BundleID: com.facebook.WebDriverAgentRunner.xctrunner
CodeIdentifier: com.apple.XCTRunner
TeamID: 59GAB85EFG
Certificate: Apple Root CA
---
Path: WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest
BundleID: com.facebook.WebDriverAgentRunner
CodeIdentifier: -
TeamID: -
Certificate: -
---
Path: WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework
BundleID: com.facebook.WebDriverAgentLib
CodeIdentifier: -
TeamID: -
Certificate: -
```

This is our WDA release package's one. With:

```
$ ./resigner \                                                              
--p12-file="/Users/kazu/Desktop/myp12.p12" \
--p12-password="1234567890" \
--profile="/Users/kazu/sign/profiles" \
--force \
--bundle-id-remap="com.facebook.WebDriverAgentRunner=com.kazucocoa.WebDriverAgentRunner.xctrunner" \
--bundle-id-remap="com.facebook.WebDriverAgentRunner.xctrunner=com.kazucocoa.WebDriverAgentRunner.xctrunner" \
--bundle-id-remap="com.facebook.WebDriverAgentLib=com.kazucocoa.WebDriverAgentRunner.xctrunner" \
/Users/kazu/Downloads/WebDriverAgentRunner-Runner.app
```
, they will be:

```
kazu $ ./resigner --inspect /Users/kazu/Downloads/WebDriverAgentRunner-Runner.app
Path: WebDriverAgentRunner-Runner.app
BundleID: com.kazucocoa.WebDriverAgentRunner.xctrunner
CodeIdentifier: com.kazucocoa.WebDriverAgentRunner.xctrunner
TeamID: <team id>
Certificate: Apple Development: <user email> (<user id>)
---
Path: WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest
BundleID: com.kazucocoa.WebDriverAgentRunner.xctrunner
CodeIdentifier: com.kazucocoa.WebDriverAgentRunner.xctrunner
TeamID: <team id>
Certificate: Apple Development: <user email> (<user id>)
---
Path: WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework
BundleID: com.kazucocoa.WebDriverAgentRunner.xctrunner
CodeIdentifier: com.kazucocoa.WebDriverAgentRunner.xctrunner
TeamID: <team id>
Certificate: Apple Development: <user email> (<user id>)
```

This is with free account example. How to build p12 etc (necessary things) are in the repository's README