### PR TITLE
chore: Set minimum axios dependency version to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "appium-xcode": "^6.0.2",
     "async-lock": "^1.4.0",
     "asyncbox": "^6.0.1",
-    "axios": "^1.4.0",
+    "axios": "^1.15.0",
     "bluebird": "^3.7.2",
     "commander": "^14.0.1",
     "css-selector-parser": "^3.0.0",


### PR DESCRIPTION
This pull request updates a dependency in the `package.json` file to keep the project up-to-date with the latest features and security patches.

Dependency updates:

* Upgraded the `axios` package from version `1.13.5` to `1.15.0` in `package.json`.