### PR TITLE
docs: update element attributes reference

### DIFF
--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -1,28 +1,164 @@
 ---
-hide:
-  - toc
-
 title: Element Attributes
 ---
 
-The XCUITest driver supports the following element attributes:
+The XCUITest driver supports various native and custom element attributes.
 
-| <div style="width:6em">Name</div> | Description | <div style="width:8em">Example</div> |
-| --- | --- | --- |
-| `name` | Could contain either element's [identifier](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500981-identifier?language=objc) or its [label](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500692-label?language=objc), depending on which one is available first. Could also be `null`. It is recommended to prefer the usage of [accessibilityIdentifier](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) over [accessibilityLabel](https://developer.apple.com/documentation/objectivec/nsobject/1615181-accessibilitylabel) for automation purposes, since the `identifier` property is supposed to stay constant under different locales and does not affect accessibility services such as VoiceOver. In applications written using [ReactNative](https://reactnative.dev/) framework this attribute reflects the value of the `testID` property. | `hello` |
-| `label` | Element's [label](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500692-label?language=objc) value. Could be `null`. Since XCUITest driver 4.7.3 (WebDriverAgent 4.8.0), the behavior of this value was better aligned with XCTest, so it could include line breaks (`\n`). Before this version, line breaks were replaced by spaces. | `hello`, `hello\nworld` |
-| `type` | Element's [type](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500614-elementtype?language=objc) name | `XCUIElementTypeButton` |
-| `visible` | Whether the element is visible. This value is not available in the "vanilla" XCTest and is read directly from the accessibility layer | `false` |
-| `focused` | Whether the element is [focused](https://developer.apple.com/documentation/xctest/xcuielementattributes/1627636-hasfocus?language=objc). Before driver version 4.25.4, this was only available for tvOS. | `true` |
-| `accessible` | Whether the element is accessible. This value is not available in the "vanilla" XCTest and is read directly from the accessibility layer | `true` |
-| `enabled` | Whether the element is [enabled](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500330-enabled?language=objc). | `false` |
-| `selected` | Whether the element is [selected](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500581-selected?language=objc) | `false` |
-| `index` | Element's index in the hierarchy relatively to its parent. Only available since Appium 1.20.0. Indexing starts from `0`. | `2` |
-| `rect` | Element's rectangle. The actual data of this attribute is based on element's [frame](https://developer.apple.com/documentation/xctest/xcuielementattributes/1500911-frame?language=objc). | `{'x': 0, 'y': 0, 'width': 100, 'height': 100}` |
-| `value` | Element's value. This is a complex attribute, whose calculation algorithm depends on the actual element type. Check [WebDriverAgent sources](https://github.com/appium/WebDriverAgent/blob/master/WebDriverAgentLib/Categories/XCUIElement%2BFBWebDriverAttributes.m) to know more about how it is compiled (method `- (NSString *)wdValue`). Could be `null` | `hello` |
-| `hittable` | Whether the element is [hittable](https://developer.apple.com/documentation/xctest/xcuielement/1500561-hittable). Note that XCTest hittable requires an element to have the [isAccessibilityElement](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/isaccessibilityelement) property enabled. It means if the element is on screen, but it sets [accessibilityElementsHidden](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/accessibilityelementshidden) to `false`, the hittable attribute will be `false`. This attribute is not included into the XML page source due to performance reasons, although you can use it in element locators or fetch its value using [getAttribute](https://www.w3.org/TR/webdriver2/#get-element-attribute) API. | `true` |
-|`placeholderValue` | Element's [placeolderValue](https://developer.apple.com/documentation/xctest/xcuielementattributes/placeholdervalue) value. | `Placeholder text`|
-|`traits` | Element's [traits](https://developer.apple.com/documentation/uikit/uiaccessibilitytraits?language=objc) value. This attribute returns a comma-separated string of accessibility traits. This attribute is not included into the XML page source, it may only be retrieved via [getAttribute](https://www.w3.org/TR/webdriver2/#get-element-attribute) API.| `Button, Adjustable`, `Button` |
-| `minValue` | Element's minimum allowed value, typically for controls like sliders or progress indicators. | `0`, `0.0`, `1` |
-| `maxValue` | Element's maximum allowed value, typically for controls like sliders or progress indicators. | `100`, `1.0` |
-| `customActions` | Custom accessibility actions attached to a single accessibility element (SwiftUI: [`accessibilityAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityaction(_:_:)), UIKit: [`UIAccessibilityCustomAction`](https://developer.apple.com/documentation/uikit/uiaccessibilitycustomaction)). | `Action 1,Action 2` |
+## type
+
+> Example: `XCUIElementTypeButton`
+
+Corresponds to the element's XCTest [`elementType`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/elementtype)
+value.
+
+## name
+
+> Example: `hello`
+
+Corresponds to the element's XCTest [`identifier`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/identifier)
+or [`label`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/label)
+property, depending on which one is available first. Can be `null`.
+
+For developers, it is recommended to use [`accessibilityIdentifier`](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/accessibilityidentifier)
+over [`accessibilityLabel`](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/accessibilitylabel)
+for automation purposes, since the `identifier` property is supposed to stay constant under
+different locales, and does not affect accessibility services such as VoiceOver.
+
+In applications written using [React Native](https://reactnative.dev/), this attribute corresponds
+to the `testID` property.
+
+## label
+
+> Examples: `hello`, `hello\nworld`
+
+Corresponds to the element's XCTest [`label`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/label)
+value. Can be `null`.
+
+## value
+
+> Example: `hello`
+
+This is a complex attribute whose calculation algorithm depends on the actual element type. Check
+[WebDriverAgent sources](https://github.com/appium/WebDriverAgent/blob/master/WebDriverAgentLib/Categories/XCUIElement%2BFBWebDriverAttributes.m)
+to know more about how it is compiled (method `- (NSString *)wdValue`). Can be `null`.
+
+## placeholderValue
+
+> Example: `Placeholder text`
+
+Corresponds to the element's XCTest [`placeholderValue`](https://developer.apple.com/documentation/xctest/xcuielementattributes/placeholdervalue)
+value.
+
+## minValue
+
+> Examples: `0`, `0.0`, `1`
+
+Returns the element's minimum allowed value, typically for controls like sliders or progress indicators.
+
+This attribute is not included in the default page source due to performance reasons, but it
+can be added by changing the [`includeMinMaxValueInPageSource`](./settings.md) setting to `true`, or
+retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
+API.
+
+## maxValue
+
+> Examples: `100`, `1.0`
+
+Returns the element's maximum allowed value, typically for controls like sliders or progress indicators.
+
+This attribute is not included in the default page source due to performance reasons, but it
+can be added by changing the [`includeMinMaxValueInPageSource`](./settings.md) setting to `true`, or
+retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
+API.
+
+## enabled
+
+> Example: `false`
+
+Corresponds to the element's XCTest [`enabled`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/isenabled)
+value.
+
+## selected
+
+> Example: `false`
+
+Corresponds to the element's XCTest [`selected`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/isselected)
+value.
+
+## focused
+
+> Example: `true`
+
+Corresponds to the element's XCTest [`hasFocus`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/hasfocus)
+value.
+
+## hittable
+
+> Example: `true`
+
+Corresponds to the element's XCTest [`isHittable`](https://developer.apple.com/documentation/xcuiautomation/xcuielement/ishittable)
+value.
+
+This attribute is not included in the default page source due to performance reasons, but it can be
+added by changing the [`includeHittableInPageSource`](./settings.md) setting to `true`, or
+retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
+API.
+
+Note that `isHittable` requires an element to have the [`isAccessibilityElement`](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/isaccessibilityelement)
+property enabled. This means that if the element is on screen, but it sets [`accessibilityElementsHidden`](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/accessibilityelementshidden)
+to `false`, then `hittable` will be set to `false`.
+
+## visible
+
+> Example: `false`
+
+Returns whether the element is visible. This value is not available in XCTest and is read directly
+from the accessibility layer.
+
+## accessible
+
+> Example: `false`
+
+Returns whether the element is accessible. This value is not available in XCTest and is read
+directly from the accessibility layer.
+
+## index
+
+> Example: `2`
+
+Returns the element's index in the hierarchy relatively to its parent. Indexing starts from `0`.
+
+## rect
+
+> Example: `{"x": 0,"y": 0,"width": 100,"height": 100}`
+
+Returns the element's position and dimensions. Based on the element's XCTest [`frame`](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes/frame)
+value.
+
+## traits
+
+> Examples: `Button, Adjustable`, `Button`
+
+Returns an comma-separated string of the element's XCTest [`UIAccessibilityTraits`](https://developer.apple.com/documentation/uikit/uiaccessibilitytraits)
+constants.
+
+## customActions
+
+> Example: `Action 1,Action 2`
+
+Returns a comma-separated string of custom accessibility actions attached to the element. Based on
+the element's[`accessibilityAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityaction(_:_:))
+and [`UIAccessibilityCustomAction`](https://developer.apple.com/documentation/uikit/uiaccessibilitycustomaction)
+values.
+
+This attribute is not included in the default page source due to performance reasons, but it
+can be added by changing the [`includeCustomActionsInPageSource`](./settings.md) setting to `true`, or
+retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
+API.
+
+## bundleId
+
+> Example: `com.apple.springboard`
+
+Returns the bundle ID of the currently active application. Only available for the root
+`XCUIElementTypeApplication` element.

--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -147,7 +147,7 @@ constants.
 > Example: `Action 1,Action 2`
 
 Returns a comma-separated string of custom accessibility actions attached to the element. Based on
-the element's[`accessibilityAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityaction(_:_:))
+the element's [`accessibilityAction`](https://developer.apple.com/documentation/swiftui/view/accessibilityaction(_:_:))
 and [`UIAccessibilityCustomAction`](https://developer.apple.com/documentation/uikit/uiaccessibilitycustomaction)
 values.
 

--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -155,10 +155,3 @@ This attribute is not included in the default page source due to performance rea
 can be added by changing the [`includeCustomActionsInPageSource`](./settings.md) setting to `true`, or
 retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
 API.
-
-## bundleId
-
-> Example: `com.apple.springboard`
-
-Returns the bundle ID of the currently active application. Only available for the root
-`XCUIElementTypeApplication` element.


### PR DESCRIPTION
This updates the element attributes reference page for better readability and page anchors to specific attribute names. I have also fixed descriptions for attributes that aren't included by default (`minValue`, `maxValue` and `customActions` did not have this disclaimer, while `traits` incorrectly did).