### PR TITLE
chore: rename safe occurrences of JWProxy

### DIFF
--- a/test/unit/commands/proxy-helper.spec.ts
+++ b/test/unit/commands/proxy-helper.spec.ts
@@ -10,32 +10,32 @@ describe('proxy commands', function () {
   const driver = new XCUITestDriver({} as any);
   driver._wda = {jwproxy: {command: async () => ({})} as any} as any;
 
-  let mockJwproxy: sinon.SinonMock;
+  let mockWDProxy: sinon.SinonMock;
 
   beforeEach(function () {
-    mockJwproxy = sinon.mock(driver.wda.jwproxy);
+    mockWDProxy = sinon.mock(driver.wda.jwproxy);
   });
 
   afterEach(function () {
-    mockJwproxy.verify();
+    mockWDProxy.verify();
   });
 
   describe('proxyCommand', function () {
     it('should send command through WDA', async function () {
-      mockJwproxy.expects('command').once().withExactArgs('/some/endpoint', 'POST', {some: 'stuff'});
+      mockWDProxy.expects('command').once().withExactArgs('/some/endpoint', 'POST', {some: 'stuff'});
       await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
     });
 
     it('should throw an error if no endpoint is given', async function () {
-      mockJwproxy.expects('command').never().called;
+      mockWDProxy.expects('command').never().called;
       await assert.rejects(driver.proxyCommand(null as any, 'POST', {some: 'stuff'}), /endpoint/);
     });
     it('should throw an error if no method is given', async function () {
-      mockJwproxy.expects('command').never().called;
+      mockWDProxy.expects('command').never().called;
       await assert.rejects(driver.proxyCommand('/some/endpoint', null as any, {some: 'stuff'}), /GET, POST/);
     });
     it('should throw an error if wda returns an error (even if http status is 200)', async function () {
-      mockJwproxy.expects('command').once().returns({status: 13, value: 'WDA error occurred'});
+      mockWDProxy.expects('command').once().returns({status: 13, value: 'WDA error occurred'});
       try {
         await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
       } catch (err) {
@@ -45,7 +45,7 @@ describe('proxy commands', function () {
       }
     });
     it('should not throw an error if no status is returned', async function () {
-      mockJwproxy.expects('command').once().returns({value: 'WDA error occurred'});
+      mockWDProxy.expects('command').once().returns({value: 'WDA error occurred'});
       await driver.proxyCommand('/some/endpoint', 'POST', {some: 'stuff'});
     });
   });

--- a/test/unit/driver.spec.ts
+++ b/test/unit/driver.spec.ts
@@ -3,7 +3,7 @@ import net from 'node:net';
 import {describe, it, beforeEach, afterEach, mock} from 'node:test';
 
 import xcode from 'appium-xcode';
-import {JWProxy} from 'appium/driver.js';
+import {WebDriverProxy} from 'appium/driver.js';
 import {createSandbox, type SinonSandbox, type SinonStubbedMember} from 'sinon';
 
 import * as helpersIndexModule from '../../lib/commands/helpers/index.js';
@@ -216,14 +216,14 @@ describe('XCUITestDriver', function () {
   describe('driver commands', function () {
     describe('status', function () {
       let driver: InstanceType<typeof XCUITestDriver>;
-      let jwproxyCommandSpy: SinonStubbedMember<typeof JWProxy.prototype.command>;
+      let wdProxyCommandSpy: SinonStubbedMember<typeof WebDriverProxy.prototype.command>;
 
       beforeEach(function () {
         driver = new XCUITestDriver({} as any);
 
         // fake the proxy to WDA
-        const jwproxy = new JWProxy();
-        jwproxyCommandSpy = sandbox.stub(jwproxy, 'command').resolves({some: 'thing'});
+        const jwproxy = new WebDriverProxy();
+        wdProxyCommandSpy = sandbox.stub(jwproxy, 'command').resolves({some: 'thing'});
         driver._wda = {
           jwproxy,
         } as any;
@@ -231,14 +231,14 @@ describe('XCUITestDriver', function () {
 
       it('should not have wda status by default', async function () {
         const status = await driver.getStatus();
-        assert.strictEqual(jwproxyCommandSpy.calledOnce, false);
+        assert.strictEqual(wdProxyCommandSpy.calledOnce, false);
         assert.strictEqual(status.wda, undefined);
       });
 
       it('should return wda status if cached', async function () {
         driver.cachedWdaStatus = {};
         const status = await driver.getStatus();
-        assert.strictEqual(jwproxyCommandSpy.called, false);
+        assert.strictEqual(wdProxyCommandSpy.called, false);
         assert.ok(status.wda);
       });
     });
@@ -415,7 +415,7 @@ describe('XCUITestDriver', function () {
 
       beforeEach(function () {
         driver = new XCUITestDriver({} as any);
-        const jwproxy = new JWProxy();
+        const jwproxy = new WebDriverProxy();
         sandbox.stub(jwproxy, 'command').resolves(deviceInfoResponse);
         driver._wda = {
           jwproxy,


### PR DESCRIPTION
Related to https://github.com/appium/appium/pull/22614

The `jwproxy` WDA property was kept as-is, since changing its name would be a breaking change.