### PR TITLE
docs: drop appiumpro.com references

### DIFF
--- a/docs/guides/gestures.md
+++ b/docs/guides/gestures.md
@@ -50,6 +50,6 @@ measures might be applied:
 
 Check the below tutorials for more details on how to build reliable action chains:
 
-- [Automating Complex Gestures with the W3C Actions API](https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api)
+- [Automating Complex Gestures with the W3C Actions API](https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api)
 - [Swiping your way through Appium by Wim Selles #AppiumConf2021](https://www.youtube.com/watch?v=oAJ7jwMNFVU)
 - [About iOS Input Events](./input-events.md)

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -470,7 +470,7 @@ Returns map of certificates installed on the real device. The response looks lik
 
 Starts iOS system logs broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/syslog` endpoint. The method will return immediately if the web socket is already listening.
 Each connected webcoket listener will receive syslog lines as soon as they are visible to Appium.
-Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) Appium Pro article for more details on this feature.
+Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://www.headspin.io/blog/using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) article for more details on this feature.
 
 Consider using [logs broadcast via BiDi](./bidi.md#logentryadded) over this extension.
 

--- a/docs/troubleshooting/element-lookup.md
+++ b/docs/troubleshooting/element-lookup.md
@@ -103,7 +103,7 @@ the active app:
   applications, it will attempt to automatically set the preferred application as active.
 
 Check the main [Troubleshooting guide](./index.md) and/or
-[Switching Between iOS Apps During a Test](https://appiumpro.com/editions/13-switching-between-ios-apps-during-a-test)
+[Switching Between iOS Apps During a Test](https://www.headspin.io/blog/switching-between-ios-apps-during-a-test)
 article for more details on how to make such elements available.
 
 

--- a/lib/commands/log.ts
+++ b/lib/commands/log.ts
@@ -221,7 +221,7 @@ export async function startLogCapture(this: XCUITestDriver): Promise<boolean> {
  * If the websocket is already running, this command does nothing.
  *
  * Each connected websocket listener will receive syslog lines as soon as they are visible to Appium.
- * @see https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium
+ * @see https://www.headspin.io/blog/using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium
  */
 export async function mobileStartLogsBroadcast(this: XCUITestDriver): Promise<void> {
   const pathname = WEBSOCKET_ENDPOINT(this.sessionId as string);


### PR DESCRIPTION
## Summary
Removes `appiumpro.com` references from this repository, since the domain is no longer maintained by the Appium team (see appium/appium#22499).

Follows the same approach as appium/appium#22500 — links are removed rather than replaced, unless removal would break surrounding prose, in which case the URL is inlined as plain text.

Closes appium/appium#22499

## Checklist
- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] No documentation update needed (only stale links removed)