### PR TITLE
feat: support native web tap inside same-origin iframes, bump remote-debugger

### DIFF
--- a/lib/commands/web-native-bridge.ts
+++ b/lib/commands/web-native-bridge.ts
@@ -43,7 +43,12 @@ const CALIBRATION_TAPS_MARKER = '__appiumCalibrationTaps';
 // existing overlay/taps array) so that a retry after a failed attempt can
 // never inherit stale taps left over from a previous attempt whose cleanup
 // call didn't actually reach the page (e.g. a transport hiccup).
-const INJECT_CALIBRATION_OVERLAY_SCRIPT = `
+//
+// This and the next 3 scripts are sent via `this.remote.execute` (see the
+// private helpers below), which evaluates them as a bare program, not a
+// function body - unlike the `execute_script` atom, it does not tolerate a
+// top-level `return`. Wrapped in an IIFE so they can use one anyway.
+const INJECT_CALIBRATION_OVERLAY_SCRIPT = `(function () {
   if (window.${CALIBRATION_OVERLAY_MARKER}) {
     window.${CALIBRATION_OVERLAY_MARKER}.remove();
   }
@@ -59,26 +64,26 @@ const INJECT_CALIBRATION_OVERLAY_SCRIPT = `
     taps.push({x: e.clientX, y: e.clientY});
   }, true);
   window.${CALIBRATION_OVERLAY_MARKER} = overlay;
-`;
+})();`;
 
-const REMOVE_CALIBRATION_OVERLAY_SCRIPT = `
+const REMOVE_CALIBRATION_OVERLAY_SCRIPT = `(function () {
   if (window.${CALIBRATION_OVERLAY_MARKER}) {
     window.${CALIBRATION_OVERLAY_MARKER}.remove();
     delete window.${CALIBRATION_OVERLAY_MARKER};
     delete window.${CALIBRATION_TAPS_MARKER};
   }
-`;
+})();`;
 
 // Returns every tap the overlay has observed so far, so the caller can
 // correlate a specific tap by index instead of trusting that the most
 // recently pushed entry corresponds to the tap it just issued (a native tap
 // resolves once WDA dispatches the touch, not once the webview's click
 // handler has necessarily run and recorded it).
-const READ_CALIBRATION_TAPS_SCRIPT = `
+const READ_CALIBRATION_TAPS_SCRIPT = `(function () {
   return window.${CALIBRATION_TAPS_MARKER} || [];
-`;
+})();`;
 
-const READ_VIEWPORT_STATE_SCRIPT = `
+const READ_VIEWPORT_STATE_SCRIPT = `(function () {
   var vv = window.visualViewport;
   return {
     innerWidth: window.innerWidth,
@@ -90,6 +95,26 @@ const READ_VIEWPORT_STATE_SCRIPT = `
     visualViewportOffsetTop: vv ? vv.offsetTop : 0,
     visualViewportScale: vv ? vv.scale : 1,
   };
