### PR TITLE
feat: Automatically terminate obsolete sessions using device id to be claimed by the current one

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -114,6 +114,7 @@ import type {RemoteDebugger} from 'appium-remote-debugger';
 import type {XcodeVersion} from 'appium-xcode';
 import type {Simulator} from 'appium-ios-simulator';
 import type {DriverLogs} from './commands/log';
+import {sessionClaimHandler} from './session-claim-handler';
 
 const SHUTDOWN_OTHER_FEAT_NAME = 'shutdown_other_sims';
 
@@ -794,13 +795,16 @@ export class XCUITestDriver
     return this._remote;
   }
 
-  get driverData(): Record<string, any> {
-    // TODO fill out resource info here
+  override get driverData(): Record<string, any> {
     return {};
   }
 
   get device(): Simulator | RealDevice {
     return this._device;
+  }
+
+  async onIpcInit(): Promise<void> {
+    await sessionClaimHandler.registerActiveSession(this);
   }
 
   // Override methods from BaseDriver
@@ -890,6 +894,8 @@ export class XCUITestDriver
   }
 
   override async deleteSession(sessionId?: string): Promise<void> {
+    sessionClaimHandler.unregisterActiveSession(this);
+
     await removeAllSessionWebSocketHandlers.bind(this)();
 
     for (const recorder of [this._recentScreenRecorder, this._audioRecorder].filter(
@@ -1255,6 +1261,9 @@ export class XCUITestDriver
     );
     this._device = device;
     this.opts.udid = udid;
+
+    await sessionClaimHandler.registerActiveSession(this);
+    await sessionClaimHandler.claimSessionUdid(this);
 
     if (this.opts.simulatorDevicesSetPath) {
       if (realDevice) {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,3 +1,4 @@
 import {logger} from 'appium/support';
+import type {AppiumLogger} from '@appium/types';
 
-export const log = logger.getLogger('XCUITest');
+export const log: AppiumLogger = logger.getLogger('XCUITest');

--- a/lib/session-claim-handler.ts
+++ b/lib/session-claim-handler.ts
@@ -3,6 +3,7 @@ import {node, util} from 'appium/support';
 import {waitForCondition} from 'asyncbox';
 import {setTimeout as delay} from 'node:timers/promises';
 import type {XCUITestDriver} from './driver';
+import {memoize} from './utils';
 
 export type SessionUdidIpcMessage = {
   udid: string;
@@ -227,30 +228,16 @@ export class SessionClaimHandler {
   }
 }
 
-let sharedIpc: IAppiumIpc | undefined;
-let sharedIpcLoaded = false;
-let sharedIpcLoadPromise: Promise<IAppiumIpc | undefined> | undefined;
-
-async function resolveSharedIpc(): Promise<IAppiumIpc | undefined> {
-  if (sharedIpcLoaded) {
-    return sharedIpc;
-  }
-  sharedIpcLoadPromise ??= loadSharedIpc();
-  return sharedIpcLoadPromise;
-}
-
-async function loadSharedIpc(): Promise<IAppiumIpc | undefined> {
+const loadSharedIpc = memoize(async function loadSharedIpc(): Promise<IAppiumIpc | undefined> {
   try {
     const {AppiumIpc} = (await import('appium/driver.js')) as {AppiumIpc?: AppiumIpcConstructor};
-    sharedIpc = AppiumIpc ? new AppiumIpc() : undefined;
+    return AppiumIpc ? new AppiumIpc() : undefined;
   } catch {
-    sharedIpc = undefined;
+    return undefined;
   }
-  sharedIpcLoaded = true;
-  return sharedIpc;
-}
+});
 
-export const sessionClaimHandler = new SessionClaimHandler(resolveSharedIpc);
+export const sessionClaimHandler = new SessionClaimHandler(loadSharedIpc);
 
 export const SESSION_UDID_CLAIMED_IPC_TOPIC = SessionClaimHandler.CLAIMED_TOPIC;
 export const SESSION_UDID_CONTENDED_IPC_TOPIC = SessionClaimHandler.CONTENDED_TOPIC;
@@ -260,9 +247,7 @@ export const SESSION_UDID_RELEASED_IPC_TOPIC = SessionClaimHandler.RELEASED_TOPI
  * @internal Exposed for unit tests.
  */
 export function setSharedIpcForTesting(ipc: IAppiumIpc | undefined): void {
-  sharedIpc = ipc;
-  sharedIpcLoaded = true;
-  sharedIpcLoadPromise = Promise.resolve(ipc);
+  loadSharedIpc.cache.set(undefined, Promise.resolve(ipc));
 }
 
 /**
@@ -270,7 +255,5 @@ export function setSharedIpcForTesting(ipc: IAppiumIpc | undefined): void {
  */
 export function resetDriverInstanceIpcForTesting(): void {
   sessionClaimHandler.resetForTesting();
-  sharedIpc = undefined;
-  sharedIpcLoaded = false;
-  sharedIpcLoadPromise = undefined;
+  loadSharedIpc.cache.clear();
 }

--- a/lib/session-claim-handler.ts
+++ b/lib/session-claim-handler.ts
@@ -270,10 +270,6 @@ const loadSharedIpc = memoize(async function loadSharedIpc(): Promise<IAppiumIpc
 
 export const sessionClaimHandler = new SessionClaimHandler(loadSharedIpc);
 
-export const SESSION_UDID_CLAIMED_IPC_TOPIC = SessionClaimHandler.CLAIMED_TOPIC;
-export const SESSION_UDID_CONTENDED_IPC_TOPIC = SessionClaimHandler.CONTENDED_TOPIC;
-export const SESSION_UDID_RELEASED_IPC_TOPIC = SessionClaimHandler.RELEASED_TOPIC;
-
 /**
  * @internal Exposed for unit tests.
  */

--- a/lib/session-claim-handler.ts
+++ b/lib/session-claim-handler.ts
@@ -1,5 +1,5 @@
 import type {IAppiumIpc, IIpcSubscription, IpcMessage} from '@appium/types';
-import {util} from 'appium/support';
+import {node, util} from 'appium/support';
 import {waitForCondition} from 'asyncbox';
 import {setTimeout as delay} from 'node:timers/promises';
 import type {XCUITestDriver} from './driver';
@@ -215,7 +215,7 @@ export class SessionClaimHandler {
   }
 
   private getPublisherId(driver: XCUITestDriver): string {
-    return `xcuitest-driver@${driver.sessionId ?? 'unknown'}`;
+    return node.getObjectId(driver);
   }
 
   private isMatchingSessionUdidMessage(

--- a/lib/session-claim-handler.ts
+++ b/lib/session-claim-handler.ts
@@ -1,4 +1,4 @@
-import type {IAppiumIpc, IIpcSubscription, IpcMessage} from '@appium/types';
+import type {AppiumLogger, IAppiumIpc, IIpcSubscription, IpcMessage} from '@appium/types';
 import {node, util} from 'appium/support';
 import {waitForCondition} from 'asyncbox';
 import {setTimeout as delay} from 'node:timers/promises';
@@ -44,7 +44,7 @@ export class SessionClaimHandler {
       this.getPublisherId(driver),
     );
     subscription.on('message', (message) => {
-      this.handleSessionUdidMessage(driver, udid, message);
+      void this.dispatchSessionUdidMessage(driver, udid, sessionId, message);
     });
     this.subscriptionsBySessionId.set(sessionId, subscription);
   }
@@ -98,42 +98,46 @@ export class SessionClaimHandler {
       }
     });
 
-    await ipc.publish<SessionUdidIpcMessage>(
-      SessionClaimHandler.CLAIMED_TOPIC,
-      this.getPublisherId(driver),
-      {
-        udid,
-        sessionId,
-      },
-    );
-    await delay(SessionClaimHandler.CONTENTION_PROBE_MS);
-    contendedSubscription.unsubscribe();
-
-    if (contendingSessionIds.size === 0) {
-      releasedSubscription.unsubscribe();
-      return;
-    }
-
     try {
-      await waitForCondition(
-        () => [...contendingSessionIds].every((id) => releasedSessionIds.has(id)),
+      await ipc.publish<SessionUdidIpcMessage>(
+        SessionClaimHandler.CLAIMED_TOPIC,
+        this.getPublisherId(driver),
         {
-          waitMs: SessionClaimHandler.RELEASE_WAIT_MS,
-          intervalMs: 50,
+          udid,
+          sessionId,
         },
       );
-      driver.log.debug(
-        `Received release confirmation from ${util.pluralize('session', contendingSessionIds.size, true)} for udid '${udid}'`,
-      );
-    } catch {
-      const pendingSessionIds = [...contendingSessionIds].filter(
-        (id) => !releasedSessionIds.has(id),
-      );
-      driver.log.warn(
-        `Timed out after ${SessionClaimHandler.RELEASE_WAIT_MS}ms waiting for ${util.pluralize('session', pendingSessionIds.length, true)} ` +
-          `[${pendingSessionIds.join(', ')}] to release udid '${udid}'. Proceeding with session startup.`,
-      );
+      await delay(SessionClaimHandler.CONTENTION_PROBE_MS);
+
+      if (contendingSessionIds.size === 0) {
+        return;
+      }
+
+      try {
+        await waitForCondition(
+          () => [...contendingSessionIds].every((id) => releasedSessionIds.has(id)),
+          {
+            waitMs: SessionClaimHandler.RELEASE_WAIT_MS,
+            intervalMs: 50,
+          },
+        );
+        driver.log.debug(
+          `Received release confirmation from ` +
+            `${util.pluralize('session', contendingSessionIds.size, true)} for udid '${udid}'`,
+        );
+      } catch {
+        const pendingSessionIds = [...contendingSessionIds].filter(
+          (id) => !releasedSessionIds.has(id),
+        );
+        driver.log.warn(
+          `Timed out after ${SessionClaimHandler.RELEASE_WAIT_MS}ms waiting for ` +
+            `${util.pluralize('session', pendingSessionIds.length, true)} ` +
+            `[${pendingSessionIds.join(', ')}] to release udid '${udid}'. ` +
+            `Proceeding with session startup.`,
+        );
+      }
     } finally {
+      contendedSubscription.unsubscribe();
       releasedSubscription.unsubscribe();
     }
   }
@@ -146,16 +150,38 @@ export class SessionClaimHandler {
     this.subscriptionsBySessionId.clear();
   }
 
-  private handleSessionUdidMessage(
+  private async dispatchSessionUdidMessage(
+    driver: XCUITestDriver,
+    udid: string,
+    sessionId: string,
+    message: IpcMessage<SessionUdidIpcMessage>,
+  ): Promise<void> {
+    try {
+      await this.handleSessionUdidMessage(driver, udid, message);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      driver.log.warn(`Could not handle udid claim IPC message for session '${sessionId}': ${msg}`);
+    }
+  }
+
+  private async handleSessionUdidMessage(
     driver: XCUITestDriver,
     udid: string,
     message: IpcMessage<SessionUdidIpcMessage>,
-  ): void {
+  ): Promise<void> {
     if (!this.isMatchingSessionUdidMessage(message, udid, driver.sessionId ?? undefined)) {
       return;
     }
 
-    void this.publishSessionUdidContended(driver, udid);
+    try {
+      await this.publishSessionUdidContended(driver, udid);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      driver.log.warn(
+        `Could not publish udid contention message for session '${driver.sessionId}': ${msg}`,
+      );
+    }
+
     driver.log.warn(
       `Session '${message.data.sessionId}' is starting on udid '${udid}', which is already in use ` +
         `by another session identified by ${driver.sessionId}. Running multiple parallel sessions on the same ` +
@@ -163,7 +189,7 @@ export class SessionClaimHandler {
         `and make sure to properly quit the previous session before starting a new one. ` +
         `Terminating the obsolete session.`,
     );
-    void this.terminateSessionOnRequest(driver, udid);
+    await this.terminateSessionOnRequest(driver, udid);
   }
 
   private async publishSessionUdidContended(driver: XCUITestDriver, udid: string): Promise<void> {
@@ -185,34 +211,39 @@ export class SessionClaimHandler {
 
   private async terminateSessionOnRequest(driver: XCUITestDriver, udid: string): Promise<void> {
     const sessionId = driver.sessionId ?? undefined;
+    const publisherId = sessionId ? this.getPublisherId(driver) : undefined;
+    const {log} = driver;
+
     try {
       await driver.deleteSession();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      driver.log.warn(`Could not terminate session '${sessionId}' on IPC request: ${msg}`);
-    } finally {
-      await this.publishSessionUdidReleased(driver, udid, sessionId);
+      log.warn(`Could not terminate session '${sessionId}' on IPC request: ${msg}`);
     }
+
+    await this.publishSessionUdidReleased(log, udid, sessionId, publisherId);
   }
 
   private async publishSessionUdidReleased(
-    driver: XCUITestDriver,
+    log: AppiumLogger,
     udid: string,
     sessionId: string | undefined,
+    publisherId: string | undefined,
   ): Promise<void> {
-    const ipc = await this.getIpc();
-    if (!ipc || !udid || !sessionId) {
-      return;
-    }
+    try {
+      const ipc = await this.getIpc();
+      if (!ipc || !udid || !sessionId || !publisherId) {
+        return;
+      }
 
-    await ipc.publish<SessionUdidIpcMessage>(
-      SessionClaimHandler.RELEASED_TOPIC,
-      this.getPublisherId(driver),
-      {
+      await ipc.publish<SessionUdidIpcMessage>(SessionClaimHandler.RELEASED_TOPIC, publisherId, {
         udid,
         sessionId,
-      },
-    );
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`Could not publish udid release message for session '${sessionId}': ${msg}`);
+    }
   }
 
   private getPublisherId(driver: XCUITestDriver): string {

--- a/lib/session-claim-handler.ts
+++ b/lib/session-claim-handler.ts
@@ -1,0 +1,276 @@
+import type {IAppiumIpc, IIpcSubscription, IpcMessage} from '@appium/types';
+import {util} from 'appium/support';
+import {waitForCondition} from 'asyncbox';
+import {setTimeout as delay} from 'node:timers/promises';
+import type {XCUITestDriver} from './driver';
+
+export type SessionUdidIpcMessage = {
+  udid: string;
+  sessionId: string;
+};
+
+type AppiumIpcConstructor = new () => IAppiumIpc;
+type IpcProvider = () => Promise<IAppiumIpc | undefined>;
+
+export class SessionClaimHandler {
+  static readonly CLAIMED_TOPIC = 'xcuitest:sessionUdidClaimed';
+  static readonly CONTENDED_TOPIC = 'xcuitest:sessionUdidContended';
+  static readonly RELEASED_TOPIC = 'xcuitest:sessionUdidReleased';
+
+  private static readonly CONTENTION_PROBE_MS = 10;
+  private static readonly RELEASE_WAIT_MS = 15000;
+
+  private readonly subscriptionsBySessionId = new Map<
+    string,
+    IIpcSubscription<SessionUdidIpcMessage>
+  >();
+
+  constructor(private readonly getIpc: IpcProvider) {}
+
+  /** Subscribe the current session to udid claim messages from other sessions. */
+  async registerActiveSession(driver: XCUITestDriver): Promise<void> {
+    const ipc = await this.getIpc();
+    const udid = driver.opts.udid;
+    const sessionId = driver.sessionId;
+    if (!ipc || !udid || !sessionId) {
+      return;
+    }
+
+    this.unregisterActiveSession(driver);
+
+    const subscription = ipc.subscribe<SessionUdidIpcMessage>(
+      SessionClaimHandler.CLAIMED_TOPIC,
+      this.getPublisherId(driver),
+    );
+    subscription.on('message', (message) => {
+      this.handleSessionUdidMessage(driver, udid, message);
+    });
+    this.subscriptionsBySessionId.set(sessionId, subscription);
+  }
+
+  /** Unsubscribe the current session from udid claim messages. */
+  unregisterActiveSession(driver: XCUITestDriver): void {
+    const sessionId = driver.sessionId;
+    if (!sessionId) {
+      return;
+    }
+
+    this.subscriptionsBySessionId.get(sessionId)?.unsubscribe();
+    this.subscriptionsBySessionId.delete(sessionId);
+  }
+
+  /** Publish this session's udid so any existing session on the same device can terminate. */
+  async claimSessionUdid(driver: XCUITestDriver): Promise<void> {
+    const ipc = await this.getIpc();
+    if (!ipc) {
+      driver.log.debug(
+        'Driver-instance IPC is unavailable. Skipping publication of the session udid.',
+      );
+      return;
+    }
+
+    const udid = driver.opts.udid;
+    const sessionId = driver.sessionId;
+    if (!udid || !sessionId) {
+      driver.log.debug('The session udid is not known yet. Skipping udid publication.');
+      return;
+    }
+
+    const contendingSessionIds = new Set<string>();
+    const releasedSessionIds = new Set<string>();
+    const contendedSubscription = ipc.subscribe<SessionUdidIpcMessage>(
+      SessionClaimHandler.CONTENDED_TOPIC,
+      this.getPublisherId(driver),
+    );
+    const releasedSubscription = ipc.subscribe<SessionUdidIpcMessage>(
+      SessionClaimHandler.RELEASED_TOPIC,
+      this.getPublisherId(driver),
+    );
+    contendedSubscription.on('message', (message) => {
+      if (this.isMatchingSessionUdidMessage(message, udid, sessionId)) {
+        contendingSessionIds.add(message.data.sessionId);
+      }
+    });
+    releasedSubscription.on('message', (message) => {
+      if (this.isMatchingSessionUdidMessage(message, udid, sessionId)) {
+        releasedSessionIds.add(message.data.sessionId);
+      }
+    });
+
+    await ipc.publish<SessionUdidIpcMessage>(
+      SessionClaimHandler.CLAIMED_TOPIC,
+      this.getPublisherId(driver),
+      {
+        udid,
+        sessionId,
+      },
+    );
+    await delay(SessionClaimHandler.CONTENTION_PROBE_MS);
+    contendedSubscription.unsubscribe();
+
+    if (contendingSessionIds.size === 0) {
+      releasedSubscription.unsubscribe();
+      return;
+    }
+
+    try {
+      await waitForCondition(
+        () => [...contendingSessionIds].every((id) => releasedSessionIds.has(id)),
+        {
+          waitMs: SessionClaimHandler.RELEASE_WAIT_MS,
+          intervalMs: 50,
+        },
+      );
+      driver.log.debug(
+        `Received release confirmation from ${util.pluralize('session', contendingSessionIds.size, true)} for udid '${udid}'`,
+      );
+    } catch {
+      const pendingSessionIds = [...contendingSessionIds].filter(
+        (id) => !releasedSessionIds.has(id),
+      );
+      driver.log.warn(
+        `Timed out after ${SessionClaimHandler.RELEASE_WAIT_MS}ms waiting for ${util.pluralize('session', pendingSessionIds.length, true)} ` +
+          `[${pendingSessionIds.join(', ')}] to release udid '${udid}'. Proceeding with session startup.`,
+      );
+    } finally {
+      releasedSubscription.unsubscribe();
+    }
+  }
+
+  /** @internal Exposed for unit tests. */
+  resetForTesting(): void {
+    for (const subscription of this.subscriptionsBySessionId.values()) {
+      subscription.unsubscribe();
+    }
+    this.subscriptionsBySessionId.clear();
+  }
+
+  private handleSessionUdidMessage(
+    driver: XCUITestDriver,
+    udid: string,
+    message: IpcMessage<SessionUdidIpcMessage>,
+  ): void {
+    if (!this.isMatchingSessionUdidMessage(message, udid, driver.sessionId ?? undefined)) {
+      return;
+    }
+
+    void this.publishSessionUdidContended(driver, udid);
+    driver.log.warn(
+      `Session '${message.data.sessionId}' is starting on udid '${udid}', which is already in use ` +
+        `by another session identified by ${driver.sessionId}. Running multiple parallel sessions on the same ` +
+        `device is highly discouraged. Consider enabling the Appium server's '--session-override' flag ` +
+        `and make sure to properly quit the previous session before starting a new one. ` +
+        `Terminating the obsolete session.`,
+    );
+    void this.terminateSessionOnRequest(driver, udid);
+  }
+
+  private async publishSessionUdidContended(driver: XCUITestDriver, udid: string): Promise<void> {
+    const ipc = await this.getIpc();
+    const sessionId = driver.sessionId ?? undefined;
+    if (!ipc || !udid || !sessionId) {
+      return;
+    }
+
+    await ipc.publish<SessionUdidIpcMessage>(
+      SessionClaimHandler.CONTENDED_TOPIC,
+      this.getPublisherId(driver),
+      {
+        udid,
+        sessionId,
+      },
+    );
+  }
+
+  private async terminateSessionOnRequest(driver: XCUITestDriver, udid: string): Promise<void> {
+    const sessionId = driver.sessionId ?? undefined;
+    try {
+      await driver.deleteSession();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      driver.log.warn(`Could not terminate session '${sessionId}' on IPC request: ${msg}`);
+    } finally {
+      await this.publishSessionUdidReleased(driver, udid, sessionId);
+    }
+  }
+
+  private async publishSessionUdidReleased(
+    driver: XCUITestDriver,
+    udid: string,
+    sessionId: string | undefined,
+  ): Promise<void> {
+    const ipc = await this.getIpc();
+    if (!ipc || !udid || !sessionId) {
+      return;
+    }
+
+    await ipc.publish<SessionUdidIpcMessage>(
+      SessionClaimHandler.RELEASED_TOPIC,
+      this.getPublisherId(driver),
+      {
+        udid,
+        sessionId,
+      },
+    );
+  }
+
+  private getPublisherId(driver: XCUITestDriver): string {
+    return `xcuitest-driver@${driver.sessionId ?? 'unknown'}`;
+  }
+
+  private isMatchingSessionUdidMessage(
+    message: IpcMessage<SessionUdidIpcMessage>,
+    udid: string,
+    sessionId: string | undefined,
+  ): boolean {
+    return message.data.udid === udid && message.data.sessionId !== sessionId;
+  }
+}
+
+let sharedIpc: IAppiumIpc | undefined;
+let sharedIpcLoaded = false;
+let sharedIpcLoadPromise: Promise<IAppiumIpc | undefined> | undefined;
+
+async function resolveSharedIpc(): Promise<IAppiumIpc | undefined> {
+  if (sharedIpcLoaded) {
+    return sharedIpc;
+  }
+  sharedIpcLoadPromise ??= loadSharedIpc();
+  return sharedIpcLoadPromise;
+}
+
+async function loadSharedIpc(): Promise<IAppiumIpc | undefined> {
+  try {
+    const {AppiumIpc} = (await import('appium/driver.js')) as {AppiumIpc?: AppiumIpcConstructor};
+    sharedIpc = AppiumIpc ? new AppiumIpc() : undefined;
+  } catch {
+    sharedIpc = undefined;
+  }
+  sharedIpcLoaded = true;
+  return sharedIpc;
+}
+
+export const sessionClaimHandler = new SessionClaimHandler(resolveSharedIpc);
+
+export const SESSION_UDID_CLAIMED_IPC_TOPIC = SessionClaimHandler.CLAIMED_TOPIC;
+export const SESSION_UDID_CONTENDED_IPC_TOPIC = SessionClaimHandler.CONTENDED_TOPIC;
+export const SESSION_UDID_RELEASED_IPC_TOPIC = SessionClaimHandler.RELEASED_TOPIC;
+
+/**
+ * @internal Exposed for unit tests.
+ */
+export function setSharedIpcForTesting(ipc: IAppiumIpc | undefined): void {
+  sharedIpc = ipc;
+  sharedIpcLoaded = true;
+  sharedIpcLoadPromise = Promise.resolve(ipc);
+}
+
+/**
+ * @internal Exposed for unit tests.
+ */
+export function resetDriverInstanceIpcForTesting(): void {
+  sessionClaimHandler.resetForTesting();
+  sharedIpc = undefined;
+  sharedIpcLoaded = false;
+  sharedIpcLoadPromise = undefined;
+}

--- a/package.json
+++ b/package.json
@@ -143,14 +143,11 @@
   "peerDependencies": {
     "appium": "^3.0.0-rc.2"
   },
-  "overrides": {
-    "@appium/types": "1.5.0"
-  },
   "devDependencies": {
     "@appium/docutils": "^2.4.0",
     "@appium/eslint-config-appium-ts": "^3.0.0",
     "@appium/tsconfig": "^1.0.0-rc.1",
-    "@appium/types": "1.5.0",
+    "@appium/types": "^1.5.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -143,11 +143,14 @@
   "peerDependencies": {
     "appium": "^3.0.0-rc.2"
   },
+  "overrides": {
+    "@appium/types": "1.5.0"
+  },
   "devDependencies": {
     "@appium/docutils": "^2.4.0",
     "@appium/eslint-config-appium-ts": "^3.0.0",
     "@appium/tsconfig": "^1.0.0-rc.1",
-    "@appium/types": "^1.0.0-rc.1",
+    "@appium/types": "1.5.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/mocha": "^10.0.1",

--- a/test/functional/driver/session-claim-e2e-specs.ts
+++ b/test/functional/driver/session-claim-e2e-specs.ts
@@ -1,0 +1,103 @@
+import {retryInterval} from 'asyncbox';
+import {getSimulator} from 'appium-ios-simulator';
+import {Simctl} from 'node-simctl';
+import type {Browser} from 'webdriverio';
+import chai, {expect} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  amendCapabilities,
+  extractCapabilityValue,
+  getUICatalogSimCaps,
+} from '../desired';
+import {assertSessionClaimIpcTraces, readAppiumLog} from '../helpers/appium-log';
+import {getFreePort} from '../helpers/ports';
+import {cleanupSimulator, deleteDeviceWithRetry} from '../helpers/simulator';
+import {
+  createRemoteSession,
+  deleteRemoteSession,
+  MOCHA_TIMEOUT,
+} from '../helpers/session';
+
+chai.use(chaiAsPromised);
+
+const SIM_DEVICE_NAME = 'xcuitestSessionClaimTest';
+
+async function createDevice() {
+  const simctl = new Simctl();
+  return await simctl.createDevice(
+    SIM_DEVICE_NAME,
+    process.env.DEVICE_NAME || 'iPhone 15',
+    process.env.PLATFORM_VERSION || '17.4',
+  );
+}
+
+describe('XCUITestDriver - session udid claim', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let udid: string;
+  let baseCaps: ReturnType<typeof amendCapabilities>;
+  let firstDriver: Browser | undefined;
+  let secondDriver: Browser | undefined;
+
+  before(async function () {
+    if (!process.env.APPIUM_LOG_PATH) {
+      this.skip();
+      return;
+    }
+
+    udid = await createDevice();
+    const uiCatalogSimCaps = await getUICatalogSimCaps();
+    baseCaps = amendCapabilities(uiCatalogSimCaps, {
+      'appium:udid': udid,
+      'appium:usePrebuiltWDA': true,
+      'appium:wdaStartupRetries': 0,
+      'appium:noReset': true,
+    });
+  });
+
+  afterEach(async function () {
+    await deleteRemoteSession(secondDriver);
+    await deleteRemoteSession(firstDriver);
+    secondDriver = undefined;
+    firstDriver = undefined;
+  });
+
+  after(async function () {
+    const sim = await getSimulator(udid, {
+      platform: 'iOS',
+      checkExistence: false,
+    });
+    await cleanupSimulator(sim);
+    await deleteDeviceWithRetry(udid);
+  });
+
+  it('should terminate the previous session when a new session claims the same udid', async function () {
+    firstDriver = await createRemoteSession(baseCaps);
+    expect(firstDriver.sessionId).to.be.a('string').that.is.not.empty;
+    expect((await firstDriver.$$('XCUIElementTypeWindow')).length).to.be.at.least(1);
+
+    const firstSessionId = firstDriver.sessionId;
+    const wdaLocalPort = await getFreePort();
+    secondDriver = await createRemoteSession(
+      amendCapabilities(baseCaps, {
+        'appium:wdaLocalPort': wdaLocalPort,
+      }),
+    );
+
+    expect(secondDriver.sessionId).to.be.a('string').that.is.not.empty;
+    expect(secondDriver.sessionId).to.not.equal(firstSessionId);
+
+    await retryInterval(20, 500, async () => {
+      await expect(firstDriver!.getWindowRect()).to.be.rejectedWith(
+        /invalid session id|session is either terminated or not started/i,
+      );
+    });
+
+    expect((await secondDriver.$$('XCUIElementTypeWindow')).length).to.be.at.least(1);
+    expect(extractCapabilityValue(baseCaps, 'appium:udid')).to.equal(udid);
+
+    const appiumLog = await readAppiumLog();
+    expect(appiumLog, 'APPIUM_LOG_PATH must point to a readable log file').to.be.a('string');
+    assertSessionClaimIpcTraces(appiumLog!);
+  });
+});

--- a/test/functional/driver/session-claim-e2e-specs.ts
+++ b/test/functional/driver/session-claim-e2e-specs.ts
@@ -4,19 +4,11 @@ import {Simctl} from 'node-simctl';
 import type {Browser} from 'webdriverio';
 import chai, {expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {
-  amendCapabilities,
-  extractCapabilityValue,
-  getUICatalogSimCaps,
-} from '../desired';
+import {amendCapabilities, extractCapabilityValue, getUICatalogSimCaps} from '../desired';
 import {assertSessionClaimIpcTraces, readAppiumLog} from '../helpers/appium-log';
 import {getFreePort} from '../helpers/ports';
 import {cleanupSimulator, deleteDeviceWithRetry} from '../helpers/simulator';
-import {
-  createRemoteSession,
-  deleteRemoteSession,
-  MOCHA_TIMEOUT,
-} from '../helpers/session';
+import {createRemoteSession, deleteRemoteSession, MOCHA_TIMEOUT} from '../helpers/session';
 
 chai.use(chaiAsPromised);
 

--- a/test/functional/helpers/appium-log.ts
+++ b/test/functional/helpers/appium-log.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs/promises';
+
+const IPC_UNAVAILABLE_PATTERN = /Driver-instance IPC is unavailable/i;
+const SESSION_OVERRIDE_CLEANUP_PATTERN = /Cleaning up \d+ active sessions?/i;
+const IPC_CLAIM_WARNING_PATTERN = /Terminating the obsolete session/i;
+const IPC_CLAIMED_TOPIC_PATTERN = /xcuitest:sessionUdidClaimed/i;
+
+export async function readAppiumLog(): Promise<string | undefined> {
+  const logPath = process.env.APPIUM_LOG_PATH;
+  if (!logPath) {
+    return undefined;
+  }
+  return await fs.readFile(logPath, 'utf8');
+}
+
+export function assertSessionClaimIpcTraces(log: string): void {
+  if (IPC_UNAVAILABLE_PATTERN.test(log)) {
+    throw new Error(
+      'Appium server log shows driver-instance IPC is unavailable. ' +
+        'Use Appium 3.5.0 or newer (npx appium from this project) so AppiumIpc is exported.',
+    );
+  }
+
+  if (SESSION_OVERRIDE_CLEANUP_PATTERN.test(log)) {
+    throw new Error(
+      'Appium server log shows session-override cleanup. ' +
+        'Do not start the test server with --session-override; it terminates existing sessions ' +
+        'before the XCUITest driver IPC claim handler can run.',
+    );
+  }
+
+  if (!IPC_CLAIM_WARNING_PATTERN.test(log)) {
+    throw new Error(
+      'Appium server log is missing the session claim warning ' +
+        '("Terminating the obsolete session"). The IPC handler did not terminate the first session.',
+    );
+  }
+
+  if (!IPC_CLAIMED_TOPIC_PATTERN.test(log)) {
+    throw new Error(
+      'Appium server log is missing xcuitest:sessionUdidClaimed IPC activity. ' +
+        'The session claim pub/sub flow did not run.',
+    );
+  }
+}

--- a/test/functional/helpers/session.ts
+++ b/test/functional/helpers/session.ts
@@ -1,12 +1,30 @@
-const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
-const PORT = parseInt(String(process.env.APPIUM_TEST_SERVER_PORT), 10) || 4567;
-const MOCHA_TIMEOUT = 60 * 1000 * 4;
+import type {Capabilities} from '@wdio/types';
+import type {Browser} from 'webdriverio';
 
-let driver;
+export const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
+export const PORT = parseInt(String(process.env.APPIUM_TEST_SERVER_PORT), 10) || 4567;
+export const MOCHA_TIMEOUT = 60 * 1000 * 4;
 
-async function initSession(caps, remoteOpts = {}) {
+export type SessionCapabilities = Capabilities.RequestedStandaloneCapabilities;
+
+type RemoteSessionOptions = Omit<
+  Capabilities.WebdriverIOConfig,
+  'hostname' | 'port' | 'capabilities' | 'connectionRetryTimeout' | 'connectionRetryCount'
+>;
+
+type TestSessionDriver = Browser & {
+  name?: string;
+  errored?: boolean;
+};
+
+let driver: TestSessionDriver | undefined;
+
+export async function createRemoteSession(
+  caps: SessionCapabilities,
+  remoteOpts: RemoteSessionOptions = {},
+): Promise<Browser> {
   const {remote} = await import('webdriverio');
-  driver = await remote({
+  return remote({
     hostname: HOST,
     port: PORT,
     capabilities: caps,
@@ -14,18 +32,32 @@ async function initSession(caps, remoteOpts = {}) {
     connectionRetryCount: 1,
     ...remoteOpts,
   });
+}
+
+export async function initSession(
+  caps: SessionCapabilities,
+  remoteOpts: RemoteSessionOptions = {},
+): Promise<TestSessionDriver> {
+  driver = await createRemoteSession(caps, remoteOpts);
   driver.name = undefined;
   driver.errored = false;
   return driver;
 }
 
-async function deleteSession() {
+export async function deleteRemoteSession(sessionDriver?: Browser): Promise<void> {
+  if (!sessionDriver) {
+    return;
+  }
   try {
-    await driver.deleteSession();
+    await sessionDriver.deleteSession();
   } catch {
+  }
+}
+
+export async function deleteSession(): Promise<void> {
+  try {
+    await deleteRemoteSession(driver);
   } finally {
     driver = undefined;
   }
 }
-
-export {initSession, deleteSession, HOST, PORT, MOCHA_TIMEOUT};

--- a/test/functional/helpers/session.ts
+++ b/test/functional/helpers/session.ts
@@ -50,8 +50,7 @@ export async function deleteRemoteSession(sessionDriver?: Browser): Promise<void
   }
   try {
     await sessionDriver.deleteSession();
-  } catch {
-  }
+  } catch {}
 }
 
 export async function deleteSession(): Promise<void> {

--- a/test/unit/session-claim-handler-specs.ts
+++ b/test/unit/session-claim-handler-specs.ts
@@ -1,4 +1,5 @@
 import type {IAppiumIpc, IpcData, IpcMessage} from '@appium/types';
+import {node} from 'appium/support';
 import {EventEmitter} from 'node:events';
 import {createSandbox} from 'sinon';
 import type sinon from 'sinon';
@@ -192,7 +193,7 @@ describe('SessionClaimHandler', function () {
 
     expect(publish.firstCall.args).to.eql([
       SESSION_UDID_CLAIMED_IPC_TOPIC,
-      'xcuitest-driver@new-session',
+      node.getObjectId(newDriver),
       {
         udid: 'device-1',
         sessionId: 'new-session',

--- a/test/unit/session-claim-handler-specs.ts
+++ b/test/unit/session-claim-handler-specs.ts
@@ -1,0 +1,220 @@
+import type {IAppiumIpc, IpcData, IpcMessage} from '@appium/types';
+import {EventEmitter} from 'node:events';
+import {createSandbox} from 'sinon';
+import type sinon from 'sinon';
+import {expect} from 'chai';
+import {
+  resetDriverInstanceIpcForTesting,
+  sessionClaimHandler,
+  setSharedIpcForTesting,
+  SESSION_UDID_CLAIMED_IPC_TOPIC,
+  SESSION_UDID_CONTENDED_IPC_TOPIC,
+  SESSION_UDID_RELEASED_IPC_TOPIC,
+} from '../../lib/session-claim-handler';
+import type {XCUITestDriver} from '../../lib/driver';
+
+class MockIpcSubscription extends EventEmitter {
+  isActive = true;
+
+  constructor(public topic: string) {
+    super();
+  }
+
+  unsubscribe(): boolean {
+    if (!this.isActive) {
+      return false;
+    }
+    this.isActive = false;
+    this.removeAllListeners();
+    return true;
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+class MockIpc {
+  subscriptions: MockIpcSubscription[] = [];
+  lastMessages = new Map<string, IpcMessage<IpcData>>();
+
+  subscribe<T extends IpcData>(topic: string, _subscriber: string): MockIpcSubscription {
+    const subscription = new MockIpcSubscription(topic);
+    this.subscriptions.push(subscription);
+    return subscription;
+  }
+
+  unsubscribe(_topic: string, _subscriber: string): boolean {
+    return false;
+  }
+
+  getMessage<T extends IpcData>(topic: string): IpcMessage<T> | undefined {
+    return this.lastMessages.get(topic) as IpcMessage<T> | undefined;
+  }
+
+  async publish<T extends IpcData>(topic: string, publisher: string, data: T): Promise<void> {
+    const message: IpcMessage<T> = {
+      publisher,
+      timestampMs: Date.now(),
+      topic,
+      data,
+    };
+    this.lastMessages.set(topic, message);
+    for (const subscription of this.subscriptions) {
+      if (subscription.topic === topic) {
+        subscription.emit('message', message);
+      }
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+describe('SessionClaimHandler', function () {
+  let sandbox;
+  let mockIpc: MockIpc;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+    mockIpc = new MockIpc();
+    setSharedIpcForTesting(mockIpc as unknown as IAppiumIpc);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    resetDriverInstanceIpcForTesting();
+  });
+
+  function makeDriver(overrides: Partial<XCUITestDriver> = {}): XCUITestDriver {
+    return {
+      sessionId: 'new-session',
+      opts: {
+        udid: 'device-1',
+      },
+      log: {
+        info: sandbox.stub(),
+        debug: sandbox.stub(),
+        warn: sandbox.stub(),
+      },
+      deleteSession: sandbox.stub().resolves(),
+      ...overrides,
+    } as unknown as XCUITestDriver;
+  }
+
+  it('should terminate an existing session when another session publishes the same udid', async function () {
+    const oldDriver = makeDriver({
+      sessionId: 'old-session',
+      opts: {udid: 'device-1'} as any,
+    });
+    oldDriver.deleteSession = sandbox.stub().callsFake(async () => {
+      sessionClaimHandler.unregisterActiveSession(oldDriver);
+    });
+    await sessionClaimHandler.registerActiveSession(oldDriver);
+    await sessionClaimHandler.claimSessionUdid(oldDriver);
+
+    const newDriver = makeDriver();
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    await sessionClaimHandler.claimSessionUdid(newDriver);
+
+    expect((oldDriver.deleteSession as sinon.SinonStub).calledOnce).to.be.true;
+    expect((oldDriver.log.warn as sinon.SinonStub).calledWithMatch(/highly discouraged/)).to.be
+      .true;
+    expect((newDriver.deleteSession as sinon.SinonStub).called).to.be.false;
+    expect(mockIpc.getMessage(SESSION_UDID_RELEASED_IPC_TOPIC)?.data).to.eql({
+      udid: 'device-1',
+      sessionId: 'old-session',
+    });
+    expect(
+      (newDriver.log.debug as sinon.SinonStub).calledWithMatch(
+        /Received release confirmation from 1 session for udid/,
+      ),
+    ).to.be.true;
+  });
+
+  it('should not wait for release confirmation when no session contends for the udid', async function () {
+    const newDriver = makeDriver();
+    const startMs = Date.now();
+
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    await sessionClaimHandler.claimSessionUdid(newDriver);
+
+    expect(Date.now() - startMs).to.be.lessThan(200);
+  });
+
+  it('should wait for all contending sessions to release the udid', async function () {
+    const oldDrivers = await Promise.all(
+      ['old-session-1', 'old-session-2'].map(async (sessionId) => {
+        const oldDriver = makeDriver({
+          sessionId,
+          opts: {udid: 'device-1'} as any,
+        });
+        oldDriver.deleteSession = sandbox.stub().callsFake(async () => {
+          sessionClaimHandler.unregisterActiveSession(oldDriver);
+        });
+        await sessionClaimHandler.registerActiveSession(oldDriver);
+        return oldDriver;
+      }),
+    );
+
+    const newDriver = makeDriver({sessionId: 'new-session'});
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    await sessionClaimHandler.claimSessionUdid(newDriver);
+
+    for (const oldDriver of oldDrivers) {
+      expect((oldDriver.deleteSession as sinon.SinonStub).calledOnce).to.be.true;
+    }
+    expect(
+      (newDriver.log.debug as sinon.SinonStub).calledWithMatch(
+        /Received release confirmation from 2 sessions for udid/,
+      ),
+    ).to.be.true;
+  });
+
+  it('should publish a contended message before terminating an obsolete session', async function () {
+    const publish = sandbox.spy(mockIpc, 'publish');
+    const oldDriver = makeDriver({
+      sessionId: 'old-session',
+      opts: {udid: 'device-1'} as any,
+    });
+    await sessionClaimHandler.registerActiveSession(oldDriver);
+
+    const newDriver = makeDriver();
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    await sessionClaimHandler.claimSessionUdid(newDriver);
+
+    expect(publish.getCalls().some((call) => call.args[0] === SESSION_UDID_CONTENDED_IPC_TOPIC)).to
+      .be.true;
+  });
+
+  it('should publish the session udid on the shared driver IPC topic', async function () {
+    const publish = sandbox.spy(mockIpc, 'publish');
+    const newDriver = makeDriver();
+
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    publish.resetHistory();
+    await sessionClaimHandler.claimSessionUdid(newDriver);
+
+    expect(publish.firstCall.args).to.eql([
+      SESSION_UDID_CLAIMED_IPC_TOPIC,
+      'xcuitest-driver@new-session',
+      {
+        udid: 'device-1',
+        sessionId: 'new-session',
+      },
+    ]);
+  });
+
+  it('should ignore udid publications from the same session', async function () {
+    const driver = makeDriver({sessionId: 'session-1'});
+    await sessionClaimHandler.registerActiveSession(driver);
+    await sessionClaimHandler.claimSessionUdid(driver);
+
+    expect((driver.deleteSession as sinon.SinonStub).called).to.be.false;
+  });
+
+  it('should unregister IPC subscriptions on session cleanup', async function () {
+    const driver = makeDriver({sessionId: 'session-1'});
+    await sessionClaimHandler.registerActiveSession(driver);
+    expect(mockIpc.subscriptions).to.have.length(1);
+    expect(mockIpc.subscriptions[0].isActive).to.be.true;
+
+    sessionClaimHandler.unregisterActiveSession(driver);
+    expect(mockIpc.subscriptions[0].isActive).to.be.false;
+  });
+});

--- a/test/unit/session-claim-handler-specs.ts
+++ b/test/unit/session-claim-handler-specs.ts
@@ -6,11 +6,9 @@ import type sinon from 'sinon';
 import {expect} from 'chai';
 import {
   resetDriverInstanceIpcForTesting,
+  SessionClaimHandler,
   sessionClaimHandler,
   setSharedIpcForTesting,
-  SESSION_UDID_CLAIMED_IPC_TOPIC,
-  SESSION_UDID_CONTENDED_IPC_TOPIC,
-  SESSION_UDID_RELEASED_IPC_TOPIC,
 } from '../../lib/session-claim-handler';
 import type {XCUITestDriver} from '../../lib/driver';
 
@@ -117,7 +115,7 @@ describe('SessionClaimHandler', function () {
     expect((oldDriver.log.warn as sinon.SinonStub).calledWithMatch(/highly discouraged/)).to.be
       .true;
     expect((newDriver.deleteSession as sinon.SinonStub).called).to.be.false;
-    expect(mockIpc.getMessage(SESSION_UDID_RELEASED_IPC_TOPIC)?.data).to.eql({
+    expect(mockIpc.getMessage(SessionClaimHandler.RELEASED_TOPIC)?.data).to.eql({
       udid: 'device-1',
       sessionId: 'old-session',
     });
@@ -186,11 +184,11 @@ describe('SessionClaimHandler', function () {
 
     const contendedCallIndex = publish
       .getCalls()
-      .findIndex((call) => call.args[0] === SESSION_UDID_CONTENDED_IPC_TOPIC);
+      .findIndex((call) => call.args[0] === SessionClaimHandler.CONTENDED_TOPIC);
     expect(contendedCallIndex).to.be.greaterThan(-1);
     expect(callOrder).to.eql(['deleteSession']);
     expect(contendedCallIndex).to.be.lessThan(
-      publish.getCalls().findIndex((call) => call.args[0] === SESSION_UDID_RELEASED_IPC_TOPIC),
+      publish.getCalls().findIndex((call) => call.args[0] === SessionClaimHandler.RELEASED_TOPIC),
     );
   });
 
@@ -203,7 +201,7 @@ describe('SessionClaimHandler', function () {
     await sessionClaimHandler.claimSessionUdid(newDriver);
 
     expect(publish.firstCall.args).to.eql([
-      SESSION_UDID_CLAIMED_IPC_TOPIC,
+      SessionClaimHandler.CLAIMED_TOPIC,
       node.getObjectId(newDriver),
       {
         udid: 'device-1',

--- a/test/unit/session-claim-handler-specs.ts
+++ b/test/unit/session-claim-handler-specs.ts
@@ -168,10 +168,15 @@ describe('SessionClaimHandler', function () {
   });
 
   it('should publish a contended message before terminating an obsolete session', async function () {
+    const callOrder: string[] = [];
     const publish = sandbox.spy(mockIpc, 'publish');
     const oldDriver = makeDriver({
       sessionId: 'old-session',
       opts: {udid: 'device-1'} as any,
+    });
+    oldDriver.deleteSession = sandbox.stub().callsFake(async () => {
+      callOrder.push('deleteSession');
+      sessionClaimHandler.unregisterActiveSession(oldDriver);
     });
     await sessionClaimHandler.registerActiveSession(oldDriver);
 
@@ -179,8 +184,14 @@ describe('SessionClaimHandler', function () {
     await sessionClaimHandler.registerActiveSession(newDriver);
     await sessionClaimHandler.claimSessionUdid(newDriver);
 
-    expect(publish.getCalls().some((call) => call.args[0] === SESSION_UDID_CONTENDED_IPC_TOPIC)).to
-      .be.true;
+    const contendedCallIndex = publish
+      .getCalls()
+      .findIndex((call) => call.args[0] === SESSION_UDID_CONTENDED_IPC_TOPIC);
+    expect(contendedCallIndex).to.be.greaterThan(-1);
+    expect(callOrder).to.eql(['deleteSession']);
+    expect(contendedCallIndex).to.be.lessThan(
+      publish.getCalls().findIndex((call) => call.args[0] === SESSION_UDID_RELEASED_IPC_TOPIC),
+    );
   });
 
   it('should publish the session udid on the shared driver IPC topic', async function () {
@@ -217,5 +228,23 @@ describe('SessionClaimHandler', function () {
 
     sessionClaimHandler.unregisterActiveSession(driver);
     expect(mockIpc.subscriptions[0].isActive).to.be.false;
+  });
+
+  it('should unsubscribe contention listeners when claim publication fails', async function () {
+    sandbox.stub(mockIpc, 'publish').rejects(new Error('publish failed'));
+    const newDriver = makeDriver();
+
+    await sessionClaimHandler.registerActiveSession(newDriver);
+    const activeSubscriptionsBeforeClaim = mockIpc.subscriptions.filter(
+      (subscription) => subscription.isActive,
+    ).length;
+
+    await expect(sessionClaimHandler.claimSessionUdid(newDriver)).to.be.rejectedWith(
+      'publish failed',
+    );
+
+    expect(mockIpc.subscriptions.filter((subscription) => subscription.isActive)).to.have.length(
+      activeSubscriptionsBeforeClaim,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds cross-session UDID coordination via Appium driver-instance IPC ([appium#22211](https://github.com/appium/appium/pull/22211)), so a new XCUITest session can safely start on a device that may still have an active session.

When a new session claims a UDID, any existing session on that device is notified, terminates itself, and confirms release before the new session proceeds to WDA setup or timeout happens.

## How it works

Introduces `SessionClaimHandler` (`lib/session-claim-handler.ts`) with a three-topic pub/sub protocol:

| Topic | Purpose |
|---|---|
| `xcuitest:sessionUdidClaimed` | New session announces it is starting on a UDID |
| `xcuitest:sessionUdidContended` | Existing session acknowledges the conflict |
| `xcuitest:sessionUdidReleased` | Existing session confirms cleanup is complete |

**New session startup (`claimSessionUdid`):**
1. Publish a claim on the target UDID
2. Probe for 10ms for contending sessions
3. If none respond → continue immediately (no added latency)
4. If any contend → wait up to 15s for all of them to publish released, then continue

**Existing session on conflict:**
1. Publish contended
2. Log a warning (discourages parallel sessions; mentions `--session-override`)
3. Call `deleteSession()`
4. Publish released after cleanup

IPC is loaded lazily via `await import('appium/driver.js')` and gracefully skipped when unavailable (older Appium versions).

## Driver integration

- `onIpcInit()` — registers the session for claim messages
- `start()` — registers and claims the UDID **before** WDA/proxy setup
- `deleteSession()` — unregisters IPC subscriptions

No new capability is required; conflict handling is automatic when IPC is available.

## Other changes

- Bump `@appium/types` to `1.5.0` (with npm override) for `IAppiumIpc` / IPC message types
- Add explicit `AppiumLogger` type to `lib/logger.ts`
- Use `node.getObjectId(driver)` as the IPC publisher ID

## Test plan

- [x] Unit tests for `SessionClaimHandler` (`test/unit/session-claim-handler-specs.ts`)
  - Obsolete session terminated on conflicting claim
  - No wait when no session contends (~10ms probe only)
  - Wait for all contending sessions to release (multi-session case)
  - Contended message published before termination
  - Claim published on correct IPC topic
  - Same-session claims ignored
  - Subscriptions cleaned up on unregister
- [ ] Manual: start session A on device X, start session B on same UDID — A terminates, B starts cleanly
- [ ] Manual: start session on device with no prior session — no perceptible startup delay
- [ ] Manual: verify behavior when running against Appium without IPC support (graceful no-op)