### PR TITLE
feat: add download-wda command

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -101,7 +101,7 @@ jobs:
         cd ~
         appium driver install --source=local "$cwd"
         appium driver doctor xcuitest
-        appium driver run xcuitest download-wda-sim  --platform=ios --outdir=$(dirname "$PREBUILT_WDA_PATH")
+        appium driver run xcuitest download-wda -- --platform=ios --outdir=$(dirname "$PREBUILT_WDA_PATH") --kind=sim
         echo "Starting Appium server on $APPIUM_TEST_SERVER_HOST:$APPIUM_TEST_SERVER_PORT"
         nohup appium server \
           --port=$APPIUM_TEST_SERVER_PORT \

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -82,7 +82,7 @@ The `download-wda` command helps to download the proper version of WDA for your 
 for simulator use.
 
 ```bash
-appium driver run xcuitest download-wda -- --outdir=/path/to/target/directory --kind=sim
+appium driver run xcuitest download-wda -- --outdir=/path/to/target/directory --kind=sim --platform=ios
 ```
 
 To see all available options for the script, including flags and defaults, run:

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -78,17 +78,17 @@ and `appium:usePreinstalledWDA` capabilities.
 These capabilities allow the XCUITest driver to install prebuilt WDA specified with
 `appium:prebuiltWDAPath` and start it **without** running `xcodebuild`.
 
