### PR TITLE
chore(deps): remove unused moment dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "commander": "^14.0.1",
     "js2xmlparser2": "^0.x",
     "lru-cache": "^11.1.0",
-    "moment": "^2.29.4",
     "moment-timezone": "^0.x",
     "node-devicectl": "^1.1.0",
     "node-simctl": "^8.1.1",


### PR DESCRIPTION
  ## Summary

  Remove the unused direct `moment` dependency from `package.json`.

  The driver imports `moment-timezone`, not `moment` directly. `moment-timezone` already declares `moment` as its own dependency, so keeping `moment` at the root is redundant.

  ## History

  `moment` was first added in dac9a79e1 for Sauce RDC/EmuSim test environment selection using `moment().dayOfYear()`.

  It was later moved to runtime dependencies in b7e967beb when `getDeviceTime` started using `moment` directly after removing `idevicedate`.

  The runtime usage was replaced by `moment-timezone` in 60d7e1e0b, and the remaining Sauce test environment files that imported `moment` were removed in 3956d3235.