+})();`;
+
+// Sums each ancestor iframe's own getBoundingClientRect() offset up to the
+// top document, giving the current frame's offset in top-page coordinates.
+// `frameElement` is null for a cross-origin frame, which doubles as that signal.
+const READ_FRAME_CHAIN_OFFSET_SCRIPT = `
+  var w = window;
+  var offsetX = 0;
+  var offsetY = 0;
+  while (w !== w.top) {
+    var fe = w.frameElement;
+    if (!fe) {
+      return {crossOrigin: true};
+    }
+    var rect = fe.getBoundingClientRect();
+    offsetX += rect.left;
+    offsetY += rect.top;
+    w = w.parent;
+  }
+  return {crossOrigin: false, offsetX: offsetX, offsetY: offsetY};
 `;
 
 // Marks arguments[0] with a throwaway `aria-label` (WebKit reflects this
@@ -132,6 +157,8 @@ const RESTORE_ELEMENT_ARIA_LABEL_SCRIPT = `
     el.removeAttribute('aria-label');
   }
 `;
+
+// ---- exported commands ----
 
 /**
  * Computes the affine transform (`native = offset + ratio * web`) that best
@@ -204,200 +231,6 @@ export function viewportSignature(state: ViewportState): string {
     `${state.visualViewportWidth}x${state.visualViewportHeight}` +
     `@${state.visualViewportOffsetLeft},${state.visualViewportOffsetTop}x${state.visualViewportScale}`;
   return `${state.orientation}:${state.innerWidth}x${state.innerHeight}:${state.isScrolledToTop ? 'top' : 'scrolled'}:${vv}`;
-}
-
-/**
- * Finds the current native XCUIElementTypeWebView and returns its rect.
- * Used to pick native points to tap during calibration.
- *
- * A single attempt: this is only ever called from inside
- * {@linkcode performCalibration}'s own retry loop, so retrying here too
- * would just compound into an excessive worst-case number of attempts.
- */
-async function findWebviewRect(this: XCUITestDriver): Promise<Rect> {
-  let webview: Element | undefined | string;
-  try {
-    webview = await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false);
-  } catch {}
-
-  if (!webview) {
-    throw new Error(`No WebView found. Unable to calibrate web coordinates for native web tap.`);
-  }
-
-  webview = util.unwrapElement(webview);
-  return (await this.proxyCommand(`/element/${webview}/rect`, 'GET')) as Rect;
-}
-
-/**
- * Reads the signals that make up the current {@linkcode ViewportState} and
- * combines them with the current context into a cache key. The context is
- * included on top of what the plan's signature covers, because switching to
- * a different webview is itself a reason any previously fitted transform no
- * longer applies.
- */
-async function computeViewportSignature(this: XCUITestDriver): Promise<string> {
-  const state = (await this.execute(READ_VIEWPORT_STATE_SCRIPT)) as Omit<ViewportState, 'orientation'>;
-  const orientation: ViewportState['orientation'] = state.innerHeight >= state.innerWidth ? 'PORTRAIT' : 'LANDSCAPE';
-  return `${this.curContext ?? ''}::${viewportSignature({...state, orientation})}`;
-}
-
-/**
- * Fits a fresh web-to-native calibration transform by injecting a temporary,
- * full-viewport click-capturing overlay into the current DOM, tapping it
- * twice through WDA, and reading back the web coordinates each tap was
- * observed at. This never navigates away from the page under test, and
- * measures whatever chrome (or lack of it) is actually on screen right now,
- * so it works the same way for Safari and hybrid-app webviews alike.
- *
- * @throws {Error} If the driver is currently switched into a sub-frame (see
- *   {@linkcode XCUITestDriver.setFrame}). The overlay this fits against is
- *   injected into whatever frame `execute` targets, but the native tap
- *   coordinates are always picked from the *whole* WebView's rect - a
- *   sub-frame only covers part of that, so unless it happens to cover the
- *   WebView's center, the overlay would never observe the calibration taps.
- *   Calibrating from the top-level frame first still lets native web tap
- *   work for elements inside sub-frames, as long as the page doesn't rely on
- *   per-frame chrome/scroll offsets the top-level calibration can't see.
- */
-async function performCalibration(this: XCUITestDriver): Promise<CalibrationCacheEntry> {
-  if (!isEmpty(this.curWebFrames)) {
-    throw new Error(
-      'Cannot calibrate web-to-native coordinates translation while switched into a sub-frame. ' +
-        "Switch back to the top-level frame first (e.g. WebdriverIO's driver.switchToFrame(null)).",
-    );
-  }
-
-  let entry: CalibrationCacheEntry | undefined;
-  await retryInterval(CALIBRATION_RETRIES, CALIBRATION_RETRY_INTERVAL_MS, async () => {
-    const rect = await findWebviewRect.call(this);
-    const centerX = rect.x + rect.width / 2;
-    const centerY = rect.y + rect.height / 2;
-
-    await this.execute(INJECT_CALIBRATION_OVERLAY_SCRIPT);
-    try {
-      const samples: CalibrationSample[] = [];
-      for (const [i, sign] of [-1, 1].entries()) {
-        const nativeX = centerX + sign * CALIBRATION_TAP_DELTA_PX;
-        const nativeY = centerY + sign * CALIBRATION_TAP_DELTA_PX;
-        await this.mobileTap(nativeX, nativeY);
-        // Correlate by index rather than trusting "the last entry in the
-        // array" to be this tap's: WDA's tap response can resolve before the
-        // webview's own click handler has run and recorded it.
-        const expectedCount = i + 1;
-        const taps = (await retryInterval(
-          CALIBRATION_TAP_READBACK_RETRIES,
-          CALIBRATION_TAP_READBACK_INTERVAL_MS,
-          async () => {
-            const result = (await this.execute(READ_CALIBRATION_TAPS_SCRIPT)) as Position[];
-            if (!Array.isArray(result) || result.length < expectedCount) {
-              throw new Error('The calibration overlay has not observed this tap yet');
-            }
-            return result;
-          },
-        )) as Position[];
-        const web = taps[expectedCount - 1];
-        if (!web || !Number.isFinite(web.x) || !Number.isFinite(web.y)) {
-          throw new Error('The calibration overlay did not observe the expected click event');
-        }
-        samples.push({native: {x: nativeX, y: nativeY}, web});
-      }
-      const data = fitAffineTransform(samples);
-      const signature = await computeViewportSignature.call(this);
-      entry = {signature, data};
-    } finally {
-      try {
-        await this.execute(REMOVE_CALIBRATION_OVERLAY_SCRIPT);
-      } catch (err) {
-        // Don't let a cleanup hiccup mask a real error from the try block
-        // above, or abort the retry loop on its own; the overlay-inject
-        // script tears down and rebuilds from scratch regardless, so a
-        // failed removal here doesn't corrupt the next attempt.
-        this.log.debug(`Failed to remove the calibration overlay: ${toErrorMessage(err)}`);
-      }
-    }
-  });
-  return entry as CalibrationCacheEntry;
-}
-
-/**
- * Returns a cached web-to-native calibration transform if the webview's
- * orientation/size/scroll state hasn't changed since it was fitted,
- * otherwise transparently (re)calibrates. This is what makes calibration
- * automatic: callers never need to notice or handle staleness themselves.
- *
- * @param force - Recalibrate unconditionally, ignoring any cached entry
- */
-async function getOrCreateWebviewCalibration(this: XCUITestDriver, force = false): Promise<CalibrationData> {
-  if (!force) {
-    const signature = await computeViewportSignature.call(this);
-    if (this._webviewCalibrationCache?.signature === signature) {
-      this.log.debug(`Reusing cached web-to-native calibration for signature '${signature}'`);
-      return this._webviewCalibrationCache.data;
-    }
-  }
-
-  this.log.debug('Fitting a new web-to-native coordinates calibration');
-  // keep track of implicit wait, and set locally to 0
-  // https://github.com/appium/appium/issues/14988
-  const implicitWaitMs = this.implicitWaitMs;
-  this.setImplicitWait(0);
-  try {
-    this._webviewCalibrationCache = await performCalibration.call(this);
-  } finally {
-    this.setImplicitWait(implicitWaitMs);
-  }
-  return this._webviewCalibrationCache.data;
-}
-
-/**
- * Attempts to tap a web element by marking it with a unique, throwaway
- * `aria-label` and looking that up as a native accessibility id. WebKit
- * reflects `aria-label` into the native accessibility label, so this
- * resolves to exactly one native element with no ambiguity heuristics,
- * including icon buttons, images, and elements with duplicate visible text.
- *
- * @param atomsElement - Atoms-compatible element to tap
- * @returns True if the native tap was successful, false otherwise
- */
-async function tapWebElementNatively(this: XCUITestDriver, atomsElement: AtomsElement): Promise<boolean> {
-  const uuid = util.uuidV4();
-  let marker: {hadAttribute: boolean; original: string | null} | null = null;
-  try {
-    marker = (await this.executeAtom('execute_script', [MARK_ELEMENT_FOR_NATIVE_TAP_SCRIPT, [atomsElement, uuid]])) as {
-      hadAttribute: boolean;
-      original: string | null;
-    } | null;
-    if (!marker) {
-      // element is genuinely inaccessible (aria-hidden, invisible, zero-size)
-      return false;
-    }
-
-    const els = (await this.findNativeElementOrElements('accessibility id', uuid, true)) as Element[];
-    if (els.length !== 1) {
-      this.log.debug(`Expected to find exactly 1 native element with accessibility id '${uuid}', found ${els.length}`);
-      return false;
-    }
-
-    const rect = (await this.proxyCommand(`/element/${util.unwrapElement(els[0])}/rect`, 'GET')) as Rect;
-    await this.mobileTap(rect.x + rect.width / 2, rect.y + rect.height / 2);
-    return true;
-  } catch (err) {
-    // any failure should fall through and trigger the more elaborate
-    // method of clicking
-    this.log.warn(`Error attempting to click: ${toErrorMessage(err)}`);
-    return false;
-  } finally {
-    if (marker) {
-      try {
-        await this.executeAtom('execute_script', [
-          RESTORE_ELEMENT_ARIA_LABEL_SCRIPT,
-          [atomsElement, marker.hadAttribute, marker.original],
-        ]);
-      } catch (err) {
-        this.log.debug(`Failed to restore the original 'aria-label' value: ${toErrorMessage(err)}`);
-      }
-    }
-  }
 }
 
 /**
@@ -499,31 +332,49 @@ export async function nativeWebTap(this: XCUITestDriver, el: Element | string): 
  *
  * Always uses a calibration transform, automatically (re)fitting one via
  * {@linkcode getOrCreateWebviewCalibration} whenever the cached one no
- * longer matches the current orientation/size/scroll state.
+ * longer matches the current orientation/size/scroll state. That transform
+ * is fitted against the top-level page, so `x`/`y` are first shifted by the
+ * current sub-frame's offset (see {@linkcode getFrameChainOffset}), if any.
  *
  * @param x - X coordinate in web space
  * @param y - Y coordinate in web space
  * @returns Translated position in native coordinates
- * @throws {Error} If no WebView is found or if calibration fails
+ * @throws {Error} If no WebView is found, if calibration fails, or if the
+ *   current frame (or one of its ancestors) has a different origin than the
+ *   top-level page
  */
 export async function translateWebCoords(this: XCUITestDriver, x: number, y: number): Promise<Position> {
   this.log.debug(`Translating web coordinates (${JSON.stringify({x, y})}) to native coordinates`);
 
-  const {offsetX, offsetY, pixelRatioX, pixelRatioY} = await getOrCreateWebviewCalibration.call(this);
+  const [{offsetX, offsetY, pixelRatioX, pixelRatioY}, frameOffset] = await Promise.all([
+    getOrCreateWebviewCalibration.call(this),
+    getFrameChainOffset.call(this),
+  ]);
+  if (frameOffset.crossOrigin) {
+    throw new Error(
+      'Cannot translate coordinates for the current frame: it (or one of its ancestor frames) has a ' +
+        "different origin than the top-level page. Safari's remote debugger cannot determine a cross-origin " +
+        "frame's position, which is required to compute where to tap. Switch back to the top-level frame " +
+        'or a same-origin ancestor before tapping elements here.',
+    );
+  }
+  const frameX = x + frameOffset.offsetX;
+  const frameY = y + frameOffset.offsetY;
+
   const cmd =
     '(function () {return {innerWidth: window.innerWidth, innerHeight: window.innerHeight, ' +
     'outerWidth: window.outerWidth, outerHeight: window.outerHeight}; })()';
-  const wvDims = (await this.remote.execute(cmd)) as {
+  const wvDims = await this.remote.execute<{
     innerWidth: number;
     innerHeight: number;
     outerWidth: number;
     outerHeight: number;
-  };
+  }>(cmd);
   // https://tripleodeon.com/2011/12/first-understand-your-screen/
   const shouldApplyPixelRatio = wvDims.innerWidth > wvDims.outerWidth || wvDims.innerHeight > wvDims.outerHeight;
   const newCoords = {
-    x: offsetX + x * (shouldApplyPixelRatio ? pixelRatioX : 1),
-    y: offsetY + y * (shouldApplyPixelRatio ? pixelRatioY : 1),
+    x: offsetX + frameX * (shouldApplyPixelRatio ? pixelRatioX : 1),
+    y: offsetY + frameY * (shouldApplyPixelRatio ? pixelRatioY : 1),
   };
 
   this.log.debug(`Converted web coords ${JSON.stringify({x, y})} into real coords ${JSON.stringify(newCoords)}`);
@@ -554,4 +405,205 @@ export async function mobileCalibrateWebToRealCoordinatesTranslation(this: XCUIT
     offsetX: Math.round(result.offsetX),
     offsetY: Math.round(result.offsetY),
   };
+}
+
+// ---- private helpers ----
+
+/**
+ * Finds the current native XCUIElementTypeWebView and returns its rect.
+ * Used to pick native points to tap during calibration.
+ *
+ * A single attempt: this is only ever called from inside
+ * {@linkcode performCalibration}'s own retry loop, so retrying here too
+ * would just compound into an excessive worst-case number of attempts.
+ */
+async function findWebviewRect(this: XCUITestDriver): Promise<Rect> {
+  let webview: Element | undefined | string;
+  try {
+    webview = await this.findNativeElementOrElements('class name', 'XCUIElementTypeWebView', false);
+  } catch {}
+
+  if (!webview) {
+    throw new Error(`No WebView found. Unable to calibrate web coordinates for native web tap.`);
+  }
+
+  webview = util.unwrapElement(webview);
+  return (await this.proxyCommand(`/element/${webview}/rect`, 'GET')) as Rect;
+}
+
+/**
+ * Reads the signals that make up the current {@linkcode ViewportState} and
+ * combines them with the current context into a cache key. The context is
+ * included on top of what the plan's signature covers, because switching to
+ * a different webview is itself a reason any previously fitted transform no
+ * longer applies.
+ *
+ * Uses `this.remote.execute` (not `this.execute`) to always read the
+ * top-level page's viewport, regardless of the current frame.
+ */
+async function computeViewportSignature(this: XCUITestDriver): Promise<string> {
+  const state = await this.remote.execute<Omit<ViewportState, 'orientation'>>(READ_VIEWPORT_STATE_SCRIPT);
+  const orientation: ViewportState['orientation'] = state.innerHeight >= state.innerWidth ? 'PORTRAIT' : 'LANDSCAPE';
+  return `${this.curContext ?? ''}::${viewportSignature({...state, orientation})}`;
+}
+
+/**
+ * Fits a fresh web-to-native calibration transform by injecting a temporary,
+ * full-viewport click-capturing overlay into the current DOM, tapping it
+ * twice through WDA, and reading back the web coordinates each tap was
+ * observed at. This never navigates away from the page under test, and
+ * measures whatever chrome (or lack of it) is actually on screen right now,
+ * so it works the same way for Safari and hybrid-app webviews alike.
+ *
+ * Uses `this.remote.execute` (not `this.execute`) to always fit against the
+ * top-level page, regardless of the current frame; {@linkcode translateWebCoords}
+ * adds a sub-frame's own offset (via {@linkcode getFrameChainOffset}) on top.
+ */
+async function performCalibration(this: XCUITestDriver): Promise<CalibrationCacheEntry> {
+  let entry: CalibrationCacheEntry | undefined;
+  await retryInterval(CALIBRATION_RETRIES, CALIBRATION_RETRY_INTERVAL_MS, async () => {
+    const rect = await findWebviewRect.call(this);
+    const centerX = rect.x + rect.width / 2;
+    const centerY = rect.y + rect.height / 2;
+
+    await this.remote.execute(INJECT_CALIBRATION_OVERLAY_SCRIPT);
+    try {
+      const samples: CalibrationSample[] = [];
+      for (const [i, sign] of [-1, 1].entries()) {
+        const nativeX = centerX + sign * CALIBRATION_TAP_DELTA_PX;
+        const nativeY = centerY + sign * CALIBRATION_TAP_DELTA_PX;
+        await this.mobileTap(nativeX, nativeY);
+        // Correlate by index rather than trusting "the last entry in the
+        // array" to be this tap's: WDA's tap response can resolve before the
+        // webview's own click handler has run and recorded it.
+        const expectedCount = i + 1;
+        const taps = (await retryInterval(
+          CALIBRATION_TAP_READBACK_RETRIES,
+          CALIBRATION_TAP_READBACK_INTERVAL_MS,
+          async () => {
+            const result = await this.remote.execute<Position[]>(READ_CALIBRATION_TAPS_SCRIPT);
+            if (!Array.isArray(result) || result.length < expectedCount) {
+              throw new Error('The calibration overlay has not observed this tap yet');
+            }
+            return result;
+          },
+        )) as Position[];
+        const web = taps[expectedCount - 1];
+        if (!web || !Number.isFinite(web.x) || !Number.isFinite(web.y)) {
+          throw new Error('The calibration overlay did not observe the expected click event');
+        }
+        samples.push({native: {x: nativeX, y: nativeY}, web});
+      }
+      const data = fitAffineTransform(samples);
+      const signature = await computeViewportSignature.call(this);
+      entry = {signature, data};
+    } finally {
+      try {
+        await this.remote.execute(REMOVE_CALIBRATION_OVERLAY_SCRIPT);
+      } catch (err) {
+        // Don't let a cleanup hiccup mask a real error from the try block
+        // above, or abort the retry loop on its own; the overlay-inject
+        // script tears down and rebuilds from scratch regardless, so a
+        // failed removal here doesn't corrupt the next attempt.
+        this.log.debug(`Failed to remove the calibration overlay: ${toErrorMessage(err)}`);
+      }
+    }
+  });
+  return entry as CalibrationCacheEntry;
+}
+
+/** Result of {@linkcode READ_FRAME_CHAIN_OFFSET_SCRIPT}. */
+type FrameChainOffset = {crossOrigin: true} | {crossOrigin: false; offsetX: number; offsetY: number};
+
+/**
+ * Offset of the current frame's viewport origin from the top-level page's,
+ * for converting a frame-relative coordinate into the top-level-relative
+ * space {@linkcode performCalibration} fits against.
+ */
+async function getFrameChainOffset(this: XCUITestDriver): Promise<FrameChainOffset> {
+  if (isEmpty(this.curWebFrames)) {
+    return {crossOrigin: false, offsetX: 0, offsetY: 0};
+  }
+  return await this.execute<FrameChainOffset>(READ_FRAME_CHAIN_OFFSET_SCRIPT);
+}
+
+/**
+ * Returns a cached web-to-native calibration transform if the webview's
+ * orientation/size/scroll state hasn't changed since it was fitted,
+ * otherwise transparently (re)calibrates. This is what makes calibration
+ * automatic: callers never need to notice or handle staleness themselves.
+ *
+ * @param force - Recalibrate unconditionally, ignoring any cached entry
+ */
+async function getOrCreateWebviewCalibration(this: XCUITestDriver, force = false): Promise<CalibrationData> {
+  if (!force) {
+    const signature = await computeViewportSignature.call(this);
+    if (this._webviewCalibrationCache?.signature === signature) {
+      this.log.debug(`Reusing cached web-to-native calibration for signature '${signature}'`);
+      return this._webviewCalibrationCache.data;
+    }
+  }
+
+  this.log.debug('Fitting a new web-to-native coordinates calibration');
+  // keep track of implicit wait, and set locally to 0
+  // https://github.com/appium/appium/issues/14988
+  const implicitWaitMs = this.implicitWaitMs;
+  this.setImplicitWait(0);
+  try {
+    this._webviewCalibrationCache = await performCalibration.call(this);
+  } finally {
+    this.setImplicitWait(implicitWaitMs);
+  }
+  return this._webviewCalibrationCache.data;
+}
+
+/**
+ * Attempts to tap a web element by marking it with a unique, throwaway
+ * `aria-label` and looking that up as a native accessibility id. WebKit
+ * reflects `aria-label` into the native accessibility label, so this
+ * resolves to exactly one native element with no ambiguity heuristics,
+ * including icon buttons, images, and elements with duplicate visible text.
+ *
+ * @param atomsElement - Atoms-compatible element to tap
+ * @returns True if the native tap was successful, false otherwise
+ */
+async function tapWebElementNatively(this: XCUITestDriver, atomsElement: AtomsElement): Promise<boolean> {
+  const uuid = util.uuidV4();
+  let marker: {hadAttribute: boolean; original: string | null} | null = null;
+  try {
+    marker = (await this.executeAtom('execute_script', [MARK_ELEMENT_FOR_NATIVE_TAP_SCRIPT, [atomsElement, uuid]])) as {
+      hadAttribute: boolean;
+      original: string | null;
+    } | null;
+    if (!marker) {
+      // element is genuinely inaccessible (aria-hidden, invisible, zero-size)
+      return false;
+    }
+
+    const els = (await this.findNativeElementOrElements('accessibility id', uuid, true)) as Element[];
+    if (els.length !== 1) {
+      this.log.debug(`Expected to find exactly 1 native element with accessibility id '${uuid}', found ${els.length}`);
+      return false;
+    }
+
+    const rect = (await this.proxyCommand(`/element/${util.unwrapElement(els[0])}/rect`, 'GET')) as Rect;
+    await this.mobileTap(rect.x + rect.width / 2, rect.y + rect.height / 2);
+    return true;
+  } catch (err) {
+    // any failure should fall through and trigger the more elaborate
+    // method of clicking
+    this.log.warn(`Error attempting to click: ${toErrorMessage(err)}`);
+    return false;
+  } finally {
+    if (marker) {
+      try {
+        await this.executeAtom('execute_script', [
+          RESTORE_ELEMENT_ARIA_LABEL_SCRIPT,
+          [atomsElement, marker.hadAttribute, marker.original],
+        ]);
+      } catch (err) {
+        this.log.debug(`Failed to restore the original 'aria-label' value: ${toErrorMessage(err)}`);
+      }
+    }
+  }
 }

--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -486,8 +486,7 @@ export async function waitForAtom<T = unknown>(this: XCUITestDriver, promise: Pr
         throw new Error(
           'Cannot run JavaScript inside this frame: it (or one of its ancestor frames) has a different ' +
             "origin than the top-level page. Safari's remote debugger can only execute JavaScript inside " +
-            "same-origin frames. Switch to a same-origin frame (e.g. WebdriverIO's driver.switchToFrame(null) " +
-            `for the top-level frame) instead. Original error: ${toErrorMessage(err)}`,
+            `same-origin frames. Switch to a same-origin frame instead. Original error: ${toErrorMessage(err)}`,
           {cause: err},
         );
       }

--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -19,7 +19,7 @@ const OBSTRUCTING_ALERT_PRESENCE_CHECK_INTERVAL_MS = 500;
 const ON_OBSTRUCTING_ALERT_EVENT = 'alert';
 const ON_APP_CRASH_EVENT = 'app_crash';
 
-// WebKit's wording for a cross-origin frame access failure (see setFrame/waitForAtom below).
+// WebKit's wording for a cross-origin frame access failure (see setFrame below).
 const CROSS_ORIGIN_FRAME_ERROR_PATTERN = /cross-origin frame|blocked a frame with origin/i;
 
 /**
@@ -44,26 +44,38 @@ export async function setFrame(this: XCUITestDriver, frame: number | string | nu
     return;
   }
 
-  let windowId: string;
-  if (isElementLike(frame)) {
-    const atomsElement = this.getAtomsElement(frame);
-    const value = (await this.executeAtom('get_frame_window', [atomsElement])) as {WINDOW: string};
-    windowId = value.WINDOW;
-  } else {
-    const atom: AtomName = typeof frame === 'number' ? 'frame_by_index' : 'frame_by_id_or_name';
-    const value = (await this.executeAtom(atom, [frame])) as {WINDOW?: string} | null;
-    if (value?.WINDOW === undefined) {
-      throw new errors.NoSuchFrameError();
-    }
-    windowId = value.WINDOW;
-  }
-
-  this.log.debug(`Entering new web frame: '${windowId}'`);
-  this.curWebFrames.unshift(windowId);
   try {
-    await this.executeAtom('execute_script', ['return true;', []]);
+    let windowId: string;
+    if (isElementLike(frame)) {
+      const atomsElement = this.getAtomsElement(frame);
+      const value = (await this.executeAtom('get_frame_window', [atomsElement])) as {WINDOW: string};
+      windowId = value.WINDOW;
+    } else {
+      const atom: AtomName = typeof frame === 'number' ? 'frame_by_index' : 'frame_by_id_or_name';
+      const value = (await this.executeAtom(atom, [frame])) as {WINDOW?: string} | null;
+      if (value?.WINDOW === undefined) {
+        throw new errors.NoSuchFrameError();
+      }
+      windowId = value.WINDOW;
+    }
+
+    this.log.debug(`Entering new web frame: '${windowId}'`);
+    this.curWebFrames.unshift(windowId);
+    try {
+      await this.executeAtom('execute_script', ['return true;', []]);
+    } catch (err) {
+      this.curWebFrames.shift();
+      throw err;
+    }
   } catch (err) {
-    this.curWebFrames.shift();
+    if (CROSS_ORIGIN_FRAME_ERROR_PATTERN.test(toErrorMessage(err))) {
+      throw new Error(
+        'Cannot switch into this frame: it (or one of its ancestor frames) has a different origin than ' +
+          "the top-level page. Safari's remote debugger can only execute JavaScript inside same-origin " +
+          `frames. Switch to a same-origin frame instead. Original error: ${toErrorMessage(err)}`,
+        {cause: err},
+      );
+    }
     throw err;
   }
 }
@@ -479,18 +491,7 @@ export async function waitForAtom<T = unknown>(this: XCUITestDriver, promise: Pr
       return await p;
     } catch (err) {
       this.log.debug(`Error received while executing atom: ${toErrorMessage(err)}`);
-      if (err instanceof TimeoutError) {
-        throw await generateAtomTimeoutError.bind(this)(timer);
-      }
-      if (CROSS_ORIGIN_FRAME_ERROR_PATTERN.test(toErrorMessage(err))) {
-        throw new Error(
-          'Cannot run JavaScript inside this frame: it (or one of its ancestor frames) has a different ' +
-            "origin than the top-level page. Safari's remote debugger can only execute JavaScript inside " +
-            `same-origin frames. Switch to a same-origin frame instead. Original error: ${toErrorMessage(err)}`,
-          {cause: err},
-        );
-      }
-      throw err;
+      throw err instanceof TimeoutError ? await generateAtomTimeoutError.bind(this)(timer) : err;
     }
   };
   // if the atom promise is fulfilled within ATOM_INITIAL_WAIT_MS

--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -1,6 +1,7 @@
 import {setTimeout as delay} from 'node:timers/promises';
 
 import type {Element, Cookie} from '@appium/types';
+import type {AtomName} from 'appium-remote-debugger';
 import {errors, isErrorType} from 'appium/driver.js';
 import {timing, util} from 'appium/support.js';
 
@@ -18,38 +19,21 @@ const OBSTRUCTING_ALERT_PRESENCE_CHECK_INTERVAL_MS = 500;
 const ON_OBSTRUCTING_ALERT_EVENT = 'alert';
 const ON_APP_CRASH_EVENT = 'app_crash';
 
-export const ATOM_NAMES = [
-  'active_element',
-  'clear',
-  'click',
-  'execute_async_script',
-  'execute_script',
-  'find_element_fragment',
-  'find_elements',
-  'frame_by_id_or_name',
-  'frame_by_index',
-  'get_attribute_value',
-  'get_frame_window',
-  'get_size',
-  'get_text',
-  'get_top_left_coordinates',
-  'get_value_of_css_property',
-  'is_displayed',
-  'is_enabled',
-  'is_selected',
-  'submit',
-  'type',
-] as const;
-
-export type AtomName = (typeof ATOM_NAMES)[number];
+// WebKit's wording for a cross-origin frame access failure (see setFrame/waitForAtom below).
+const CROSS_ORIGIN_FRAME_ERROR_PATTERN = /cross-origin frame|blocked a frame with origin/i;
 
 /**
  * Sets the current web frame context.
+ *
+ * A cross-origin frame can be entered but not scripted, so entering verifies
+ * the frame is actually usable and rolls back immediately if not, rather
+ * than failing later on some unrelated command.
  *
  * @param frame - Frame identifier (number, string, or null to return to default content)
  * @group Mobile Web Only
  * @throws {errors.NotImplementedError} If not in a web context
  * @throws {errors.NoSuchFrameError} If the specified frame is not found
+ * @throws {Error} If the frame (or one of its ancestors) has a different origin than the top-level page
  */
 export async function setFrame(this: XCUITestDriver, frame: number | string | null): Promise<void> {
   requireWebContext(this);
@@ -60,19 +44,27 @@ export async function setFrame(this: XCUITestDriver, frame: number | string | nu
     return;
   }
 
+  let windowId: string;
   if (isElementLike(frame)) {
     const atomsElement = this.getAtomsElement(frame);
     const value = (await this.executeAtom('get_frame_window', [atomsElement])) as {WINDOW: string};
-    this.log.debug(`Entering new web frame: '${value.WINDOW}'`);
-    this.curWebFrames.unshift(value.WINDOW);
+    windowId = value.WINDOW;
   } else {
     const atom: AtomName = typeof frame === 'number' ? 'frame_by_index' : 'frame_by_id_or_name';
     const value = (await this.executeAtom(atom, [frame])) as {WINDOW?: string} | null;
     if (value?.WINDOW === undefined) {
       throw new errors.NoSuchFrameError();
     }
-    this.log.debug(`Entering new web frame: '${value.WINDOW}'`);
-    this.curWebFrames.unshift(value.WINDOW);
+    windowId = value.WINDOW;
+  }
+
+  this.log.debug(`Entering new web frame: '${windowId}'`);
+  this.curWebFrames.unshift(windowId);
+  try {
+    await this.executeAtom('execute_script', ['return true;', []]);
+  } catch (err) {
+    this.curWebFrames.shift();
+    throw err;
   }
 }
 
@@ -130,7 +122,7 @@ export async function refresh(this: XCUITestDriver): Promise<void> {
 export async function getUrl(this: XCUITestDriver): Promise<string> {
   requireWebContext(this);
 
-  return (await this.remote.execute('window.location.href')) as string;
+  return await this.remote.execute<string>('window.location.href');
 }
 
 /**
@@ -142,7 +134,7 @@ export async function getUrl(this: XCUITestDriver): Promise<string> {
 export async function title(this: XCUITestDriver): Promise<string> {
   requireWebContext(this);
 
-  return (await this.remote.execute('window.document.title')) as string;
+  return await this.remote.execute<string>('window.document.title');
 }
 
 /**
@@ -487,7 +479,19 @@ export async function waitForAtom<T = unknown>(this: XCUITestDriver, promise: Pr
       return await p;
     } catch (err) {
       this.log.debug(`Error received while executing atom: ${toErrorMessage(err)}`);
-      throw err instanceof TimeoutError ? await generateAtomTimeoutError.bind(this)(timer) : err;
+      if (err instanceof TimeoutError) {
+        throw await generateAtomTimeoutError.bind(this)(timer);
+      }
+      if (CROSS_ORIGIN_FRAME_ERROR_PATTERN.test(toErrorMessage(err))) {
+        throw new Error(
+          'Cannot run JavaScript inside this frame: it (or one of its ancestor frames) has a different ' +
+            "origin than the top-level page. Safari's remote debugger can only execute JavaScript inside " +
+            "same-origin frames. Switch to a same-origin frame (e.g. WebdriverIO's driver.switchToFrame(null) " +
+            `for the top-level frame) instead. Original error: ${toErrorMessage(err)}`,
+          {cause: err},
+        );
+      }
+      throw err;
     }
   };
   // if the atom promise is fulfilled within ATOM_INITIAL_WAIT_MS

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@colors/colors": "^1.6.0",
     "appium-ios-device": "^3.1.12",
     "appium-ios-simulator": "^9.0.0",
-    "appium-remote-debugger": "^17.0.6",
+    "appium-remote-debugger": "^17.1.0",
     "appium-webdriveragent": "^16.1.4",
     "appium-xcode": "^7.0.0",
     "async-lock": "^1.4.0",

--- a/test/fixtures/guinea-pig/test/iframe-wrap-cross-origin.html
+++ b/test/fixtures/guinea-pig/test/iframe-wrap-cross-origin.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Cross-origin iframe wrap guinea pig</title>
+</head>
+<body>
+  <h1>I wrap a cross-origin page in an iframe</h1>
+  <iframe id="id-cross-origin" name="crossorigin" src="<%= crossOriginBaseUrl %>/test/guinea-pig" width="800" height="900"></iframe>
+</body>
+</html>

--- a/test/fixtures/guinea-pig/test/iframe-wrap-nested.html
+++ b/test/fixtures/guinea-pig/test/iframe-wrap-nested.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Nested iframe wrap guinea pig</title>
+</head>
+<body>
+  <h1>I wrap the iframe-wrapping page in another iframe</h1>
+  <iframe id="id-outer-wrap" name="outerwrap" src="/test/iframe-wrap.html" width="850" height="950"></iframe>
+</body>
+</html>

--- a/test/fixtures/guinea-pig/test/iframe-wrap.html
+++ b/test/fixtures/guinea-pig/test/iframe-wrap.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Iframe wrap guinea pig</title>
+</head>
+<body>
+  <h1>I wrap a guinea pig page in an iframe</h1>
+  <iframe id="id-wrapped" name="wrapped" src="/test/guinea-pig" width="800" height="900"></iframe>
+</body>
+</html>

--- a/test/functional/helpers/guinea-pig/index.ts
+++ b/test/functional/helpers/guinea-pig/index.ts
@@ -29,6 +29,21 @@ export function guineaPigIframePage(baseUrl: string): string {
   return buildGuineaPigUrl(baseUrl, '/test/iframes.html');
 }
 
+// Wraps the standard guinea pig page in a same-origin iframe.
+export function guineaPigIframeWrapPage(baseUrl: string): string {
+  return buildGuineaPigUrl(baseUrl, '/test/iframe-wrap.html');
+}
+
+// Same as guineaPigIframeWrapPage, nested one level deeper.
+export function guineaPigNestedIframeWrapPage(baseUrl: string): string {
+  return buildGuineaPigUrl(baseUrl, '/test/iframe-wrap-nested.html');
+}
+
+// Wraps the standard guinea pig page, served from crossOriginBaseUrl, in an iframe.
+export function guineaPigCrossOriginIframeWrapPage(baseUrl: string, crossOriginBaseUrl: string): string {
+  return `${buildGuineaPigUrl(baseUrl, '/test/iframe-wrap-cross-origin')}?crossOriginBaseUrl=${encodeURIComponent(crossOriginBaseUrl)}`;
+}
+
 export function createGuineaPigServerSession(): GuineaPigServerSession {
   let server: GuineaPigServer | undefined;
 

--- a/test/functional/helpers/guinea-pig/server.ts
+++ b/test/functional/helpers/guinea-pig/server.ts
@@ -14,6 +14,7 @@ const DYNAMIC_ROUTES: Record<string, string> = {
   '/test/guinea-pig': 'guinea-pig.html',
   '/test/guinea-pig-scrollable': 'guinea-pig-scrollable.html',
   '/test/guinea-pig-app-banner': 'guinea-pig-app-banner.html',
+  '/test/iframe-wrap-cross-origin': 'iframe-wrap-cross-origin.html',
 };
 
 const MIME_TYPES: Record<string, string> = {
@@ -118,6 +119,7 @@ async function handleGuineaPigTemplate(
     serverTime: new Date(),
     userAgent: req.headers['user-agent'],
     comment: 'None',
+    crossOriginBaseUrl: url.searchParams.get('crossOriginBaseUrl') ?? '',
   };
 
   if (req.method === 'POST') {

--- a/test/functional/web/helpers/index.ts
+++ b/test/functional/web/helpers/index.ts
@@ -6,6 +6,9 @@ export {
   guineaPigAppBannerPage,
   guineaPigFramePage,
   guineaPigIframePage,
+  guineaPigIframeWrapPage,
+  guineaPigNestedIframeWrapPage,
+  guineaPigCrossOriginIframeWrapPage,
 } from '../../helpers/guinea-pig/index.js';
 export {newCookie, oldCookie1, oldCookie2, doesIncludeCookie, doesNotIncludeCookie} from './cookies.js';
 export {spinTitle, spinBodyIncludes, spinTitleEquals, spinWait, resetWindows, openPage} from './page.js';

--- a/test/functional/web/native-web-tap-e2e.spec.ts
+++ b/test/functional/web/native-web-tap-e2e.spec.ts
@@ -9,6 +9,9 @@ import {initSession, deleteSession} from '../helpers/session.js';
 import {
   createGuineaPigServerSession,
   guineaPigAppBannerPage,
+  guineaPigCrossOriginIframeWrapPage,
+  guineaPigIframeWrapPage,
+  guineaPigNestedIframeWrapPage,
   guineaPigPage,
   guineaPigScrollablePage,
   openPage,
@@ -181,6 +184,64 @@ describe('native web tap -', function () {
           await spinTitleEquals(driver, PAGE_3_TITLE, SPIN_RETRIES);
         } finally {
           await driver.setOrientation('PORTRAIT');
+        }
+      });
+    });
+
+    // nativeWebTapStrict forces the coordinate-translation path, which is what
+    // needs to account for a sub-frame's offset; plain nativeWebTap doesn't.
+    describe('nativeWebTapStrict - frames -', function () {
+      let driver: Browser;
+
+      before(async function () {
+        driver = await initSafariDriver({'appium:nativeWebTapStrict': true});
+      });
+
+      after(async function () {
+        await deleteSession();
+      });
+
+      it('should be able to tap on an element inside a same-origin iframe', async function () {
+        await loadPage(driver, guineaPigIframeWrapPage(baseUrl));
+        await driver.switchToFrame(await driver.$('#id-wrapped'));
+
+        await driver.$(`=${PAGE_3_LINK}`).click();
+
+        // The click navigates the iframe itself, which can detach it and reset
+        // curWebFrames - read the new title from the top level instead of
+        // assuming the driver is still switched into the (now-stale) frame.
+        await driver.switchToFrame(null);
+        await retryInterval(SPIN_RETRIES, 500, async function () {
+          const title = await driver.execute("return document.getElementById('id-wrapped').contentDocument.title;");
+          assert.strictEqual(title, PAGE_3_TITLE);
+        });
+      });
+
+      it('should be able to tap on an element inside a nested same-origin iframe', async function () {
+        await loadPage(driver, guineaPigNestedIframeWrapPage(baseUrl));
+        await driver.switchToFrame(await driver.$('#id-outer-wrap'));
+        await driver.switchToFrame(await driver.$('#id-wrapped'));
+
+        await driver.$(`=${PAGE_3_LINK}`).click();
+
+        await driver.switchToFrame(null);
+        await retryInterval(SPIN_RETRIES, 500, async function () {
+          const title = await driver.execute(
+            "return document.getElementById('id-outer-wrap').contentDocument.getElementById('id-wrapped').contentDocument.title;",
+          );
+          assert.strictEqual(title, PAGE_3_TITLE);
+        });
+      });
+
+      it('should fail with a clear error when switching into a cross-origin iframe', async function () {
+        const crossOriginServer = createGuineaPigServerSession();
+        try {
+          const crossOriginBaseUrl = (await crossOriginServer.setup()).baseUrl;
+          await loadPage(driver, guineaPigCrossOriginIframeWrapPage(baseUrl, crossOriginBaseUrl));
+
+          await assert.rejects(driver.switchToFrame(await driver.$('#id-cross-origin')), /different origin/);
+        } finally {
+          await crossOriginServer.teardown();
         }
       });
     });

--- a/test/unit/commands/web.spec.ts
+++ b/test/unit/commands/web.spec.ts
@@ -166,18 +166,4 @@ describe('web commands', function () {
       assert.notStrictEqual(viewportSignature(BASE_STATE), viewportSignature({...BASE_STATE, visualViewportScale: 2}));
     });
   });
-
-  describe('mobileCalibrateWebToRealCoordinatesTranslation', function () {
-    afterEach(function () {
-      driver.curContext = null;
-      driver.curWebFrames = [];
-    });
-
-    it('should reject calibration while switched into a sub-frame', async function () {
-      driver.curContext = 'WEBVIEW_1';
-      driver.curWebFrames = ['frame1'];
-
-      await assert.rejects(driver.mobileCalibrateWebToRealCoordinatesTranslation(), /switched into a sub-frame/);
-    });
-  });
 });


### PR DESCRIPTION
Calibration now always fits against the top-level page (via this.remote.execute, bypassing curWebFrames) instead of refusing to run inside a sub-frame. translateWebCoords adds the current frame's offset within the top-level page before applying the fitted transform, so native web tap works for elements inside (nested) same-origin iframes.

Safari's remote debugger can only script same-origin frames; switching into or running JavaScript inside a cross-origin frame now fails with a clear, actionable error instead of a raw WebKit SecurityError message.

Also bumps appium-remote-debugger to ^17.1.0 and drops the driver's own duplicated ATOM_NAMES/AtomName in favor of the package's export.