### PR TITLE
chore(deps-dev): remove unused mocha-junit-reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.0.1",
-    "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "pem": "^1.14.8",
     "prettier": "^3.0.0",


### PR DESCRIPTION
  ## Summary

  Remove the unused `mocha-junit-reporter` dev dependency.

  ## Details

  `mocha-junit-reporter` was added in edcc0b81d (Add PR validation on Azure Pipelines (#894)) for the old Azure Pipelines functional test setup.

  The direct `--reporter mocha-junit-reporter` usage was replaced with `mocha-multi-reporters` in 95c39e8ab (Update CI to Mojave with iOS 12.2 (#930)). It remained indirectly used
  through `ci-jobs/mocha-config.json` until 29d92c940 (refactor: Decouple the module from @appium/gulp-plugins (#1433)) removed that config.

  Since then, the dependency has remained in `package.json` without any repository references. The current functional test workflow uses `mocha-multi-reporters` with Mocha's built-in `xunit`
  reporter.