-The `download-wda-sim` command helps to download the proper version of WDA for your XCUITest driver version
+The `download-wda` command helps to download the proper version of WDA for your XCUITest driver version
 for simulator use.
 
 ```bash
-appium driver run xcuitest download-wda-sim --outdir=/path/to/target/directory
+appium driver run xcuitest download-wda -- --outdir=/path/to/target/directory --kind=sim
 ```
 
 To see all available options for the script, including flags and defaults, run:
 
 ```bash
-appium driver run xcuitest download-wda-sim -- --help
+appium driver run xcuitest download-wda -- --help
 ```
 
 Then, starting a new session with capabilities below:

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -95,7 +95,50 @@ appium driver run xcuitest cleanup-videos -- --udid=<udid>
     ```
 
 
+### `download-wda`
+
+Downloads a prebuilt WebDriverAgent (WDA) application from the WDA project's [GitHub Releases page](https://github.com/appium/WebDriverAgent/releases)
+for use in a real device.
+
+For information about running tests with a prebuilt WDA application, [refer to this guide](../guides/run-prebuilt-wda.md).
+
+#### Usage
+
+```
+appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platform> --kind=<real|sim>
+```
+
+|<div style="width:6em">Argument</div>|Description|Type|Default|
+|--|--|--|--|
+|`--outdir`|Target directory where the WDA app should be downloaded. The directory must not exist. Relative paths are resolved starting from the XCUITest driver install directory.|string|`./wda`|
+|`--platform`|Target platform of the WDA app. Supported values are `ios` and `tvos` (case-insensitive)|string|`ios`|
+|`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`. Note that the same WDA app builds can be used for both real devices and simulators, so this argument is only used for filtering the available assets on the GitHub Releases page.|string|`real`|
+
+##### Optional Arguments
+
+|Argument|Description|
+|--|--|
+|`--help`, `-h`|Return help text and exit|
+
+#### Examples
+
+- Download the iOS version of the WDA app (`WebDriverAgentRunner-Runner.app`) into the `wda`
+    subdirectory of the XCUITest driver's install directory:
+
+        ```
+        appium driver run xcuitest download-wda -- --platform=ios --outdir=wda
+        ```
+
+- Download the tvOS version of the WDA app (`WebDriverAgentRunner_tvOS-Runner.app`) into `/path/to/dir`:
+
+        ```
+        appium driver run xcuitest download-wda -- --platform=tvos --outdir=/path/to/dir
+        ```
+
+
 ### `download-wda-sim`
+
+**Deprecated in favor of `download-wda` since the same WDA app builds can be used for both real devices and simulators.**
 
 Downloads a prebuilt WebDriverAgent (WDA) application from the WDA project's [GitHub Releases page](https://github.com/appium/WebDriverAgent/releases)
 for use in a simulator device.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -98,7 +98,7 @@ appium driver run xcuitest cleanup-videos -- --udid=<udid>
 ### `download-wda`
 
 Downloads a prebuilt WebDriverAgent (WDA) application from the WDA project's [GitHub Releases page](https://github.com/appium/WebDriverAgent/releases)
-for use in a real device.
+for use with real devices or simulators.
 
 For information about running tests with a prebuilt WDA application, [refer to this guide](../guides/run-prebuilt-wda.md).
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -110,8 +110,8 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 
 |<div style="width:6em">Argument</div>|Description|Type|Default|
 |--|--|--|--|
-|`--outdir`|Target directory where the WDA app should be downloaded. The directory must not exist. Relative paths are resolved starting from the XCUITest driver install directory.|string|`./wda`|
-|`--platform`|Target platform of the WDA app. Supported values are `ios` and `tvos` (case-insensitive)|string|`ios`|
+|`--outdir`|Target directory where the WDA app should be downloaded. The directory must not exist. Relative paths are resolved starting from the XCUITest driver install directory.|string| - |
+|`--platform`|Target platform of the WDA app. Supported values are `ios` and `tvos` (case-insensitive)|string| - |
 |`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`. Note that the same WDA app builds can be used for both real devices and simulators, so this argument is only used for filtering the available assets on the GitHub Releases page.|string|`real`|
 
 ##### Optional Arguments

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -112,7 +112,7 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 |--|--|--|--|
 |`--outdir`|Target directory where the WDA app should be downloaded. The directory must not exist. Relative paths are resolved starting from the XCUITest driver install directory.|string| - |
 |`--platform`|Target platform of the WDA app. Supported values are `ios` and `tvos` (case-insensitive)|string| - |
-|`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`. Note that the same WDA app builds can be used for both real devices and simulators, so this argument is only used for filtering the available assets on the GitHub Releases page.|string|`real`|
+|`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`.|string|`real`|
 
 ##### Optional Arguments
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -138,7 +138,7 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 
 ### `download-wda-sim`
 
-**Deprecated in favor of `download-wda` since the same WDA app builds can be used for both real devices and simulators.**
+**Deprecated in favor of `download-wda`; use `download-wda` with the appropriate build kind for simulator or real-device usage.**
 
 Downloads a prebuilt WebDriverAgent (WDA) application from the WDA project's [GitHub Releases page](https://github.com/appium/WebDriverAgent/releases)
 for use in a simulator device.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "build-wda": "./scripts/build-wda.mjs",
       "open-wda": "./scripts/open-wda.mjs",
       "tunnel-creation": "./scripts/tunnel-creation.mjs",
+      "download-wda": "./scripts/download-wda.mjs",
       "download-wda-sim": "./scripts/download-wda-sim.mjs",
       "image-mounter": "./scripts/image-mounter.mjs",
       "list-real-devices": "./scripts/list-real-devices.mjs",

--- a/scripts/download-wda-sim.mjs
+++ b/scripts/download-wda-sim.mjs
@@ -29,6 +29,7 @@ EXAMPLES:
   appium driver run xcuitest download-wda-sim --outdir ./wda-sim-tvos --platform tvOS`,
     )
     .action(async (options) => {
+      // eslint-disable-next-line no-console
       console.warn(DEPRECATION_MESSAGE);
       await getWDAPrebuiltPackage({...options, kind: 'sim'});
     });

--- a/scripts/download-wda-sim.mjs
+++ b/scripts/download-wda-sim.mjs
@@ -1,73 +1,9 @@
-import {fs, logger, zip, net, node} from 'appium/support.js';
-import _ from 'lodash';
-import os from 'node:os';
-import path from 'node:path';
+import {getWDAPrebuiltPackage} from './download-wda.mjs';
 import {Command} from 'commander';
 
