### PR TITLE
chore: Replace the deprecated getDerivedDataPath usages on wda instance

### DIFF
--- a/lib/commands/wda/cleanup.ts
+++ b/lib/commands/wda/cleanup.ts
@@ -6,6 +6,7 @@ import {exec} from 'teen_process';
 import type {XCUITestDriver} from '../../driver';
 import {log} from '../../logger';
 import {isXcodebuildNeeded, SHARED_RESOURCES_GUARD, XCUITEST_DRIVER_SYNC_NAME} from './constants';
+import {getDerivedDataPath} from './utils';
 
 const XCTEST_LOG_FILES_PATTERNS = [
   /^Session-WebDriverAgentRunner.*\.log$/i,
@@ -119,12 +120,12 @@ export async function cleanup(driver: XCUITestDriver): Promise<void> {
   }
 
   let synchronizationKey = XCUITEST_DRIVER_SYNC_NAME;
-  const derivedDataPath = await driver.wda.retrieveDerivedDataPath();
+  const derivedDataPath = await getDerivedDataPath(driver.wda);
   if (derivedDataPath) {
     synchronizationKey = path.normalize(derivedDataPath);
   }
   await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
-    await clearSystemFiles(() => driver.wda.retrieveDerivedDataPath());
+    await clearSystemFiles(async () => derivedDataPath);
   });
 }
 

--- a/lib/commands/wda/startup.ts
+++ b/lib/commands/wda/startup.ts
@@ -21,6 +21,7 @@ import {
   WDA_STARTUP_RETRY_INTERVAL,
   XCUITEST_DRIVER_SYNC_NAME,
 } from './constants';
+import {getDerivedDataPath} from './utils';
 
 interface StartupRetryOptions {
   startupRetries: number;
@@ -125,7 +126,7 @@ async function setupConnection(driver: XCUITestDriver): Promise<void> {
 
 async function getSynchronizationKey(driver: XCUITestDriver): Promise<string> {
   if (driver.opts.useXctestrunFile || !(await driver.wda.isSourceFresh())) {
-    const derivedDataPath = await driver.wda.retrieveDerivedDataPath();
+    const derivedDataPath = await getDerivedDataPath(driver.wda);
     if (derivedDataPath) {
       return path.normalize(derivedDataPath);
     }
@@ -356,7 +357,7 @@ async function establishProxySession(
 
 async function finalizeSuccessfulStartup(driver: XCUITestDriver): Promise<void> {
   if (driver.opts.clearSystemFiles && isXcodebuildNeeded(driver.opts)) {
-    await markSystemFilesForCleanup(() => driver.wda.retrieveDerivedDataPath());
+    await markSystemFilesForCleanup(() => getDerivedDataPath(driver.wda));
   }
 
   if (driver.cachedWdaStatus?.build) {

--- a/lib/commands/wda/utils.ts
+++ b/lib/commands/wda/utils.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import type {WebDriverAgent} from 'appium-webdriveragent';
+
+/**
+ * Returns the WebDriverAgent derived data root from Xcode build settings.
+ */
+export async function getDerivedDataPath(wda: WebDriverAgent): Promise<string | undefined> {
+  const buildSettings = await wda.retrieveBuildSettings({
+    scheme: 'WebDriverAgentRunner',
+  });
+  const buildDir = buildSettings?.BUILD_DIR;
+  return buildDir ? path.dirname(path.dirname(path.normalize(buildDir))) : undefined;
+}

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -74,6 +74,7 @@ import * as voiceOverCommands from './commands/voiceover';
 import * as webCommands from './commands/web';
 import {start, startWdaSession} from './commands/wda/startup';
 import {stop} from './commands/wda/stop';
+import {getDerivedDataPath} from './commands/wda/utils';
 import * as xctestCommands from './commands/xctest';
 import * as xctestRecordScreenCommands from './commands/xctest-record-screen';
 import * as increaseContrastCommands from './commands/increase-contrast';
@@ -1372,7 +1373,7 @@ export class XCUITestDriver
     // whenever it is needed
     void (async () => {
       try {
-        await this.wda.retrieveDerivedDataPath();
+        await getDerivedDataPath(this.wda);
       } catch (e) {
         this.log.debug(e);
       }


### PR DESCRIPTION
## Summary

- Replaces direct usages of deprecated `WebDriverAgent.retrieveDerivedDataPath()` with a local `getDerivedDataPath()` helper.
- Derives the WDA derived data root from `retrieveBuildSettings({scheme: 'WebDriverAgentRunner'})`, matching the current WebDriverAgent implementation.
- Updates startup, cleanup, and driver initialization paths to use the non-deprecated build settings API.
