### PR TITLE
feat: Make Apple TV discovery timeout configurable

### DIFF
--- a/docs/guides/remotexpc-tunnels-real-devices.md
+++ b/docs/guides/remotexpc-tunnels-real-devices.md
@@ -57,7 +57,8 @@ sudo appium driver run xcuitest tunnel-creation
 ```
 
 Refer to [the script reference page](../reference/scripts.md#tunnel-creation) for a list of
-additional options.
+additional options. If wireless Apple TV devices are slow to appear, increase the discovery
+window with `--appletv-discovery-timeout-ms`.
 
 The script executes the following actions:
 

--- a/docs/guides/tvos.md
+++ b/docs/guides/tvos.md
@@ -49,7 +49,8 @@ section, though they are limited and less reliable compared to Remote XPC.
         ```
 
         The above command will return a prompt for selecting a specific device. You can also skip
-        interactive selection by using the `--device` option. See [the Scripts reference page](../reference/scripts.md#pair-appletv)
+        interactive selection by using the `--device` option, or increase the discovery window with
+        `--discovery-timeout-ms` if the Apple TV is slow to appear. See [the Scripts reference page](../reference/scripts.md#pair-appletv)
         for more information.
 
     3. When prompted, enter the PIN that appears on the Apple TV
@@ -69,7 +70,8 @@ section, though they are limited and less reliable compared to Remote XPC.
     ```
 
     It is also recommended to set the `--disconnect-retry-max-attempts` flag to `3` or more, as
-    disconnects are likely to occur. Refer to the [Remote XPC guide](./remotexpc-tunnels-real-devices.md)
+    disconnects are likely to occur. Use `--appletv-discovery-timeout-ms` to increase the wireless
+    Apple TV discovery window when needed. Refer to the [Remote XPC guide](./remotexpc-tunnels-real-devices.md)
     and [Scripts reference page](../reference/scripts.md#tunnel-creation) for more details.
 
 5. Launch the Appium server (in a separate process from the Remote XPC tunnel), then start a

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -473,6 +473,7 @@ sudo appium driver run xcuitest pair-appletv
 |<div style="width:7em">Argument</div>|Description|Type|
 |--|--|--|
 |`--device`, `-d`|Selector of the Apple TV device. Can be the device name (`"Living Room"`), UDID (`AA:BB:CC:DD:EE:FF`), or index (`0`). If not provided, a prompt for device selection is shown.|string or integer|
+|`--discovery-timeout-ms`|Apple TV pairing discovery timeout, in milliseconds. Defaults to the `APPLETV_DISCOVERY_TIMEOUT` environment variable value, or `10000` if unset.|integer|
 |`--help`, `-h`|Return help text and exit||
 
 #### Examples
@@ -487,6 +488,12 @@ sudo appium driver run xcuitest pair-appletv
 
     ```
     sudo appium driver run xcuitest pair-appletv -- --device "Conference Room"
+    ```
+
+- Pair with a longer discovery timeout:
+
+    ```
+    sudo appium driver run xcuitest pair-appletv -- --discovery-timeout-ms 30000
     ```
 
 
@@ -518,6 +525,7 @@ sudo appium driver run xcuitest tunnel-creation
 |<div style="width:14em">Argument</div>|Description|Type|Default|
 |--|--|--|--|
 |`--appletv-device-id`|Identifier of a paired Apple TV device (returned by [`pair-appletv`](#pair-appletv)) to create the tunnel for. Repeat this argument to target multiple paired Apple TV devices. If omitted, the script creates one tunnel per discovered paired Apple TV device. If this is provided without `--udid`, setup of non-Apple TV devices is skipped.|string (repeatable)||
+|`--appletv-discovery-timeout-ms`|Apple TV wireless discovery timeout, in milliseconds. Applies to initial discovery and Apple TV tunnel creation/reconnection.|integer|10000|
 |`--disconnect-retry-max-attempts`|Maximum number of tunnel recreation attempts after an unexpected disconnect. Set to `0` for unlimited retries. If omitted, retries are disabled and the tunnel is removed from registry.|integer||
 |`--disconnect-retry-interval-ms`|Delay between tunnel recreation attempts in milliseconds.|integer|1000|
 |`--tunnel-registry-port`|Port of the tunnel registry server, hosted at `http://localhost:<port>/remotexpc/tunnels`|integer|42314|
@@ -553,4 +561,10 @@ sudo appium driver run xcuitest tunnel-creation
 
     ```
     sudo appium driver run xcuitest tunnel-creation -- --disconnect-retry-max-attempts 10 --disconnect-retry-interval-ms 2000
+    ```
+
+- Create Apple TV tunnels with a longer wireless discovery timeout:
+
+    ```
+    sudo appium driver run xcuitest tunnel-creation -- --appletv-discovery-timeout-ms 30000
     ```

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^5.1.0"
+    "appium-ios-remotexpc": "^5.1.5"
   },
   "scripts": {
     "build": "tsc -b",

--- a/scripts/lib/options.mjs
+++ b/scripts/lib/options.mjs
@@ -1,0 +1,12 @@
+/**
+ * @param {string} value
+ * @param {string} label
+ * @returns {number}
+ */
+export function parsePositiveIntegerOption(value, label) {
+  const num = Number.parseInt(value, 10);
+  if (!Number.isFinite(num) || num <= 0) {
+    throw new Error(`Invalid ${label}: ${value}. Expected a positive integer.`);
+  }
+  return num;
+}

--- a/scripts/lib/progress.mjs
+++ b/scripts/lib/progress.mjs
@@ -1,0 +1,44 @@
+/**
+ * Logs a timeout-based progress bar while an operation without native progress callbacks is running.
+ *
+ * @param {{log: {info: (message: string) => void}, label: string, startedAt: number, timeoutMs: number, barWidth: number, intervalMs: number}} opts
+ * @returns {{succeed: (message?: string) => void, fail: (message?: string) => void}}
+ */
+export function startTimeoutProgressLogger({log, label, startedAt, timeoutMs, barWidth, intervalMs}) {
+  /** @type {NodeJS.Timeout | null} */
+  let timer = null;
+  let isStopped = false;
+
+  const logProgress = (status, isComplete = false) => {
+    const elapsedMs = performance.now() - startedAt;
+    const boundedElapsedMs = Math.min(elapsedMs, timeoutMs);
+    const progress = isComplete ? 1 : boundedElapsedMs / timeoutMs;
+    const filledWidth = Math.round(progress * barWidth);
+    const emptyWidth = barWidth - filledWidth;
+    const bar = `${'#'.repeat(filledWidth)}${'-'.repeat(emptyWidth)}`;
+    log.info(`${label}: [${bar}]${status && status !== 'waiting' ? ` - ${status}` : ''}`);
+  };
+
+  const stop = (status, isComplete = false) => {
+    if (isStopped) {
+      return;
+    }
+    isStopped = true;
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    logProgress(status, isComplete);
+  };
+
+  logProgress('waiting');
+  timer = setInterval(() => {
+    logProgress('waiting');
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    succeed: (message = 'done') => stop(message, true),
+    fail: (message = 'failed') => stop(message),
+  };
+}

--- a/scripts/lib/root.mjs
+++ b/scripts/lib/root.mjs
@@ -1,0 +1,15 @@
+/**
+ * Ensures a driver helper script is run with elevated privileges on platforms that expose getuid.
+ *
+ * @param {string} scriptName
+ */
+export function assertRoot(scriptName) {
+  if (typeof process.getuid !== 'function') {
+    return;
+  }
+  if (process.getuid() !== 0) {
+    throw new Error(
+      `This script must be run as root (e.g. sudo appium driver run xcuitest ${scriptName} ...).`,
+    );
+  }
+}

--- a/scripts/pair-appletv.mjs
+++ b/scripts/pair-appletv.mjs
@@ -16,27 +16,26 @@
  *                             - Device name (e.g. "Living Room")
  *                             - Device identifier (e.g. "AA:BB:CC:DD:EE:FF")
  *                             - Device index (e.g. "0", "1", "2")
+ *   --discovery-timeout-ms <ms>
+ *                             Apple TV pairing discovery timeout in milliseconds
  */
 
 import {logger} from 'appium/support.js';
 import {Command} from 'commander';
 import {AppleTVPairingService, UserInputService} from 'appium-ios-remotexpc';
 
-const log = logger.getLogger('AppleTVPairing');
+import {parsePositiveIntegerOption} from './lib/options.mjs';
+import {startTimeoutProgressLogger} from './lib/progress.mjs';
+import {assertRoot} from './lib/root.mjs';
 
-function assertRoot() {
-  if (typeof process.getuid !== 'function') {
-    return;
-  }
-  if (process.getuid() !== 0) {
-    throw new Error(
-      'This script must be run as root (e.g. sudo appium driver run xcuitest pair-appletv ...).',
-    );
-  }
-}
+const log = logger.getLogger('AppleTVPairing');
+const APPLETV_PAIRING_DISCOVERY_PROGRESS_INTERVAL_MS = 1000;
+const DEFAULT_APPLETV_PAIRING_DISCOVERY_TIMEOUT_MS =
+  Number(process.env.APPLETV_DISCOVERY_TIMEOUT) || 10_000;
+const APPLETV_PAIRING_DISCOVERY_PROGRESS_BAR_WIDTH = 24;
 
 async function main() {
-  assertRoot();
+  assertRoot('pair-appletv');
   const program = new Command();
   program
     .name('appium driver run xcuitest pair-appletv')
@@ -44,6 +43,12 @@ async function main() {
     .option(
       '-d, --device <selector>',
       'Apple TV device selector (name, identifier, or index)',
+    )
+    .option(
+      '--discovery-timeout-ms <ms>',
+      'Apple TV pairing discovery timeout in milliseconds',
+      (value) => parsePositiveIntegerOption(value, 'discovery timeout'),
+      DEFAULT_APPLETV_PAIRING_DISCOVERY_TIMEOUT_MS,
     );
 
   program.parse(process.argv);
@@ -52,9 +57,25 @@ async function main() {
   const userInput = new UserInputService();
   const pairingService = new AppleTVPairingService(userInput);
 
-  const result = await pairingService.discoverAndPair(options.device);
+  const devices = await discoverAppleTVPairingDevices(
+    pairingService,
+    options.discoveryTimeoutMs,
+  );
+  if (devices.length === 0) {
+    log.info(getNoAppleTVPairingDevicesMessage());
+    return;
+  }
+
+  const result = await pairingService.discoverAndPair(options.device, {
+    devices,
+    discoveryTimeoutMs: options.discoveryTimeoutMs,
+  });
 
   if (!result.success) {
+    if (isNoAppleTVPairingDevicesFoundError(result.error)) {
+      log.info(getNoAppleTVPairingDevicesMessage());
+      return;
+    }
     throw result.error ?? new Error('Pairing failed');
   }
 
@@ -64,5 +85,57 @@ async function main() {
   );
 }
 
+/**
+ * @param {import('appium-ios-remotexpc').AppleTVPairingService} pairingService
+ * @param {number} discoveryTimeoutMs
+ * @returns {Promise<AppleTVDevice[]>}
+ */
+async function discoverAppleTVPairingDevices(pairingService, discoveryTimeoutMs) {
+  const startedAt = performance.now();
+  const pairingDiscoveryProgress = startTimeoutProgressLogger({
+    log,
+    label: 'Waiting for Apple TV pairing discovery',
+    startedAt,
+    timeoutMs: discoveryTimeoutMs,
+    barWidth: APPLETV_PAIRING_DISCOVERY_PROGRESS_BAR_WIDTH,
+    intervalMs: APPLETV_PAIRING_DISCOVERY_PROGRESS_INTERVAL_MS,
+  });
+
+  try {
+    const devices = await pairingService.discoverDevices({
+      timeoutMs: discoveryTimeoutMs,
+    });
+    pairingDiscoveryProgress.succeed(
+      `Apple TV pairing discovery completed: ${devices.length} device(s) found`,
+    );
+    return devices;
+  } catch (err) {
+    pairingDiscoveryProgress.fail('Apple TV pairing discovery failed');
+    throw err;
+  }
+}
+
+/**
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isNoAppleTVPairingDevicesFoundError(err) {
+  return (
+    err instanceof Error &&
+    (err.message === getNoAppleTVPairingDevicesMessage() ||
+      ('code' in err && err.code === 'NO_DEVICES'))
+  );
+}
+
+/**
+ * @returns {string}
+ */
+function getNoAppleTVPairingDevicesMessage() {
+  return 'No Apple TV pairing devices found. Please ensure your Apple TV is on the same network and in pairing mode.';
+}
 
 await main();
+
+/**
+ * @typedef {import('appium-ios-remotexpc').AppleTVDevice} AppleTVDevice
+ */

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -24,19 +24,28 @@ import {
 import {strongbox, BaseItem} from '@appium/strongbox';
 import {Command} from 'commander';
 
+import {parsePositiveIntegerOption} from './lib/options.mjs';
+import {startTimeoutProgressLogger} from './lib/progress.mjs';
+import {assertRoot} from './lib/root.mjs';
+
 const log = logger.getLogger('TunnelCreation');
 const TUNNEL_REGISTRY_PORT = 'tunnelRegistryPort';
 const DEFAULT_TUNNEL_REGISTRY_PORT = 42314;
 const WIRELESS_APPLETV_DISCOVERY_PROGRESS_INTERVAL_MS = 1000;
-const WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS = 10_000;
+const DEFAULT_WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS = 10_000;
 const WIRELESS_APPLETV_DISCOVERY_PROGRESS_BAR_WIDTH = 24;
 
 /**
  * TunnelCreator class for managing tunnel creation and related operations (USB and optional Apple TV over WiFi).
  */
 class TunnelCreator {
-  constructor() {
+  /**
+   * @param {{appleTVDiscoveryTimeoutMs?: number}} [opts]
+   */
+  constructor(opts = {}) {
     this._tunnelRegistryPort = DEFAULT_TUNNEL_REGISTRY_PORT;
+    this._appleTVDiscoveryTimeoutMs =
+      opts.appleTVDiscoveryTimeoutMs ?? DEFAULT_WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS;
     /** @type {import('appium-ios-remotexpc').TunnelRegistryServer | null} */
     this._registryServer = null;
     /** @type {import('appium-ios-remotexpc').TunnelReadinessCoordinator} */
@@ -412,13 +421,14 @@ class TunnelCreator {
 
   /**
    * @param {string[] | undefined} specificDeviceIds
-   * @returns {{startedAt: number, promise: Promise<{devices: AppleTVDevice[] | null, error: unknown | null}>}}
+   * @returns {{startedAt: number, timeoutMs: number, promise: Promise<{devices: AppleTVDevice[] | null, error: unknown | null}>}}
    */
   prefetchAppleTVDevices(specificDeviceIds) {
     const startedAt = performance.now();
     if (specificDeviceIds && specificDeviceIds.length > 0) {
       return {
         startedAt,
+        timeoutMs: this._appleTVDiscoveryTimeoutMs,
         promise: Promise.resolve({devices: null, error: null}),
       };
     }
@@ -426,7 +436,7 @@ class TunnelCreator {
     const promise = (async () => {
       try {
         const devices = await tunnelService.discoverDevices({
-          timeoutMs: WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS,
+          timeoutMs: this._appleTVDiscoveryTimeoutMs,
         });
         return {devices, error: null};
       } catch (err) {
@@ -437,7 +447,7 @@ class TunnelCreator {
         } catch {}
       }
     })();
-    return {startedAt, promise};
+    return {startedAt, timeoutMs: this._appleTVDiscoveryTimeoutMs, promise};
   }
 
   /**
@@ -454,7 +464,7 @@ class TunnelCreator {
 
     const startResult = await tunnelService.startTunnel(undefined, udid, {
       devices: prefetchedDevice ? [prefetchedDevice] : undefined,
-      discoveryTimeoutMs: WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS,
+      discoveryTimeoutMs: this._appleTVDiscoveryTimeoutMs,
     });
     if (!startResult.tcpSocket) {
       throw new Error('Apple TV TCP socket to listener port not established');
@@ -740,14 +750,15 @@ function isNoAppleTVDevicesFoundError(err) {
 }
 
 /**
- * @param {{startedAt: number, promise: Promise<{devices: AppleTVDevice[] | null, error: unknown | null}>}} discovery
+ * @param {{startedAt: number, timeoutMs: number, promise: Promise<{devices: AppleTVDevice[] | null, error: unknown | null}>}} discovery
  * @returns {Promise<AppleTVDevice[] | null>}
  */
 async function waitForAppleTVDiscovery(discovery) {
   const wirelessDiscoveryProgress = startTimeoutProgressLogger({
+    log,
     label: 'Waiting for wireless Apple TV discovery',
     startedAt: discovery.startedAt,
-    timeoutMs: WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS,
+    timeoutMs: discovery.timeoutMs,
     barWidth: WIRELESS_APPLETV_DISCOVERY_PROGRESS_BAR_WIDTH,
     intervalMs: WIRELESS_APPLETV_DISCOVERY_PROGRESS_INTERVAL_MS,
   });
@@ -776,51 +787,6 @@ async function sleep(ms) {
 }
 
 /**
- * Logs a timeout-based progress bar while an operation without native progress callbacks is running.
- *
- * @param {{label: string, startedAt: number, timeoutMs: number, barWidth: number, intervalMs: number}} opts
- * @returns {{succeed: (message?: string) => void, fail: (message?: string) => void}}
- */
-function startTimeoutProgressLogger({label, startedAt, timeoutMs, barWidth, intervalMs}) {
-  /** @type {NodeJS.Timeout | null} */
-  let timer = null;
-  let isStopped = false;
-
-  const logProgress = (status, isComplete = false) => {
-    const elapsedMs = performance.now() - startedAt;
-    const boundedElapsedMs = Math.min(elapsedMs, timeoutMs);
-    const progress = isComplete ? 1 : boundedElapsedMs / timeoutMs;
-    const filledWidth = Math.round(progress * barWidth);
-    const emptyWidth = barWidth - filledWidth;
-    const bar = `${'#'.repeat(filledWidth)}${'-'.repeat(emptyWidth)}`;
-    log.info(`${label}: [${bar}]${status && status !== 'waiting' ? ` - ${status}` : ''}`);
-  };
-
-  const stop = (status, isComplete = false) => {
-    if (isStopped) {
-      return;
-    }
-    isStopped = true;
-    if (timer) {
-      clearInterval(timer);
-      timer = null;
-    }
-    logProgress(status, isComplete);
-  };
-
-  logProgress('waiting');
-  timer = setInterval(() => {
-    logProgress('waiting');
-  }, intervalMs);
-  timer.unref?.();
-
-  return {
-    succeed: (message = 'done') => stop(message, true),
-    fail: (message = 'failed') => stop(message),
-  };
-}
-
-/**
  * @param {string} value
  * @param {string} label
  * @returns {number}
@@ -844,19 +810,6 @@ function parseNonNegativeIntegerOption(value, label) {
     throw new Error(`Invalid ${label}: ${value}. Expected an integer >= 0.`);
   }
   return count;
-}
-
-/**
- * @param {string} value
- * @param {string} label
- * @returns {number}
- */
-function parsePositiveIntegerOption(value, label) {
-  const num = Number.parseInt(value, 10);
-  if (!Number.isFinite(num) || num <= 0) {
-    throw new Error(`Invalid ${label}: ${value}. Expected a positive integer.`);
-  }
-  return num;
 }
 
 /**
@@ -932,19 +885,8 @@ function setupCleanupHandlers(tunnelCreator) {
   return cleanupOnce;
 }
 
-function assertRoot() {
-  if (typeof process.getuid !== 'function') {
-    return;
-  }
-  if (process.getuid() !== 0) {
-    throw new Error(
-      'This script must be run as root (e.g. sudo appium driver run xcuitest tunnel-creation ...).',
-    );
-  }
-}
-
 async function main() {
-  assertRoot();
+  assertRoot('tunnel-creation');
   const program = new Command();
   program
     .name('appium driver run xcuitest tunnel-creation')
@@ -969,6 +911,12 @@ async function main() {
       [],
     )
     .option(
+      '--appletv-discovery-timeout-ms <ms>',
+      'Apple TV wireless discovery timeout in milliseconds',
+      (value) => parsePositiveIntegerOption(value, 'Apple TV discovery timeout'),
+      DEFAULT_WIRELESS_APPLETV_DISCOVERY_TIMEOUT_MS,
+    )
+    .option(
       '--disconnect-retry-max-attempts <count>',
       'Max tunnel recreation attempts after unexpected disconnect: 0 = unlimited; omit to disable retries',
       (value) => parseNonNegativeIntegerOption(value, 'disconnect retry max attempts'),
@@ -989,7 +937,9 @@ async function main() {
   const shouldRunUsbFlow = !hasRequestedAppleTVIds || hasRequestedUdids;
   const shouldRunAppleTVFlow = !hasRequestedUdids || hasRequestedAppleTVIds;
 
-  const tunnelCreator = new TunnelCreator();
+  const tunnelCreator = new TunnelCreator({
+    appleTVDiscoveryTimeoutMs: options.appletvDiscoveryTimeoutMs,
+  });
   const cleanupOnce = setupCleanupHandlers(tunnelCreator);
 
   try {
@@ -1126,7 +1076,7 @@ await main();
  */
 
 /**
- * @typedef {Awaited<ReturnType<import('appium-ios-remotexpc').AppleTVTunnelService['discoverDevices']>>[number]} AppleTVDevice
+ * @typedef {import('appium-ios-remotexpc').AppleTVDevice} AppleTVDevice
  */
 
 /**


### PR DESCRIPTION
## Summary

- Improve `pair-appletv` progress reporting by pre-discovering Apple TV pairing devices with a timeout-based progress logger.
- Extract shared script helpers for root checks, progress logging, and positive integer option parsing into `scripts/lib`.
- Add configurable Apple TV discovery timeouts:
  - `pair-appletv -- --discovery-timeout-ms <ms>`
  - `tunnel-creation -- --appletv-discovery-timeout-ms <ms>`
- Treat “no Apple TV pairing devices found” as an informational no-op instead of surfacing an exception.
- Update Apple TV Remote XPC docs and script reference entries for the new timeout options.
- Bump optional `appium-ios-remotexpc` dependency to `^5.1.5`.
