### PR TITLE
feat: bump WDA to 14 for Xcode 27 build support

### DIFF
--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -81,7 +81,7 @@ application (which the driver installs on the device under test) is also downgra
 
 | iOS/iPadOS/tvOS version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
-| >= 27 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= 14.0.0) | Latest |
+| >= 27.0 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= 14.0.0) | Latest |
 | >= 26.4 | >= [10.23.2](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | 26.0 - 26.3 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | 18.0 - 18.7 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -81,7 +81,7 @@ application (which the driver installs on the device under test) is also downgra
 
 | iOS/iPadOS/tvOS version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
-| >= 27 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
+| >= 27 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= 14.0.0) | Latest |
 | >= 26.4 | >= [10.23.2](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | 26.0 - 26.3 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | 18.0 - 18.7 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -81,7 +81,7 @@ application (which the driver installs on the device under test) is also downgra
 
 | iOS/iPadOS/tvOS version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
-| >= 27.0 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= 14.0.0) | Latest |
+| >= 27.0 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= [14.0.0](https://github.com/appium/WebDriverAgent/pull/1152)) | Latest |
 | >= 26.4 | >= [10.23.2](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | 26.0 - 26.3 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | 18.0 - 18.7 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -81,7 +81,6 @@ application (which the driver installs on the device under test) is also downgra
 
 | iOS/iPadOS/tvOS version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
-| >= 27.0 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= [14.0.0](https://github.com/appium/WebDriverAgent/pull/1152)) | Latest |
 | >= 26.4 | >= [10.23.2](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | 26.0 - 26.3 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | 18.0 - 18.7 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |
@@ -94,6 +93,7 @@ application (which the driver installs on the device under test) is also downgra
 
 | Xcode version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
+| Xcode >= 27.0 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2865) (WDA >= [14.0.0](https://github.com/appium/WebDriverAgent/pull/1152)) | Latest |
 | Xcode >= 26.0 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | Xcode 16.0 - 16.4 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |
 | Xcode 15.0 - 15.4 | [4.32.23](https://github.com/appium/appium-xcuitest-driver/pull/1822) - 10.1.0 (WDA 5.6.0 - 10.1.0) | Latest (not tested) |

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -45,6 +45,7 @@ narrowed for XCUITest driver compatibility:
 
 | iOS/iPadOS/tvOS version | Supported Xcode versions (driver-adjusted) | Supported macOS versions |
 | --- | --- | -- |
+| 27 | Xcode >= 27 | macOS >= 26.4 |
 | 26 | Xcode >= 26 | macOS >= 15.6 |
 | 18 | Xcode >= 16 | macOS >= 14.3 |
 | 17 | Xcode >= 15 | macOS >= 13.3 |
@@ -80,6 +81,7 @@ application (which the driver installs on the device under test) is also downgra
 
 | iOS/iPadOS/tvOS version | Fully supported driver/WDA versions | Last likely working driver/WDA version |
 | --- | --- | --- |
+| >= 27 | >= [11.10.0](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | >= 26.4 | >= [10.23.2](https://github.com/appium/appium-xcuitest-driver/pull/2733) (WDA >= 11.1.5) | Latest |
 | 26.0 - 26.3 | >= 9.5.0 (WDA >= [9.14.1](https://github.com/appium/WebDriverAgent/pull/1032)) | Latest |
 | 18.0 - 18.7 | >= 7.24.15 (WDA >= [8.9.1](https://github.com/appium/WebDriverAgent/pull/935)) | Latest |

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "appium-ios-device": "^3.1.12",
     "appium-ios-simulator": "^8.0.0",
     "appium-remote-debugger": "^15.7.3",
-    "appium-webdriveragent": "^13.2.0",
+    "appium-webdriveragent": "^14.0.0",
     "appium-xcode": "^6.0.2",
     "async-lock": "^1.4.0",
     "asyncbox": "^6.3.0",


### PR DESCRIPTION
This WDA version update will not drop iOS 15 from table below, so this can be just a feat without any breaking changes 

<img width="731" height="449" alt="Screenshot 2026-06-08 at 10 45 34 PM" src="https://github.com/user-attachments/assets/049b63d7-b67f-47f7-a05f-fb0e01da8f1d" />
