### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [11.17.0](https://github.com/appium/appium-xcuitest-driver/compare/v11.16.3...v11.17.0) (2026-07-01)
 
+### Features
+
+* Extend `mobile: getClipboard` and `mobile: setClipboard` APIs ([#2895](https://github.com/appium/appium-xcuitest-driver/issues/2895)) ([4505068](https://github.com/appium/appium-xcuitest-driver/commit/450506893aabdb7487e5dd9c6a1bd13fbe9de9a4))
+
 ## [11.16.3](https://github.com/appium/appium-xcuitest-driver/compare/v11.16.2...v11.16.3) (2026-06-29)
 
 ### Miscellaneous Chores

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "@types/portscanner": "^2.1.1",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "mocha": "^11.0.1",
     "mocha-multi-reporters": "^1.5.1",
     "pem": "^1.14.8",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177

I've also manually updated CHANGELOG.md for the latest version, since it was a feature released after the conventionalcommits v10 bump.