### PR TITLE
feat: Add customizable exponential backoff for tunnel reconnect retries

### DIFF
--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -531,6 +531,7 @@ sudo appium driver run xcuitest tunnel-creation
 |`--disconnect-retry-interval-ms`|Delay between tunnel recreation attempts in milliseconds. With `--disconnect-retry-strategy exponential`, this is the initial delay, before it starts growing.|integer|1000|
 |`--disconnect-retry-backoff-multiplier`|Factor the delay grows by on each attempt when `--disconnect-retry-strategy` is `exponential`. Must be greater than `1`.|number|2|
 |`--disconnect-retry-backoff-max-interval-ms`|Upper bound on the delay between tunnel recreation attempts when `--disconnect-retry-strategy` is `exponential`.|integer|30000|
+|`--disconnect-retry-backoff-jitter`|Fraction of the delay to randomize away on each attempt when `--disconnect-retry-strategy` is `exponential`, between `0` (no jitter) and `1` (full jitter). Spreads out devices that dropped together instead of having them retry in lockstep.|number|0.5|
 |`--tunnel-registry-port`|Port of the tunnel registry server, hosted at `http://localhost:<port>/remotexpc/tunnels`|integer|42314|
 |`--udid`|Identifier of a specific non-Apple TV device to create the tunnel for. Repeat this argument to target multiple specific devices. By default, the tunnel is created for all connected devices. If this is provided without `--appletv-device-id`, Apple TV discovery/setup is skipped.|string (repeatable)||
 
