### PR TITLE
fix: honor implicit wait for findElements in web contexts

### DIFF
--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -320,17 +320,17 @@ export function cacheWebElements(this: XCUITestDriver, response: any): any {
 /**
  * Executes a Selenium atom script in the current web context.
  *
+ * @template T - Expected result type; defaults to `any` for callers that don't need it
  * @param atom - Name of the atom to execute
  * @param args - Arguments to pass to the atom
  * @param alwaysDefaultFrame - If true, always use the default frame instead of current frames
- * @privateRemarks This should return `Promise<T>` where `T` extends `unknown`, but that's going to cause a lot of things to break.
  */
-export async function executeAtom(
+export async function executeAtom<T = any>(
   this: XCUITestDriver,
   atom: string,
   args: unknown[],
   alwaysDefaultFrame: boolean = false,
-): Promise<any> {
+): Promise<T> {
   const frames = alwaysDefaultFrame === true ? [] : this.curWebFrames;
   const promise = this.remote.executeAtom(atom, args, frames);
   return await this.waitForAtom(promise);
@@ -424,15 +424,40 @@ export async function findWebElementOrElements(
   this: XCUITestDriver,
   strategy: string,
   selector: string,
+  many: true,
+  ctx?: Element | string | null,
+): Promise<Element[]>;
+export async function findWebElementOrElements(
+  this: XCUITestDriver,
+  strategy: string,
+  selector: string,
+  many?: false,
+  ctx?: Element | string | null,
+): Promise<Element>;
+export async function findWebElementOrElements(
+  this: XCUITestDriver,
+  strategy: string,
+  selector: string,
+  many?: boolean,
+  ctx?: Element | string | null,
+): Promise<Element | Element[]>;
+export async function findWebElementOrElements(
+  this: XCUITestDriver,
+  strategy: string,
+  selector: string,
   many?: boolean,
   ctx?: Element | string | null,
 ): Promise<Element | Element[]> {
-  const contextElement = ctx == null ? null : this.getAtomsElement(ctx);
+  const contextElement: AtomsElement | null = ctx == null ? null : this.getAtomsElement(ctx);
   const atomName = many ? 'find_elements' : 'find_element_fragment';
-  let element: any;
-  const doFind = async () => {
-    element = await this.executeAtom(atomName, [strategy, selector, contextElement]);
-    return element !== null;
+  let element: AtomsElement | AtomsElement[] | null = null;
+  const doFind = async (): Promise<boolean> => {
+    element = await this.executeAtom<AtomsElement | AtomsElement[] | null>(atomName, [
+      strategy,
+      selector,
+      contextElement,
+    ]);
+    return !isEmpty(element);
   };
   try {
     await this.implicitWaitForCondition(doFind);

--- a/test/unit/commands/web.spec.ts
+++ b/test/unit/commands/web.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it, afterEach} from 'node:test';
+import {performance} from 'node:perf_hooks';
 
 import sinon from 'sinon';
 
@@ -43,9 +44,9 @@ describe('web commands', function () {
       driver.implicitWaitMs = 5000;
       atomSpy.resolves({ELEMENT: 'elId'});
 
-      const started = Date.now();
+      const started = performance.now();
       await driver.findWebElementOrElements('id', 'foo', false);
-      const elapsed = Date.now() - started;
+      const elapsed = performance.now() - started;
 
       assert.strictEqual(atomSpy.callCount, 1);
       assert.ok(elapsed < 500, `expected the lookup to resolve quickly, but it took ${elapsed}ms`);

--- a/test/unit/commands/web.spec.ts
+++ b/test/unit/commands/web.spec.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import {describe, it, afterEach} from 'node:test';
+
+import sinon from 'sinon';
+
+import {XCUITestDriver} from '../../../lib/driver.js';
+
+describe('web commands', function () {
+  const driver = new XCUITestDriver({} as any);
+  const atomSpy = sinon.stub(driver, 'executeAtom');
+  afterEach(function () {
+    atomSpy.reset();
+    driver.implicitWaitMs = 0;
+  });
+
+  describe('findWebElementOrElements', function () {
+    it('should honor implicit wait when find_elements atom keeps returning an empty array', async function () {
+      driver.implicitWaitMs = 700;
+      atomSpy.resolves([]);
+
+      const els = await driver.findWebElementOrElements('id', 'foo', true);
+
+      assert.deepStrictEqual(els, []);
+      assert.ok(
+        atomSpy.callCount > 1,
+        `expected executeAtom to be retried while waiting, but it was only called ${atomSpy.callCount} time(s)`,
+      );
+    });
+
+    it('should honor implicit wait when find_element_fragment atom keeps returning null', async function () {
+      driver.implicitWaitMs = 700;
+      atomSpy.resolves(null);
+
+      await assert.rejects(driver.findWebElementOrElements('id', 'foo', false), /NoSuchElementError/);
+
+      assert.ok(
+        atomSpy.callCount > 1,
+        `expected executeAtom to be retried while waiting, but it was only called ${atomSpy.callCount} time(s)`,
+      );
+    });
+
+    it('should return immediately once an element is found', async function () {
+      driver.implicitWaitMs = 5000;
+      atomSpy.resolves({ELEMENT: 'elId'});
+
+      const started = Date.now();
+      await driver.findWebElementOrElements('id', 'foo', false);
+      const elapsed = Date.now() - started;
+
+      assert.strictEqual(atomSpy.callCount, 1);
+      assert.ok(elapsed < 500, `expected the lookup to resolve quickly, but it took ${elapsed}ms`);
+    });
+  });
+});

--- a/test/unit/commands/web.spec.ts
+++ b/test/unit/commands/web.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import {describe, it, afterEach} from 'node:test';
 import {performance} from 'node:perf_hooks';
+import {describe, it, afterEach} from 'node:test';
 
 import sinon from 'sinon';
 


### PR DESCRIPTION
findWebElementOrElements checked `element !== null` to decide whether implicitWaitForCondition should keep polling, but the find_elements atom resolves to an empty array (never null) when nothing matches, so the wait loop always exited after the first attempt. Switch to isEmpty() so multi-element web lookups retry for the full implicit wait like their native and single-element counterparts do.

Also tighten typing in findWebElementOrElements (overloads keyed on the `many` literal, typed contextElement/element) and make executeAtom's return type generic so callers can request a typed result instead of casting with `as`.

Fixes https://github.com/appium/appium/issues/14885