### PR TITLE
feat: Add VoiceOver mobile wrappers

### DIFF
--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -2127,7 +2127,6 @@ elementAttributes | dict | JSON object containing various attributes of the elem
 Enables VoiceOver on the device under test. Wraps WebDriverAgent's `/wda/voiceOver/enable` route, which uses XCTest's `XCUIDevice.voiceOverService`.
 
 Requires **iOS/tvOS 27+** (`appium:platformVersion`). The driver rejects the command on older platform versions before proxying to WDA.
-Requires **WebDriverAgent 14.1.0+** (bundled via `appium-webdriveragent`; a custom WDA build via `appium:webDriverAgentUrl` must include the VoiceOver routes).
 
 > **Warning**
 > Do not forget to call [mobile: disableVoiceOver](#mobile-disablevoiceover) in test teardown.
@@ -2137,13 +2136,13 @@ Requires **WebDriverAgent 14.1.0+** (bundled via `appium-webdriveragent`; a cust
 
 Disables VoiceOver on the device under test.
 
-Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+Requires **iOS/tvOS 27+** (`appium:platformVersion`).
 
 ### mobile: isVoiceOverEnabled
 
 Returns whether VoiceOver is currently enabled.
 
-Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+Requires **iOS/tvOS 27+** (`appium:platformVersion`).
 
 #### Returned Result
 
@@ -2155,7 +2154,7 @@ enabled | boolean | Whether VoiceOver is enabled | true
 
 Moves VoiceOver focus in the given direction and returns the utterance spoken after the move.
 
-Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**. On tvOS, only `forward` and `backward` are supported; `in` and `out` are iOS-only.
+Requires **iOS/tvOS 27+** (`appium:platformVersion`). On tvOS, only `forward` and `backward` are supported; `in` and `out` are iOS-only.
 
 #### Arguments
 
@@ -2173,7 +2172,7 @@ utterance | string or null | The spoken utterance after the move, or `null` | Bu
 
 Returns the current VoiceOver utterance without moving focus.
 
-Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+Requires **iOS/tvOS 27+** (`appium:platformVersion`).
 
 #### Returned Result
 

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -2122,6 +2122,65 @@ elementAttributes | dict | JSON object containing various attributes of the elem
 }
 ```
 
+### mobile: enableVoiceOver
+
+Enables VoiceOver on the device under test. Wraps WebDriverAgent's `/wda/voiceOver/enable` route, which uses XCTest's `XCUIDevice.voiceOverService`.
+
+Requires **iOS/tvOS 27+** (`appium:platformVersion`). The driver rejects the command on older platform versions before proxying to WDA.
+Requires **WebDriverAgent 14.1.0+** (bundled via `appium-webdriveragent`; a custom WDA build via `appium:webDriverAgentUrl` must include the VoiceOver routes).
+
+> **Warning**
+> Do not forget to call [mobile: disableVoiceOver](#mobile-disablevoiceover) in test teardown.
+> If VoiceOver is not disabled explicitly, it may remain enabled until the device is restarted.
+
+### mobile: disableVoiceOver
+
+Disables VoiceOver on the device under test.
+
+Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+
+### mobile: isVoiceOverEnabled
+
+Returns whether VoiceOver is currently enabled.
+
+Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+
+#### Returned Result
+
+Name | Type | Description | Example
+--- | --- | --- | ---
+enabled | boolean | Whether VoiceOver is enabled | true
+
+### mobile: voiceOverMove
+
+Moves VoiceOver focus in the given direction and returns the utterance spoken after the move.
+
+Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**. On tvOS, only `forward` and `backward` are supported; `in` and `out` are iOS-only.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+direction | string | yes | One of `forward`, `backward`, `in` (iOS only), or `out` (iOS only). Case-insensitive at WDA. | forward
+
+#### Returned Result
+
+Name | Type | Description | Example
+--- | --- | --- | --- |
+utterance | string or null | The spoken utterance after the move, or `null` | Button
+
+### mobile: voiceOverCurrentSpeech
+
+Returns the current VoiceOver utterance without moving focus.
+
+Requires **iOS/tvOS 27+** (`appium:platformVersion`) and **WebDriverAgent 14.1.0+**.
+
+#### Returned Result
+
+Name | Type | Description | Example
+--- | --- | --- | ---
+utterance | string or null | The current spoken utterance, or `null` | Button
+
 ### mobile: startScreenRecording
 
 Starts recording the device screen to an MPEG-4 file using **ffmpeg** and the WebDriverAgent **MJPEG** stream. Equivalent to [`startRecordingScreen`](./commands.md#startrecordingscreen) over HTTP. Requires `ffmpeg` on `PATH`. Audio is not recorded.

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -2130,7 +2130,7 @@ Requires **iOS/tvOS 27+** (`appium:platformVersion`). The driver rejects the com
 
 > **Warning**
 > Do not forget to call [mobile: disableVoiceOver](#mobile-disablevoiceover) in test teardown.
-> If VoiceOver is not disabled explicitly, it may remain enabled until the device is restarted.
+> If VoiceOver is not disabled explicitly, it may remain enabled until disabled explicitly.
 
 ### mobile: disableVoiceOver
 

--- a/lib/commands/helpers/index.ts
+++ b/lib/commands/helpers/index.ts
@@ -16,6 +16,8 @@ export {
   isIos17OrNewerPlatform,
   isIos18OrNewer,
   isIos18OrNewerPlatform,
+  isIos27OrNewer,
+  isIos27OrNewerPlatform,
   isTvOs,
   normalizePlatformName,
   normalizePlatformVersion,

--- a/lib/commands/helpers/platform.ts
+++ b/lib/commands/helpers/platform.ts
@@ -35,6 +35,11 @@ export function isIos18OrNewerPlatform(platformVersion?: string | null): boolean
   return !!platformVersion && util.compareVersions(platformVersion, '>=', '18.0');
 }
 
+/** Platform-version predicate for iOS 27+. */
+export function isIos27OrNewerPlatform(platformVersion?: string | null): boolean {
+  return !!platformVersion && util.compareVersions(platformVersion, '>=', '27.0');
+}
+
 /** Version-gate helper for iOS 17+ capabilities. */
 export function isIos17OrNewer(opts: PlatformVersionOpts): boolean {
   return isIos17OrNewerPlatform(opts.platformVersion);
@@ -43,4 +48,9 @@ export function isIos17OrNewer(opts: PlatformVersionOpts): boolean {
 /** Version-gate helper for iOS 18+ capabilities. */
 export function isIos18OrNewer(opts: PlatformVersionOpts): boolean {
   return isIos18OrNewerPlatform(opts.platformVersion);
+}
+
+/** Version-gate helper for iOS 27+ capabilities. */
+export function isIos27OrNewer(opts: PlatformVersionOpts): boolean {
+  return isIos27OrNewerPlatform(opts.platformVersion);
 }

--- a/lib/commands/voiceover.ts
+++ b/lib/commands/voiceover.ts
@@ -1,0 +1,83 @@
+import {errors} from 'appium/driver';
+import {isIos27OrNewer} from './helpers';
+import type {XCUITestDriver} from '../driver';
+
+export interface VoiceOverSpeechResult {
+  utterance: string | null;
+}
+
+export interface VoiceOverEnabledResult {
+  enabled: boolean;
+}
+
+function requireIos27VoiceOver(driver: XCUITestDriver, script: string): void {
+  if (!isIos27OrNewer(driver.opts)) {
+    throw new errors.InvalidArgumentError(
+      `${script} requires iOS/tvOS 27 or newer. ` +
+        `The current platformVersion is '${driver.opts.platformVersion ?? 'unknown'}'.`,
+    );
+  }
+}
+
+/**
+ * Enables VoiceOver on the device under test.
+ *
+ * @since iOS/tvOS 27
+ */
+export async function mobileEnableVoiceOver(this: XCUITestDriver): Promise<void> {
+  requireIos27VoiceOver(this, 'mobile: enableVoiceOver');
+  await this.proxyCommand('/wda/voiceOver/enable', 'POST');
+}
+
+/**
+ * Disables VoiceOver on the device under test.
+ *
+ * @since iOS/tvOS 27
+ */
+export async function mobileDisableVoiceOver(this: XCUITestDriver): Promise<void> {
+  requireIos27VoiceOver(this, 'mobile: disableVoiceOver');
+  await this.proxyCommand('/wda/voiceOver/disable', 'POST');
+}
+
+/**
+ * Returns whether VoiceOver is currently enabled.
+ *
+ * @since iOS/tvOS 27
+ */
+export async function mobileIsVoiceOverEnabled(
+  this: XCUITestDriver,
+): Promise<VoiceOverEnabledResult> {
+  requireIos27VoiceOver(this, 'mobile: isVoiceOverEnabled');
+  return await this.proxyCommand<any, VoiceOverEnabledResult>('/wda/voiceOver/enabled', 'GET');
+}
+
+/**
+ * Moves VoiceOver focus in the given direction.
+ *
+ * @since iOS/tvOS 27
+ * @param direction - One of `forward`, `backward`, `in` (iOS only), or `out` (iOS only).
+ * @returns The utterance spoken after the move, or `null`.
+ */
+export async function mobileVoiceOverMove(
+  this: XCUITestDriver,
+  direction: string,
+): Promise<VoiceOverSpeechResult> {
+  requireIos27VoiceOver(this, 'mobile: voiceOverMove');
+  return await this.proxyCommand<{direction: string}, VoiceOverSpeechResult>(
+    '/wda/voiceOver/move',
+    'POST',
+    {direction},
+  );
+}
+
+/**
+ * Returns the current VoiceOver utterance without moving focus.
+ *
+ * @since iOS/tvOS 27
+ */
+export async function mobileVoiceOverCurrentSpeech(
+  this: XCUITestDriver,
+): Promise<VoiceOverSpeechResult> {
+  requireIos27VoiceOver(this, 'mobile: voiceOverCurrentSpeech');
+  return await this.proxyCommand<any, VoiceOverSpeechResult>('/wda/voiceOver/currentSpeech', 'GET');
+}

--- a/lib/commands/voiceover.ts
+++ b/lib/commands/voiceover.ts
@@ -10,15 +10,6 @@ export interface VoiceOverEnabledResult {
   enabled: boolean;
 }
 
-function requireIos27VoiceOver(driver: XCUITestDriver, script: string): void {
-  if (!isIos27OrNewer(driver.opts)) {
-    throw new errors.InvalidArgumentError(
-      `${script} requires iOS/tvOS 27 or newer. ` +
-        `The current platformVersion is '${driver.opts.platformVersion ?? 'unknown'}'.`,
-    );
-  }
-}
-
 /**
  * Enables VoiceOver on the device under test.
  *
@@ -80,4 +71,13 @@ export async function mobileVoiceOverCurrentSpeech(
 ): Promise<VoiceOverSpeechResult> {
   requireIos27VoiceOver(this, 'mobile: voiceOverCurrentSpeech');
   return await this.proxyCommand<any, VoiceOverSpeechResult>('/wda/voiceOver/currentSpeech', 'GET');
+}
+
+function requireIos27VoiceOver(driver: XCUITestDriver, script: string): void {
+  if (!isIos27OrNewer(driver.opts)) {
+    throw new errors.InvalidArgumentError(
+      `${script} requires iOS/tvOS 27 or newer. ` +
+        `The current platformVersion is '${driver.opts.platformVersion ?? 'unknown'}'.`,
+    );
+  }
 }

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -73,6 +73,7 @@ import * as screenshotCommands from './commands/screenshots';
 import * as sourceCommands from './commands/source';
 import * as simctlCommands from './commands/simctl';
 import * as timeoutCommands from './commands/timeouts';
+import * as voiceOverCommands from './commands/voiceover';
 import * as webCommands from './commands/web';
 import {start, startWdaSession} from './commands/wda/startup';
 import {stop} from './commands/wda/stop';
@@ -499,6 +500,15 @@ export class XCUITestDriver
   mobileGetSimulatedLocation = geolocationCommands.mobileGetSimulatedLocation;
   mobileSetSimulatedLocation = geolocationCommands.mobileSetSimulatedLocation;
   mobileResetSimulatedLocation = geolocationCommands.mobileResetSimulatedLocation;
+
+  /*-----------+
+   | VOICEOVER |
+   +-----------+*/
+  mobileEnableVoiceOver = voiceOverCommands.mobileEnableVoiceOver;
+  mobileDisableVoiceOver = voiceOverCommands.mobileDisableVoiceOver;
+  mobileIsVoiceOverEnabled = voiceOverCommands.mobileIsVoiceOverEnabled;
+  mobileVoiceOverMove = voiceOverCommands.mobileVoiceOverMove;
+  mobileVoiceOverCurrentSpeech = voiceOverCommands.mobileVoiceOverCurrentSpeech;
 
   /*---------+
    | GESTURE |

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -516,6 +516,24 @@ export const executeMethodMap = {
   'mobile: resetSimulatedLocation': {
     command: 'mobileResetSimulatedLocation',
   },
+  'mobile: enableVoiceOver': {
+    command: 'mobileEnableVoiceOver',
+  },
+  'mobile: disableVoiceOver': {
+    command: 'mobileDisableVoiceOver',
+  },
+  'mobile: isVoiceOverEnabled': {
+    command: 'mobileIsVoiceOverEnabled',
+  },
+  'mobile: voiceOverMove': {
+    command: 'mobileVoiceOverMove',
+    params: {
+      required: ['direction'],
+    },
+  },
+  'mobile: voiceOverCurrentSpeech': {
+    command: 'mobileVoiceOverCurrentSpeech',
+  },
   'mobile: shake': {
     command: 'mobileShake',
   },

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "appium-ios-device": "^3.1.12",
     "appium-ios-simulator": "^8.0.0",
     "appium-remote-debugger": "^15.7.3",
-    "appium-webdriveragent": "^14.0.0",
+    "appium-webdriveragent": "^14.1.0",
     "appium-xcode": "^6.0.2",
     "async-lock": "^1.4.0",
     "asyncbox": "^6.3.0",

--- a/test/unit/commands/voiceover-specs.ts
+++ b/test/unit/commands/voiceover-specs.ts
@@ -1,0 +1,124 @@
+import {errors} from 'appium/driver';
+import sinon from 'sinon';
+import {XCUITestDriver} from '../../../lib/driver';
+import chai, {expect} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+
+describe('voiceover commands', function () {
+  let driver: XCUITestDriver;
+  let proxySpy: sinon.SinonStub;
+
+  beforeEach(function () {
+    driver = new XCUITestDriver({} as any);
+    proxySpy = sinon.stub(driver, 'proxyCommand');
+  });
+
+  afterEach(function () {
+    proxySpy.restore();
+  });
+
+  describe('with platformVersion 27.0', function () {
+    beforeEach(function () {
+      driver.opts.platformVersion = '27.0';
+    });
+
+    it('mobileEnableVoiceOver should proxy POST /wda/voiceOver/enable', async function () {
+      proxySpy.withArgs('/wda/voiceOver/enable', 'POST').resolves();
+
+      await driver.mobileEnableVoiceOver();
+
+      expect(proxySpy.calledOnceWithExactly('/wda/voiceOver/enable', 'POST')).to.be.true;
+    });
+
+    it('mobileDisableVoiceOver should proxy POST /wda/voiceOver/disable', async function () {
+      proxySpy.withArgs('/wda/voiceOver/disable', 'POST').resolves();
+
+      await driver.mobileDisableVoiceOver();
+
+      expect(proxySpy.calledOnceWithExactly('/wda/voiceOver/disable', 'POST')).to.be.true;
+    });
+
+    it('mobileIsVoiceOverEnabled should proxy GET /wda/voiceOver/enabled', async function () {
+      proxySpy.withArgs('/wda/voiceOver/enabled', 'GET').resolves({enabled: true});
+
+      const result = await driver.mobileIsVoiceOverEnabled();
+
+      expect(proxySpy.calledOnceWithExactly('/wda/voiceOver/enabled', 'GET')).to.be.true;
+      expect(result).to.eql({enabled: true});
+    });
+
+    it('mobileVoiceOverMove should proxy direction as-is to WDA', async function () {
+      proxySpy
+        .withArgs('/wda/voiceOver/move', 'POST', {direction: 'forward'})
+        .resolves({utterance: 'Button'});
+
+      const result = await driver.mobileVoiceOverMove('forward');
+
+      expect(proxySpy.calledOnceWithExactly('/wda/voiceOver/move', 'POST', {direction: 'forward'}))
+        .to.be.true;
+      expect(result).to.eql({utterance: 'Button'});
+    });
+
+    it('mobileVoiceOverCurrentSpeech should proxy GET /wda/voiceOver/currentSpeech', async function () {
+      proxySpy
+        .withArgs('/wda/voiceOver/currentSpeech', 'GET')
+        .resolves({utterance: 'Current item'});
+
+      const result = await driver.mobileVoiceOverCurrentSpeech();
+
+      expect(proxySpy.calledOnceWithExactly('/wda/voiceOver/currentSpeech', 'GET')).to.be.true;
+      expect(result).to.eql({utterance: 'Current item'});
+    });
+  });
+
+  describe('with platformVersion 26.0', function () {
+    beforeEach(function () {
+      driver.opts.platformVersion = '26.0';
+    });
+
+    const versionGateMessage =
+      /requires iOS\/tvOS 27 or newer.*The current platformVersion is '26\.0'/;
+
+    it('mobileEnableVoiceOver should reject without proxying', async function () {
+      await expect(driver.mobileEnableVoiceOver()).to.be.rejectedWith(
+        errors.InvalidArgumentError,
+        versionGateMessage,
+      );
+      expect(proxySpy.called).to.be.false;
+    });
+
+    it('mobileDisableVoiceOver should reject without proxying', async function () {
+      await expect(driver.mobileDisableVoiceOver()).to.be.rejectedWith(
+        errors.InvalidArgumentError,
+        versionGateMessage,
+      );
+      expect(proxySpy.called).to.be.false;
+    });
+
+    it('mobileIsVoiceOverEnabled should reject without proxying', async function () {
+      await expect(driver.mobileIsVoiceOverEnabled()).to.be.rejectedWith(
+        errors.InvalidArgumentError,
+        versionGateMessage,
+      );
+      expect(proxySpy.called).to.be.false;
+    });
+
+    it('mobileVoiceOverMove should reject without proxying', async function () {
+      await expect(driver.mobileVoiceOverMove('forward')).to.be.rejectedWith(
+        errors.InvalidArgumentError,
+        versionGateMessage,
+      );
+      expect(proxySpy.called).to.be.false;
+    });
+
+    it('mobileVoiceOverCurrentSpeech should reject without proxying', async function () {
+      await expect(driver.mobileVoiceOverCurrentSpeech()).to.be.rejectedWith(
+        errors.InvalidArgumentError,
+        versionGateMessage,
+      );
+      expect(proxySpy.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds five `mobile:` execute-script helpers that proxy to WebDriverAgent's `/wda/voiceOver/*` routes, enabling VoiceOver automation from Appium clients. This pairs with the WDA VoiceOver work in **appium-webdriveragent 14.1.0+**.

- **`mobile: enableVoiceOver`** / **`mobile: disableVoiceOver`** — turn VoiceOver on/off
- **`mobile: isVoiceOverEnabled`** — returns `{enabled: boolean}`
- **`mobile: voiceOverMove`** — moves focus (`forward`, `backward`, `in`, `out`) and returns `{utterance: string | null}`
- **`mobile: voiceOverCurrentSpeech`** — returns the current utterance without moving focus

All commands are gated on **`appium:platformVersion` ≥ 27.0** via a new `isIos27OrNewer` helper (matching the pattern used by network monitor and geolocation). On older platform versions the driver throws `InvalidArgumentError` before proxying to WDA. Direction validation is left to WDA.

Bumps bundled `appium-webdriveragent` from `^14.0.0` to `^14.1.0` (minimum release that ships the VoiceOver routes).

## Example

```js
await driver.execute('mobile: enableVoiceOver');
const {utterance} = await driver.execute('mobile: voiceOverMove', {direction: 'forward'});
const {enabled} = await driver.execute('mobile: isVoiceOverEnabled');
await driver.execute('mobile: disableVoiceOver');
```
