### PR TITLE
docs: Add nativeAccessibilityElement attribute and setting

### DIFF
--- a/docs/reference/element-attributes.md
+++ b/docs/reference/element-attributes.md
@@ -122,6 +122,20 @@ from the accessibility layer.
 Returns whether the element is accessible. This value is not available in XCTest and is read
 directly from the accessibility layer.
 
+## nativeAccessibilityElement
+
+> Example: `false`
+
+Corresponds to the element's native [`isAccessibilityElement`](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/isaccessibilityelement)
+value, as reported by the accessibility layer. Unlike [`accessible`](#accessible), which is a value
+computed by WebDriverAgent using additional logic, this attribute returns the raw platform flag
+without any extra processing.
+
+This attribute is not included in the default page source due to performance reasons, but it can be
+added by changing the [`includeNativeAccessibilityElementInPageSource`](./settings.md#includenativeaccessibilityelementinpagesource)
+setting to `true`, or retrieved using the [Get Element Attribute](https://www.w3.org/TR/webdriver2/#get-element-attribute)
+API.
+
 ## index
 
 > Example: `2`

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -156,6 +156,15 @@ source XML tree.
 Whether the [`minValue`](./element-attributes.md#minvalue) and [`maxValue`](./element-attributes.md#maxvalue)
 attributes should be included in the page source XML tree.
 
+## includeNativeAccessibilityElementInPageSource
+
+| Type | Default |
+| -- | -- |
+| `boolean` | `false` |
+
+Whether the [`nativeAccessibilityElement`](./element-attributes.md#nativeaccessibilityelement)
+attribute should be included in the page source XML tree.
+
 ## keyboardAutocorrection
 
 | Type | Default |


### PR DESCRIPTION
## Summary
Documents the new `nativeAccessibilityElement` element attribute and the
`includeNativeAccessibilityElementInPageSource` setting, added to WebDriverAgent
in appium/WebDriverAgent#1146 (shipped in WDA v13.3.0).
- `nativeAccessibilityElement` exposes the raw native `isAccessibilityElement` value,
  as opposed to the computed `accessible` attribute.
- Off by default; enabled via the `includeNativeAccessibilityElementInPageSource` setting.
