### PR TITLE
fix: Only assert root after arguments parsing is finished

### DIFF
--- a/scripts/lib/root.mjs
+++ b/scripts/lib/root.mjs
@@ -1,15 +1,33 @@
+import { exec } from 'teen_process';
+
 /**
- * Ensures a driver helper script is run with elevated privileges on platforms that expose getuid.
+ * Ensures a helper script is run with elevated privileges.
  *
- * @param {string} scriptName
+ * @param {string} relativeScriptPath
  */
-export function assertRoot(scriptName) {
+export async function assertRoot(relativeScriptPath) {
+  if (process.platform === 'win32') {
+    await assertWindowsAdmin(relativeScriptPath);
+    return;
+  }
+
   if (typeof process.getuid !== 'function') {
     return;
   }
   if (process.getuid() !== 0) {
+    throw new Error(`This script must be run as root/admin (e.g. sudo node "${relativeScriptPath}").`);
+  }
+}
+
+/**
+ * @param {string} relativeScriptPath
+ */
+async function assertWindowsAdmin(relativeScriptPath) {
+  try {
+    await exec('net', ['session']);
+  } catch {
     throw new Error(
-      `This script must be run as root (e.g. sudo appium driver run xcuitest ${scriptName} ...).`,
+      `This script must be run as Administrator (e.g. from an elevated terminal: node "${relativeScriptPath}").`,
     );
   }
 }

--- a/scripts/lib/root.mjs
+++ b/scripts/lib/root.mjs
@@ -1,13 +1,15 @@
 import { exec } from 'teen_process';
 
+const COMMAND_PREFIX = 'appium driver run xcuitest';
+
 /**
  * Ensures a helper script is run with elevated privileges.
  *
- * @param {string} relativeScriptPath
+ * @param {string} scriptName
  */
-export async function assertRoot(relativeScriptPath) {
+export async function assertRoot(scriptName) {
   if (process.platform === 'win32') {
-    await assertWindowsAdmin(relativeScriptPath);
+    await assertWindowsAdmin(scriptName);
     return;
   }
 
@@ -15,19 +17,21 @@ export async function assertRoot(relativeScriptPath) {
     return;
   }
   if (process.getuid() !== 0) {
-    throw new Error(`This script must be run as root/admin (e.g. sudo node "${relativeScriptPath}").`);
+    throw new Error(
+      `This script must be run as root/admin (e.g. sudo ${COMMAND_PREFIX} "${scriptName}").`
+    );
   }
 }
 
 /**
- * @param {string} relativeScriptPath
+ * @param {string} scriptName
  */
-async function assertWindowsAdmin(relativeScriptPath) {
+async function assertWindowsAdmin(scriptName) {
   try {
     await exec('net', ['session']);
   } catch {
     throw new Error(
-      `This script must be run as Administrator (e.g. from an elevated terminal: node "${relativeScriptPath}").`,
+      `This script must be run as Administrator (e.g. from an elevated terminal: ${COMMAND_PREFIX} "${scriptName}").`,
     );
   }
 }

--- a/scripts/pair-appletv.mjs
+++ b/scripts/pair-appletv.mjs
@@ -54,10 +54,7 @@ async function main() {
   program.parse(process.argv);
   const options = program.opts();
 
-  await assertRoot(path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    path.basename(fileURLToPath(import.meta.url))
-  ));
+  await assertRoot(path.parse(fileURLToPath(import.meta.url)).name);
 
   const userInput = new UserInputService();
   const pairingService = new AppleTVPairingService(userInput);

--- a/scripts/pair-appletv.mjs
+++ b/scripts/pair-appletv.mjs
@@ -23,7 +23,8 @@
 import {logger} from 'appium/support.js';
 import {Command} from 'commander';
 import {AppleTVPairingService, UserInputService} from 'appium-ios-remotexpc';
-
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {parsePositiveIntegerOption} from './lib/options.mjs';
 import {startTimeoutProgressLogger} from './lib/progress.mjs';
 import {assertRoot} from './lib/root.mjs';
@@ -35,7 +36,6 @@ const DEFAULT_APPLETV_PAIRING_DISCOVERY_TIMEOUT_MS =
 const APPLETV_PAIRING_DISCOVERY_PROGRESS_BAR_WIDTH = 24;
 
 async function main() {
-  assertRoot('pair-appletv');
   const program = new Command();
   program
     .name('appium driver run xcuitest pair-appletv')
@@ -53,6 +53,11 @@ async function main() {
 
   program.parse(process.argv);
   const options = program.opts();
+
+  await assertRoot(path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    path.basename(fileURLToPath(import.meta.url))
+  ));
 
   const userInput = new UserInputService();
   const pairingService = new AppleTVPairingService(userInput);

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -938,10 +938,7 @@ async function main() {
   const shouldRunUsbFlow = !hasRequestedAppleTVIds || hasRequestedUdids;
   const shouldRunAppleTVFlow = !hasRequestedUdids || hasRequestedAppleTVIds;
 
-  await assertRoot(path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    path.basename(fileURLToPath(import.meta.url))
-  ));
+  await assertRoot(path.parse(fileURLToPath(import.meta.url)).name);
 
   const tunnelCreator = new TunnelCreator({
     appleTVDiscoveryTimeoutMs: options.appletvDiscoveryTimeoutMs,

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -6,6 +6,8 @@
  * Must be run as root (e.g. sudo appium driver run xcuitest tunnel-creation).
  */
 import {logger} from 'appium/support.js';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {
   AppleTVTunnelService,
@@ -886,7 +888,6 @@ function setupCleanupHandlers(tunnelCreator) {
 }
 
 async function main() {
-  assertRoot('tunnel-creation');
   const program = new Command();
   program
     .name('appium driver run xcuitest tunnel-creation')
@@ -936,6 +937,11 @@ async function main() {
   const hasRequestedAppleTVIds = requestedAppleTVIds.length > 0;
   const shouldRunUsbFlow = !hasRequestedAppleTVIds || hasRequestedUdids;
   const shouldRunAppleTVFlow = !hasRequestedUdids || hasRequestedAppleTVIds;
+
+  await assertRoot(path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    path.basename(fileURLToPath(import.meta.url))
+  ));
 
   const tunnelCreator = new TunnelCreator({
     appleTVDiscoveryTimeoutMs: options.appletvDiscoveryTimeoutMs,


### PR DESCRIPTION
this way we could still, for example, see --help output without running the command with sudo