### PR TITLE
docs: tune BiDi document

### DIFF
--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -1,85 +1,130 @@
 ---
-title: BiDi Events
+title: BiDi Commands and Events
 ---
 
 The XCUITest driver has partial support of the [WebDriver BiDi Protocol](https://w3c.github.io/webdriver-bidi/).
-Only the events and commands mentioned below are supported. All other entities described in the
-specification throw not implemented errors.
+It inherits [the BiDi commands and events supported by the Appium base driver](https://appium.io/docs/en/latest/reference/api/bidi/),
+and additionally defines the events and commands listed below.
 
-For other BiDi events recognized by the Appium server, see
-[their Appium docs reference page](https://appium.io/docs/en/latest/reference/api/bidi/).
+## Events
 
-## log.entryAdded
+### log.entryAdded
 
-This event is emitted if the driver retrieves a new entry for any of the below log types. Logs collection might be disabled by the `appium:skipLogCapture` capability.
+> WebDriver BiDi documentation: [log.entryAdded](https://w3c.github.io/webdriver-bidi/#event-log-entryAdded)
 
-### crashlog
+Indicates that a new log entry is available for consumption.
 
-Events are emitted for both emulator and real devices. On real devices, crash logs require **iOS/tvOS 18+** and the optional [`appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc) package. Each event contains a particular device crash report entry.
-Events are always emitted with the `NATIVE_APP` context.
+This event is emitted when the driver retrieves a new entry for any of the log types listed below. 
+Log capture can also be disabled using the [`appium:skipLogCapture`](./capabilities.md) capability.
 
-### syslog
-
-Events are emitted for both emulator and real devices. Each event contains a single device system log line.
-Events are always emitted with the `NATIVE_APP` context.
-
-### safariConsole
-
-Events are emitted for both emulator and real devices. Each event contains a single Safari console log line.
-Events are always emitted with the appropriate web context name from which they were generated.
-Events are only emitted if the `appium:showSafariConsoleLog` capability value is provided.
-
-### safariNetwork
-
-Events are emitted for both emulator and real devices. Each event contains a single Safari network log line.
-Events are always emitted with the appropriate web context name from which they were generated.
-Events are only emitted if the `appium:showSafariNetworkLog` capability value is provided.
-
-### performance
-
-Events are emitted for both emulator and real devices. Each event contains a single Safari performance log line.
-Events are always emitted with the appropriate web context name from which they were generated.
-Events are only emitted if the `appium:enablePerformanceLogging` capability value is provided.
-
-### server
-
-Events are emitted for both emulator and real devices. Each event contains a single Appium server log line.
-Events are always emitted with the `NATIVE_APP` context.
-Events are only emitted if the `get_server_logs` server security feature is enabled.
-
-## appium:xcuitest.contextUpdate
-
-This event is emitted upon the context change, either explicit or implicit.
-The event is always emitted upon new session initialization.
-See the [GitHub feature ticket](https://github.com/appium/appium/issues/20741) for more details.
-
-### CDDL
+#### Event Type (CDDL)
 
 ```cddl
-appium:xcuitest.contextUpdated = {
+log.entryAded = (
+  context: text,
+  method: "log.entryAdded",
+  params: {
+    type: text,
+    level: "debug" / "info" / "warn" / "error",
+    source: {
+      realm: '',
+      context: text,
+    },
+    text: text,
+    timestamp: js-uint,
+  },
+)
+```
+
+| Parameter | Description |
+| -- | -- |
+| `context` | The context in which the log was created, usually either native or webview |
+| `type` | One of the supported log types listed below |
+| `text` | Contents of the log entry |
+| `timestamp` | Timestamp of the log entry |
+
+#### Supported Types
+
+Event emission of all of these log types is supported for both real devices and emulators.
+
+* `crashlog`
+    * Each event contains a particular device crash report entry
+    * `context` is always set to `NATIVE_APP`
+    * Real devices must have iOS/tvOS 18 or later, and the `appium-ios-remotexpc` package must be installed. Refer to the [RemoteXPC Tunnels guide](../guides/remotexpc-tunnels-real-devices.md) for more details.
+* `syslog`
+    * Each event contains a single device system log line
+    * `context` is always set to `NATIVE_APP`
+* `safariConsole`
+    * Each event contains a single Safari console log line
+    * `context` is always set to the appropriate web context name
+    * Events are only emitted if the [`appium:showSafariConsoleLog`](./capabilities.md) capability is set
+* `safariNetwork`
+    * Each event contains a single Safari network log line
+    * `context` is always set to the appropriate web context name
+    * Events are only emitted if the [`appium:showSafariNetworkLog`](./capabilities.md) capability is set
+* `performance`
+    * Each event contains a single Safari performance log line
+    * `context` is always set to the appropriate web context name
+    * Events are only emitted if the [`appium:enablePerformanceLogging`](./capabilities.md) capability is set
+* `server`
+    * Each event contains a single Appium server log line
+    * `context` is always set to `NATIVE_APP`
+    * Events are only emitted if the [`get_server_logs`](./security-flags.md) insecure feature is enabled
+
+### appium:xcuitest.contextUpdated
+
+Indicates a change in the current Appium context.
+
+This event is emitted upon context change, either explicit or implicit. It is also emitted at the
+start of a new session.
+
+See the [GitHub feature ticket](https://github.com/appium/appium/issues/20741) for more details.
+
+#### Event Type (CDDL)
+
+```cddl
+appium:xcuitest.contextUpdated = (
   method: "appium:xcuitest.contextUpdated",
   params: {
     name: text,
     type: "NATIVE" / "WEB",
   },
-}
+)
 ```
 
-The event contains the following params:
+| Parameter | Description |
+| -- | -- |
+| `name` | The name of the new context |
+| `type` | The type of the currently active context. Supported values are `NATIVE` or `WEB`. |
 
-### name
+### appium:xcuitest.networkMonitor
 
-Contains the actual name of the new context, for example `NATIVE_APP`.
+Indicates that a new network event is available for consumption.
 
-### type
+This event is continuously emitted as soon as the [`mobile: startNetworkMonitor`](./execute-methods.md#mobile-startnetworkmonitor) is invoked. Event emission stops as soon as the [`mobile: stopNetworkMonitor`](./execute-methods.md#mobile-stopnetworkmonitor)
+execute method is called.
 
-Either `NATIVE` or `WEB` depending on which context is currently active in the driver session.
+Events are only supported for real devices running iOS/tvOS 18 or later, and the
+`appium-ios-remotexpc` package must be installed. Refer to the [RemoteXPC Tunnels guide](../guides/remotexpc-tunnels-real-devices.md)
+for more details.
 
-## appium:xcuitest.networkMonitor
+#### Event Type (CDDL)
 
-Emitted once per sample from Apple’s DVT networking instrument (`com.apple.instruments.server.services.networking`) while [`mobile: startNetworkMonitor`](./execute-methods.md#mobile-startnetworkmonitor) is active. **Not** a packet capture: you receive structured **interface**, **connection**, and **statistics** events (similar to Instruments’ network activity view), not raw PCAP bytes.
+The CDDL defines 3 types of network events, each of which has its own shape.
 
-**Requirements:** real device, **iOS/tvOS 18+**, and [`appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc) installed on the Appium host. Stop the stream with [`mobile: stopNetworkMonitor`](./execute-methods.md#mobile-stopnetworkmonitor). Events use the `NATIVE_APP` context.
+```cddl
+appium:xcuitest.networkMonitor = (
+  method: "appium:xcuitest.networkMonitor",
+  context: "NATIVE_APP",
+  params: {
+    event: {
+      appium:xcuitest.networkMonitor.InterfaceDetectionEntry /
+      appium:xcuitest.networkMonitor.ConnectionDetectionEntry /
+      appium:xcuitest.networkMonitor.ConnectionUpdateEntry
+    },
+  },
+)
+```
 
 Each BiDi notification has `method: "appium:xcuitest.networkMonitor"` and `params.event`, where `params.event.type` discriminates the payload:
 

--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -110,7 +110,8 @@ for more details.
 
 #### Event Type (CDDL)
 
-The CDDL defines 3 types of network events, each of which has its own shape.
+There are 3 types of supported network events, each of which has its own shape. Event shapes match
+[the NetworkEvent types used in `appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc/blob/main/src/lib/types.ts).
 
 ```cddl
 appium:xcuitest.networkMonitor = (
@@ -126,112 +127,111 @@ appium:xcuitest.networkMonitor = (
 )
 ```
 
-Each BiDi notification has `method: "appium:xcuitest.networkMonitor"` and `params.event`, where `params.event.type` discriminates the payload:
+All event entries include the `type` field, which is used to distinguish them:
 
-| `type` | Name | Meaning |
+| Type| <div style="width:10em">Name</div> | Meaning |
 | --- | --- | --- |
 | `0` | Interface detection | An interface appeared or was reported (index + kernel name). |
 | `1` | Connection detection | A local/remote socket pair was observed (addresses, PID, interface, serial). |
 | `2` | Connection update | Counters and RTT for an existing flow; correlate with detection via `connectionSerial`. |
 
-### Example: interface detection (`type: 0`)
-
-```json
-{
-  "method": "appium:xcuitest.networkMonitor",
-  "params": {
-    "event": {
-      "type": 0,
-      "interfaceIndex": 25,
-      "name": "utun5"
-    }
-  },
-  "context": "NATIVE_APP"
-}
-```
-
-### Example: connection detection (`type: 1`)
-
-IPv4/IPv6 addresses are normalized strings; `family` is the raw `sockaddr` family (e.g. `2` = IPv4, `30` = IPv6).
-
-```json
-{
-  "method": "appium:xcuitest.networkMonitor",
-  "params": {
-    "event": {
-      "type": 1,
-      "localAddress": {
-        "len": 28,
-        "family": 30,
-        "port": 50063,
-        "address": "fdc2:1118:d2ac::1",
-        "flowInfo": 0,
-        "scopeId": 0
-      },
-      "remoteAddress": {
-        "len": 28,
-        "family": 30,
-        "port": 443,
-        "address": "2600:1900::",
-        "flowInfo": 0,
-        "scopeId": 0
-      },
-      "interfaceIndex": 25,
-      "pid": 1234,
-      "recvBufferSize": 131072,
-      "recvBufferUsed": 4096,
-      "serialNumber": 42,
-      "kind": 1
-    }
-  },
-  "context": "NATIVE_APP"
-}
-```
-
-### Example: connection update (`type: 2`)
-
-Use `connectionSerial` to tie updates back to a prior `type: 1` event’s `serialNumber` when you need per-flow accounting.
-
-```json
-{
-  "method": "appium:xcuitest.networkMonitor",
-  "params": {
-    "event": {
-      "type": 2,
-      "rxPackets": 120,
-      "rxBytes": 98304,
-      "txPackets": 80,
-      "txBytes": 8192,
-      "rxDups": 0,
-      "rx000": 0,
-      "txRetx": 2,
-      "minRtt": 12,
-      "avgRtt": 18,
-      "connectionSerial": 42,
-      "time": 1690000000000
-    }
-  },
-  "context": "NATIVE_APP"
-}
-```
-
-Field names and semantics match [`appium-ios-remotexpc`’s `NetworkEvent` types](https://github.com/appium/appium-ios-remotexpc/blob/main/src/lib/types.ts) (interface / connection detection / connection update).
-
-### CDDL (shape)
-
-Matches the object emitted on the driver event bus (same top-level fields as the JSON examples above), including `context`.
+#### Interface Detection Event
 
 ```cddl
-appium:xcuitest.networkMonitor = {
-  method: "appium:xcuitest.networkMonitor",
-  context: text,
-  params: {
-    event: {
-      type: 0 / 1 / 2,
-      ; type 0: interfaceIndex, name
-      ; type 1: localAddress, remoteAddress, interfaceIndex, pid, recvBufferSize, recvBufferUsed, serialNumber, kind
-      ; type 2: rxPackets, rxBytes, txPackets, txBytes, rxDups, rx000, txRetx, minRtt, avgRtt, connectionSerial, time
-    },
-  },
+appium:xcuitest.networkMonitor.InterfaceDetectionEntry = {
+  type: 0,
+  interfaceIndex: js-uint,
+  name: text,
 }
 ```
+
+| Parameter | Description |
+| -- | -- |
+| `interfaceIndex` | Interface index |
+| `name` | Interface name |
+
+#### Connection Detection Event
+
+```cddl
+appium:xcuitest.networkMonitor.ConnectionDetectionEntry = {
+  type: 1,
+  localAddress: appium:xcuitest.networkMonitor.NetworkAddress,
+  remoteAddress: appium:xcuitest.networkMonitor.NetworkAddress,
+  interfaceIndex: js-uint,
+  pid: js-uint,
+  recvBufferSize: js-uint,
+  recvBufferUsed: js-uint,
+  serialNumber: js-uint,
+  kind: js-uint,
+}
+```
+
+| Parameter | Description |
+| -- | -- |
+| `localAddress` | Local address information |
+| `remoteAddress` | Remote address information |
+| `interfaceIndex` | Interface index |
+| `pid` | ID of the process owning the connection |
+| `recvBufferSize` | Receive buffer size |
+| `recvBufferUsed` | Receive buffer used |
+| `serialNumber` | Connection serial number |
+| `kind` | Connection kind/type |
+
+```cddl
+appium:xcuitest.networkMonitor.NetworkAddress = {
+  len: js-uint,
+  family: js-uint,
+  port: js-uint,
+  address: text,
+  flowInfo: js-uint,
+  scopeId: js-uint,
+}
+```
+
+| Parameter | Description |
+| -- | -- |
+| `len` | Length of the address structure |
+| `family` | Address family |
+| `port` | Port number |
+| `address` | Parsed IP address string |
+| `flowInfo` | Flow info (IPv6 only) |
+| `scopeId` | Scope ID (IPv6 only) |
+
+IPv4/IPv6 addresses are normalized strings; `family` is the raw `sockaddr` family (e.g. `2` = IPv4,
+`30` = IPv6).
+
+#### Connection Update Event
+
+```cddl
+appium:xcuitest.networkMonitor.ConnectionUpdateEntry = {
+  type: js-uint,
+  rxPackets: js-uint,
+  rxBytes: js-uint,
+  txPackets: js-uint,
+  txBytes: js-uint,
+  rxDups: js-uint,
+  rx000: js-uint,
+  txRetx: js-uint,
+  minRtt: js-uint,
+  avgRtt: js-uint,
+  connectionSerial: js-uint,
+  time: js-uint,
+}
+```
+
+| Parameter | Description |
+| -- | -- |
+| `rxPackets` | Number of received packets |
+| `rxBytes` | Number of received bytes |
+| `txPackets` | Number of transmitted packets |
+| `txBytes` | Number of transmitted bytes |
+| `rxDups` | Number of duplicate received packets |
+| `rx000` | Reserved field |
+| `txRetx` | Number of retransmitted packets |
+| `minRtt` | Minimum round-trip time |
+| `avgRtt` | Average round-trip time |
+| `connectionSerial` | Connection serial number |
+| `time` | Timestamp |
+
+You can use the value of `connectionSerial` to link back to a prior `type: 1` event with a matching
+`serialNumber` value.


### PR DESCRIPTION
Update the BiDi document to use more consistent formatting between its defined events, as well as with the Mac2 driver docs. Raw examples are also converted to CDDL.