### PR TITLE
ci: enable xcode 27

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -78,8 +78,10 @@ jobs:
       - run: xcrun simctl list runtimes
         name: List Runtimes
       - name: Start iOS Simulator UI
+        if: ${{ matrix.xcodeVersion != '27.0-beta' }}
         run: open -Fn "$(xcode-select --print-path)/Applications/Simulator.app"
       - name: Prepare iOS simulator
+        if: ${{ matrix.xcodeVersion != '27.0-beta' }}
         id: prepareSimulator
         uses: futureware-tech/simulator-action@v5
         with:
@@ -88,6 +90,7 @@ jobs:
           shutdown_after_job: false
           wait_for_boot: true
       - name: Finalize iOS simulator boot
+        if: ${{ matrix.xcodeVersion != '27.0-beta' }}
         run: xcrun --sdk iphonesimulator --show-sdk-version
 
       - run: |

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -33,8 +33,14 @@ jobs:
           # - driver
           - web
           - long
-        xcodeVersion: ['26.4', '16.4']
+        xcodeVersion: ['27.0-beta', '26.4', '16.4']
         include:
+          - xcodeVersion: '27.0-beta'
+            iosVersion: '27.0'
+            deviceName: 'iPhone 17'
+            tvosVersion: '27.0'
+            tvosDeviceName: 'Apple TV'
+            platform: xcode-27
           - xcodeVersion: '26.4'
             iosVersion: '26.4'
             deviceName: 'iPhone 17'


### PR DESCRIPTION
This is just to run xcode 27 for now.

I haven't dropped old ones as this is still beta. No strong opinion to drop them as well.