### PR TITLE
docs: add non-macOS hosts guide

### DIFF
--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -5,6 +5,7 @@ title: System Requirements
 There are three primary requirements to use the XCUITest driver:
 
 * macOS host machine
+    * Windows and Linux hosts have limited support - see the [Non-macOS Hosts guide](../guides/non-macos-hosts.md)
 * Xcode
 * Appium
 
@@ -23,8 +24,8 @@ to help identify your target Xcode, macOS, driver and Appium server versions.
 
 !!! note
 
-    If you already have the driver installed, you can also verify its requirements with the
-    built-in Appium Doctor support:
+    If you already have the driver installed, you can also verify most of its requirements with the
+    built-in Appium Doctor:
 
     ```
     appium driver doctor xcuitest

--- a/docs/guides/non-macos-hosts.md
+++ b/docs/guides/non-macos-hosts.md
@@ -1,0 +1,63 @@
+---
+title: Non-macOS Hosts
+---
+
+The XCUITest driver has limited support for Windows and Linux host machines.
+
+The key constraint for such sessions is the lack of Xcode and its related utilities. This brings
+several limitations:
+
+* Only real devices are supported (simulators can only be run on macOS)
+* Real devices must be running iOS/tvOS 18 or later
+* Automatic device selection is not supported
+* The default `xcodebuild`-based WebDriverAgent (WDA) startup strategy is not supported
+
+## Prerequisites
+
+Device communication on non-macOS hosts is provided by the `appium-ios-remotexpc` optional
+dependency. It will typically be automatically installed along with the XCUITest driver, but
+otherwise make sure to install version `5.1.0` or later.
+
+The package has its own prerequisites, which are described in [the RemoteXPC Tunnels guide](./remotexpc-tunnels-real-devices.md).
+
+## Creating a Session
+
+All Windows and Linux sessions must use several additional capabilities in order to avoid
+Xcode-related codepaths.
+
+Since automatic device selection is not supported, the device must be explicitly specified using
+the [`appium:udid` and `appium:platformVersion` capabilities](../reference/capabilities.md).
+Furthermore, since it is not possible to build WDA without Xcode, one of the following approaches
+must be used:
+
+* WDA can be already pre-installed on the device, which can be specified using the
+  `appium:usePreinstalledWDA` capability - see [the Run Preinstalled WDA guide](./run-preinstalled-wda.md).
+* WDA can be managed externally, which can be specified using the `appium:webDriverAgentUrl`
+  capability - see [the Attach to a Running WDA guide](./attach-to-running-wda.md).
+
+## Example Capability Sets
+
+If using the pre-installed WDA approach:
+
+```json
+{
+  "platformName": "ios",
+  "appium:automationName": "xcuitest",
+  "appium:platformVersion": "26.0",
+  "appium:udid": "<device udid>",
+  "appium:usePreinstalledWDA": true,
+  "appium:updatedWDABundleId": "<updated bundle id>"
+}
+```
+
+If using the externally managed WDA approach:
+
+```json
+{
+  "platformName": "ios",
+  "appium:automationName": "xcuitest",
+  "appium:platformVersion": "26.0",
+  "appium:udid": "<device udid>",
+  "appium:webDriverAgentUrl": "http://<reachable ip address for the device>:8100"
+}
+```

--- a/docs/guides/non-macos-hosts.md
+++ b/docs/guides/non-macos-hosts.md
@@ -15,20 +15,25 @@ several limitations:
 ## Prerequisites
 
 Device communication on non-macOS hosts is provided by the `appium-ios-remotexpc` optional
-dependency. It will typically be automatically installed along with the XCUITest driver, but
-otherwise make sure to install version `5.1.0` or later.
+dependency. In most cases, it will be automatically installed along with the XCUITest driver. If
+installing manually, ensure you are using version `5.1.0` or later.
 
-The package has its own prerequisites, which are described in [the RemoteXPC Tunnels guide](./remotexpc-tunnels-real-devices.md).
+Once the package is installed, you should:
+
+* Set up its Windows/Linux-specific prerequisites
+* Create a RemoteXPC tunnel
+
+Check [the RemoteXPC Tunnels guide](./remotexpc-tunnels-real-devices.md) for further information.
 
 ## Creating a Session
 
 All Windows and Linux sessions must use several additional capabilities in order to avoid
 Xcode-related codepaths.
 
-Since automatic device selection is not supported, the device must be explicitly specified using
-the [`appium:udid` and `appium:platformVersion` capabilities](../reference/capabilities.md).
-Furthermore, since it is not possible to build WDA without Xcode, one of the following approaches
-must be used:
+Since automatic device selection is not supported, it is always required to use the
+[`appium:udid` and `appium:platformVersion` capabilities](../reference/capabilities.md) in order to
+explicitly specify the device under test. Furthermore, since it is not possible to build WDA without
+Xcode, one of the following approaches must be used:
 
 * WDA can be already pre-installed on the device, which can be specified using the
   `appium:usePreinstalledWDA` capability - see [the Run Preinstalled WDA guide](./run-preinstalled-wda.md).

--- a/docs/guides/remotexpc-tunnels-real-devices.md
+++ b/docs/guides/remotexpc-tunnels-real-devices.md
@@ -19,6 +19,7 @@ interfaces and Remote XPC endpoints. The XCUITest driver utilizes them for the f
 (non-exhaustive list):
 
 - General communication with wireless Apple TV devices
+- General device communication on Windows/Linux hosts
 - Retrieval of various logs
 - Network monitoring
 - Certificate management
@@ -34,10 +35,10 @@ interfaces and Remote XPC endpoints. The XCUITest driver utilizes them for the f
     - The driver declares this package as an **optional dependency**, so in a normal
       installation npm will install it automatically. You only need to install it manually if
       the optional dependency step failed or you are wiring a custom environment.
-- On Windows hosts it is mandatory to have Apple Mobile Device drivers installed. These are required for USB
-  communication with iOS devices. Install them through Apple's standalone iTunes package for Windows
-  (the non-Microsoft Store installer already bundles them).
-- On Linux hosts it is necessary to load the TUN/TAP kernel module and give the user permissions to tun devices:
+- On Windows hosts, Apple Mobile Device drivers are required. They can be installed through Apple's
+  standalone iTunes package for Windows (the non-Microsoft Store installer already bundles them).
+- On Linux hosts, it is necessary to load the TUN/TAP kernel module and give the user permissions to
+  tun devices:
 
     ```bash
     # Check if the module is loaded
