### PR TITLE
feat(app): use zip_conduit service for IPA installation/upgrade

### DIFF
--- a/lib/device/real-device-management.ts
+++ b/lib/device/real-device-management.ts
@@ -9,6 +9,7 @@ import {
   withTimeout,
 } from '../commands/helpers';
 import {isEmpty, isPlainObject} from '../utils';
+import {IPA_EXT} from '../commands/constants';
 import {log as defaultLogger} from '../logger';
 import {Devicectl} from 'node-devicectl';
 import type {AppiumLogger} from '@appium/types';
@@ -19,6 +20,7 @@ import {InstallationProxyClient} from './installation-proxy-client';
 import {NotificationClient} from './notification-client';
 import {LockdownClient} from './lockdown-client';
 import {AppTerminationClient} from './app-termination-client';
+import {ZipConduitClient} from './zip-conduit-client';
 
 const DEFAULT_APP_INSTALLATION_TIMEOUT_MS = 8 * 60 * 1000;
 export const IO_TIMEOUT_MS = 4 * 60 * 1000;
@@ -114,6 +116,16 @@ export class RealDevice {
     const {timeoutMs = IO_TIMEOUT_MS} = opts;
     const timer = new timing.Timer().start();
     const useRemoteXPC = isIos18OrNewer(this.driverOpts);
+
+    // first try with zip_conduit service for iOS/tvOS 18+ and IPA only
+    // fall through to the AFC + installation_proxy path for other cases/zip_conduit failure
+    if (useRemoteXPC && (await this.installViaZipConduit(appPath, timeoutMs))) {
+      this.log.info(
+        `The installation of '${bundleId}' succeeded after ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`,
+      );
+      return;
+    }
+
     const afcClient = await AfcClient.createForDevice(this.udid, useRemoteXPC);
     try {
       let bundlePathOnPhone: string;
@@ -332,6 +344,44 @@ export class RealDevice {
       throw err;
     }
     this.log.debug(`Reset: removed '${bundleId}'`);
+  }
+
+  /**
+   * Attempt a streaming zip_conduit install of an `.ipa` over RemoteXPC.
+   *
+   * @param appPath - Local path to the app package
+   * @param timeoutMs - Overall install timeout in milliseconds
+   * @returns `true` when the app was installed via zip_conduit; `false` when the
+   * package is not an eligible `.ipa`, the service is unavailable, or the
+   * streamed install failed. A `false` result tells the caller to fall back to
+   * the AFC upload + installation_proxy path.
+   */
+  private async installViaZipConduit(appPath: string, timeoutMs: number): Promise<boolean> {
+    // zip_conduit only accepts .ipa archives. Unpacked .app bundles (and any
+    // other non-.ipa package) must use the AFC + installation_proxy
+    // path, so anything that is not a regular .ipa file is skipped here.
+    if (!appPath.toLowerCase().endsWith(IPA_EXT) || !(await fs.stat(appPath)).isFile()) {
+      return false;
+    }
+
+    let client: ZipConduitClient | null = null;
+    try {
+      client = await ZipConduitClient.create(this.udid, this.log);
+      if (!client) {
+        return false;
+      }
+      this.log.debug(`Installing '${path.basename(appPath)}' via streaming zip_conduit`);
+      await client.install(appPath, {timeoutMs});
+      return true;
+    } catch (err) {
+      this.log.warn(
+        `Fast zip_conduit install of '${path.basename(appPath)}' failed; falling back to ` +
+          `AFC upload + installation_proxy. Original error: ${(err as Error).message}`,
+      );
+      return false;
+    } finally {
+      await client?.close();
+    }
   }
 }
 

