### PR TITLE
feat: Add mobile extensions for DVT sysmontap system monitoring

### DIFF
--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -244,16 +244,15 @@ consumption.
 This event is continuously emitted as soon as [`mobile: startSystemMonitor`](./execute-methods.md#mobile-startsystemmonitor) is invoked. Event emission stops as soon as the [`mobile: stopSystemMonitor`](./execute-methods.md#mobile-stopsystemmonitor)
 execute method is called.
 
-Events are only supported for real devices, and the `appium-ios-remotexpc` package must be
-installed. Refer to the [RemoteXPC Tunnels guide](../guides/remotexpc-tunnels-real-devices.md)
-for more details.
+Events are only supported for real devices running iOS/tvOS 18 or later, and the
+`appium-ios-remotexpc` package must be installed. Refer to the
+[RemoteXPC Tunnels guide](../guides/remotexpc-tunnels-real-devices.md) for more details.
 
 #### Event Type (CDDL)
 
 The device streams two kinds of samples, discriminated by `event.kind`. The attribute set for
-each kind is queried from the device at connection time (`DeviceInfo.sysmonProcessAttributes()` /
-`sysmonSystemAttributes()`), so the exact fields present can vary slightly across OS versions.
-Refer to
+each kind is queried from the device at connection time, so the exact fields present can vary
+slightly across OS versions. Refer to
 [the `Sysmontap` instrument used in `appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc/blob/main/src/services/ios/dvt/instruments/sysmontap.ts)
 for the labelling logic.
 

--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -235,3 +235,67 @@ appium:xcuitest.networkMonitor.ConnectionUpdateEntry = {
 
 You can use the value of `connectionSerial` to link back to a prior `type: 1` event with a matching
 `serialNumber` value.
+
+### appium:xcuitest.systemMonitor
+
+Indicates that a new labelled DVT sysmontap sample (system-wide or per-process) is available for
+consumption.
+
+This event is continuously emitted as soon as [`mobile: startSystemMonitor`](./execute-methods.md#mobile-startsystemmonitor) is invoked. Event emission stops as soon as the [`mobile: stopSystemMonitor`](./execute-methods.md#mobile-stopsystemmonitor)
+execute method is called.
+
+Events are only supported for real devices, and the `appium-ios-remotexpc` package must be
+installed. Refer to the [RemoteXPC Tunnels guide](../guides/remotexpc-tunnels-real-devices.md)
+for more details.
+
+#### Event Type (CDDL)
+
+The device streams two kinds of samples, discriminated by `event.kind`. The attribute set for
+each kind is queried from the device at connection time (`DeviceInfo.sysmonProcessAttributes()` /
+`sysmonSystemAttributes()`), so the exact fields present can vary slightly across OS versions.
+Refer to
+[the `Sysmontap` instrument used in `appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc/blob/main/src/services/ios/dvt/instruments/sysmontap.ts)
+for the labelling logic.
+
+```cddl
+appium:xcuitest.systemMonitor = (
+  method: "appium:xcuitest.systemMonitor",
+  context: "NATIVE_APP",
+  params: {
+    event: appium:xcuitest.systemMonitor.SystemEntry / appium:xcuitest.systemMonitor.ProcessesEntry,
+  },
+)
+
+appium:xcuitest.systemMonitor.SystemEntry = {
+  kind: "system",
+  system: {
+    * text => any,
+  },
+}
+
+appium:xcuitest.systemMonitor.ProcessesEntry = {
+  kind: "processes",
+  processes: [* appium:xcuitest.systemMonitor.ProcessInfo],
+}
+
+appium:xcuitest.systemMonitor.ProcessInfo = {
+  pid: js-uint,
+  ? name: text,
+  ? cpuUsage: number,
+  ? physFootprint: js-uint,
+  * text => any,
+}
+```
+
+| Parameter | Description |
+| -- | -- |
+| `kind` | Discriminates the sample: `"system"` for a device-wide snapshot, `"processes"` for a per-process snapshot array |
+| `system` | Device-wide metrics, keyed by the system attribute names reported by the device (e.g. total CPU usage, memory size) |
+| `processes` | One entry per process observed in this sample |
+| `pid` | Process ID (also included as an attribute if the device reports one; the attribute value takes precedence) |
+| `name` | Process name, when reported |
+| `cpuUsage` | Per-process CPU usage, when reported |
+| `physFootprint` | Per-process physical memory footprint in bytes, when reported |
+
+The first `processes` snapshot after starting the monitor typically has uninitialised `cpuUsage`
+values (there is no prior sample to diff against) and is commonly ignored by consumers.

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -1014,7 +1014,7 @@ Stops DVT network monitoring started with `mobile: startNetworkMonitor` and tear
 
 Starts streaming DVT sysmontap samples (CPU usage, memory footprint, and other per-process/system metrics) from the device. Each labelled sample is published on the WebDriver BiDi bus as **`appium:xcuitest.systemMonitor`** with a `params.event` object (discriminated by `event.kind`: `"system"` for a device-wide snapshot, `"processes"` for a per-process snapshot array); see [BiDi: systemMonitor](./bidi.md#appiumxcuitestsystemmonitor) for full examples and field meanings.
 
-Requires a **real** device, the optional [`appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc) package installed, and a BiDi-capable client subscribed to that method.
+Requires a **real** device running **iOS/tvOS 18+**, the optional [`appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc) package installed, and a BiDi-capable client subscribed to that method.
 
 If a monitor is already running, the call does nothing so the existing stream continues.
 

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -1010,6 +1010,24 @@ If a monitor is already running, the call does nothing so the existing stream co
 
 Stops DVT network monitoring started with `mobile: startNetworkMonitor` and tears down the underlying Remote XPC / DVT connection.
 
+### mobile: startSystemMonitor
+
+Starts streaming DVT sysmontap samples (CPU usage, memory footprint, and other per-process/system metrics) from the device. Each labelled sample is published on the WebDriver BiDi bus as **`appium:xcuitest.systemMonitor`** with a `params.event` object (discriminated by `event.kind`: `"system"` for a device-wide snapshot, `"processes"` for a per-process snapshot array); see [BiDi: systemMonitor](./bidi.md#appiumxcuitestsystemmonitor) for full examples and field meanings.
+
+Requires a **real** device, the optional [`appium-ios-remotexpc`](https://github.com/appium/appium-ios-remotexpc) package installed, and a BiDi-capable client subscribed to that method.
+
+If a monitor is already running, the call does nothing so the existing stream continues.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+intervalMs | number | no | Sampling interval in milliseconds, forwarded to the underlying sysmontap `configure()` call. Defaults to sysmontap's own default (500ms) when omitted. | 1000
+
+### mobile: stopSystemMonitor
+
+Stops DVT sysmontap streaming started with `mobile: startSystemMonitor` and tears down the underlying Remote XPC / DVT connection.
+
 ### mobile: runXCTest
 
 Runs a native XCTest suite on the device under test.

--- a/lib/commands/bidi/constants.ts
+++ b/lib/commands/bidi/constants.ts
@@ -3,3 +3,4 @@ const DOMAIN = 'xcuitest';
 export const CONTEXT_UPDATED_EVENT = `appium:${DOMAIN}.contextUpdated`;
 export const LOG_ENTRY_ADDED_EVENT = 'log.entryAdded';
 export const NETWORK_MONITOR_EVENT = `appium:${DOMAIN}.networkMonitor`;
+export const SYSTEM_MONITOR_EVENT = `appium:${DOMAIN}.systemMonitor`;

--- a/lib/commands/bidi/models.ts
+++ b/lib/commands/bidi/models.ts
@@ -1,7 +1,18 @@
 import {NATIVE_WIN} from '../constants.js';
 import type {LogEntry} from '../types.js';
-import {CONTEXT_UPDATED_EVENT, LOG_ENTRY_ADDED_EVENT, NETWORK_MONITOR_EVENT} from './constants.js';
-import type {LogEntryAddedEvent, ContextUpdatedEvent, BiDiLogLevel, NetworkMonitorBiDiEvent} from './types.js';
+import {
+  CONTEXT_UPDATED_EVENT,
+  LOG_ENTRY_ADDED_EVENT,
+  NETWORK_MONITOR_EVENT,
+  SYSTEM_MONITOR_EVENT,
+} from './constants.js';
+import type {
+  LogEntryAddedEvent,
+  ContextUpdatedEvent,
+  BiDiLogLevel,
+  NetworkMonitorBiDiEvent,
+  SystemMonitorBiDiEvent,
+} from './types.js';
 
 function toContextUpdatedEvent(method: string, contextName: string): ContextUpdatedEvent {
   return {
@@ -25,6 +36,21 @@ export function makeNetworkMonitorEvent(event: object): NetworkMonitorBiDiEvent 
   return {
     context: NATIVE_WIN,
     method: NETWORK_MONITOR_EVENT,
+    params: {
+      event: structuredClone(event) as Record<string, unknown>,
+    },
+  };
+}
+
+/**
+ * Builds a BiDi event for a single labelled DVT sysmontap sample (system or per-process snapshot).
+ * Clones the payload with `structuredClone` so subscribers get a plain snapshot (safe if anything
+ * downstream mutates) without the lossiness of `JSON.stringify` (e.g. `NaN`, `undefined` handling).
+ */
+export function makeSystemMonitorEvent(event: object): SystemMonitorBiDiEvent {
+  return {
+    context: NATIVE_WIN,
+    method: SYSTEM_MONITOR_EVENT,
     params: {
       event: structuredClone(event) as Record<string, unknown>,
     },

--- a/lib/commands/bidi/types.ts
+++ b/lib/commands/bidi/types.ts
@@ -22,6 +22,24 @@ export interface NetworkMonitorBiDiEvent extends BiDiEvent<NetworkMonitorEventPa
   context: string;
 }
 
+export interface SystemMonitorEventParams {
+  /**
+   * DVT sysmontap sample, labelled by attribute name. Tagged by `kind`:
+   * `system` carries device-wide metrics (`event.system`), `processes` carries a
+   * per-process snapshot array (`event.processes`).
+   */
+  event: Record<string, unknown>;
+}
+
+/**
+ * BiDi event emitted for each labelled DVT sysmontap sample while `mobile: startSystemMonitor` is active.
+ *
+ * @see https://github.com/appium/appium-ios-remotexpc
+ */
+export interface SystemMonitorBiDiEvent extends BiDiEvent<SystemMonitorEventParams> {
+  context: string;
+}
+
 interface BiDiEvent<TParams> {
   method: string;
   params: TParams;

--- a/lib/commands/system-monitor.ts
+++ b/lib/commands/system-monitor.ts
@@ -1,12 +1,15 @@
+import {errors} from 'appium/driver.js';
+
 import {SystemMonitorSession} from '../device/system-monitor-session.js';
 import type {XCUITestDriver} from '../driver.js';
+import {isIos18OrNewer} from '../utils/index.js';
 import {requireRealDevice} from './helpers/index.js';
 
 /**
  * Starts streaming DVT sysmontap (CPU / memory / per-process) samples to WebDriver BiDi subscribers
  * (`appium:xcuitest.systemMonitor`).
  *
- * Requires a real device and appium-ios-remotexpc.
+ * Requires a real device on iOS/tvOS 18+ and appium-ios-remotexpc.
  *
  * @see https://github.com/appium/appium-ios-remotexpc
  *
@@ -17,6 +20,13 @@ import {requireRealDevice} from './helpers/index.js';
  */
 export async function mobileStartSystemMonitor(this: XCUITestDriver, intervalMs?: number): Promise<void> {
   requireRealDevice(this, 'DVT system monitor');
+
+  if (!isIos18OrNewer(this.opts)) {
+    throw new errors.InvalidArgumentError(
+      `mobile: startSystemMonitor requires iOS/tvOS 18 or newer. ` +
+        `The current platformVersion is '${this.opts.platformVersion ?? 'unknown'}'.`,
+    );
+  }
 
   if (this._systemMonitorSession?.isRunning()) {
     this.log.info(`DVT system monitor is already active; continuing`);

--- a/lib/commands/system-monitor.ts
+++ b/lib/commands/system-monitor.ts
@@ -1,0 +1,47 @@
+import {SystemMonitorSession} from '../device/system-monitor-session.js';
+import type {XCUITestDriver} from '../driver.js';
+import {requireRealDevice} from './helpers/index.js';
+
+/**
+ * Starts streaming DVT sysmontap (CPU / memory / per-process) samples to WebDriver BiDi subscribers
+ * (`appium:xcuitest.systemMonitor`).
+ *
+ * Requires a real device and appium-ios-remotexpc.
+ *
+ * @see https://github.com/appium/appium-ios-remotexpc
+ *
+ * @param intervalMs - Optional sampling interval in milliseconds, forwarded to `sysmontap.configure()`.
+ * Uses the sysmontap default (500ms) when omitted.
+ *
+ * If a monitor is already running, this is a no-op so the session keeps streaming.
+ */
+export async function mobileStartSystemMonitor(this: XCUITestDriver, intervalMs?: number): Promise<void> {
+  requireRealDevice(this, 'DVT system monitor');
+
+  if (this._systemMonitorSession?.isRunning()) {
+    this.log.info(`DVT system monitor is already active; continuing`);
+    return;
+  }
+  if (this._systemMonitorSession) {
+    this._systemMonitorSession = null;
+  }
+
+  const session = new SystemMonitorSession(this.log, this.device.udid, this.remoteXPCFacade);
+  try {
+    await session.start(this.eventEmitter, {intervalMs});
+  } catch (e) {
+    await session.interrupt();
+    throw e;
+  }
+  this._systemMonitorSession = session;
+}
+
+/** Stops DVT sysmontap streaming started with `mobile: startSystemMonitor`. */
+export async function mobileStopSystemMonitor(this: XCUITestDriver): Promise<void> {
+  if (!this._systemMonitorSession) {
+    this.log.info('System monitor has not been started; nothing to stop');
+    return;
+  }
+  await this._systemMonitorSession.interrupt();
+  this._systemMonitorSession = null;
+}

--- a/lib/device/system-monitor-session.ts
+++ b/lib/device/system-monitor-session.ts
@@ -1,0 +1,141 @@
+import type {EventEmitter} from 'node:events';
+
+import type {AppiumLogger} from '@appium/types';
+import type {DVTInstruments, SysmonSample} from 'appium-ios-remotexpc';
+
+import {BIDI_EVENT_NAME} from '../commands/bidi/constants.js';
+import {makeSystemMonitorEvent} from '../commands/bidi/models.js';
+import type {RemoteXPCFacade} from './remote-xpc/index.js';
+
+export interface SystemMonitorSessionOptions {
+  /** Sampling interval in milliseconds, forwarded to `sysmontap.configure()`. */
+  intervalMs?: number;
+}
+
+/**
+ * Active DVT sysmontap session: streams labelled CPU/memory/process samples to the driver BiDi event bus.
+ */
+export class SystemMonitorSession {
+  private dvt: DVTInstruments | null = null;
+  private runPromise: Promise<void> | null = null;
+  private stopped = false;
+
+  /**
+   * @param log - Logger for this session (typically the driver logger).
+   * @param udid - Target device UDID for `startDVTService`.
+   */
+  constructor(
+    private readonly log: AppiumLogger,
+    private readonly udid: string,
+    private readonly remoteXPCFacade: RemoteXPCFacade | null,
+  ) {}
+
+  /**
+   * @returns `true` only while the consume loop may still be receiving events (`this.dvt` is set).
+   * After normal completion, error, or {@link interrupt}, this becomes `false`.
+   */
+  isRunning(): boolean {
+    return this.dvt !== null;
+  }
+
+  /**
+   * Opens `startDVTService` and begins iterating `sysmontap.messages()`, labelling each raw sample and
+   * emitting it on `eventEmitter` using `BIDI_EVENT_NAME` and `makeSystemMonitorEvent`
+   * (BiDi `appium:xcuitest.systemMonitor`).
+   *
+   * @param eventEmitter - Typically the session driver's `eventEmitter` (WebDriver BiDi bus).
+   */
+  async start(eventEmitter: EventEmitter, options: SystemMonitorSessionOptions = {}): Promise<void> {
+    this.stopped = false;
+    if (!this.remoteXPCFacade) {
+      throw new Error(`RemoteXPC is not available for device '${this.udid}'`);
+    }
+    const dvt = await this.remoteXPCFacade.requireService('system monitor', (Services) =>
+      Services.startDVTService(this.udid),
+    );
+    this.dvt = dvt;
+    if (options.intervalMs !== undefined) {
+      await dvt.sysmontap.configure({intervalMs: options.intervalMs});
+    }
+    this.runPromise = this.consumeEvents(dvt, eventEmitter);
+  }
+
+  /**
+   * Stops monitoring and waits for the consume loop to finish. DVT is closed in
+   * {@link consumeEvents} after the sysmontap iterator exits (same pattern as
+   * condition inducer `disable()` → `close()`).
+   */
+  async interrupt(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
+    this.stopped = true;
+    const dvt = this.dvt;
+    const runPromise = this.runPromise;
+    this.dvt = null;
+    this.runPromise = null;
+
+    if (dvt) {
+      try {
+        await dvt.sysmontap.stop();
+      } catch (err: any) {
+        this.log.debug(`Error stopping system monitor: ${err?.message ?? err}`);
+      }
+    }
+
+    if (runPromise) {
+      try {
+        await runPromise;
+      } catch (err: any) {
+        this.log.debug(`Error while finishing system monitor consume loop: ${err?.message ?? err}`);
+      }
+    }
+  }
+
+  private async consumeEvents(dvt: DVTInstruments, eventEmitter: EventEmitter): Promise<void> {
+    try {
+      for await (const sample of dvt.sysmontap.messages()) {
+        this.emitSample(dvt, sample, eventEmitter);
+      }
+    } catch (err: any) {
+      if (!this.stopped) {
+        this.log.error('System monitor stream ended unexpectedly', err);
+      }
+    } finally {
+      await this.closeDvt(dvt);
+    }
+  }
+
+  private emitSample(dvt: DVTInstruments, sample: SysmonSample, eventEmitter: EventEmitter): void {
+    if (sample.System) {
+      const system = zipAttributes(dvt.sysmontap.getSystemAttributes(), sample.System);
+      eventEmitter.emit(BIDI_EVENT_NAME, makeSystemMonitorEvent({kind: 'system', system}));
+    }
+
+    if (sample.Processes) {
+      const processAttributes = dvt.sysmontap.getProcessAttributes();
+      const processes = Object.entries(sample.Processes)
+        .filter(([, values]) => Array.isArray(values))
+        .map(([pid, values]) => ({pid: Number(pid), ...zipAttributes(processAttributes, values)}));
+      eventEmitter.emit(BIDI_EVENT_NAME, makeSystemMonitorEvent({kind: 'processes', processes}));
+    }
+  }
+
+  private async closeDvt(dvt: DVTInstruments): Promise<void> {
+    try {
+      await dvt.dvtService.close();
+    } catch (err: any) {
+      this.log.debug(`Error closing DVT service for system monitor: ${err?.message ?? err}`);
+    }
+  }
+}
+
+/** Zip an ordered list of attribute names with a raw sysmontap value tuple. */
+function zipAttributes(attributes: string[], values: unknown[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (let i = 0; i < attributes.length; i++) {
+    result[attributes[i]] = values[i];
+  }
+  return result;
+}

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -84,6 +84,7 @@ import * as screenshotCommands from './commands/screenshots.js';
 import * as simctlCommands from './commands/simctl.js';
 import * as simulatorCommands from './commands/simulator.js';
 import * as sourceCommands from './commands/source.js';
+import * as systemMonitorCommands from './commands/system-monitor.js';
 import * as timeoutCommands from './commands/timeouts.js';
 import type {WaitingAtoms, LogListener, FullContext} from './commands/types.js';
 import * as voiceOverCommands from './commands/voiceover.js';
@@ -111,6 +112,7 @@ import {
   runSimulatorReset,
   shutdownSimulator,
 } from './device/simulator-management.js';
+import type {SystemMonitorSession} from './device/system-monitor-session.js';
 import {
   assertWdaHostPlatformSupported,
   assertWdaHostSessionCapsSupported,
@@ -251,6 +253,7 @@ export class XCUITestDriver
   _audioRecorder: AudioRecorder | null;
   xcodeVersion: XcodeVersion | undefined;
   _networkMonitorSession: NetworkMonitorSession | null;
+  _systemMonitorSession: SystemMonitorSession | null;
   _remoteXPCFacade: RemoteXPCFacade | null;
   _recentScreenRecorder!: ScreenRecorder | null;
   _device!: Simulator | RealDevice;
@@ -617,6 +620,13 @@ export class XCUITestDriver
   mobileStartNetworkMonitor = networkMonitorCommands.mobileStartNetworkMonitor;
   mobileStopNetworkMonitor = networkMonitorCommands.mobileStopNetworkMonitor;
 
+  /*-----------------+
+   | SYSTEM MONITOR  |
+   +-----------------+*/
+
+  mobileStartSystemMonitor = systemMonitorCommands.mobileStartSystemMonitor;
+  mobileStopSystemMonitor = systemMonitorCommands.mobileStopSystemMonitor;
+
   /*-------------+
    | PERFORMANCE |
    +-------------+*/
@@ -769,6 +779,7 @@ export class XCUITestDriver
     this.settings = new DeviceSettings(DEFAULT_SETTINGS, this.onSettingsUpdate.bind(this));
     this.logs = {} as DriverLogs;
     this._networkMonitorSession = null;
+    this._systemMonitorSession = null;
     this._remoteXPCFacade = null;
     // memoize functions here, so that they are done on a per-instance basis
     for (const fn of MEMOIZED_FUNCTIONS) {
@@ -901,6 +912,8 @@ export class XCUITestDriver
     }
     await this._networkMonitorSession?.interrupt();
     this._networkMonitorSession = null;
+    await this._systemMonitorSession?.interrupt();
+    this._systemMonitorSession = null;
 
     if (!isEmpty(this._perfRecorders)) {
       await Promise.all(this._perfRecorders.map((x) => x.stop(true)));

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -467,6 +467,15 @@ export const executeMethodMap = {
   'mobile: stopNetworkMonitor': {
     command: 'mobileStopNetworkMonitor',
   },
+  'mobile: startSystemMonitor': {
+    command: 'mobileStartSystemMonitor',
+    params: {
+      optional: ['intervalMs'],
+    },
+  },
+  'mobile: stopSystemMonitor': {
+    command: 'mobileStopSystemMonitor',
+  },
   'mobile: listConditionInducers': {
     command: 'listConditionInducers',
   },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "appium": "^3.0.0-rc.2"
   },
   "optionalDependencies": {
-    "appium-ios-remotexpc": "^5.6.1",
+    "appium-ios-remotexpc": "^5.13.2",
     "sharp": "^0.x"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Adds mobile: startSystemMonitor / mobile: stopSystemMonitor execute methods that stream live DVT sysmontap samples (CPU usage, memory footprint, and other per-process/system metrics) from a real device to the client over WebDriver BiDi, as a new appium:xcuitest.systemMonitor event. Follows the same pattern as the existing mobile: startNetworkMonitor/stopNetworkMonitor feature (appium-ios-remotexpc DVT service, RemoteXPCFacade-gated to real devices, session cleaned up on deleteSession).
- Each raw sysmontap sample is labelled with the device's own attribute names and emitted as one of two discriminated shapes: {kind: 'system', system: {...}} for device-wide snapshots, or {kind: 'processes', processes: [...]} for per-process snapshots. An optional intervalMs argument is forwarded to sysmontap.configure().
- Bumps the optional appium-ios-remotexpc dependency from ^5.6.1 to ^5.13.2 (latest).
- Documents the new BiDi event and execute methods in docs/reference/bidi.md and docs/reference/execute-methods.md.
