### PR TITLE
fix: prevent ECONNRESET by removing redundant RSD connections in AfcClient

### DIFF
--- a/lib/device/afc-client.ts
+++ b/lib/device/afc-client.ts
@@ -49,13 +49,22 @@ interface WalkDirPullWalkContext {
  */
 export class AfcClient {
   private readonly service: RemoteXPCAfcService | IOSDeviceAfcService;
+  private readonly _isRemoteXPC: boolean;
+  /**
+   * Optional discovery RemoteXPC connection retained for ownership/cleanup.
+   * Only set when a service-vending RSD must outlive its discovery call
+   * (currently: none — both creation paths close the discovery RSD eagerly,
+   * matching the go-ios pattern of "probe once, close immediately").
+   */
   private readonly remoteXPCConnection?: RemoteXpcConnection;
 
   private constructor(
     service: RemoteXPCAfcService | IOSDeviceAfcService,
+    isRemoteXPC: boolean = false,
     remoteXPCConnection?: RemoteXpcConnection,
   ) {
     this.service = service;
+    this._isRemoteXPC = isRemoteXPC;
     this.remoteXPCConnection = remoteXPCConnection;
   }
 
@@ -63,7 +72,7 @@ export class AfcClient {
    * Check if this client is using RemoteXPC
    */
   private get isRemoteXPC(): boolean {
-    return !!this.remoteXPCConnection;
+    return this._isRemoteXPC;
   }
 
   /**
@@ -89,17 +98,21 @@ export class AfcClient {
    */
   static async createForDevice(udid: string, useRemoteXPC: boolean): Promise<AfcClient> {
     if (useRemoteXPC) {
-      const client = await AfcClient.withRemoteXpcConnection(async () => {
+      // Best-practice pattern (matches go-ios `defer rsd.Close()` and
+      // pymobiledevice3 single-RSD-per-session): perform exactly one RSD
+      // probe via `startAfcService`, which discovers the AFC port, closes
+      // its discovery RSD eagerly, and returns a self-contained AfcService
+      // bound to its own per-service TCP socket. Opening an extra RSD here
+      // would only race with the one inside `startAfcService` and trigger
+      // an ECONNRESET from the on-device `remoted` daemon.
+      try {
         const Services = await getRemoteXPCServices();
-        const connectionResult = await Services.createRemoteXPCConnection(udid);
         const afcService = await Services.startAfcService(udid);
-        return {
-          service: afcService,
-          connection: connectionResult.remoteXPC,
-        };
-      });
-      if (client) {
-        return client;
+        return new AfcClient(afcService, true);
+      } catch (err: any) {
+        log.error(
+          `Failed to create AFC client via RemoteXPC: ${err.message}, falling back to appium-ios-device`,
+        );
       }
     }
 
@@ -126,23 +139,33 @@ export class AfcClient {
     const isDocuments = !skipDocumentsCheck && containerType?.toLowerCase() === 'documents';
 
     if (useRemoteXPC) {
-      const client = await AfcClient.withRemoteXpcConnection(async () => {
+      // Best-practice pattern (matches go-ios `defer rsd.Close()`): one RSD
+      // probe via `startHouseArrestService`, vend the AFC service, then
+      // release the discovery RSD eagerly. The vended AfcService has its
+      // own dedicated socket so it does not need the discovery RSD to
+      // remain open. Avoids the prior pattern of overlapping RSD probes
+      // that triggered ECONNRESETs from the on-device `remoted` daemon.
+      let houseArrestRemoteXPC: RemoteXpcConnection | undefined;
+      try {
         const Services = await getRemoteXPCServices();
-        const connectionResult = await Services.createRemoteXPCConnection(udid);
-        const {houseArrestService, remoteXPC: houseArrestRemoteXPC} =
-          await Services.startHouseArrestService(udid);
+        const result = await Services.startHouseArrestService(udid);
+        houseArrestRemoteXPC = result.remoteXPC;
         const afcService = isDocuments
-          ? await houseArrestService.vendDocuments(bundleId)
-          : await houseArrestService.vendContainer(bundleId);
-        // Use the remoteXPC from house arrest service if available, otherwise use the one from connection
-        const connection = houseArrestRemoteXPC ?? connectionResult.remoteXPC;
-        return {
-          service: afcService,
-          connection,
-        };
-      });
-      if (client) {
-        return client;
+          ? await result.houseArrestService.vendDocuments(bundleId)
+          : await result.houseArrestService.vendContainer(bundleId);
+        return new AfcClient(afcService, true);
+      } catch (err: any) {
+        log.error(
+          `Failed to create AFC client via RemoteXPC: ${err.message}, falling back to appium-ios-device`,
+        );
+      } finally {
+        if (houseArrestRemoteXPC) {
+          try {
+            await houseArrestRemoteXPC.close();
+          } catch {
+            // ignore cleanup errors
+          }
+        }
       }
     }
 
@@ -151,39 +174,6 @@ export class AfcClient {
       ? await houseArrestService.vendDocuments(bundleId)
       : await houseArrestService.vendContainer(bundleId);
     return new AfcClient(afcService);
-  }
-
-  /**
-   * Helper to safely execute remoteXPC operations with connection cleanup
-   * @param operation - Async operation that returns an AfcClient
-   * @returns AfcClient on success, null on failure
-   */
-  private static async withRemoteXpcConnection<T extends RemoteXPCAfcService | IOSDeviceAfcService>(
-    operation: () => Promise<{service: T; connection: RemoteXpcConnection}>,
-  ): Promise<AfcClient | null> {
-    let remoteXPCConnection: RemoteXpcConnection | undefined;
-    let succeeded = false;
-    try {
-      const {service, connection} = await operation();
-      remoteXPCConnection = connection;
-      const client = new AfcClient(service, remoteXPCConnection);
-      succeeded = true;
-      return client;
-    } catch (err: any) {
-      log.error(
-        `Failed to create AFC client via RemoteXPC: ${err.message}, falling back to appium-ios-device`,
-      );
-      return null;
-    } finally {
-      // Only close connection if we failed (if succeeded, the client owns it)
-      if (remoteXPCConnection && !succeeded) {
-        try {
-          await remoteXPCConnection.close();
-        } catch {
-          // Ignore cleanup errors
-        }
-      }
-    }
   }
 
   /**

--- a/lib/device/afc-client.ts
+++ b/lib/device/afc-client.ts
@@ -50,22 +50,13 @@ interface WalkDirPullWalkContext {
 export class AfcClient {
   private readonly service: RemoteXPCAfcService | IOSDeviceAfcService;
   private readonly _isRemoteXPC: boolean;
-  /**
-   * Optional discovery RemoteXPC connection retained for ownership/cleanup.
-   * Only set when a service-vending RSD must outlive its discovery call
-   * (currently: none — both creation paths close the discovery RSD eagerly,
-   * matching the go-ios pattern of "probe once, close immediately").
-   */
-  private readonly remoteXPCConnection?: RemoteXpcConnection;
 
   private constructor(
     service: RemoteXPCAfcService | IOSDeviceAfcService,
     isRemoteXPC: boolean = false,
-    remoteXPCConnection?: RemoteXpcConnection,
   ) {
     this.service = service;
     this._isRemoteXPC = isRemoteXPC;
-    this.remoteXPCConnection = remoteXPCConnection;
   }
 
   /**
@@ -306,15 +297,10 @@ export class AfcClient {
   }
 
   /**
-   * Close the AFC service connection and remoteXPC connection if present
+   * Close the AFC service connection
    */
   async close(): Promise<void> {
     this.service.close();
-    if (this.remoteXPCConnection) {
-      try {
-        await this.remoteXPCConnection.close();
-      } catch {}
-    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^1.1.8"
+    "appium-ios-remotexpc": "^1.1.10"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
- Removes the explicit `createRemoteXPCConnection` calls in `createForDevice` and `createForApp`.
- `startAfcService` and `startHouseArrestService` now properly manage their own single RSD connection lifecycle.
- Prevents iOS `remoted` from forcefully resetting the connection when multiple RSD handshakes occur on the same tunnel.