@@ -152,6 +153,9 @@ No extra capabilities are required to "enable" tunnels; they are automatically u
 - the tunnel registry server is reachable
 - the platform is a real device running iOS/tvOS 18 or later
 
+Refer to [the Non-macOS Hosts guide](./non-macos-hosts.md) for additional requirements in order to
+run sessions on Windows/Linux hosts.
+
 ### Multiple Sessions
 
 The tunnel creation script is multi‑device aware: it creates and registers an independent tunnel
@@ -184,11 +188,3 @@ tunnel‑creation process per container/VM. In such cases, use distinct `--tunne
 values for each isolation boundary. This keeps tunnel state scoped to each environment, but within
 that boundary you should still avoid running multiple competing tunnel‑creation scripts
 simultaneously, as they may fight over TUN/TAP configuration and `usbmuxd` connections.
-
-### Non-macOS Sessions Limitations
-
-Since neither Linux nor Windows supports deploying Xcode, the only way to run a test session on these
-platforms is if WebDriverAgent is already preinstalled on a real device under test (e.g., when
-the `appium:udid`, `appium:platformVersion`, and either `appium:webDriverAgentUrl` or `appium:usePreinstalledWDA`
-capabilities are provided). Simulator sessions, automatic device selection, and the default xcodebuild
-WebDriverAgent startup strategy all require macOS.

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -8,13 +8,6 @@ about capabilities, refer to the [Appium documentation](https://appium.io/docs/e
 For other capabilities recognized by the Appium server, see
 [their Appium docs reference page](https://appium.io/docs/en/latest/reference/session/caps/).
 
-Running the driver on a host other than macOS is only supported for real-device sessions that avoid
-Xcode and Simulator utilities. Such sessions must provide an explicit `appium:udid` and either
-`appium:webDriverAgentUrl` for an externally managed WebDriverAgent or `appium:usePreinstalledWDA`
-with `appium:platformVersion` set to iOS/tvOS 18.0 or newer so RemoteXPC eligibility can be checked
-without probing Xcode. Simulator sessions, automatic device selection, and the default xcodebuild
-WebDriverAgent startup strategy require macOS.
-
 ### General
 
 | <div style="width:10em">Capability</div> | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - guides/gestures.md
       - Other:
           - guides/tvos.md
+          - guides/non-macos-hosts.md
           - guides/input-events.md
   - Troubleshooting:
       - troubleshooting/index.md


### PR DESCRIPTION
This should make the Windows/Linux setup procedure much clearer.