@@ -570,6 +571,12 @@ sudo appium driver run xcuitest tunnel-creation
 
     ```
     sudo appium driver run xcuitest tunnel-creation -- --disconnect-retry-max-attempts 0 --disconnect-retry-strategy exponential --disconnect-retry-backoff-max-interval-ms 30000
+    ```
+
+- Same as above, but with full jitter (delay is uniformly random between 0 and the computed value) instead of the default:
+
+    ```
+    sudo appium driver run xcuitest tunnel-creation -- --disconnect-retry-max-attempts 0 --disconnect-retry-strategy exponential --disconnect-retry-backoff-max-interval-ms 30000 --disconnect-retry-backoff-jitter 1
     ```
 
 - Create Apple TV tunnels with a longer wireless discovery timeout:

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -527,7 +527,10 @@ sudo appium driver run xcuitest tunnel-creation
 |`--appletv-device-id`|Identifier of a paired Apple TV device (returned by [`pair-appletv`](#pair-appletv)) to create the tunnel for. Repeat this argument to target multiple paired Apple TV devices. If omitted, the script creates one tunnel per discovered paired Apple TV device. If this is provided without `--udid`, setup of non-Apple TV devices is skipped.|string (repeatable)||
 |`--appletv-discovery-timeout-ms`|Apple TV wireless discovery timeout, in milliseconds. Applies to initial discovery and Apple TV tunnel creation/reconnection.|integer|10000|
 |`--disconnect-retry-max-attempts`|Maximum number of tunnel recreation attempts after an unexpected disconnect. Set to `0` for unlimited retries. If omitted, retries are disabled and the tunnel is removed from registry.|integer||
-|`--disconnect-retry-interval-ms`|Delay between tunnel recreation attempts in milliseconds.|integer|1000|
+|`--disconnect-retry-strategy`|Delay strategy between tunnel recreation attempts: `fixed` (same delay every attempt) or `exponential` (delay grows on each attempt, up to a cap).|`fixed` \| `exponential`|`fixed`|
+|`--disconnect-retry-interval-ms`|Delay between tunnel recreation attempts in milliseconds. With `--disconnect-retry-strategy exponential`, this is the initial delay, before it starts growing.|integer|1000|
+|`--disconnect-retry-backoff-multiplier`|Factor the delay grows by on each attempt when `--disconnect-retry-strategy` is `exponential`. Must be greater than `1`.|number|2|
+|`--disconnect-retry-backoff-max-interval-ms`|Upper bound on the delay between tunnel recreation attempts when `--disconnect-retry-strategy` is `exponential`.|integer|30000|
 |`--tunnel-registry-port`|Port of the tunnel registry server, hosted at `http://localhost:<port>/remotexpc/tunnels`|integer|42314|
 |`--udid`|Identifier of a specific non-Apple TV device to create the tunnel for. Repeat this argument to target multiple specific devices. By default, the tunnel is created for all connected devices. If this is provided without `--appletv-device-id`, Apple TV discovery/setup is skipped.|string (repeatable)||
 
@@ -561,6 +564,12 @@ sudo appium driver run xcuitest tunnel-creation
 
     ```
     sudo appium driver run xcuitest tunnel-creation -- --disconnect-retry-max-attempts 10 --disconnect-retry-interval-ms 2000
+    ```
+
+- Recreate tunnel on disconnect indefinitely, starting at 1s and backing off exponentially up to 30s:
+
+    ```
+    sudo appium driver run xcuitest tunnel-creation -- --disconnect-retry-max-attempts 0 --disconnect-retry-strategy exponential --disconnect-retry-backoff-max-interval-ms 30000
     ```
 
 - Create Apple TV tunnels with a longer wireless discovery timeout:

--- a/scripts/lib/retry-policy.mjs
+++ b/scripts/lib/retry-policy.mjs
@@ -1,6 +1,7 @@
 export const DEFAULT_DISCONNECT_RETRY_INTERVAL_MS = 1000;
 export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER = 2;
 export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS = 30_000;
+export const DEFAULT_DISCONNECT_RETRY_BACKOFF_JITTER = 0.5;
 
 /**
  * @abstract
@@ -65,9 +66,13 @@ export class FixedIntervalRetryPolicy extends RetryPolicy {
  */
 export class ExponentialBackoffRetryPolicy extends RetryPolicy {
   /**
-   * @param {{maxAttempts: number | null, intervalMs: number, backoffMultiplier: number, backoffMaxIntervalMs: number}} opts
+   * @param {{maxAttempts: number | null, intervalMs: number, backoffMultiplier: number, backoffMaxIntervalMs: number, jitter: number}} opts
+   * - jitter: fraction of the delay to randomize away, in [0, 1]. 0 always returns the exact
+   * computed delay; 1 returns a value uniformly distributed between 0 and the computed delay.
+   * Jitter spreads out devices that dropped together instead of having them retry in lockstep and
+   * stay synchronised once they reach the cap.
    */
-  constructor({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs}) {
+  constructor({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs, jitter}) {
     super({maxAttempts, intervalMs});
     if (backoffMaxIntervalMs < intervalMs) {
       throw new Error(
@@ -75,8 +80,12 @@ export class ExponentialBackoffRetryPolicy extends RetryPolicy {
           `Expected a value >= the initial interval (${intervalMs}).`,
       );
     }
+    if (jitter < 0 || jitter > 1) {
+      throw new Error(`Invalid disconnect retry backoff jitter: ${jitter}. Expected a value between 0 and 1.`);
+    }
     this._backoffMultiplier = backoffMultiplier;
     this._backoffMaxIntervalMs = backoffMaxIntervalMs;
+    this._jitter = jitter;
   }
 
   /**
@@ -86,14 +95,12 @@ export class ExponentialBackoffRetryPolicy extends RetryPolicy {
   getDelayMs(attempt) {
     const delayMs = this._intervalMs * this._backoffMultiplier ** (attempt - 1);
     const cappedDelayMs = Math.min(delayMs, this._backoffMaxIntervalMs);
-    // Jitter spreads out devices that dropped together instead of having them retry in lockstep
-    // and stay synchronised once they reach the cap.
-    return Math.round(cappedDelayMs * (0.5 + Math.random() * 0.5));
+    return Math.round(cappedDelayMs * (1 - this._jitter * Math.random()));
   }
 }
 
 /**
- * @param {{strategy: 'fixed' | 'exponential', maxAttempts: number | null, intervalMs: number, backoffMultiplier?: number, backoffMaxIntervalMs?: number}} opts
+ * @param {{strategy: 'fixed' | 'exponential', maxAttempts: number | null, intervalMs: number, backoffMultiplier?: number, backoffMaxIntervalMs?: number, jitter?: number}} opts
  * @returns {RetryPolicy}
  */
 export function createDisconnectRetryPolicy({
@@ -102,12 +109,19 @@ export function createDisconnectRetryPolicy({
   intervalMs,
   backoffMultiplier = DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
   backoffMaxIntervalMs = DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
+  jitter = DEFAULT_DISCONNECT_RETRY_BACKOFF_JITTER,
 }) {
   if (strategy === 'fixed') {
     return new FixedIntervalRetryPolicy({maxAttempts, intervalMs});
   }
   if (strategy === 'exponential') {
-    return new ExponentialBackoffRetryPolicy({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs});
+    return new ExponentialBackoffRetryPolicy({
+      maxAttempts,
+      intervalMs,
+      backoffMultiplier,
+      backoffMaxIntervalMs,
+      jitter,
+    });
   }
   throw new Error(`Invalid disconnect retry strategy: ${strategy}. Expected 'fixed' or 'exponential'.`);
 }

--- a/scripts/lib/retry-policy.mjs
+++ b/scripts/lib/retry-policy.mjs
@@ -29,7 +29,11 @@ export class RetryPolicy {
    * @returns {boolean}
    */
   hasAttemptsRemaining(attemptsMade) {
-    return !this.maxAttempts || attemptsMade < this.maxAttempts;
+    const {maxAttempts} = this;
+    if (maxAttempts === null) {
+      return false;
+    }
+    return maxAttempts === 0 || attemptsMade < maxAttempts;
   }
 
   /**
@@ -81,7 +85,10 @@ export class ExponentialBackoffRetryPolicy extends RetryPolicy {
    */
   getDelayMs(attempt) {
     const delayMs = this._intervalMs * this._backoffMultiplier ** (attempt - 1);
-    return Math.min(delayMs, this._backoffMaxIntervalMs);
+    const cappedDelayMs = Math.min(delayMs, this._backoffMaxIntervalMs);
+    // Jitter spreads out devices that dropped together instead of having them retry in lockstep
+    // and stay synchronised once they reach the cap.
+    return Math.round(cappedDelayMs * (0.5 + Math.random() * 0.5));
   }
 }
 
@@ -96,7 +103,11 @@ export function createDisconnectRetryPolicy({
   backoffMultiplier = DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
   backoffMaxIntervalMs = DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
 }) {
-  return strategy === 'exponential'
-    ? new ExponentialBackoffRetryPolicy({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs})
-    : new FixedIntervalRetryPolicy({maxAttempts, intervalMs});
+  if (strategy === 'fixed') {
+    return new FixedIntervalRetryPolicy({maxAttempts, intervalMs});
+  }
+  if (strategy === 'exponential') {
+    return new ExponentialBackoffRetryPolicy({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs});
+  }
+  throw new Error(`Invalid disconnect retry strategy: ${strategy}. Expected 'fixed' or 'exponential'.`);
 }

--- a/scripts/lib/retry-policy.mjs
+++ b/scripts/lib/retry-policy.mjs
@@ -1,0 +1,83 @@
+export const DEFAULT_DISCONNECT_RETRY_INTERVAL_MS = 1000;
+export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER = 2;
+export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS = 30_000;
+
+/**
+ * Fixed-interval retry policy: waits the same delay between every attempt.
+ */
+export class FixedIntervalRetryPolicy {
+  /**
+   * @param {{maxAttempts: number | null, intervalMs: number}} opts - maxAttempts: null disables
+   * retries entirely; 0 means unlimited retries
+   */
+  constructor({maxAttempts, intervalMs}) {
+    this.maxAttempts = maxAttempts;
+    this._intervalMs = intervalMs;
+  }
+
+  get isEnabled() {
+    return this.maxAttempts !== null;
+  }
+
+  /**
+   * @param {number} attemptsMade - number of attempts already made
+   * @returns {boolean}
+   */
+  hasAttemptsRemaining(attemptsMade) {
+    return !this.maxAttempts || attemptsMade < this.maxAttempts;
+  }
+
+  /**
+   * @param {number} _attempt - 1-based number of the attempt about to be made
+   * @returns {number}
+   */
+  getDelayMs(_attempt) {
+    return this._intervalMs;
+  }
+}
+
+/**
+ * Exponential-backoff retry policy: the delay grows by a multiplier on each attempt, capped at a
+ * configured maximum.
+ */
+export class ExponentialBackoffRetryPolicy extends FixedIntervalRetryPolicy {
+  /**
+   * @param {{maxAttempts: number | null, intervalMs: number, backoffMultiplier: number, backoffMaxIntervalMs: number}} opts
+   */
+  constructor({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs}) {
+    super({maxAttempts, intervalMs});
+    if (backoffMaxIntervalMs < intervalMs) {
+      throw new Error(
+        `Invalid disconnect retry backoff max interval: ${backoffMaxIntervalMs}. ` +
+          `Expected a value >= the initial interval (${intervalMs}).`,
+      );
+    }
+    this._backoffMultiplier = backoffMultiplier;
+    this._backoffMaxIntervalMs = backoffMaxIntervalMs;
+  }
+
+  /**
+   * @param {number} attempt - 1-based number of the attempt about to be made
+   * @returns {number}
+   */
+  getDelayMs(attempt) {
+    const delayMs = super.getDelayMs(attempt) * this._backoffMultiplier ** (attempt - 1);
+    return Math.min(delayMs, this._backoffMaxIntervalMs);
+  }
+}
+
+/**
+ * @param {{strategy: 'fixed' | 'exponential', maxAttempts: number | null, intervalMs: number, backoffMultiplier?: number, backoffMaxIntervalMs?: number}} opts
+ * @returns {FixedIntervalRetryPolicy}
+ */
+export function createDisconnectRetryPolicy({
+  strategy,
+  maxAttempts,
+  intervalMs,
+  backoffMultiplier = DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
+  backoffMaxIntervalMs = DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
+}) {
+  return strategy === 'exponential'
+    ? new ExponentialBackoffRetryPolicy({maxAttempts, intervalMs, backoffMultiplier, backoffMaxIntervalMs})
+    : new FixedIntervalRetryPolicy({maxAttempts, intervalMs});
+}

--- a/scripts/lib/retry-policy.mjs
+++ b/scripts/lib/retry-policy.mjs
@@ -3,14 +3,19 @@ export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER = 2;
 export const DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS = 30_000;
 
 /**
- * Fixed-interval retry policy: waits the same delay between every attempt.
+ * @abstract
+ * Common attempt-counting behavior shared by all retry policies. Subclasses only need to implement
+ * `getDelayMs()`.
  */
-export class FixedIntervalRetryPolicy {
+export class RetryPolicy {
   /**
    * @param {{maxAttempts: number | null, intervalMs: number}} opts - maxAttempts: null disables
    * retries entirely; 0 means unlimited retries
    */
   constructor({maxAttempts, intervalMs}) {
+    if (new.target === RetryPolicy) {
+      throw new TypeError('RetryPolicy is abstract and cannot be instantiated directly');
+    }
     this.maxAttempts = maxAttempts;
     this._intervalMs = intervalMs;
   }
@@ -28,6 +33,20 @@ export class FixedIntervalRetryPolicy {
   }
 
   /**
+   * @abstract
+   * @param {number} _attempt - 1-based number of the attempt about to be made
+   * @returns {number}
+   */
+  getDelayMs(_attempt) {
+    throw new Error('Not implemented');
+  }
+}
+
+/**
+ * Fixed-interval retry policy: waits the same delay between every attempt.
+ */
+export class FixedIntervalRetryPolicy extends RetryPolicy {
+  /**
    * @param {number} _attempt - 1-based number of the attempt about to be made
    * @returns {number}
    */
@@ -40,7 +59,7 @@ export class FixedIntervalRetryPolicy {
  * Exponential-backoff retry policy: the delay grows by a multiplier on each attempt, capped at a
  * configured maximum.
  */
-export class ExponentialBackoffRetryPolicy extends FixedIntervalRetryPolicy {
+export class ExponentialBackoffRetryPolicy extends RetryPolicy {
   /**
    * @param {{maxAttempts: number | null, intervalMs: number, backoffMultiplier: number, backoffMaxIntervalMs: number}} opts
    */
@@ -61,14 +80,14 @@ export class ExponentialBackoffRetryPolicy extends FixedIntervalRetryPolicy {
    * @returns {number}
    */
   getDelayMs(attempt) {
-    const delayMs = super.getDelayMs(attempt) * this._backoffMultiplier ** (attempt - 1);
+    const delayMs = this._intervalMs * this._backoffMultiplier ** (attempt - 1);
     return Math.min(delayMs, this._backoffMaxIntervalMs);
   }
 }
 
 /**
  * @param {{strategy: 'fixed' | 'exponential', maxAttempts: number | null, intervalMs: number, backoffMultiplier?: number, backoffMaxIntervalMs?: number}} opts
- * @returns {FixedIntervalRetryPolicy}
+ * @returns {RetryPolicy}
  */
 export function createDisconnectRetryPolicy({
   strategy,

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -969,6 +969,23 @@ async function main() {
   const shouldRunUsbFlow = !hasRequestedAppleTVIds || hasRequestedUdids;
   const shouldRunAppleTVFlow = !hasRequestedUdids || hasRequestedAppleTVIds;
 
+  /** @type {import('./lib/retry-policy.mjs').RetryPolicy} */
+  let disconnectRetryPolicy;
+  try {
+    disconnectRetryPolicy = createDisconnectRetryPolicy({
+      strategy: options.disconnectRetryStrategy,
+      maxAttempts: options.disconnectRetryMaxAttempts ?? null,
+      intervalMs: options.disconnectRetryIntervalMs,
+      backoffMultiplier: options.disconnectRetryBackoffMultiplier,
+      backoffMaxIntervalMs: options.disconnectRetryBackoffMaxIntervalMs,
+    });
+  } catch (err) {
+    // program.error() never returns (it exits the process); the throw below is unreachable and
+    // only here so TS can see disconnectRetryPolicy is always assigned past this point.
+    program.error(/** @type {Error} */ (err).message);
+    throw err;
+  }
+
   await assertRoot(path.parse(fileURLToPath(import.meta.url)).name);
 
   const tunnelCreator = new TunnelCreator({
@@ -1000,15 +1017,7 @@ async function main() {
       });
     }
 
-    tunnelCreator.setDisconnectRetryPolicy(
-      createDisconnectRetryPolicy({
-        strategy: options.disconnectRetryStrategy,
-        maxAttempts: options.disconnectRetryMaxAttempts ?? null,
-        intervalMs: options.disconnectRetryIntervalMs,
-        backoffMultiplier: options.disconnectRetryBackoffMultiplier,
-        backoffMaxIntervalMs: options.disconnectRetryBackoffMaxIntervalMs,
-      }),
-    );
+    tunnelCreator.setDisconnectRetryPolicy(disconnectRetryPolicy);
 
     await tunnelCreator.startRegistryServer();
 

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -72,7 +72,7 @@ class TunnelCreator {
     /** @type {Map<string, import('appium-ios-remotexpc').AppleTVTunnelService>} */
     this._appletvTunnelServicesByUdid = new Map();
     this._isCleaningUp = false;
-    /** @type {FixedIntervalRetryPolicy} */
+    /** @type {import('./lib/retry-policy.mjs').RetryPolicy} */
     this._disconnectRetryPolicy = new FixedIntervalRetryPolicy({
       maxAttempts: null,
       intervalMs: DEFAULT_DISCONNECT_RETRY_INTERVAL_MS,
@@ -92,7 +92,7 @@ class TunnelCreator {
   }
 
   /**
-   * @param {FixedIntervalRetryPolicy} policy
+   * @param {import('./lib/retry-policy.mjs').RetryPolicy} policy
    */
   setDisconnectRetryPolicy(policy) {
     this._disconnectRetryPolicy = policy;

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -29,6 +29,7 @@ import {parsePositiveIntegerOption} from './lib/options.mjs';
 import {startTimeoutProgressLogger} from './lib/progress.mjs';
 import {
   createDisconnectRetryPolicy,
+  DEFAULT_DISCONNECT_RETRY_BACKOFF_JITTER,
   DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
   DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
   DEFAULT_DISCONNECT_RETRY_INTERVAL_MS,
@@ -830,6 +831,19 @@ function parseRetryBackoffMultiplierOption(value, label) {
 
 /**
  * @param {string} value
+ * @param {string} label
+ * @returns {number}
+ */
+function parseRetryBackoffJitterOption(value, label) {
+  const jitter = Number.parseFloat(value);
+  if (!Number.isFinite(jitter) || jitter < 0 || jitter > 1) {
+    throw new Error(`Invalid ${label}: ${value}. Expected a number between 0 and 1.`);
+  }
+  return jitter;
+}
+
+/**
+ * @param {string} value
  * @param {string[]} previous
  * @returns {string[]}
  */
@@ -958,6 +972,14 @@ async function main() {
       'Upper bound on the delay between tunnel recreation attempts when --disconnect-retry-strategy is exponential',
       (value) => parsePositiveIntegerOption(value, 'disconnect retry backoff max interval'),
       DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
+    )
+    .option(
+      '--disconnect-retry-backoff-jitter <factor>',
+      'Fraction of the delay to randomize away on each attempt when --disconnect-retry-strategy is exponential, ' +
+        'between 0 (no jitter) and 1 (full jitter). Spreads out devices that dropped together instead of having ' +
+        'them retry in lockstep',
+      (value) => parseRetryBackoffJitterOption(value, 'disconnect retry backoff jitter'),
+      DEFAULT_DISCONNECT_RETRY_BACKOFF_JITTER,
     );
 
   program.parse(process.argv);
@@ -978,6 +1000,7 @@ async function main() {
       intervalMs: options.disconnectRetryIntervalMs,
       backoffMultiplier: options.disconnectRetryBackoffMultiplier,
       backoffMaxIntervalMs: options.disconnectRetryBackoffMaxIntervalMs,
+      jitter: options.disconnectRetryBackoffJitter,
     });
   } catch (err) {
     // program.error() never returns (it exits the process); the throw below is unreachable and

--- a/scripts/tunnel-creation.mjs
+++ b/scripts/tunnel-creation.mjs
@@ -27,6 +27,13 @@ import {Command} from 'commander';
 
 import {parsePositiveIntegerOption} from './lib/options.mjs';
 import {startTimeoutProgressLogger} from './lib/progress.mjs';
+import {
+  createDisconnectRetryPolicy,
+  DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
+  DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
+  DEFAULT_DISCONNECT_RETRY_INTERVAL_MS,
+  FixedIntervalRetryPolicy,
+} from './lib/retry-policy.mjs';
 import {assertRoot} from './lib/root.mjs';
 
 const log = logger.getLogger('TunnelCreation');
@@ -65,9 +72,11 @@ class TunnelCreator {
     /** @type {Map<string, import('appium-ios-remotexpc').AppleTVTunnelService>} */
     this._appletvTunnelServicesByUdid = new Map();
     this._isCleaningUp = false;
-    /** @type {number | null} */
-    this._disconnectRetryMaxAttempts = null;
-    this._disconnectRetryIntervalMs = 1000;
+    /** @type {FixedIntervalRetryPolicy} */
+    this._disconnectRetryPolicy = new FixedIntervalRetryPolicy({
+      maxAttempts: null,
+      intervalMs: DEFAULT_DISCONNECT_RETRY_INTERVAL_MS,
+    });
   }
 
   get tunnelRegistryPort() {
@@ -83,12 +92,10 @@ class TunnelCreator {
   }
 
   /**
-   * @param {number | null} maxAttempts - null disables retries; 0 means unlimited retries
-   * @param {number} intervalMs
+   * @param {FixedIntervalRetryPolicy} policy
    */
-  setDisconnectRetryPolicy(maxAttempts, intervalMs) {
-    this._disconnectRetryMaxAttempts = maxAttempts;
-    this._disconnectRetryIntervalMs = intervalMs;
+  setDisconnectRetryPolicy(policy) {
+    this._disconnectRetryPolicy = policy;
   }
 
   /**
@@ -576,10 +583,6 @@ class TunnelCreator {
         if (!this._isRetryEnabledForUdid(udid)) {
           return;
         }
-        const maxAttempts = this._disconnectRetryMaxAttempts;
-        if (maxAttempts === null) {
-          return;
-        }
 
         const device = this._usbDevicesByUdid.get(udid);
         const isAppleTV = this._appleTVDeviceIds.has(udid);
@@ -587,17 +590,19 @@ class TunnelCreator {
           return;
         }
 
-        let attempt = 0;
+        const policy = this._disconnectRetryPolicy;
+        let attemptsMade = 0;
         while (!this._isCleaningUp) {
-          if (maxAttempts !== 0 && attempt >= maxAttempts) {
+          if (!policy.hasAttemptsRemaining(attemptsMade)) {
             log.warn(`Retry limit reached for ${udid}; keeping it removed from the registry`);
             return;
           }
-          attempt += 1;
+          attemptsMade += 1;
+          const delayMs = policy.getDelayMs(attemptsMade);
           log.warn(
-            `Retrying tunnel creation for ${udid} (attempt ${attempt}${maxAttempts === 0 ? ', unlimited' : `/${maxAttempts}`}) in ${this._disconnectRetryIntervalMs}ms...`,
+            `Retrying tunnel creation for ${udid} (attempt ${attemptsMade}${policy.maxAttempts === 0 ? ', unlimited' : `/${policy.maxAttempts}`}) in ${delayMs}ms...`,
           );
-          await sleep(this._disconnectRetryIntervalMs);
+          await sleep(delayMs);
 
           try {
             this._registryServer?.markTunnelPending(udid);
@@ -635,8 +640,7 @@ class TunnelCreator {
    */
   _isRetryEnabledForUdid(udid) {
     return (
-      (this._usbDevicesByUdid.has(udid) || this._appleTVDeviceIds.has(udid)) &&
-      this._disconnectRetryMaxAttempts !== null
+      (this._usbDevicesByUdid.has(udid) || this._appleTVDeviceIds.has(udid)) && this._disconnectRetryPolicy.isEnabled
     );
   }
 
@@ -802,6 +806,30 @@ function parseNonNegativeIntegerOption(value, label) {
 
 /**
  * @param {string} value
+ * @returns {'fixed' | 'exponential'}
+ */
+function parseRetryStrategyOption(value) {
+  if (value !== 'fixed' && value !== 'exponential') {
+    throw new Error(`Invalid disconnect retry strategy: ${value}. Expected 'fixed' or 'exponential'.`);
+  }
+  return value;
+}
+
+/**
+ * @param {string} value
+ * @param {string} label
+ * @returns {number}
+ */
+function parseRetryBackoffMultiplierOption(value, label) {
+  const multiplier = Number.parseFloat(value);
+  if (!Number.isFinite(multiplier) || multiplier <= 1) {
+    throw new Error(`Invalid ${label}: ${value}. Expected a number greater than 1.`);
+  }
+  return multiplier;
+}
+
+/**
+ * @param {string} value
  * @param {string[]} previous
  * @returns {string[]}
  */
@@ -907,10 +935,29 @@ async function main() {
       (value) => parseNonNegativeIntegerOption(value, 'disconnect retry max attempts'),
     )
     .option(
+      '--disconnect-retry-strategy <strategy>',
+      "Delay strategy between tunnel recreation attempts: 'fixed' or 'exponential'",
+      (value) => parseRetryStrategyOption(value),
+      'fixed',
+    )
+    .option(
       '--disconnect-retry-interval-ms <ms>',
-      'Delay between tunnel recreation attempts in milliseconds (default 1000)',
+      'Delay between tunnel recreation attempts in milliseconds. ' +
+        'With --disconnect-retry-strategy exponential, this is the initial delay, before it starts growing',
       (value) => parsePositiveIntegerOption(value, 'disconnect retry interval'),
-      1000,
+      DEFAULT_DISCONNECT_RETRY_INTERVAL_MS,
+    )
+    .option(
+      '--disconnect-retry-backoff-multiplier <factor>',
+      'Factor the delay grows by on each attempt when --disconnect-retry-strategy is exponential (must be > 1)',
+      (value) => parseRetryBackoffMultiplierOption(value, 'disconnect retry backoff multiplier'),
+      DEFAULT_DISCONNECT_RETRY_BACKOFF_MULTIPLIER,
+    )
+    .option(
+      '--disconnect-retry-backoff-max-interval-ms <ms>',
+      'Upper bound on the delay between tunnel recreation attempts when --disconnect-retry-strategy is exponential',
+      (value) => parsePositiveIntegerOption(value, 'disconnect retry backoff max interval'),
+      DEFAULT_DISCONNECT_RETRY_BACKOFF_MAX_INTERVAL_MS,
     );
 
   program.parse(process.argv);
@@ -954,8 +1001,13 @@ async function main() {
     }
 
     tunnelCreator.setDisconnectRetryPolicy(
-      options.disconnectRetryMaxAttempts ?? null,
-      options.disconnectRetryIntervalMs,
+      createDisconnectRetryPolicy({
+        strategy: options.disconnectRetryStrategy,
+        maxAttempts: options.disconnectRetryMaxAttempts ?? null,
+        intervalMs: options.disconnectRetryIntervalMs,
+        backoffMultiplier: options.disconnectRetryBackoffMultiplier,
+        backoffMaxIntervalMs: options.disconnectRetryBackoffMaxIntervalMs,
+      }),
     );
 
     await tunnelCreator.startRegistryServer();


### PR DESCRIPTION
The tunnel-creation script's disconnect-retry loop only supported a flat delay between reconnect attempts, which risks a hot retry loop for a permanently-failing device. Extract the retry math into standalone FixedIntervalRetryPolicy and ExponentialBackoffRetryPolicy classes and inject one into TunnelCreator via a new --disconnect-retry-strategy flag, with --disconnect-retry-backoff-multiplier and --disconnect-retry-backoff-max-interval-ms to tune the exponential curve.

Related to https://github.com/appium/appium-ios-remotexpc/pull/286