### PR TITLE
docs: adjust guide page titles & grouping

### DIFF
--- a/docs/guides/attach-to-running-wda.md
+++ b/docs/guides/attach-to-running-wda.md
@@ -2,7 +2,7 @@
 hide:
   - toc
 
-title: Attach to a Running WebDriverAgent
+title: Attach to a Running WDA
 ---
 
 The XCUITest driver provides the __`appium:webDriverAgentUrl`__ capability to attach to a running

--- a/docs/guides/capability-sets.md
+++ b/docs/guides/capability-sets.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Examples of Session Capability Sets
+title: Capability Set Examples
 ---
 
 This article describes necessary capabilities that must be provided in order

--- a/docs/guides/gestures.md
+++ b/docs/guides/gestures.md
@@ -1,4 +1,7 @@
 ---
+hide:
+  - toc
+
 title: Gestures
 ---
 

--- a/docs/guides/hybrid.md
+++ b/docs/guides/hybrid.md
@@ -1,5 +1,5 @@
 ---
-title: Automating Hybrid Apps
+title: Hybrid Apps
 ---
 
 One of the core principles of XCUITest driver is that you shouldn't have to change your

--- a/docs/guides/input-events.md
+++ b/docs/guides/input-events.md
@@ -1,5 +1,5 @@
 ---
-title: About iOS Input Events
+title: iOS Input Events
 ---
 
 ## What Are Input Events

--- a/docs/guides/multiple-xcode-versions.md
+++ b/docs/guides/multiple-xcode-versions.md
@@ -2,7 +2,7 @@
 hide:
   - toc
 
-title: Managing Multiple Xcodes
+title: Multiple Xcode Installs
 ---
 
 If you have multiple Xcode installations, you may choose which toolset Appium should use with one

--- a/docs/guides/parallel-tests.md
+++ b/docs/guides/parallel-tests.md
@@ -2,7 +2,7 @@
 hide:
   - toc
 
-title: Testing in Parallel
+title: Running Tests in Parallel
 ---
 
 It is possible to execute tests in parallel using XCUITest driver. Appium allows to do this on a

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -1,5 +1,5 @@
 ---
-title: Run Prebuilt WebDriverAgentRunner
+title: Run Prebuilt WDA
 ---
 
 The XCUITest driver runs `xcodebuild` to build and install the WebDriverAgentRunner (WDA) app on the

--- a/docs/guides/run-preinstalled-wda.md
+++ b/docs/guides/run-preinstalled-wda.md
@@ -1,5 +1,5 @@
 ---
-title: Run Preinstalled WebDriverAgentRunner
+title: Run Preinstalled WDA
 ---
 
 The XCUITest driver can be configured to launch an already-installed `WebDriverAgentRunner-Runner`

--- a/docs/guides/wda-custom-server.md
+++ b/docs/guides/wda-custom-server.md
@@ -1,5 +1,5 @@
 ---
-title: Manage WebDriverAgent by Yourself
+title: Manage WDA by Yourself
 ---
 
 The XCUITest driver uses [WebDriverAgent](https://github.com/appium/WebDriverAgent) (WDA) as the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,15 +59,19 @@ nav:
           - reference/element-attributes.md
   - Guides:
       - Environment Configuration:
-          - guides/parallel-tests.md
           - guides/ci-setup.md
           - guides/multiple-xcode-versions.md
           - guides/remotexpc-tunnels-real-devices.md
-          - Improve Session Startup Performance:
+          - Tune WebDriverAgent Startup Performance:
               - guides/run-preinstalled-wda.md
               - guides/run-prebuilt-wda.md
               - guides/attach-to-running-wda.md
-          - guides/wda-custom-server.md
+              - guides/wda-custom-server.md
+      - Session Configuration:
+          - guides/capability-sets.md
+          - guides/parallel-tests.md
+          - guides/hybrid.md
+          - guides/mjpeg.md
       - Driver Actions:
           - guides/audio-capture.md
           - guides/file-transfer.md
@@ -78,9 +82,6 @@ nav:
       - Other:
           - guides/tvos.md
           - guides/input-events.md
-          - guides/capability-sets.md
-          - guides/hybrid.md
-          - guides/mjpeg.md
   - Troubleshooting:
       - troubleshooting/index.md
       - troubleshooting/element-lookup.md


### PR DESCRIPTION
Fairly small adjustment to the page titles of some guides, as well as moving some pages to a new Session Configuration group for better organization. The actual contents have not been changed for any page.