### PR TITLE
feat: wire watchOS support into the TS driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 
 ---
 
-This is an Appium driver for automating native and hybrid applications on iOS, iPadOS, and tvOS.
+This is an Appium driver for automating native and hybrid applications on iOS, iPadOS, tvOS, and
+watchOS (Simulator only).
 
 > [!IMPORTANT]
 > Since major version *10.0.0*, this driver is only compatible with Appium 3.

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -17,12 +17,6 @@ to help identify your target Xcode, macOS, driver and Appium server versions.
 
 !!! note
 
-    watchOS Simulator SDKs ship alongside the same Xcode releases as iOS/iPadOS/tvOS, so the same
-    Xcode/macOS compatibility tables below apply to watchOS. See [watchOS Automation](../guides/watchos.md)
-    for details - only the Simulator is supported, real watchOS devices are not.
-
-!!! note
-
     This document only lists compatibility information starting from iOS/tvOS 9.3 and Xcode 11, as
     these were the minimum supported versions in XCUITest driver 4.0.0, which was the first
     version supporting Appium 2. For iOS/tvOS/Xcode support in driver versions older than 4.0.0

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -17,6 +17,12 @@ to help identify your target Xcode, macOS, driver and Appium server versions.
 
 !!! note
 
+    watchOS Simulator SDKs ship alongside the same Xcode releases as iOS/iPadOS/tvOS, so the same
+    Xcode/macOS compatibility tables below apply to watchOS. See [watchOS Automation](../guides/watchos.md)
+    for details - only the Simulator is supported, real watchOS devices are not.
+
+!!! note
+
     This document only lists compatibility information starting from iOS/tvOS 9.3 and Xcode 11, as
     these were the minimum supported versions in XCUITest driver 4.0.0, which was the first
     version supporting Appium 2. For iOS/tvOS/Xcode support in driver versions older than 4.0.0

--- a/docs/guides/watchos.md
+++ b/docs/guides/watchos.md
@@ -1,0 +1,48 @@
+---
+title: watchOS Automation
+---
+
+The XCUITest driver supports automation of the watchOS platform. **Only the Simulator is
+supported** - there is no viable real-device WDA distribution/testing story for watchOS, so
+sessions requesting a real watchOS device will fail.
+
+All watchOS sessions must set their `platformName` capability to `watchOS` (instead of `iOS`).
+
+## Simulator Setup
+
+Apart from installing the simulator itself, no additional configuration is needed - you can start a
+session right away. Make sure to provide the simulator's `deviceName` and `platformVersion`:
+
+```json
+{
+    "platformName": "watchOS",
+    "appium:automationName": "XCUITest",
+    "appium:deviceName": "<apple-watch-simulator-name>",
+    "appium:platformVersion": "<watchos-version>",
+    ...
+}
+```
+
+## Session Actions
+
+Unlike tvOS, watchOS apps are automated the same way as regular iOS/iPadOS apps - the standard
+`findElement`/`click` methods and other native element interactions work as usual.
+
+Hardware button presses are available through the [`mobile: pressButton`](../reference/execute-methods.md#mobile-pressbutton)
+extension. watchOS only exposes the `home` button (and `action`, on models/OS versions that have a
+hardware Action button).
+
+## Known Limitations
+
+* Only the Simulator is supported; real watchOS devices cannot be used as automation targets
+* Gesture commands do not work
+* WebDriverAgent itself exposes Digital Crown rotation (`/wda/rotateDigitalCrown`) and hand gesture
+  (`/wda/performHandGesture`) endpoints for watchOS, but the XCUITest driver does not yet expose
+  corresponding `mobile:` commands for them
+
+## Related Tickets
+
+* <https://github.com/appium/WebDriverAgent/pull/1209>
+* <https://github.com/appium/WebDriverAgent/pull/1215>
+* <https://github.com/appium/WebDriverAgent/pull/1216>
+* <https://github.com/appium/WebDriverAgent/pull/1217>

--- a/docs/guides/watchos.md
+++ b/docs/guides/watchos.md
@@ -46,3 +46,4 @@ hardware Action button).
 * <https://github.com/appium/WebDriverAgent/pull/1215>
 * <https://github.com/appium/WebDriverAgent/pull/1216>
 * <https://github.com/appium/WebDriverAgent/pull/1217>
