### PR TITLE
fix: force-kill hung performance recordings and restore device e2e tests

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -27,8 +27,7 @@ jobs:
       matrix:
         e2eRoot:
           - basic
-          # TODO: Uncomment these tests when they are stable
-          # - device
+          - device
           # In CI env driver tests are unstable, because it's expensive to start and stop simulators
           # - driver
           - web

--- a/lib/commands/performance.ts
+++ b/lib/commands/performance.ts
@@ -190,6 +190,10 @@ export class PerfRecorder {
     try {
       await this._process?.stop('SIGINT', STOP_TIMEOUT_MS);
     } catch {
+      // SIGINT was not enough to make the process exit in time. Force-kill it, otherwise
+      // it stays orphaned and keeps the simulator's Instruments channel pinned, which then
+      // wedges every subsequent command against the same device.
+      await this._enforceTermination();
       throw this._logger.errorWithException(`Performance recording has failed to exit after ${STOP_TIMEOUT_MS}ms`);
     }
     return await this.getZippedReportPath();

--- a/test/functional/device/performance-e2e.spec.ts
+++ b/test/functional/device/performance-e2e.spec.ts
@@ -8,7 +8,10 @@ import {getUICatalogCaps} from '../desired.js';
 import {initSession, deleteSession} from '../helpers/session.js';
 
 describe('XCUITestDriver - performance', function () {
-  const profileName = 'Time Profiler';
+  // 'Time Profiler' requires kernel-level CPU sampling (kperf/kdebug) that needs a one-time
+  // Instruments authorization grant on the host Mac; 'Network' needs no special permissions
+  // and is supported on simulators, so it exercises the same start/stop/report flow reliably.
+  const profileName = 'Network';
 
   let driver: Browser;
 


### PR DESCRIPTION
PerfRecorder.stop() only threw when the graceful SIGINT-based stop timed out, leaving the xctrace/instruments subprocess orphaned and pinning the simulator's Instruments channel for every subsequent command. Force-kill it via the existing _enforceTermination() fallback so a failed stop can't wedge the rest of the suite.

Also switch the performance e2e spec from the 'Time Profiler' template, which needs a kernel-tracing (kperf/kdebug) authorization not available in all environments, to 'Network', which needs no special permissions and is supported on simulators, and re-enable the device e2eRoot in CI now that the suite passes reliably.