### PR TITLE
chore: bump remotexpc to 1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^1.1.6"
+    "appium-ios-remotexpc": "^1.1.8"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Summary

Bumps the `appium-ios-remotexpc` optional dependency from `^1.1.6` to `^1.1.8`

Changes pulled in from remotexpc `1.1.7` and `1.1.8`:
- fix(apple-tv): correct mDNS service usage for pair-setup and tunnel (appium/appium-ios-remotexpc#205)
- fix(discovery): accept single-digit hour in dns-sd timestamps (appium/appium-ios-remotexpc#207)