+* <https://github.com/appium/appium-xcuitest-driver/pull/2952>

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ title: Welcome
 </div>
 
 Welcome to the Appium XCUITest Driver documentation! The XCUITest driver is a test automation
-framework for iOS, iPadOS and tvOS devices, enabling automated black-box testing of native, hybrid
-and WebKit web apps, on both emulators and real devices. 
+framework for iOS, iPadOS, tvOS and watchOS devices, enabling automated black-box testing of
+native, hybrid and WebKit web apps, on both emulators and real devices (watchOS: Simulator only). 
 
 The XCUITest driver is part of the Appium test automation tool. For information on Appium itself,
 please visit [the Appium documentation](https://appium.io).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,7 @@ The driver supports the following Apple platforms as automation targets:
 |iOS|:white_check_mark:|:white_check_mark:|
 |iPadOS|:white_check_mark:|:white_check_mark:|
 |tvOS|:white_check_mark:|:white_check_mark:|
-|watchOS|:x:|:x:|
+|watchOS|:white_check_mark:|:x: [^watchos]|
 |visionOS|:x:|:x:|
 |macOS|N/A|:x: [^macos]|
 |Safari (mobile)|:white_check_mark: [^safari-mob]|:white_check_mark: [^safari-mob]|
@@ -133,5 +133,6 @@ flowchart TD
 - This driver to simulators: host-simulator communication uses `xcrun simctl` (plus related CoreSimulator tooling).
 
 [^macos]: Supported by the [Appium Mac2 driver](https://github.com/appium/appium-mac2-driver)
+[^watchos]: There is no viable real-device WDA distribution/testing story for watchOS, so only the Simulator is supported. See [watchOS Automation](./guides/watchos.md).
 [^safari-mob]: Also supported by the [Appium Safari driver](https://github.com/appium/appium-safari-driver)
 [^safari-desktop]: Supported by the [Appium Safari driver](https://github.com/appium/appium-safari-driver)

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -580,6 +580,11 @@ The following values are supported on iOS:
 * `action` (Xcode 15+, iOS 16+ supported devices only)
 * `camera` (Xcode 16+, iOS 16+ supported real devices only)
 
+The following values are supported on watchOS (Simulator only):
+
+* `home`
+* `action` (Xcode 15+, watchOS 9+ supported devices only)
+
 The following values are supported on tvOS:
 
 * `home`

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -136,13 +136,6 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
     appium driver run xcuitest download-wda -- --platform=tvos --outdir=/path/to/dir --kind=sim
     ```
 
-- Download the watchOS simulator version of the WDA app (`WebDriverAgentRunner_watchOS-Runner.app`)
-  into `/path/to/dir`:
-
-    ```
-    appium driver run xcuitest download-wda -- --platform=watchos --outdir=/path/to/dir --kind=sim
-    ```
-
 
 ### `download-wda-sim`
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -111,8 +111,8 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 |<div style="width:6em">Argument</div>|Description|Type|Default|
 |--|--|--|--|
 |`--outdir`|Target directory where the WDA app should be downloaded. The directory must not exist. Relative paths are resolved starting from the XCUITest driver install directory.|string| - |
-|`--platform`|Target platform of the WDA app. Supported values are `ios` and `tvos` (case-insensitive)|string| - |
-|`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`.|string|`real`|
+|`--platform`|Target platform of the WDA app. Supported values are `ios`, `tvos` and `watchos` (case-insensitive)|string| - |
+|`--kind`|Kind of the WDA app to download. Supported values are `real` and `sim`. Note that watchOS only supports `sim`, since real watchOS device testing is not supported.|string|`real`|
 
 ##### Optional Arguments
 
@@ -134,6 +134,13 @@ appium driver run xcuitest download-wda -- --outdir=<outdir> --platform=<platfor
 
     ```
     appium driver run xcuitest download-wda -- --platform=tvos --outdir=/path/to/dir --kind=sim
+    ```
+
+- Download the watchOS simulator version of the WDA app (`WebDriverAgentRunner_watchOS-Runner.app`)
+  into `/path/to/dir`:
+
+    ```
+    appium driver run xcuitest download-wda -- --platform=watchos --outdir=/path/to/dir --kind=sim
     ```
 
 

--- a/lib/commands/helpers/app.ts
+++ b/lib/commands/helpers/app.ts
@@ -23,7 +23,7 @@ import {installToRealDevice, type RealDevice} from '../../device/real-device-man
 import {installToSimulator} from '../../device/simulator-management.js';
 import type {XCUITestDriver} from '../../driver.js';
 import {log} from '../../logger.js';
-import {isEmpty, isPlainObject, isTvOs} from '../../utils/index.js';
+import {isEmpty, isPlainObject, isTvOs, isWatchOs} from '../../utils/index.js';
 import {APP_EXT, IPA_EXT, SUPPORTED_EXTENSIONS} from '../constants.js';
 import type {AutInstallationState, AutInstallationStateOptions} from '../types.js';
 
@@ -371,6 +371,17 @@ export async function onPostConfigureApp(
 }
 
 // Private functions
+/** @returns The `CFBundleSupportedPlatforms` prefix (e.g. `AppleTVSimulator`/`AppleTVOS`) for the given platform. */
+function getBundlePlatformPrefix(platformName: string | null | undefined): string {
+  if (isTvOs(platformName)) {
+    return 'AppleTV';
+  }
+  if (isWatchOs(platformName)) {
+    return 'Watch';
+  }
+  return 'iPhone';
+}
+
 /**
  * Verify whether the given application is compatible to the
  * platform where it is going to be installed and tested.
@@ -385,8 +396,7 @@ async function verifyApplicationPlatform(driver: XCUITestDriver): Promise<void> 
   }
 
   const supportedPlatforms = await driver.appInfosCache.extractAppPlatforms(driver.opts.app);
-  const isTvOS = isTvOs(driver.opts.platformName);
-  const prefix = isTvOS ? 'AppleTV' : 'iPhone';
+  const prefix = getBundlePlatformPrefix(driver.opts.platformName);
   const suffix = driver.isSimulator() ? 'Simulator' : 'OS';
   const dstPlatform = `${prefix}${suffix}`;
   if (!supportedPlatforms.includes(dstPlatform)) {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,3 +3,4 @@ export const UDID_AUTO = 'auto';
 /** Valid values for the `platformName` capability (also used in simulator names). */
 export const PLATFORM_NAME_IOS = 'iOS';
 export const PLATFORM_NAME_TVOS = 'tvOS';
+export const PLATFORM_NAME_WATCHOS = 'watchOS';

--- a/lib/desired-caps.ts
+++ b/lib/desired-caps.ts
@@ -1,13 +1,13 @@
 import type {Constraints} from '@appium/types';
 
-import {PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS} from './constants.js';
+import {PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS, PLATFORM_NAME_WATCHOS} from './constants.js';
 
 export const desiredCapConstraints = {
   platformName: {
     // override
     presence: true,
     isString: true,
-    inclusionCaseInsensitive: [PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS],
+    inclusionCaseInsensitive: [PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS, PLATFORM_NAME_WATCHOS],
   },
   browserName: {
     isString: true,

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -123,7 +123,7 @@ import {executeMethodMap} from './execute-method-map.js';
 import {newMethodMap} from './method-map.js';
 import {sessionClaimHandler} from './session-claim-handler.js';
 import type {CalibrationCacheEntry, IConditionInducer, LifecycleData} from './types.js';
-import {isEmpty, isPlainObject, memoize, normalizePlatformVersion} from './utils/index.js';
+import {isEmpty, isPlainObject, isWatchOs, memoize, normalizePlatformVersion} from './utils/index.js';
 
 const defaultServerCaps = {
   webStorageEnabled: false,
@@ -1265,6 +1265,13 @@ export class XCUITestDriver
     this.log.info(`Determining device to run tests on: udid: '${udid}', real device: ${realDevice}`);
     this._device = device;
     this.opts.udid = udid;
+
+    if (realDevice && isWatchOs(this.opts.platformName)) {
+      throw new Error(
+        'Real watchOS device testing is not supported; watchOS is only available via the Simulator. ' +
+          'Make sure the requested deviceName/platformVersion match an existing watchOS Simulator.',
+      );
+    }
 
     await sessionClaimHandler.registerActiveSession(this);
     await sessionClaimHandler.claimSessionUdid(this);

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -18,6 +18,7 @@ export {
   isIos27OrNewer,
   isIos27OrNewerPlatform,
   isTvOs,
+  isWatchOs,
   normalizePlatformName,
   normalizePlatformVersion,
 } from './platform.js';

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -1,7 +1,7 @@
 import {util} from 'appium/support.js';
 import * as semver from 'semver';
 
-import {PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS} from '../constants.js';
+import {PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS, PLATFORM_NAME_WATCHOS} from '../constants.js';
 
 export interface PlatformVersionOpts {
   platformVersion?: string | null;
@@ -12,9 +12,20 @@ export function isTvOs(platformName: string | null | undefined): boolean {
   return String(platformName ?? '').toLowerCase() === PLATFORM_NAME_TVOS.toLowerCase();
 }
 
+/** Check if platform name is the watchOS one. */
+export function isWatchOs(platformName: string | null | undefined): boolean {
+  return String(platformName ?? '').toLowerCase() === PLATFORM_NAME_WATCHOS.toLowerCase();
+}
+
 /** Return normalized platform name. */
 export function normalizePlatformName(platformName: string | null | undefined): string {
-  return isTvOs(platformName) ? PLATFORM_NAME_TVOS : PLATFORM_NAME_IOS;
+  if (isTvOs(platformName)) {
+    return PLATFORM_NAME_TVOS;
+  }
+  if (isWatchOs(platformName)) {
+    return PLATFORM_NAME_WATCHOS;
+  }
+  return PLATFORM_NAME_IOS;
 }
 
 /** Normalizes platformVersion to a valid iOS version string. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - guides/gestures.md
       - Other:
           - guides/tvos.md
+          - guides/watchos.md
           - guides/non-macos-hosts.md
           - guides/input-events.md
   - Troubleshooting:

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "e2e-test:parallel": "node --enable-source-maps scripts/ci/run-e2e-tests.mjs \"./build/test/functional/parallel/**/*.spec.js\"",
     "e2e-test:web": "node --enable-source-maps scripts/ci/run-e2e-tests.mjs \"./build/test/functional/web/**/*.spec.js\"",
     "e2e-test:native-web-tap": "node --enable-source-maps scripts/ci/run-e2e-tests.mjs \"./build/test/functional/web/native-web-tap*.spec.js\"",
+    "e2e-test:tv": "node --enable-source-maps scripts/ci/run-e2e-tests.mjs \"./build/test/functional/tv/**/*.spec.js\"",
+    "e2e-test:watch": "node --enable-source-maps scripts/ci/run-e2e-tests.mjs \"./build/test/functional/watch/**/*.spec.js\"",
     "start": "appium --relaxed-security --port 4567 --keep-alive-timeout 1200"
   },
   "dependencies": {
@@ -75,7 +77,7 @@
     "appium-ios-device": "^3.1.12",
     "appium-ios-simulator": "^9.0.0",
     "appium-remote-debugger": "^17.1.0",
-    "appium-webdriveragent": "^16.1.4",
+    "appium-webdriveragent": "^16.5.0",
     "appium-xcode": "^7.0.0",
     "async-lock": "^1.4.0",
     "asyncbox": "^6.3.0",
@@ -125,7 +127,8 @@
     "automationName": "XCUITest",
     "platformNames": [
       "iOS",
-      "tvOS"
+      "tvOS",
+      "watchOS"
     ],
     "mainClass": "XCUITestDriver",
     "scripts": {

--- a/scripts/download-wda.mjs
+++ b/scripts/download-wda.mjs
@@ -40,8 +40,11 @@ export async function getWDAPrebuiltPackage(options) {
   }
 }
 
+/** @type {Record<string, string>} */
+const PLATFORM_SCHEME_SUFFIXES = {tvos: '_tvOS', watchos: '_watchOS'};
+
 const destZip = (/** @type {string} */ platform, /** @type {WDAKind} */ kind) => {
-  const scheme = `WebDriverAgentRunner${String(platform).toLowerCase() === 'tvos' ? '_tvOS' : ''}`;
+  const scheme = `WebDriverAgentRunner${PLATFORM_SCHEME_SUFFIXES[String(platform).toLowerCase()] ?? ''}`;
   if (kind === WDA_KIND_SIM) {
     return `${scheme}-Build-Sim-${os.arch() === 'arm64' ? 'arm64' : 'x86_64'}.zip`;
   }
@@ -114,9 +117,9 @@ async function main() {
 
   program
     .name('appium driver run xcuitest download-wda')
-    .description('Download a prebuilt WebDriverAgentRunner for iOS/tvOS real devices or simulators')
+    .description('Download a prebuilt WebDriverAgentRunner for iOS/tvOS/watchOS real devices or simulators')
     .requiredOption('--outdir <path>', 'Destination directory to download and unpack into')
-    .requiredOption('--platform <platform>', 'Target platform (e.g. iOS or tvOS)', (value) => value)
+    .requiredOption('--platform <platform>', 'Target platform (e.g. iOS, tvOS or watchOS)', (value) => value)
     .option(
       '--kind <kind>',
       `Target package type: ${WDA_KIND_REAL} (real devices) or ${WDA_KIND_SIM} (simulators). Default: ${WDA_KIND_REAL}`,
@@ -129,7 +132,10 @@ EXAMPLES:
   appium driver run xcuitest download-wda -- --outdir ./wda-real --platform iOS
 
   # Download WDA for tvOS simulator
-  appium driver run xcuitest download-wda -- --outdir ./wda-sim-tvos --platform tvOS --kind sim`,
+  appium driver run xcuitest download-wda -- --outdir ./wda-sim-tvos --platform tvOS --kind sim
+
+  # Download WDA for watchOS simulator (watchOS only supports the Simulator, not real devices)
+  appium driver run xcuitest download-wda -- --outdir ./wda-sim-watchos --platform watchOS --kind sim`,
     )
     .action(async (options) => {
       await getWDAPrebuiltPackage({

--- a/test/functional/desired.ts
+++ b/test/functional/desired.ts
@@ -109,3 +109,9 @@ export const TVOS_CAPS = amendCapabilities(GENERIC_CAPS, {
   'appium:bundleId': 'com.apple.TVSettings',
   'appium:deviceName': 'Apple TV',
 });
+
+export const WATCHOS_CAPS = amendCapabilities(GENERIC_CAPS, {
+  platformName: 'watchOS',
+  'appium:bundleId': 'com.apple.NanoSettings',
+  'appium:deviceName': 'Apple Watch Series 11 (46mm)',
+});

--- a/test/functional/watch/watchos-e2e.spec.ts
+++ b/test/functional/watch/watchos-e2e.spec.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
+
+import {getSimulator} from 'appium-ios-simulator';
+import {Simctl} from 'node-simctl';
+
+import {WATCHOS_CAPS, extractCapabilityValue} from '../desired.js';
+import {initSession, deleteSession} from '../helpers/session.js';
+import {cleanupSimulator} from '../helpers/simulator.js';
+
+const SIM_DEVICE_NAME = 'xcuitestDriverTest';
+
+const simctl = new Simctl();
+
+describe('watchOS', function () {
+  let baseCaps: Record<string, any>;
+  let udid: string;
+
+  before(async function () {
+    udid = await simctl.createDevice(
+      SIM_DEVICE_NAME,
+      extractCapabilityValue(WATCHOS_CAPS, 'appium:deviceName'),
+      extractCapabilityValue(WATCHOS_CAPS, 'appium:platformVersion'),
+      {platform: extractCapabilityValue(WATCHOS_CAPS, 'platformName')},
+    );
+  });
+
+  after(async function () {
+    if (udid) {
+      const sim = await getSimulator(udid, {
+        platform: extractCapabilityValue(WATCHOS_CAPS, 'platformName'),
+        checkExistence: false,
+      });
+      await cleanupSimulator(sim);
+    }
+  });
+
+  beforeEach(function () {
+    baseCaps = {...WATCHOS_CAPS, udid};
+  });
+
+  afterEach(async function () {
+    await deleteSession();
+  });
+
+  it('should launch com.apple.NanoSettings', async function () {
+    baseCaps.autoLaunch = true;
+    const driver = await initSession(baseCaps);
+    assert.ok(await driver.$('~General'));
+  });
+
+  it('should launch com.apple.NanoSettings with autoLaunch false', async function () {
+    baseCaps.autoLaunch = false;
+    const driver = await initSession(baseCaps);
+    await driver.execute('mobile: activateApp', {bundleId: 'com.apple.NanoSettings'});
+    assert.ok(await driver.$('~General'));
+  });
+});

--- a/test/unit/driver.spec.ts
+++ b/test/unit/driver.spec.ts
@@ -381,6 +381,24 @@ describe('XCUITestDriver', function () {
         assert.strictEqual(spy.notCalled, true);
       });
 
+      it(
+        'should reject watchOS sessions that resolved to a real device',
+        {timeout: UNIT_LONG_TIMEOUT_MS},
+        async function () {
+          realDevice = {} as any;
+          await assert.rejects(
+            driver.createSession(
+              null as any,
+              null as any,
+              mergeDeep({}, structuredClone(caps), {
+                alwaysMatch: {platformName: 'watchOS'},
+              }) as any,
+            ),
+            /Real watchOS device testing is not supported/,
+          );
+        },
+      );
+
       it('should throw an error if mjpegServerPort is occupied', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
         delete device.simctl;
         device.devicectl = true;


### PR DESCRIPTION
## Summary

Wires watchOS through the TS driver as a third platform alongside iOS/tvOS, now that `appium-webdriveragent@16.5.0` ships watchOS support end-to-end.

## Changes

- Platform plumbing: `PLATFORM_NAME_WATCHOS`, `isWatchOs()`, and a fix to `normalizePlatformName()` (previously collapsed any non-tvOS platform to `'iOS'`). `watchOS` is now an accepted `platformName` value.
- App bundle-platform verification recognizes the `Watch{Simulator,OS}` prefix used by watchOS bundles.
- `download-wda` script and its docs support `--platform watchOS`.
- Sessions that resolve to a real watchOS device (e.g. no Simulator matched) are rejected immediately in `determineDevice()`, before any real-device-specific setup runs - not just deep inside WDA launch.
- New `test/functional/watch/watchos-e2e.spec.ts` + `"e2e-test:watch"` npm script, verified against a real watchOS Simulator. Also added the missing `"e2e-test:tv"` script.
- New `docs/guides/watchos.md`, plus updates to the platform support matrix, README/index scope statements, and `mobile: pressButton`'s documented values.

## Not included

- `mobile: rotateDigitalCrown` / `mobile: performHandGesture` commands (WDA exposes the routes; driver-side commands are a follow-up).
- CI matrix wiring for watchOS (the existing tvOS matrix entries are themselves dead/unused today - out of scope here).