-const log = logger.getLogger('download-wda-sim');
-const wdaUrl = (/** @type {string} */ version, /** @type {string} */ zipFileName) =>
-  `https://github.com/appium/WebDriverAgent/releases/download/v${version}/${zipFileName}`;
-const destZip = (/** @type {string} */ platform) => {
-  const scheme = `WebDriverAgentRunner${_.toLower(platform) === 'tvos' ? '_tvOS' : ''}`;
-  return `${scheme}-Build-Sim-${os.arch() === 'arm64' ? 'arm64' : 'x86_64'}.zip`;
-};
-
-/**
- * Return installed appium-webdriveragent package version
- * @returns {Promise<string>}
- */
-async function webdriveragentPkgVersion() {
-  const moduleRoot = node.getModuleRootSync('appium-xcuitest-driver', import.meta.url);
-  if (!moduleRoot) {
-    throw new Error('Cannot resolve module root for appium-xcuitest-driver');
-  }
-  const pkgPath = path.join(
-    moduleRoot,
-    'node_modules',
-    'appium-webdriveragent',
-    'package.json'
-  );
-  const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
-  return String(pkg.version);
-};
-
-/**
- * Prepare the working root directory.
- * @param {string} outdir
- * @returns {Promise<string>} Root directory to download and unzip.
- */
-async function prepareRootDir(outdir) {
-  const destDir = path.resolve(process.cwd(), outdir);
-  if (await fs.exists(destDir)) {
-    throw new Error(`${destDir} already exists`);
-  }
-  await fs.mkdir(destDir, {recursive: true});
-  return destDir;
-}
-
-/**
- * @param {DownloadOptions} options
- */
-async function getWDAPrebuiltPackage(options) {
-  const destDir = await prepareRootDir(options.outdir);
-  const zipFileName = destZip(options.platform);
-  const wdaVersion = await webdriveragentPkgVersion();
-  const urlToDownload = wdaUrl(wdaVersion, zipFileName);
-  const downloadedZipFile = path.join(destDir, zipFileName);
-  try {
-    log.info(`Downloading ${urlToDownload}`);
-    await net.downloadFile(urlToDownload, downloadedZipFile);
-
-    log.info(`Unpacking ${downloadedZipFile} into ${destDir}`);
-    await zip.extractAllTo(downloadedZipFile, destDir);
-
-    log.info(`Deleting ${downloadedZipFile}`);
-  } finally {
-    if (await fs.exists(downloadedZipFile)) {
-      await fs.unlink(downloadedZipFile);
-    }
-  }
-}
+const DEPRECATION_MESSAGE =
+  "[DEPRECATED] 'download-wda-sim' is deprecated. " +
+  "Use 'appium driver run xcuitest download-wda -- --kind=sim --platform=<platform> --outdir=<outdir>' instead.";
 
 async function main() {
   const program = new Command();
@@ -75,6 +11,7 @@ async function main() {
   program
     .name('appium driver run xcuitest download-wda-sim')
     .description('Download a prebuilt WebDriverAgentRunner for iOS/tvOS simulator')
+    .addHelpText('beforeAll', `${DEPRECATION_MESSAGE}\n\n`)
     .requiredOption('--outdir <path>', 'Destination directory to download and unpack into')
     .requiredOption(
       '--platform <platform>',
@@ -92,7 +29,8 @@ EXAMPLES:
   appium driver run xcuitest download-wda-sim --outdir ./wda-sim-tvos --platform tvOS`,
     )
     .action(async (options) => {
-      await getWDAPrebuiltPackage(options);
+      console.warn(DEPRECATION_MESSAGE);
+      await getWDAPrebuiltPackage({...options, kind: 'sim'});
     });
 
   await program.parseAsync(process.argv);

--- a/scripts/download-wda-sim.mjs
+++ b/scripts/download-wda-sim.mjs
@@ -1,5 +1,6 @@
 import {getWDAPrebuiltPackage} from './download-wda.mjs';
 import {Command} from 'commander';
+import { deprecate } from 'node:util';
 
 const DEPRECATION_MESSAGE =
   "[DEPRECATED] 'download-wda-sim' is deprecated. " +
@@ -7,6 +8,13 @@ const DEPRECATION_MESSAGE =
 
 async function main() {
   const program = new Command();
+
+  const oldHandler = deprecate(
+    async (options) => {
+      await getWDAPrebuiltPackage({...options, kind: 'sim'});
+    },
+    DEPRECATION_MESSAGE
+  );
 
   program
     .name('appium driver run xcuitest download-wda-sim')
@@ -23,16 +31,12 @@ async function main() {
       `
 EXAMPLES:
   # Download WDA for iOS simulator
-  appium driver run xcuitest download-wda-sim --outdir ./wda-sim --platform iOS
+  appium driver run xcuitest download-wda-sim -- --outdir ./wda-sim --platform iOS
 
   # Download WDA for tvOS simulator
-  appium driver run xcuitest download-wda-sim --outdir ./wda-sim-tvos --platform tvOS`,
+  appium driver run xcuitest download-wda-sim -- --outdir ./wda-sim-tvos --platform tvOS`,
     )
-    .action(async (options) => {
-      // eslint-disable-next-line no-console
-      console.warn(DEPRECATION_MESSAGE);
-      await getWDAPrebuiltPackage({...options, kind: 'sim'});
-    });
+    .action(oldHandler);
 
   await program.parseAsync(process.argv);
 }

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -12,6 +12,31 @@ const wdaUrl = (/** @type {string} */ version, /** @type {string} */ zipFileName
   `https://github.com/appium/WebDriverAgent/releases/download/v${version}/${zipFileName}`;
 
 /**
+ * @param {DownloadOptions} options
+ */
+export async function getWDAPrebuiltPackage(options) {
+  const kind = normalizeKind(options.kind);
+  const destDir = await prepareRootDir(options.outdir);
+  const zipFileName = destZip(options.platform, kind);
+  const wdaVersion = await webdriveragentPkgVersion();
+  const urlToDownload = wdaUrl(wdaVersion, zipFileName);
+  const downloadedZipFile = path.join(destDir, zipFileName);
+  try {
+    log.info(`Downloading ${urlToDownload}`);
+    await net.downloadFile(urlToDownload, downloadedZipFile);
+
+    log.info(`Unpacking ${downloadedZipFile} into ${destDir}`);
+    await zip.extractAllTo(downloadedZipFile, destDir);
+
+    log.info(`Deleting ${downloadedZipFile}`);
+  } finally {
+    if (await fs.exists(downloadedZipFile)) {
+      await fs.unlink(downloadedZipFile);
+    }
+  }
+}
+
+/**
  * @param {string | undefined} kind
  * @returns {'real' | 'sim'}
  */
@@ -62,31 +87,6 @@ async function prepareRootDir(outdir) {
   }
   await fs.mkdir(destDir, {recursive: true});
   return destDir;
-}
-
-/**
- * @param {DownloadOptions} options
- */
-export async function getWDAPrebuiltPackage(options) {
-  const kind = normalizeKind(options.kind);
-  const destDir = await prepareRootDir(options.outdir);
-  const zipFileName = destZip(options.platform, kind);
-  const wdaVersion = await webdriveragentPkgVersion();
-  const urlToDownload = wdaUrl(wdaVersion, zipFileName);
-  const downloadedZipFile = path.join(destDir, zipFileName);
-  try {
-    log.info(`Downloading ${urlToDownload}`);
-    await net.downloadFile(urlToDownload, downloadedZipFile);
-
-    log.info(`Unpacking ${downloadedZipFile} into ${destDir}`);
-    await zip.extractAllTo(downloadedZipFile, destDir);
-
-    log.info(`Deleting ${downloadedZipFile}`);
-  } finally {
-    if (await fs.exists(downloadedZipFile)) {
-      await fs.unlink(downloadedZipFile);
-    }
-  }
 }
 
 async function main() {

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -1,0 +1,139 @@
+import {fs, logger, zip, net, node} from 'appium/support.js';
+import os from 'node:os';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {Command} from 'commander';
+
+const log = logger.getLogger('download-wda');
+const WDA_KIND_REAL = 'real';
+const WDA_KIND_SIM = 'sim';
+
+const wdaUrl = (/** @type {string} */ version, /** @type {string} */ zipFileName) =>
+  `https://github.com/appium/WebDriverAgent/releases/download/v${version}/${zipFileName}`;
+
+/**
+ * @param {string | undefined} kind
+ * @returns {'real' | 'sim'}
+ */
+function normalizeKind(kind) {
+  const normalized = String(kind || WDA_KIND_REAL).toLowerCase();
+  if (normalized !== WDA_KIND_REAL && normalized !== WDA_KIND_SIM) {
+    throw new Error(`Unsupported kind '${kind}'. Supported values are '${WDA_KIND_REAL}' and '${WDA_KIND_SIM}'`);
+  }
+  return /** @type {'real' | 'sim'} */ (normalized);
+}
+
+const destZip = (/** @type {string} */ platform, /** @type {'real' | 'sim'} */ kind) => {
+  const scheme = `WebDriverAgentRunner${String(platform).toLowerCase() === 'tvos' ? '_tvOS' : ''}`;
+  if (kind === WDA_KIND_SIM) {
+    return `${scheme}-Build-Sim-${os.arch() === 'arm64' ? 'arm64' : 'x86_64'}.zip`;
+  }
+  return `${scheme}-Runner.zip`;
+};
+
+/**
+ * Return installed appium-webdriveragent package version
+ * @returns {Promise<string>}
+ */
+async function webdriveragentPkgVersion() {
+  const moduleRoot = node.getModuleRootSync('appium-xcuitest-driver', import.meta.url);
+  if (!moduleRoot) {
+    throw new Error('Cannot resolve module root for appium-xcuitest-driver');
+  }
+  const pkgPath = path.join(
+    moduleRoot,
+    'node_modules',
+    'appium-webdriveragent',
+    'package.json'
+  );
+  const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
+  return String(pkg.version);
+};
+
+/**
+ * Prepare the working root directory.
+ * @param {string} outdir
+ * @returns {Promise<string>} Root directory to download and unzip.
+ */
+async function prepareRootDir(outdir) {
+  const destDir = path.resolve(process.cwd(), outdir);
+  if (await fs.exists(destDir)) {
+    throw new Error(`${destDir} already exists`);
+  }
+  await fs.mkdir(destDir, {recursive: true});
+  return destDir;
+}
+
+/**
+ * @param {DownloadOptions} options
+ */
+export async function getWDAPrebuiltPackage(options) {
+  const kind = normalizeKind(options.kind);
+  const destDir = await prepareRootDir(options.outdir);
+  const zipFileName = destZip(options.platform, kind);
+  const wdaVersion = await webdriveragentPkgVersion();
+  const urlToDownload = wdaUrl(wdaVersion, zipFileName);
+  const downloadedZipFile = path.join(destDir, zipFileName);
+  try {
+    log.info(`Downloading ${urlToDownload}`);
+    await net.downloadFile(urlToDownload, downloadedZipFile);
+
+    log.info(`Unpacking ${downloadedZipFile} into ${destDir}`);
+    await zip.extractAllTo(downloadedZipFile, destDir);
+
+    log.info(`Deleting ${downloadedZipFile}`);
+  } finally {
+    if (await fs.exists(downloadedZipFile)) {
+      await fs.unlink(downloadedZipFile);
+    }
+  }
+}
+
+async function main() {
+  const program = new Command();
+
+  program
+    .name('appium driver run xcuitest download-wda')
+    .description('Download a prebuilt WebDriverAgentRunner for iOS/tvOS real devices or simulators')
+    .requiredOption('--outdir <path>', 'Destination directory to download and unpack into')
+    .requiredOption(
+      '--platform <platform>',
+      'Target platform (e.g. iOS or tvOS)',
+      (value) => value,
+    )
+    .option(
+      '--kind <kind>',
+      `Target package type: ${WDA_KIND_REAL} (real devices) or ${WDA_KIND_SIM} (simulators)`
+    )
+    .addHelpText(
+      'after',
+      `
+EXAMPLES:
+  # Download WDA for iOS real device (default)
+  appium driver run xcuitest download-wda --outdir ./wda-real --platform iOS
+
+  # Download WDA for tvOS simulator
+  appium driver run xcuitest download-wda --outdir ./wda-sim-tvos --platform tvOS --kind sim`,
+    )
+    .action(async (options) => {
+      await getWDAPrebuiltPackage({
+        ...options,
+        kind: options.kind ?? WDA_KIND_REAL,
+      });
+    });
+
+  await program.parseAsync(process.argv);
+}
+
+const isMainModule =
+  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+  await main();
+}
+
+/**
+ * @typedef {Object} DownloadOptions
+ * @property {string} outdir
+ * @property {string} platform
+ * @property {string | undefined} [kind]
+ */

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -110,10 +110,10 @@ async function main() {
       `
 EXAMPLES:
   # Download WDA for iOS real device (default)
-  appium driver run xcuitest download-wda --outdir ./wda-real --platform iOS
+  appium driver run xcuitest download-wda -- --outdir ./wda-real --platform iOS
 
   # Download WDA for tvOS simulator
-  appium driver run xcuitest download-wda --outdir ./wda-sim-tvos --platform tvOS --kind sim`,
+  appium driver run xcuitest download-wda -- --outdir ./wda-sim-tvos --platform tvOS --kind sim`,
     )
     .action(async (options) => {
       await getWDAPrebuiltPackage({

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -76,7 +76,10 @@ async function getWebdriveragentPkgVersion() {
     'package.json'
   );
   const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
-  return String(pkg.version);
+  if (!pkg.version || typeof pkg.version !== 'string') {
+    throw new Error(`Cannot find version in ${pkgPath}`);
+  }
+  return pkg.version;
 };
 
 /**

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -1,4 +1,5 @@
 import {fs, logger, zip, net, node} from 'appium/support.js';
+import {constants as fsConstants, promises as fsPromises} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {pathToFileURL} from 'node:url';
@@ -12,13 +13,15 @@ const wdaUrl = (/** @type {string} */ version, /** @type {string} */ zipFileName
   `https://github.com/appium/WebDriverAgent/releases/download/v${version}/${zipFileName}`;
 
 /**
+ * Download and unpack a prebuilt WDA package for the given platform and kind.
  * @param {DownloadOptions} options
+ * @returns {Promise<void>}
  */
 export async function getWDAPrebuiltPackage(options) {
   const kind = normalizeKind(options.kind);
   const destDir = await prepareRootDir(options.outdir);
   const zipFileName = destZip(options.platform, kind);
-  const wdaVersion = await webdriveragentPkgVersion();
+  const wdaVersion = await getWebdriveragentPkgVersion();
   const urlToDownload = wdaUrl(wdaVersion, zipFileName);
   const downloadedZipFile = path.join(destDir, zipFileName);
   try {
@@ -36,19 +39,7 @@ export async function getWDAPrebuiltPackage(options) {
   }
 }
 
-/**
- * @param {string | undefined} kind
- * @returns {'real' | 'sim'}
- */
-function normalizeKind(kind) {
-  const normalized = String(kind || WDA_KIND_REAL).toLowerCase();
-  if (normalized !== WDA_KIND_REAL && normalized !== WDA_KIND_SIM) {
-    throw new Error(`Unsupported kind '${kind}'. Supported values are '${WDA_KIND_REAL}' and '${WDA_KIND_SIM}'`);
-  }
-  return /** @type {'real' | 'sim'} */ (normalized);
-}
-
-const destZip = (/** @type {string} */ platform, /** @type {'real' | 'sim'} */ kind) => {
+const destZip = (/** @type {string} */ platform, /** @type {WDAKind} */ kind) => {
   const scheme = `WebDriverAgentRunner${String(platform).toLowerCase() === 'tvos' ? '_tvOS' : ''}`;
   if (kind === WDA_KIND_SIM) {
     return `${scheme}-Build-Sim-${os.arch() === 'arm64' ? 'arm64' : 'x86_64'}.zip`;
@@ -57,10 +48,23 @@ const destZip = (/** @type {string} */ platform, /** @type {'real' | 'sim'} */ k
 };
 
 /**
+ * Normalize the kind value, ensuring it is either 'real' or 'sim'. Default to 'real' if undefined.
+ * @param {string | undefined} kind
+ * @returns {WDAKind}
+ */
+function normalizeKind(kind) {
+  const normalized = String(kind || WDA_KIND_REAL).toLowerCase();
+  if (![WDA_KIND_REAL, WDA_KIND_SIM].includes(normalized)) {
+    throw new Error(`Unsupported kind '${kind}'. Supported values are '${WDA_KIND_REAL}' and '${WDA_KIND_SIM}'`);
+  }
+  return /** @type {WDAKind} */ (normalized);
+}
+
+/**
  * Return installed appium-webdriveragent package version
  * @returns {Promise<string>}
  */
-async function webdriveragentPkgVersion() {
+async function getWebdriveragentPkgVersion() {
   const moduleRoot = node.getModuleRootSync('appium-xcuitest-driver', import.meta.url);
   if (!moduleRoot) {
     throw new Error('Cannot resolve module root for appium-xcuitest-driver');
@@ -85,7 +89,24 @@ async function prepareRootDir(outdir) {
   if (await fs.exists(destDir)) {
     throw new Error(`${destDir} already exists`);
   }
-  await fs.mkdir(destDir, {recursive: true});
+
+  const parentDir = path.dirname(destDir);
+  try {
+    await fsPromises.access(parentDir, fsConstants.W_OK);
+  } catch (err) {
+    throw new Error(`Parent directory '${parentDir}' is not writable`, {
+      cause: err,
+    });
+  }
+
+  try {
+    await fs.mkdir(destDir, {recursive: true});
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Cannot create directory '${destDir}': ${message}`, {
+      cause: err,
+    });
+  }
   return destDir;
 }
 
@@ -103,7 +124,7 @@ async function main() {
     )
     .option(
       '--kind <kind>',
-      `Target package type: ${WDA_KIND_REAL} (real devices) or ${WDA_KIND_SIM} (simulators)`
+      `Target package type: ${WDA_KIND_REAL} (real devices) or ${WDA_KIND_SIM} (simulators). Default: ${WDA_KIND_REAL}`,
     )
     .addHelpText(
       'after',
@@ -132,8 +153,12 @@ if (isMainModule) {
 }
 
 /**
+ * @typedef {'real' | 'sim'} WDAKind
+ */
+
+/**
  * @typedef {Object} DownloadOptions
  * @property {string} outdir
  * @property {string} platform
- * @property {string | undefined} [kind]
+ * @property {WDAKind | undefined} [kind]
  */


### PR DESCRIPTION
Added `download-wda` and an argument to download a sim or a real device.
I'd like to add a command to resign like `Option 1 (primary) — Download prebuilt WDA from GitHub releases` does later
https://github.com/appium/skills/blob/main/skills/xcuitest-real-device-config/SKILL.md