### PR TITLE
docs: tune recent changes

### DIFF
--- a/docs/getting-started/provisioning-profile/generic-device-config.md
+++ b/docs/getting-started/provisioning-profile/generic-device-config.md
@@ -1,12 +1,11 @@
 ---
-hide:
-  - toc
-
 title: Manual Configuration for a Generic Device
 ---
 
-It is possible to build `WebDriverAgentRunner` for a generic iOS/iPadOS/tvOS device, and install the
-generated `.app` package to a real device.
+It is possible to use a version of `WebDriverAgentRunner` built for a generic iOS/iPadOS/tvOS
+device, and install the generated `.app` package to a real device.
+
+## Building WDA Yourself
 
 ```bash
 # iOS/iPadOS
@@ -25,51 +24,34 @@ provided as `derivedDataPath` argument.
     If the build fails, please make sure `WebDriverAgent.xcodeproj` has codesigning properties
     configured properly. For example, you may need to change the bundle id for the provisioning profile.
 
-The `WebDriverAgentRunner-Runner.app` can now be installed to any real device as allowed by the
-provisioning profile.
+As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO`, then
+manually codesign it as described in the [Signing WDA](#signing-wda) section.
 
-You can install the package with 3rd party tools and manage it separately as explained in
-[How To Set Up And Customize WebDriverAgent Server](../../guides/wda-custom-server.md). Note that if
-the codesigning was not correct, the installation will fail.
+You can now use third-party tools to install and manage `WebDriverAgentRunner-Runner.app` as
+explained in [the WDA Custom Server guide](../../guides/wda-custom-server.md). Note that if the
+codesigning was not correct, the installation will fail.
 
-As a more advanced method, you can generate the package with `CODE_SIGNING_ALLOWED=NO` and do
-[`codesign`](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format)
-by yourself. This would make the device management more flexible, but you would need to know about
-advanced codesign usage scenarios.
+## Using Appium-Provided Prebuilt WDA
 
 The Appium team distributes generic builds with `CODE_SIGNING_ALLOWED=NO` at
-[WebDriverAgent package releases](https://github.com/appium/WebDriverAgent/releases).
-It is recommended to sign packages with a wildcard (`*`) provisioning profile,
-although such profiles require a paid Apple Developer account.
-For example, if you're preparing such a provisioning profile for `io.appium.WebDriverAgentRunner.xctrunner`, it will be for `io.appium.*`, `io.appium.WebDriverAgentRunner.*` or `*`.
+[WebDriverAgent package releases](https://github.com/appium/WebDriverAgent/releases). These builds
+must be codesigned first, after which they can be installed as described in the previous section.
 
-In case of a free account or paid account without `*` provisioning profile,
-you may need to update the bundle id before building so `xcodebuild` can produce
-a properly signed WebDriverAgent package. Another option is to re-sign an existing
-package and remap its bundle ids with 3rd party tools such as [resigner](https://github.com/appium/resigner).
-The tool can remap the bundle ids to values allowed by the free provisioning profile and
-then sign the package with that profile.
+## Signing WDA
 
-Please check the tool's readme for details, but in short, you can use the following command to
-re-sign the package with bundle id remapping:
+In most cases, Xcode will automatically codesign your WDA package if you have a valid provisioning
+profile. It is recommended to sign packages with a wildcard (`*`) provisioning profile, although
+such profiles require a paid Apple Developer account. For example, if you're preparing such a
+provisioning profile for `io.appium.WebDriverAgentRunner.xctrunner`, it will be for `io.appium.*`,
+`io.appium.WebDriverAgentRunner.*` or `*`.
 
-```
-P12_PASSWORD="<password of p12>" resigner \
-  --p12-file "<path to p12 file>" \
-  --profile "<path to provisioning profiles>" \
-  --force \
-  --bundle-id-remap "com.facebook.WebDriverAgentRunner=<valid bundle id for the profile>" \
-  --bundle-id-remap "com.facebook.WebDriverAgentRunner.xctrunner=<valid bundle id for the profile>" \
-  --bundle-id-remap "com.facebook.WebDriverAgentLib=<valid bundle id for the profile>" \
-  /path/to/WebDriverAgentRunner-Runner.app
-```
+In case of a free account or paid account without `*` provisioning profile, you may need to update
+the bundle id before building so `xcodebuild` can produce a properly signed WebDriverAgent package.
 
-Or
+For WDA packages built with `CODE_SIGNING_ALLOWED=NO`, manual signing is possible using the macOS
+[`codesign` utility](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format).
 
-```
-P12_PASSWORD="<password of p12>" appium driver run xcuitest sign-wda -- \
-  --wda-path=<path> \
-  --p12-file=<path> \
-  --profile-dir=<path to provisioning profiles> \
-  --bundle-id=<valid bundle id for the profile>
-```
+Another option is to use the [`sign-wda` driver script](../../reference/scripts.md#sign-wda) to
+re-sign an existing package and remap its bundle ids. The script itself is based on the
+[`resigner` tool](https://github.com/appium/resigner), which can remap the bundle ids to values
+allowed by the free provisioning profile and then sign the package with that profile.

--- a/docs/guides/run-prebuilt-wda.md
+++ b/docs/guides/run-prebuilt-wda.md
@@ -63,11 +63,11 @@ xcodebuild test-without-building \
 This approach allows the XCUITest driver to start WDA without running `xcodebuild` by using prebuilt WDA packages.
 We recommend this method if you don't need to modify the WDA source code.
 
-!!! warning "iOS/tvOS 17+ required for `usePreinstalledWDA`"
+!!! warning "iOS/tvOS 17+ required (WebDriverAgent v13+)"
 
-    With WebDriverAgent v13+, `appium:usePreinstalledWDA` and `appium:prebuiltWDAPath` require **iOS/tvOS 17.0 or newer**.
-    They are **not supported on iOS 16 and below**. See [Run Preinstalled WebDriverAgentRunner](./run-preinstalled-wda.md)
-    for details and alternatives (`xcodebuild` or `appium:webDriverAgentUrl`).
+    As of WebDriverAgent v13 (XCUITest driver v11.5.0), this approach is only supported on
+    iOS/tvOS 17 and newer. For older OS versions, use the default `xcodebuild` flow, or provide
+    `appium:webDriverAgentUrl` if you already have a running WDA server.
 
 [The Appium WebDriverAgent GitHub page](https://github.com/appium/WebDriverAgent/releases) provides
 downloads for WebDriverAgent packages for real devices and simulators.

--- a/docs/guides/run-preinstalled-wda.md
+++ b/docs/guides/run-preinstalled-wda.md
@@ -8,13 +8,9 @@ command execution, improving the session startup performance.
 
 !!! warning "iOS/tvOS 17+ required (WebDriverAgent v13+)"
 
-    Bundled WebDriverAgent v13+ (see [appium/WebDriverAgent#1137](https://github.com/appium/WebDriverAgent/pull/1137))
-    launches preinstalled WDA with `devicectl` only. The legacy launch path through `appium-ios-device` /
-    Instruments is no longer available.
-
-    As a result, `appium:usePreinstalledWDA` and `appium:prebuiltWDAPath` work on **iOS/tvOS 17.0 and newer only**.
-    They are **not supported on iOS 16 and below**. For older OS versions, use the default `xcodebuild` flow or
-    provide `appium:webDriverAgentUrl` if you already have a running WDA server.
+    As of WebDriverAgent v13 (XCUITest driver v11.5.0), this approach is only supported on
+    iOS/tvOS 17 and newer. For older OS versions, use the default `xcodebuild` flow, or provide
+    `appium:webDriverAgentUrl` if you already have a running WDA server.
 
 ## Capabilities
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -122,23 +122,26 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 
 #### Examples
 
-- Download the iOS version of the WDA app (`WebDriverAgentRunner-Runner.app`) into the `wda`
-    subdirectory of the XCUITest driver's install directory:
+- Download the iOS real device version of the WDA app (`WebDriverAgentRunner-Runner.app`) into the
+  `wda` subdirectory of the XCUITest driver's install directory:
 
-        ```
-        appium driver run xcuitest download-wda -- --platform=ios --outdir=wda
-        ```
+    ```
+    appium driver run xcuitest download-wda -- --platform=ios --outdir=wda
+    ```
 
-- Download the tvOS version of the WDA app (`WebDriverAgentRunner_tvOS-Runner.app`) into `/path/to/dir`:
+- Download the tvOS simulator version of the WDA app (`WebDriverAgentRunner_tvOS-Runner.app`) into
+  `/path/to/dir`:
 
-        ```
-        appium driver run xcuitest download-wda -- --platform=tvos --outdir=/path/to/dir
-        ```
+    ```
+    appium driver run xcuitest download-wda -- --platform=tvos --outdir=/path/to/dir --kind=sim
+    ```
 
 
 ### `download-wda-sim`
 
-**Deprecated in favor of `download-wda`; use `download-wda` with the appropriate build kind for simulator or real-device usage.**
+!!! warning "Deprecated"
+
+    Use the `download-wda` script with the `--kind=sim` flag instead
 
 Downloads a prebuilt WebDriverAgent (WDA) application from the WDA project's [GitHub Releases page](https://github.com/appium/WebDriverAgent/releases)
 for use in a simulator device.
@@ -180,48 +183,26 @@ appium driver run xcuitest download-wda-sim -- --outdir=<outdir> --platform=<pla
 
 ### `sign-wda`
 
-Signs or inspects a downloaded WebDriverAgent (WDA) app bundle using
-[`resigner`](https://github.com/appium/resigner).
-The `resigner` tool must be available on your `PATH`.
+Signs or inspects a downloaded WebDriverAgent (WDA) app bundle using the
+[`resigner`](https://github.com/appium/resigner) tool. The tool must be available on your `PATH`.
 
-By default, it signs the app using a `.p12` certificate and provisioning profiles. With
-`--inspect`, it runs inspect-only mode and prints bundle/signing details without modifying the app.
+The script supports three modes of operation:
 
-#### Generating or Using a Certificate
+1. Sign the app using provided `.cer` and `.key` files. This will automatically generate a temporary
+ `.p12` file with an auto-generated password
+2. Sign the app using a provided `.p12` certificate file, along with its password specified in the
+  `P12_PASSWORD` environment variable
+3. Inspect the app's bundle/signing details without making any modifications
 
-Before signing, you need a signing certificate. You can use certificates in two ways:
+For Mode 1, the `.cer` and `.key` files can be downloaded from the [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list).
 
-**Option 1: Use `.cer` and `.key` files directly (recommended — no password needed!)**
+In contrast, for Mode 2, the `.p12` certificate file can be extracted from the macOS Keychain. Find your
+certificate in _Keychain Access → My Certificates_ (it should be named _Apple Development: ..._),
+then right-click → _Export_ -> _Personal Information Exchange (.p12)_. You will be prompted to
+enter a password, which you should use as the value for the `P12_PASSWORD` environment variable.
 
-If you've downloaded a `.cer` (certificate) and `.key` (private key) file from the [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list), you can use them directly without conversion. The script automatically converts them to a temporary `.p12` file with an auto-generated password — **no need to manage a password yourself!**
-
-```bash
-appium driver run xcuitest sign-wda -- \
-  --wda-path ./wda/WebDriverAgentRunner-Runner.app \
-  --p12-cert ~/certificate.cer \
-  --p12-key ~/private.key
-```
-
-**Option 2: Create a `.p12` file from Keychain (macOS — requires P12_PASSWORD)**
-
-If your certificate is in your macOS Keychain:
-
-1. Open **Keychain Access** → **My Certificates**.
-2. Find your iOS development or distribution certificate (e.g. `Apple Development: ...`).
-3. Right-click → **Export** → choose **Personal Information Exchange (.p12)**.
-4. Set a password — this becomes your `P12_PASSWORD` environment variable.
-
-Then use it with:
-
-```bash
-P12_PASSWORD=mypassword appium driver run xcuitest sign-wda -- \
-  --wda-path ./wda/WebDriverAgentRunner-Runner.app \
-  --p12-file ~/sign.p12
-```
-
-**Option 3: Manually convert `.cer` and `.key` to `.p12` (requires P12_PASSWORD)**
-
-If you prefer to create a `.p12` file manually:
+You can also manually generate the `.p12` file from `.cer` and `.key` files, though this approach
+still requires you to specify a password:
 
 ```bash
 # Convert Apple-issued .cer to .pem
@@ -235,24 +216,54 @@ openssl pkcs12 -export \
   -passout pass:mypassword
 ```
 
-Then use the `.p12` file as in Option 2 with `P12_PASSWORD` environment variable.
+#### Usage (Mode 1 - `.cer` and `.key` files)
 
-!!! note "Certificate Options"
+```
+appium driver run xcuitest sign-wda -- --wda-path=<path> --p12-cert=<path> --p12-key=<path>
+```
 
-    The script supports two mutually exclusive approaches:
+##### Required Arguments
 
-    - **`--p12-cert` + `--p12-key`** (recommended): Automatically converts `.cer` and `.key` files to a temporary `.p12` with an auto-generated password. **No `P12_PASSWORD` needed!**
-    - **`--p12-file`**: Uses a preconverted `.p12` file. **Requires `P12_PASSWORD` environment variable.**
+|Argument|Description|Type|
+|--|--|--|
+|`--p12-cert`|Path to the `.cer` certificate file from Apple Developer portal|string|
+|`--p12-key`|Path to the `.key` private key file from Apple Developer portal|string|
+|`--wda-path`|Path to the `WebDriverAgentRunner-Runner.app` bundle to sign|string|
 
-    Choose one approach; you cannot use both in the same command.
+##### Optional Arguments
 
-#### Usage
+|<div style="width:8em">Argument</div>|Description|Type|
+|--|--|--|
+|`--profile-dir`|Directory containing provisioning profiles (`.mobileprovision` files). Default is auto-discovered from default locations `~/Library/Developer/Xcode/UserData/Provisioning Profiles` and `~/Library/MobileDevice/Provisioning Profiles`.|string|
+|`--bundle-id`|Remap the default WebDriverAgent bundle IDs with the specified bundle ID. It is useful when your provisioning profile is tied to a specific bundle ID.|string|
+
+#### Usage (Mode 2 - `.p12` file)
 
 ```
 P12_PASSWORD=<password> appium driver run xcuitest sign-wda -- --wda-path=<path> --p12-file=<path>
 ```
 
-#### Usage (inspect-only)
+##### Environment Variables
+
+|Variable|Description|
+|--|--|
+|`P12_PASSWORD`|Password for the `.p12` signing certificate file|
+
+##### Required Arguments
+
+|<Argument|Description|Type|
+|--|--|--|
+|`--p12-file`|Path to the `.p12` signing certificate file|string|
+|`--wda-path`|Path to the `WebDriverAgentRunner-Runner.app` bundle to sign|string|
+
+##### Optional Arguments
+
+|<div style="width:8em">Argument</div>|Description|Type|
+|--|--|--|
+|`--profile-dir`|Directory containing provisioning profiles (`.mobileprovision` files). Default is auto-discovered from default locations `~/Library/Developer/Xcode/UserData/Provisioning Profiles` and `~/Library/MobileDevice/Provisioning Profiles`.|string|
+|`--bundle-id`|Remap the default WebDriverAgent bundle IDs with the specified bundle ID. It is useful when your provisioning profile is tied to a specific bundle ID.|string|
+
+#### Usage (Mode 3 - inspect)
 
 ```
 appium driver run xcuitest sign-wda -- --wda-path=<path> --inspect
@@ -262,36 +273,18 @@ appium driver run xcuitest sign-wda -- --wda-path=<path> --inspect
 
 |Argument|Description|Type|
 |--|--|--|
+|`--inspect`|Instruct the `resigner` tool to run `--inspect` only|boolean|
 |`--wda-path`|Path to the `WebDriverAgentRunner-Runner.app` bundle to sign|string|
 
 ##### Optional Arguments
 
-|Argument|Description|Type|
+|<div style="width:8em">Argument</div>|Description|Type|
 |--|--|--|
-|`--p12-file`|Path to the `.p12` signing certificate file. **Mutually exclusive with `--p12-cert` and `--p12-key`.** Requires `P12_PASSWORD` environment variable.|string|
-|`--p12-cert`|Path to the `.cer` certificate file from Apple Developer portal. **Mutually exclusive with `--p12-file`.** Auto-converts to `.p12` with generated password (no `P12_PASSWORD` needed). Must be used with `--p12-key`.|string|
-|`--p12-key`|Path to the `.key` private key file from Apple Developer portal. **Mutually exclusive with `--p12-file`.** Auto-converts to `.p12` with generated password (no `P12_PASSWORD` needed). Must be used with `--p12-cert`.|string|
-|`--profile-dir`|Directory containing provisioning profiles (`.mobileprovision` files.) Default is auto-discovered from default locations `~/Library/Developer/Xcode/UserData/Provisioning Profiles` and `~/Library/MobileDevice/Provisioning Profiles`.|string|
-|`--bundle-id`|Remap the default WebDriverAgent bundle IDs with the specified bundle ID. It is useful when your provisioning profile is tied to a specific bundle ID.|string|
-|`--inspect`|Run `resigner --inspect` only. In this mode, signing options (`--p12-file`, `--p12-cert`/`--p12-key`, `P12_PASSWORD`, `--profile-dir`) are not required.|boolean|
-
-##### Environment Variables
-|Variable|Description|
-|--|--|
-|`P12_PASSWORD`|Password for the `.p12` signing certificate file. **Required only when using `--p12-file`**. Not needed when using `--p12-cert` and `--p12-key` (which auto-generate a password).|
+|`--profile-dir`|Directory containing provisioning profiles (`.mobileprovision` files). Default is auto-discovered from default locations `~/Library/Developer/Xcode/UserData/Provisioning Profiles` and `~/Library/MobileDevice/Provisioning Profiles`.|string|
 
 #### Examples
 
-- Sign WDA with `.p12` certificate (requires P12_PASSWORD):
-
-    ```
-    P12_PASSWORD=mypassword appium driver run xcuitest sign-wda -- \
-      --wda-path=./wda/WebDriverAgentRunner-Runner.app \
-      --p12-file=~/sign.p12 \
-      --bundle-id=com.example.wda
-    ```
-
-- Sign WDA with `.cer` and `.key` files (no password needed — auto-converted!):
+- Sign WDA with `.cer` and `.key` files:
 
     ```
     appium driver run xcuitest sign-wda -- \
@@ -318,6 +311,15 @@ appium driver run xcuitest sign-wda -- --wda-path=<path> --inspect
       --p12-cert=~/certificate.cer \
       --p12-key=~/private.key \
       --profile-dir=/path/to/provisioning/profiles
+    ```
+
+- Sign WDA with `.p12` certificate file (requires `P12_PASSWORD`):
+
+    ```
+    P12_PASSWORD=mypassword appium driver run xcuitest sign-wda -- \
+      --wda-path=./wda/WebDriverAgentRunner-Runner.app \
+      --p12-file=~/sign.p12 \
+      --bundle-id=com.example.wda
     ```
 
 - Inspect a WDA app without signing:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,6 @@ plugins:
       'execute-methods.md': 'reference/execute-methods.md'
       'ios-predicate.md': 'reference/ios-predicate.md'
       'locator-strategies.md': 'reference/locator-strategies.md'
-      'xpath-extensions.md': 'reference/xpath-extensions.md'
       'security-flags.md': 'reference/security-flags.md'
       'server-args.md': 'reference/server-args.md'
       'settings.md': 'reference/settings.md'


### PR DESCRIPTION
A few adjustments to recently updated documents:
* Update the `sign-wda` script reference for clarity
* Update "Manual Configuration for a Generic Device" in an attempt to make the signing related information easier to understand. Remove examples as they can remain on the `sign-wda` script page.
* Remove unneeded redirect map entry for `xpath-extensions.md`
* Adjust warning message for WDA 13 related `usePreinstalledWDA` changes