### PR TITLE
refactor: Isolate MJPEG helpers in the driver

### DIFF
--- a/lib/commands/helpers/index.ts
+++ b/lib/commands/helpers/index.ts
@@ -17,6 +17,9 @@ export type {DeviceGuardDriver} from './guards.js';
 export {encodeBase64OrUpload, getPIDsListeningOnPort, isLocalHost} from './network.js';
 export type {UploadOptions} from './network.js';
 
+export {handleMjpegOptions} from './mjpeg.js';
+export type {MJpegStream} from './mjpeg.js';
+
 export {getDriverInfo, printUser} from './runtime.js';
 export type {DriverInfo} from './runtime.js';
 

--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -240,13 +240,14 @@ export class MJpegStream extends Writable {
     this.clear();
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars -- Writable.write signature requires encoding and callback */
   override write(
     data: Buffer | string | Uint8Array,
-    _encoding?: BufferEncoding | ((error: Error | null) => void),
-    _callback?: (error: Error | null) => void,
+    encoding?: BufferEncoding | ((error: Error | null) => void),
+    // eslint-disable-next-line promise/prefer-await-to-callbacks
+    callback?: (error: Error | null) => void,
   ): boolean {
-    /* eslint-enable @typescript-eslint/no-unused-vars */
+    void encoding;
+    void callback;
     this.lastChunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
     this.updateCount++;
     if (this.registerStartSuccess) {

--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -171,26 +171,35 @@ export class MJpegStream extends Writable {
 
     this.consumer = new MjpegFrameParser();
     const url = this.url;
+    // Bound only the connect phase with an abort signal; axios's own `timeout` option would
+    // otherwise keep ticking for the whole request lifetime and race with the "first frame"
+    // watchdog below, since both would share the same deadline.
+    const connectController = new AbortController();
+    const connectTimeoutId = setTimeout(() => connectController.abort(), serverTimeout);
     try {
-      this.responseStream = (
-        await axios({
-          url,
-          responseType: 'stream',
-          timeout: serverTimeout,
-        })
-      ).data as Readable;
-    } catch (e) {
-      let message: string;
-      if (e && typeof e === 'object' && 'response' in e) {
-        message = JSON.stringify((e as {response: unknown}).response);
-      } else if (e instanceof Error) {
-        message = e.message;
-      } else {
-        message = String(e);
+      try {
+        this.responseStream = (
+          await axios({
+            url,
+            responseType: 'stream',
+            signal: connectController.signal,
+          })
+        ).data as Readable;
+      } catch (e) {
+        let message: string;
+        if (e && typeof e === 'object' && 'response' in e) {
+          message = JSON.stringify((e as {response: unknown}).response);
+        } else if (e instanceof Error) {
+          message = e.message;
+        } else {
+          message = String(e);
+        }
+        throw new Error(`Cannot connect to the MJPEG stream at ${url}. Original error: ${message}`, {
+          cause: e,
+        });
       }
-      throw new Error(`Cannot connect to the MJPEG stream at ${url}. Original error: ${message}`, {
-        cause: e,
-      });
+    } finally {
+      clearTimeout(connectTimeoutId);
     }
 
     const onErr = (err: Error) => {

--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -51,8 +51,9 @@ class MjpegFrameParser extends Transform {
     }
     const hasEnd = end > start;
     const copyEnd = hasEnd ? end + JPEG_EOI.length : chunk.length;
-    chunk.copy(this.buffer, 0, start, copyEnd);
-    this.bytesWritten = copyEnd - start;
+    // Buffer.copy() silently truncates if the destination has less room than requested,
+    // so bytesWritten must track what was actually copied, not the requested range size.
+    this.bytesWritten = chunk.copy(this.buffer, 0, start, copyEnd);
 
     if (hasEnd) {
       this.emitFrame();
@@ -67,8 +68,9 @@ class MjpegFrameParser extends Transform {
     }
     const copyStart = start > -1 ? start : 0;
     const copyEnd = end > -1 ? end + JPEG_EOI.length : chunk.length;
-    chunk.copy(this.buffer, this.bytesWritten, copyStart, copyEnd);
-    this.bytesWritten += copyEnd - copyStart;
+    // Buffer.copy() silently truncates if the destination has less room than requested,
+    // so bytesWritten must track what was actually copied, not the requested range size.
+    this.bytesWritten += chunk.copy(this.buffer, this.bytesWritten, copyStart, copyEnd);
 
     if (end > -1 || this.bytesWritten === this.expectedLength) {
       this.emitFrame();
@@ -249,22 +251,17 @@ export class MJpegStream extends Writable {
     this.clear();
   }
 
-  override write(
-    data: Buffer | string | Uint8Array,
-    encoding?: BufferEncoding | ((error: Error | null) => void),
-    // eslint-disable-next-line promise/prefer-await-to-callbacks
-    callback?: (error: Error | null) => void,
-  ): boolean {
-    void encoding;
-    void callback;
-    this.lastChunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  /* eslint-disable promise/prefer-await-to-callbacks -- Writable._write is callback-based */
+  override _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.lastChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     this.updateCount++;
     if (this.registerStartSuccess) {
       this.registerStartSuccess();
       this.registerStartSuccess = null;
     }
-    return true;
+    callback();
   }
+  /* eslint-enable promise/prefer-await-to-callbacks */
 }
 
 /**

--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -1,0 +1,303 @@
+import {Transform, Writable, type Readable, type TransformCallback, type WritableOptions} from 'node:stream';
+
+import {logger} from 'appium/support.js';
+import axios from 'axios';
+import type sharp from 'sharp';
+
+import type {XCUITestDriver} from '../../driver.js';
+
+const log = logger.getLogger('MJPEG');
+
+const DEFAULT_SERVER_TIMEOUT_MS = 10000;
+const DEFAULT_MJPEG_SERVER_PORT = 9100;
+const JPEG_SOI = Buffer.from([0xff, 0xd8]);
+const JPEG_EOI = Buffer.from([0xff, 0xd9]);
+const CONTENT_LENGTH_RE = /Content-Length:\s*(\d+)/i;
+
+/**
+ * Extracts individual JPEG frames out of a multipart MJPEG-over-HTTP byte stream by
+ * scanning for JPEG start/end-of-image markers and the multipart `Content-Length` header.
+ */
+class MjpegFrameParser extends Transform {
+  private buffer: Buffer | null = null;
+  private expectedLength = 0;
+  private bytesWritten = 0;
+  private isReading = false;
+
+  /* eslint-disable promise/prefer-await-to-callbacks -- Transform._transform is callback-based */
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    const startIdx = chunk.indexOf(JPEG_SOI);
+    const endIdx = chunk.indexOf(JPEG_EOI);
+    const lengthMatch = CONTENT_LENGTH_RE.exec(chunk.toString('latin1'));
+
+    if (this.buffer && (this.isReading || startIdx > -1)) {
+      this.appendChunk(chunk, startIdx, endIdx);
+    }
+    if (lengthMatch) {
+      this.startFrame(Number(lengthMatch[1]), chunk, startIdx, endIdx);
+    }
+    callback();
+  }
+  /* eslint-enable promise/prefer-await-to-callbacks */
+
+  private startFrame(length: number, chunk: Buffer, start: number, end: number): void {
+    this.expectedLength = length;
+    this.buffer = Buffer.alloc(length);
+    this.bytesWritten = 0;
+    this.isReading = false;
+
+    if (start < 0) {
+      return;
+    }
+    const hasEnd = end > start;
+    const copyEnd = hasEnd ? end + JPEG_EOI.length : chunk.length;
+    chunk.copy(this.buffer, 0, start, copyEnd);
+    this.bytesWritten = copyEnd - start;
+
+    if (hasEnd) {
+      this.emitFrame();
+    } else {
+      this.isReading = true;
+    }
+  }
+
+  private appendChunk(chunk: Buffer, start: number, end: number): void {
+    if (!this.buffer) {
+      return;
+    }
+    const copyStart = start > -1 && start < end ? start : 0;
+    const copyEnd = end > -1 ? end + JPEG_EOI.length : chunk.length;
+    chunk.copy(this.buffer, this.bytesWritten, copyStart, copyEnd);
+    this.bytesWritten += copyEnd - copyStart;
+
+    if (end > -1 || this.bytesWritten === this.expectedLength) {
+      this.emitFrame();
+    } else {
+      this.isReading = true;
+    }
+  }
+
+  private emitFrame(): void {
+    this.isReading = false;
+    if (this.buffer) {
+      this.push(this.buffer);
+    }
+  }
+}
+
+let sharpModule: typeof sharp | null = null;
+
+async function requireSharp(): Promise<typeof sharp> {
+  if (sharpModule) {
+    return sharpModule;
+  }
+  try {
+    sharpModule = (await import('sharp')).default;
+    return sharpModule;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Cannot load the 'sharp' module needed for MJPEG frame processing. ` +
+        `Consider visiting https://sharp.pixelplumbing.com/install for troubleshooting. ` +
+        `Original error: ${message}`,
+      {cause: err},
+    );
+  }
+}
+
+const noop = () => {};
+
+/**
+ * Connects to an MJPEG-over-HTTP stream and keeps track of the last JPEG frame received,
+ * so that it can be used as a cheap, low-latency screenshot source.
+ */
+export class MJpegStream extends Writable {
+  readonly errorHandler: (err: Error) => void;
+  readonly url: string;
+  private updateCount = 0;
+  private lastChunk: Buffer | null = null;
+  private registerStartSuccess: (() => void) | null = null;
+  private registerStartFailure: ((err: Error) => void) | null = null;
+  private responseStream: Readable | null = null;
+  private consumer: MjpegFrameParser | null = null;
+
+  /**
+   * @param mJpegUrl - URL of the MJPEG-over-HTTP stream
+   * @param errorHandler - additional function that will be called in the case of any errors
+   * @param options - Options to pass to the Writable constructor
+   */
+  constructor(mJpegUrl: string, errorHandler: (err: Error) => void = noop, options: WritableOptions = {}) {
+    super(options);
+    this.errorHandler = errorHandler;
+    this.url = mJpegUrl;
+    this.clear();
+  }
+
+  get lastChunkBase64(): string | null {
+    const lastChunk = this.lastChunk;
+    return lastChunk && lastChunk.length > 0 ? lastChunk.toString('base64') : null;
+  }
+
+  async lastChunkPNG(): Promise<Buffer | null> {
+    const chunk = this.lastChunk;
+    if (!chunk || chunk.length === 0) {
+      return null;
+    }
+    try {
+      const sharp = await requireSharp();
+      return await sharp(chunk).png().toBuffer();
+    } catch (err: any) {
+      log.warn(`Cannot convert MJPEG chunk to PNG: ${err.message}`);
+      return null;
+    }
+  }
+
+  async lastChunkPNGBase64(): Promise<string | null> {
+    const png = await this.lastChunkPNG();
+    return png ? png.toString('base64') : null;
+  }
+
+  clear(): void {
+    this.registerStartSuccess = null;
+    this.registerStartFailure = null;
+    this.responseStream = null;
+    this.consumer = null;
+    this.lastChunk = null;
+    this.updateCount = 0;
+  }
+
+  async start(serverTimeout = DEFAULT_SERVER_TIMEOUT_MS): Promise<void> {
+    this.stop();
+
+    this.consumer = new MjpegFrameParser();
+    const url = this.url;
+    try {
+      this.responseStream = (
+        await axios({
+          url,
+          responseType: 'stream',
+          timeout: serverTimeout,
+        })
+      ).data as Readable;
+    } catch (e) {
+      let message: string;
+      if (e && typeof e === 'object' && 'response' in e) {
+        message = JSON.stringify((e as {response: unknown}).response);
+      } else if (e instanceof Error) {
+        message = e.message;
+      } else {
+        message = String(e);
+      }
+      throw new Error(`Cannot connect to the MJPEG stream at ${url}. Original error: ${message}`, {
+        cause: e,
+      });
+    }
+
+    const onErr = (err: Error) => {
+      this.lastChunk = null;
+      log.error(`Error getting MJPEG screenshot chunk: ${err.message}`);
+      this.errorHandler(err);
+      this.registerStartFailure?.(err);
+    };
+    const onClose = () => {
+      log.debug(`The connection to MJPEG server at ${url} has been closed`);
+      this.lastChunk = null;
+    };
+
+    let timeoutId: NodeJS.Timeout | undefined;
+    const startPromise = new Promise<void>((resolve, reject) => {
+      this.registerStartSuccess = resolve;
+      this.registerStartFailure = reject;
+      timeoutId = setTimeout(
+        () => reject(new Error(`Waited ${serverTimeout}ms but the MJPEG server never sent any images`)),
+        serverTimeout,
+      );
+    });
+
+    (this.responseStream as Readable & {pipe<T extends Writable>(dest: T): T})
+      .once('close', onClose)
+      .on('error', onErr)
+      .pipe(this.consumer)
+      .pipe(this);
+
+    try {
+      await startPromise;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  stop(): void {
+    if (this.consumer) {
+      this.consumer.unpipe(this);
+    }
+    if (this.responseStream) {
+      if (this.consumer) {
+        this.responseStream.unpipe(this.consumer);
+      }
+      this.responseStream.destroy();
+    }
+    this.clear();
+  }
+
+  /* eslint-disable @typescript-eslint/no-unused-vars -- Writable.write signature requires encoding and callback */
+  override write(
+    data: Buffer | string | Uint8Array,
+    _encoding?: BufferEncoding | ((error: Error | null) => void),
+    _callback?: (error: Error | null) => void,
+  ): boolean {
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+    this.lastChunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    this.updateCount++;
+    if (this.registerStartSuccess) {
+      this.registerStartSuccess();
+      this.registerStartSuccess = null;
+    }
+    return true;
+  }
+}
+
+/**
+ * Forwards the device's MJPEG broadcast port and starts reading the MJPEG stream
+ * if `mjpegScreenshotUrl` was requested.
+ */
+export async function handleMjpegOptions(driver: XCUITestDriver): Promise<void> {
+  await allocateMjpegServerPort(driver);
+  // turn on mjpeg stream reading if requested
+  if (driver.opts.mjpegScreenshotUrl) {
+    driver.log.info(`Starting MJPEG stream reading URL: '${driver.opts.mjpegScreenshotUrl}'`);
+    driver.mjpegStream = new MJpegStream(driver.opts.mjpegScreenshotUrl);
+    await driver.mjpegStream.start();
+  }
+}
+
+/**
+ * Forwards the device's MJPEG broadcast port to the local port of the same number.
+ */
+export async function allocateMjpegServerPort(driver: XCUITestDriver): Promise<void> {
+  const mjpegServerPort = Number(driver.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT);
+  driver.log.debug(`Forwarding MJPEG server port ${mjpegServerPort} to local port ${mjpegServerPort}`);
+  try {
+    await driver.deviceConnectionsFactory.requestConnection(driver.opts.udid, mjpegServerPort, {
+      devicePort: mjpegServerPort,
+      usePortForwarding: driver.isRealDevice(),
+      remoteXPCFacade: driver.isRealDevice() ? driver.remoteXPCFacade : null,
+    });
+  } catch (error) {
+    if (driver.opts.mjpegServerPort === undefined) {
+      driver.log.warn(
+        `Cannot forward the device port ${DEFAULT_MJPEG_SERVER_PORT} to the local port ${DEFAULT_MJPEG_SERVER_PORT}. ` +
+          `Certain features, like MJPEG-based screen recording, will be unavailable during this session. ` +
+          `Try to customize the value of 'mjpegServerPort' capability as a possible solution`,
+      );
+    } else {
+      driver.log.debug((error as Error).stack);
+      throw new Error(
+        `Cannot ensure MJPEG broadcast functionality by forwarding the local port ${mjpegServerPort} ` +
+          `requested by the 'mjpegServerPort' capability to the device port ${mjpegServerPort}. ` +
+          `Original error: ${error}`,
+        {cause: error},
+      );
+    }
+  }
+}

--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -65,7 +65,7 @@ class MjpegFrameParser extends Transform {
     if (!this.buffer) {
       return;
     }
-    const copyStart = start > -1 && start < end ? start : 0;
+    const copyStart = start > -1 ? start : 0;
     const copyEnd = end > -1 ? end + JPEG_EOI.length : chunk.length;
     chunk.copy(this.buffer, this.bytesWritten, copyStart, copyEnd);
     this.bytesWritten += copyEnd - copyStart;

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -15,7 +15,7 @@ import type {RemoteDebugger} from 'appium-remote-debugger';
 import {WebDriverAgent, type WebDriverAgentArgs} from 'appium-webdriveragent';
 import type {XcodeVersion} from 'appium-xcode';
 import {BaseDriver, DeviceSettings} from 'appium/driver.js';
-import {mjpeg, util} from 'appium/support.js';
+import {util} from 'appium/support.js';
 import {LRUCache} from 'lru-cache';
 
 import {AppInfosCache} from './app-infos-cache.js';
@@ -48,6 +48,7 @@ import {
   checkAppPresent,
   getAndCheckXcodeVersion,
   getDriverInfo,
+  handleMjpegOptions,
   installAUT,
   normalizeCommandTimeouts,
   onDownloadApp,
@@ -55,6 +56,7 @@ import {
   printUser,
   removeAllSessionWebSocketHandlers,
   shouldSetInitialSafariUrl,
+  type MJpegStream,
 } from './commands/helpers/index.js';
 import * as increaseContrastCommands from './commands/increase-contrast.js';
 import * as iohidCommands from './commands/iohid.js';
@@ -150,7 +152,6 @@ const DEFAULT_SETTINGS = {
 // affect shared resources of the other parallel sessions
 const WEB_ELEMENTS_CACHE_SIZE = 500;
 const SUPPORTED_ORIENATIONS = ['LANDSCAPE', 'PORTRAIT'];
-const DEFAULT_MJPEG_SERVER_PORT = 9100;
 
 /* eslint-disable no-useless-escape */
 const NO_PROXY_NATIVE_LIST: RouteMatcher[] = [
@@ -269,7 +270,7 @@ export class XCUITestDriver
   _currentUrl!: string | null;
   pageLoadMs!: number;
   landscapeWebCoordsOffset!: number;
-  mjpegStream?: mjpeg.MJpegStream;
+  mjpegStream?: MJpegStream;
 
   readonly deviceConnectionsFactory: DeviceConnectionsFactory;
 
@@ -877,7 +878,7 @@ export class XCUITestDriver
       // ensure WDA gets our defaults instead of whatever its own might be
       await this.updateSettings(wdaSettings);
 
-      await this.handleMjpegOptions();
+      await handleMjpegOptions(this);
 
       return [sessionId, caps];
     } catch (e) {
@@ -1200,44 +1201,6 @@ export class XCUITestDriver
       (this.opts as Record<string, any>)[key] = value;
     }
     return didMerge;
-  }
-
-  private async handleMjpegOptions(): Promise<void> {
-    await this.allocateMjpegServerPort();
-    // turn on mjpeg stream reading if requested
-    if (this.opts.mjpegScreenshotUrl) {
-      this.log.info(`Starting MJPEG stream reading URL: '${this.opts.mjpegScreenshotUrl}'`);
-      this.mjpegStream = new mjpeg.MJpegStream(this.opts.mjpegScreenshotUrl);
-      await this.mjpegStream.start();
-    }
-  }
-
-  private async allocateMjpegServerPort(): Promise<void> {
-    const mjpegServerPort = Number(this.opts.mjpegServerPort || DEFAULT_MJPEG_SERVER_PORT);
-    this.log.debug(`Forwarding MJPEG server port ${mjpegServerPort} to local port ${mjpegServerPort}`);
-    try {
-      await this.deviceConnectionsFactory.requestConnection(this.opts.udid, mjpegServerPort, {
-        devicePort: mjpegServerPort,
-        usePortForwarding: this.isRealDevice(),
-        remoteXPCFacade: this.isRealDevice() ? this.remoteXPCFacade : null,
-      });
-    } catch (error) {
-      if (this.opts.mjpegServerPort === undefined) {
-        this.log.warn(
-          `Cannot forward the device port ${DEFAULT_MJPEG_SERVER_PORT} to the local port ${DEFAULT_MJPEG_SERVER_PORT}. ` +
-            `Certain features, like MJPEG-based screen recording, will be unavailable during this session. ` +
-            `Try to customize the value of 'mjpegServerPort' capability as a possible solution`,
-        );
-      } else {
-        this.log.debug((error as Error).stack);
-        throw new Error(
-          `Cannot ensure MJPEG broadcast functionality by forwarding the local port ${mjpegServerPort} ` +
-            `requested by the 'mjpegServerPort' capability to the device port ${mjpegServerPort}. ` +
-            `Original error: ${error}`,
-          {cause: error},
-        );
-      }
-    }
   }
 
   private getDefaultUrl(): string {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "oxfmt": "^0.x",
     "pem": "^1.14.8",
     "semantic-release": "^25.0.2",
+    "sharp": "^0.x",
     "sinon": "^22.0.0",
     "typescript": "^6.0.2",
     "webdriverio": "^9.4.1"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "oxfmt": "^0.x",
     "pem": "^1.14.8",
     "semantic-release": "^25.0.2",
-    "sharp": "^0.x",
     "sinon": "^22.0.0",
     "typescript": "^6.0.2",
     "webdriverio": "^9.4.1"
@@ -122,7 +121,8 @@
     "appium": "^3.0.0-rc.2"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^5.6.1"
+    "appium-ios-remotexpc": "^5.6.1",
+    "sharp": "^0.x"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/test/unit/commands/helpers/mjpeg.spec.ts
+++ b/test/unit/commands/helpers/mjpeg.spec.ts
@@ -1,0 +1,261 @@
+import http, {type Server} from 'node:http';
+import {describe, it, before, beforeEach, afterEach} from 'node:test';
+
+import {expect, use} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {createSandbox} from 'sinon';
+import type sinon from 'sinon';
+import sharp from 'sharp';
+
+import type {XCUITestDriver} from '../../../../lib/driver.js';
+import {
+  allocateMjpegServerPort,
+  handleMjpegOptions,
+  MJpegStream,
+} from '../../../../lib/commands/helpers/mjpeg.js';
+import {UNIT_LONG_TIMEOUT_MS} from '../../helpers.js';
+
+use(chaiAsPromised);
+
+function buildMultipartFrame(jpeg: Buffer): Buffer {
+  const header = `--frame\r\nContent-Type: image/jpeg\r\nContent-Length: ${jpeg.length}\r\n\r\n`;
+  return Buffer.concat([Buffer.from(header), jpeg, Buffer.from('\r\n')]);
+}
+
+describe('mjpeg helpers', function () {
+  describe('MJpegStream', function () {
+    let jpeg: Buffer;
+    let server: Server;
+    let serverUrl: string;
+    let framesToSend: number;
+    let frameIntervalMs: number;
+    let stream: MJpegStream | null;
+
+    before(async function () {
+      jpeg = await sharp({
+        create: {width: 2, height: 2, channels: 3, background: {r: 255, g: 0, b: 0}},
+      })
+        .jpeg()
+        .toBuffer();
+    });
+
+    beforeEach(async function () {
+      framesToSend = 1;
+      frameIntervalMs = 10;
+      stream = null;
+      server = http.createServer((_req, res) => {
+        res.writeHead(200, {'Content-Type': 'multipart/x-mixed-replace; boundary=frame'});
+        res.flushHeaders();
+        let sent = 0;
+        const timer = setInterval(() => {
+          if (sent >= framesToSend) {
+            clearInterval(timer);
+            return;
+          }
+          res.write(buildMultipartFrame(jpeg));
+          sent++;
+        }, frameIntervalMs);
+        res.on('close', () => clearInterval(timer));
+      });
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      serverUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async function () {
+      stream?.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it('should have no last chunk before start() is called', function () {
+      stream = new MJpegStream(serverUrl);
+      expect(stream.lastChunkBase64).to.be.null;
+    });
+
+    it('should capture the first JPEG frame once started', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+      stream = new MJpegStream(serverUrl);
+      await stream.start();
+      expect(stream.lastChunkBase64).to.equal(jpeg.toString('base64'));
+    });
+
+    it('should convert the last chunk to a PNG', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+      stream = new MJpegStream(serverUrl);
+      await stream.start();
+      const pngBase64 = await stream.lastChunkPNGBase64();
+      expect(pngBase64).to.not.be.null;
+      const png = Buffer.from(pngBase64 as string, 'base64');
+      // PNG signature
+      expect(png.subarray(0, 8).toString('hex')).to.equal('89504e470d0a1a0a');
+    });
+
+    it('should keep track of newer frames as they arrive', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+      framesToSend = 3;
+      frameIntervalMs = 20;
+      stream = new MJpegStream(serverUrl);
+      await stream.start();
+      await new Promise((resolve) => setTimeout(resolve, frameIntervalMs * framesToSend + 50));
+      expect((stream as unknown as {updateCount: number}).updateCount).to.be.greaterThanOrEqual(2);
+    });
+
+    it('should clear the last chunk on stop()', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+      stream = new MJpegStream(serverUrl);
+      await stream.start();
+      expect(stream.lastChunkBase64).to.not.be.null;
+      stream.stop();
+      expect(stream.lastChunkBase64).to.be.null;
+    });
+
+    it('should reject if the server cannot be reached', async function () {
+      stream = new MJpegStream('http://127.0.0.1:1');
+      await expect(stream.start(200)).to.be.rejectedWith(/Cannot connect to the MJPEG stream/);
+    });
+
+    it('should reject if no frame arrives before the timeout', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+      framesToSend = 0;
+      stream = new MJpegStream(serverUrl);
+      // The server flushes headers immediately, so axios resolves well within the deadline;
+      // the rejection comes from MJpegStream's own "no frame yet" guard.
+      await expect(stream.start(300)).to.be.rejectedWith(/never sent any images/);
+    });
+  });
+
+  describe('allocateMjpegServerPort', function () {
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(function () {
+      sandbox = createSandbox();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    function makeDriver(overrides: Partial<XCUITestDriver> = {}): XCUITestDriver {
+      return {
+        opts: {udid: 'device-1'},
+        log: {
+          info: sandbox.stub(),
+          debug: sandbox.stub(),
+          warn: sandbox.stub(),
+        },
+        isRealDevice: sandbox.stub().returns(false),
+        remoteXPCFacade: undefined,
+        deviceConnectionsFactory: {
+          requestConnection: sandbox.stub().resolves(),
+        },
+        ...overrides,
+      } as unknown as XCUITestDriver;
+    }
+
+    it('should forward the default port when mjpegServerPort is not set', async function () {
+      const driver = makeDriver();
+      await allocateMjpegServerPort(driver);
+      expect(
+        (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledWith('device-1', 9100, {
+          devicePort: 9100,
+          usePortForwarding: false,
+          remoteXPCFacade: null,
+        }),
+      ).to.be.true;
+    });
+
+    it('should forward the requested port when mjpegServerPort is set', async function () {
+      const driver = makeDriver({opts: {udid: 'device-1', mjpegServerPort: 9200} as any});
+      await allocateMjpegServerPort(driver);
+      expect(
+        (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledWith('device-1', 9200, {
+          devicePort: 9200,
+          usePortForwarding: false,
+          remoteXPCFacade: null,
+        }),
+      ).to.be.true;
+    });
+
+    it('should only warn if the default port cannot be forwarded', async function () {
+      const driver = makeDriver();
+      (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).rejects(new Error('port busy'));
+      await allocateMjpegServerPort(driver);
+      expect((driver.log.warn as sinon.SinonStub).calledWithMatch(/Certain features/)).to.be.true;
+    });
+
+    it('should throw if a custom mjpegServerPort cannot be forwarded', async function () {
+      const driver = makeDriver({opts: {udid: 'device-1', mjpegServerPort: 9200} as any});
+      (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).rejects(new Error('port busy'));
+      await expect(allocateMjpegServerPort(driver)).to.be.rejectedWith(/mjpegServerPort.*port busy/);
+    });
+
+    it('should request a real-device connection with remoteXPCFacade when applicable', async function () {
+      const remoteXPCFacade = {fake: true};
+      const driver = makeDriver({
+        isRealDevice: sandbox.stub().returns(true),
+        remoteXPCFacade: remoteXPCFacade as any,
+      });
+      await allocateMjpegServerPort(driver);
+      expect(
+        (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledWith('device-1', 9100, {
+          devicePort: 9100,
+          usePortForwarding: true,
+          remoteXPCFacade,
+        }),
+      ).to.be.true;
+    });
+  });
+
+  describe('handleMjpegOptions', function () {
+    let sandbox: sinon.SinonSandbox;
+    let startStub: sinon.SinonStub;
+
+    beforeEach(function () {
+      sandbox = createSandbox();
+      startStub = sandbox.stub(MJpegStream.prototype, 'start').resolves();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    function makeDriver(overrides: Partial<XCUITestDriver> = {}): XCUITestDriver {
+      return {
+        opts: {udid: 'device-1'},
+        log: {
+          info: sandbox.stub(),
+          debug: sandbox.stub(),
+          warn: sandbox.stub(),
+        },
+        isRealDevice: sandbox.stub().returns(false),
+        remoteXPCFacade: undefined,
+        deviceConnectionsFactory: {
+          requestConnection: sandbox.stub().resolves(),
+        },
+        ...overrides,
+      } as unknown as XCUITestDriver;
+    }
+
+    it('should not create a stream if mjpegScreenshotUrl is not set', async function () {
+      const driver = makeDriver();
+      await handleMjpegOptions(driver);
+      expect(driver.mjpegStream).to.be.undefined;
+      expect(startStub.called).to.be.false;
+    });
+
+    it('should create and start a stream if mjpegScreenshotUrl is set', async function () {
+      const driver = makeDriver({
+        opts: {udid: 'device-1', mjpegScreenshotUrl: 'http://127.0.0.1:9100/mjpeg'} as any,
+      });
+      await handleMjpegOptions(driver);
+      expect(driver.mjpegStream).to.be.instanceOf(MJpegStream);
+      expect(startStub.calledOnce).to.be.true;
+    });
+
+    it('should allocate the MJPEG server port before starting the stream', async function () {
+      const driver = makeDriver({
+        opts: {udid: 'device-1', mjpegScreenshotUrl: 'http://127.0.0.1:9100/mjpeg'} as any,
+      });
+      await handleMjpegOptions(driver);
+      expect(
+        (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledBefore(startStub),
+      ).to.be.true;
+    });
+  });
+});

--- a/test/unit/commands/helpers/mjpeg.spec.ts
+++ b/test/unit/commands/helpers/mjpeg.spec.ts
@@ -3,16 +3,12 @@ import {describe, it, before, beforeEach, afterEach} from 'node:test';
 
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import sharp from 'sharp';
 import {createSandbox} from 'sinon';
 import type sinon from 'sinon';
-import sharp from 'sharp';
 
+import {allocateMjpegServerPort, handleMjpegOptions, MJpegStream} from '../../../../lib/commands/helpers/mjpeg.js';
 import type {XCUITestDriver} from '../../../../lib/driver.js';
-import {
-  allocateMjpegServerPort,
-  handleMjpegOptions,
-  MJpegStream,
-} from '../../../../lib/commands/helpers/mjpeg.js';
 import {UNIT_LONG_TIMEOUT_MS} from '../../helpers.js';
 
 use(chaiAsPromised);
@@ -253,9 +249,7 @@ describe('mjpeg helpers', function () {
         opts: {udid: 'device-1', mjpegScreenshotUrl: 'http://127.0.0.1:9100/mjpeg'} as any,
       });
       await handleMjpegOptions(driver);
-      expect(
-        (driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledBefore(startStub),
-      ).to.be.true;
+      expect((driver.deviceConnectionsFactory.requestConnection as sinon.SinonStub).calledBefore(startStub)).to.be.true;
     });
   });
 });

--- a/test/unit/commands/helpers/mjpeg.spec.ts
+++ b/test/unit/commands/helpers/mjpeg.spec.ts
@@ -21,9 +21,10 @@ function buildMultipartFrame(jpeg: Buffer): Buffer {
 describe('mjpeg helpers', function () {
   describe('MJpegStream', function () {
     let jpeg: Buffer;
+    let jpeg2: Buffer;
     let server: Server;
     let serverUrl: string;
-    let framesToSend: number;
+    let framesToSend: Buffer[];
     let frameIntervalMs: number;
     let stream: MJpegStream | null;
 
@@ -33,10 +34,15 @@ describe('mjpeg helpers', function () {
       })
         .jpeg()
         .toBuffer();
+      jpeg2 = await sharp({
+        create: {width: 2, height: 2, channels: 3, background: {r: 0, g: 0, b: 255}},
+      })
+        .jpeg()
+        .toBuffer();
     });
 
     beforeEach(async function () {
-      framesToSend = 1;
+      framesToSend = [jpeg];
       frameIntervalMs = 10;
       stream = null;
       server = http.createServer((_req, res) => {
@@ -44,11 +50,11 @@ describe('mjpeg helpers', function () {
         res.flushHeaders();
         let sent = 0;
         const timer = setInterval(() => {
-          if (sent >= framesToSend) {
+          if (sent >= framesToSend.length) {
             clearInterval(timer);
             return;
           }
-          res.write(buildMultipartFrame(jpeg));
+          res.write(buildMultipartFrame(framesToSend[sent]));
           sent++;
         }, frameIntervalMs);
         res.on('close', () => clearInterval(timer));
@@ -86,12 +92,13 @@ describe('mjpeg helpers', function () {
     });
 
     it('should keep track of newer frames as they arrive', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
-      framesToSend = 3;
+      framesToSend = [jpeg, jpeg2];
       frameIntervalMs = 20;
       stream = new MJpegStream(serverUrl);
       await stream.start();
-      await new Promise((resolve) => setTimeout(resolve, frameIntervalMs * framesToSend + 50));
-      expect((stream as unknown as {updateCount: number}).updateCount).to.be.greaterThanOrEqual(2);
+      expect(stream.lastChunkBase64).to.equal(jpeg.toString('base64'));
+      await new Promise((resolve) => setTimeout(resolve, frameIntervalMs * framesToSend.length + 50));
+      expect(stream.lastChunkBase64).to.equal(jpeg2.toString('base64'));
     });
 
     it('should clear the last chunk on stop()', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
@@ -108,7 +115,7 @@ describe('mjpeg helpers', function () {
     });
 
     it('should reject if no frame arrives before the timeout', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
-      framesToSend = 0;
+      framesToSend = [];
       stream = new MJpegStream(serverUrl);
       // The server flushes headers immediately, so axios resolves well within the deadline;
       // the rejection comes from MJpegStream's own "no frame yet" guard.


### PR DESCRIPTION
## Summary

@appium/support's mjpeg and sharp-backed image-util helpers are deprecated and slated for removal from Appium core ("Consumers are expected to implement MJpegStream class on their side"). This PR ports the MJpegStream implementation into xcuitest-driver itself so the driver no longer depends on it.

- Added lib/commands/helpers/mjpeg.ts:
  - MJpegStream: connects to an MJPEG-over-HTTP URL via axios (already a direct dependency), parses multipart JPEG frames with a small vendored frame parser (replacing the external mjpeg-consumer package), and exposes lastChunkBase64/lastChunkPNG(Base64)/start()/stop() with the same semantics as the original.
  - handleMjpegOptions(driver) / allocateMjpegServerPort(driver): moved out of driver.ts as plain functions that take the driver instance as an argument, rather than private driver methods.
- sharp moved from devDependencies to optionalDependencies (mirroring @appium/support's own approach) since MJpegStream.lastChunkPNG() now lazily loads it directly at runtime instead of going through appium's deprecated imageUtil.requireSharp().
- lib/commands/helpers/index.ts (barrel) only re-exports what's used externally — handleMjpegOptions and the MJpegStream type. allocateMjpegServerPort stays internal to the module (importable directly by unit tests).
- lib/driver.ts updated to import from the helpers barrel and call handleMjpegOptions(this) instead of this.handleMjpegOptions(); no behavioral changes to session setup/cleanup.
- Added test/unit/commands/helpers/mjpeg.spec.ts: exercises MJpegStream against a real local HTTP server (frame capture, JPEG→PNG conversion, multi-frame updates, stop() clearing state, unreachable-server rejection, no-frame timeout rejection), plus allocateMjpegServerPort/handleMjpegOptions against a mocked driver.