--- a/lib/device/zip-conduit-client.ts
+++ b/lib/device/zip-conduit-client.ts
@@ -1,0 +1,83 @@
+import {tryGetRemoteXPCServices} from './remotexpc-utils';
+import {log} from '../logger';
+import type {AppiumLogger} from '@appium/types';
+import type {ZipConduitService as RemoteXPCZipConduitService} from 'appium-ios-remotexpc';
+
+/**
+ * Options accepted by {@link ZipConduitClient.install}
+ */
+export interface ZipConduitInstallOptions {
+  /** Maximum number of milliseconds to wait for the streamed installation to finish */
+  timeoutMs?: number;
+}
+
+/**
+ * Thin wrapper around the RemoteXPC streaming `zip_conduit` service.
+ *
+ * `zip_conduit` streams an `.ipa` straight into the on-device installer, avoiding the separate AFC upload +
+ * `installation_proxy` round trip. It is RemoteXPC-only (iOS/tvOS 18+ with an
+ * active tunnel) and only accepts `.ipa` archives, so callers must keep a
+ * fallback for unpacked `.app` bundles and older devices.
+ */
+export class ZipConduitClient {
+  private _lastLoggedProgress?: {percent?: number; status?: string};
+
+  private constructor(
+    private readonly service: RemoteXPCZipConduitService,
+    private readonly _log: AppiumLogger = log,
+  ) {}
+
+  /**
+   * Create a zip_conduit client for the device
+   *
+   * @param udid - Device UDID
+   * @param logger - Optional logger
+   * @returns A connected client, or `null` when zip_conduit is unavailable
+   */
+  static async create(udid: string, logger: AppiumLogger = log): Promise<ZipConduitClient | null> {
+    const Services = await tryGetRemoteXPCServices();
+    if (!Services || typeof Services.startZipConduitService !== 'function') {
+      return null;
+    }
+    const service = await Services.startZipConduitService(udid);
+    return new ZipConduitClient(service, logger);
+  }
+
+  /**
+   * Stream-install an `.ipa`. Handles both fresh installs and upgrades; the
+   * device resolves the target by bundle id from the archive contents, so no
+   * separate upgrade call is needed.
+   *
+   * @param ipaPath - Absolute path to the local `.ipa`
+   * @param opts - Install options
+   */
+  async install(ipaPath: string, opts: ZipConduitInstallOptions = {}): Promise<void> {
+    this._lastLoggedProgress = undefined;
+    await this.service.install(ipaPath, {
+      timeoutMs: opts.timeoutMs,
+      progress: ({percent, status}) => this.logInstallProgress(percent, status),
+    });
+  }
+
+  /**
+   * Close the underlying socket.
+   */
+  async close(): Promise<void> {
+    try {
+      this.service.close();
+    } catch (err: any) {
+      this._log.debug(`Error closing zip_conduit service: ${err.message}`);
+    }
+  }
+
+  private logInstallProgress(percent: number, status: string): void {
+    if (
+      percent === this._lastLoggedProgress?.percent &&
+      status === this._lastLoggedProgress?.status
+    ) {
+      return;
+    }
+    this._lastLoggedProgress = {percent, status};
+    this._log.debug(`App install progress: ${percent}%${status ? ` (${status})` : ''}`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^2.2.2"
+    "appium-ios-remotexpc": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/test/unit/real-device-management-specs.ts
+++ b/test/unit/real-device-management-specs.ts
@@ -1,5 +1,8 @@
 import {createSandbox} from 'sinon';
+import {fs} from 'appium/support';
 import {installToRealDevice, RealDevice} from '../../lib/device/real-device-management';
+import {AfcClient} from '../../lib/device/afc-client';
+import {ZipConduitClient} from '../../lib/device/zip-conduit-client';
 import {XCUITestDriver} from '../../lib/driver';
 import type {XCUITestDriverOpts} from '../../lib/driver';
 import chai, {expect} from 'chai';
@@ -141,5 +144,86 @@ describe('installToRealDevice', function () {
     );
     expect(removeStub.called).to.be.false;
     expect(installStub.calledOnce).to.be.true;
+  });
+});
+
+describe('RealDevice install routing (zip_conduit fast path)', function () {
+  const udid = 'test-udid';
+  const ipaPath = '/path/to/app.ipa';
+  const appDir = '/path/to/app.app';
+  const bundleId = 'test.bundle.id';
+
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  const stubStat = (isFile: boolean) =>
+    sandbox.stub(fs, 'stat').resolves({isFile: () => isFile} as any);
+
+  // The AFC + installation_proxy fallback is exercised elsewhere; here we only
+  // assert routing, so we short-circuit it with a sentinel rejection from the
+  // very first call it makes.
+  const stubAfcSentinel = () =>
+    sandbox.stub(AfcClient, 'createForDevice').rejects(new Error('afc-sentinel')) as SinonStub;
+
+  it('streams an .ipa via zip_conduit on iOS 18+ and skips the AFC path', async function () {
+    const realDevice = new RealDevice(udid, {platformVersion: '18.0'} as XCUITestDriverOpts);
+    stubStat(true);
+    const installStub = sandbox.stub().resolves();
+    const closeStub = sandbox.stub().resolves();
+    const createStub = sandbox
+      .stub(ZipConduitClient, 'create')
+      .resolves({install: installStub, close: closeStub} as any) as SinonStub;
+    const afcStub = sandbox.stub(AfcClient, 'createForDevice') as SinonStub;
+
+    await realDevice.install(ipaPath, bundleId);
+
+    expect(createStub.calledOnce).to.be.true;
+    expect(installStub.calledOnceWith(ipaPath)).to.be.true;
+    expect(closeStub.calledOnce).to.be.true;
+    expect(afcStub.called).to.be.false;
+  });
+
+  it('falls back to the legacy AFC path and closes the client when zip_conduit fails', async function () {
+    const realDevice = new RealDevice(udid, {platformVersion: '18.0'} as XCUITestDriverOpts);
+    stubStat(true);
+    const closeStub = sandbox.stub().resolves();
+    sandbox.stub(ZipConduitClient, 'create').resolves({
+      install: sandbox.stub().rejects(new Error('stream-failed')),
+      close: closeStub,
+    } as any);
+    const afcStub = stubAfcSentinel();
+
+    await expect(realDevice.install(ipaPath, bundleId)).to.be.rejectedWith(/afc-sentinel/);
+    expect(closeStub.calledOnce).to.be.true;
+    expect(afcStub.calledOnce).to.be.true;
+  });
+
+  it('does not use zip_conduit for unpacked .app bundles', async function () {
+    const realDevice = new RealDevice(udid, {platformVersion: '18.0'} as XCUITestDriverOpts);
+    stubStat(false);
+    const createStub = sandbox.stub(ZipConduitClient, 'create') as SinonStub;
+    const afcStub = stubAfcSentinel();
+
+    await expect(realDevice.install(appDir, bundleId)).to.be.rejectedWith(/afc-sentinel/);
+    expect(createStub.called).to.be.false;
+    expect(afcStub.calledOnce).to.be.true;
+  });
+
+  it('does not use zip_conduit on iOS < 18', async function () {
+    const realDevice = new RealDevice(udid, {platformVersion: '17.4'} as XCUITestDriverOpts);
+    stubStat(true);
+    const createStub = sandbox.stub(ZipConduitClient, 'create') as SinonStub;
+    const afcStub = stubAfcSentinel();
+
+    await expect(realDevice.install(ipaPath, bundleId)).to.be.rejectedWith(/afc-sentinel/);
+    expect(createStub.called).to.be.false;
+    expect(afcStub.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
Utilizes zip conduit service added in https://github.com/appium/appium-ios-remotexpc/pull/229 for app installation and upgradation.

Only IPA files are supported by zip conduit service. `.app` bundles falls back to AFC+installation proxy method. ios-device fallback is also wired in.