### PR TITLE
feat: add mobile: rotateDigitalCrown and mobile: performHandGesture for watchOS

### DIFF
--- a/docs/guides/watchos.md
+++ b/docs/guides/watchos.md
@@ -32,13 +32,16 @@ Hardware button presses are available through the [`mobile: pressButton`](../ref
 extension. watchOS only exposes the `home` button (and `action`, on models/OS versions that have a
 hardware Action button).
 
+Digital Crown rotation and hand gestures are available through the
+[`mobile: rotateDigitalCrown`](../reference/execute-methods.md#mobile-rotatedigitalcrown) and
+[`mobile: performHandGesture`](../reference/execute-methods.md#mobile-performhandgesture) extensions.
+
 ## Known Limitations
 
 * Only the Simulator is supported; real watchOS devices cannot be used as automation targets
-* Gesture commands do not work
-* WebDriverAgent itself exposes Digital Crown rotation (`/wda/rotateDigitalCrown`) and hand gesture
-  (`/wda/performHandGesture`) endpoints for watchOS, but the XCUITest driver does not yet expose
-  corresponding `mobile:` commands for them
+* Standard W3C gesture/touch actions (e.g. tap/swipe via the Actions API) do not work; use
+  [`mobile: performHandGesture`](../reference/execute-methods.md#mobile-performhandgesture) instead
+* The `flick` hand gesture requires watchOS 26+; only `doubleTap` is universally supported
 
 ## Related Tickets
 

--- a/docs/guides/watchos.md
+++ b/docs/guides/watchos.md
@@ -39,9 +39,7 @@ Digital Crown rotation and hand gestures are available through the
 ## Known Limitations
 
 * Only the Simulator is supported; real watchOS devices cannot be used as automation targets
-* Standard W3C gesture/touch actions (e.g. tap/swipe via the Actions API) do not work; use
-  [`mobile: performHandGesture`](../reference/execute-methods.md#mobile-performhandgesture) instead
-* The `flick` hand gesture requires watchOS 26+; only `doubleTap` is universally supported
+* Standard W3C gesture/touch actions (e.g. tap/swipe via the Actions API) do not work
 
 ## Related Tickets
 

--- a/docs/reference/execute-methods.md
+++ b/docs/reference/execute-methods.md
@@ -609,6 +609,34 @@ Name | Type | Required | Description | Example
 name | string | yes | The name of the button to be pressed. Must match one of the values listed above (case-insensitive)  | `home`
 durationSeconds | number | no | (tvOS only) Duration to keep the button pressed for, in float seconds | 10
 
+### mobile: rotateDigitalCrown
+
+Rotates the Digital Crown on a watchOS Simulator. Only supported on watchOS. Wraps
+[`rotateDigitalCrown(delta:velocity:)`](https://developer.apple.com/documentation/xcuiautomation/xcuidevice/rotatedigitalcrown(delta:velocity:)).
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+delta | number | yes | The number of full crown rotations, e.g. `1.0` is one complete turn. The sign gives the direction: positive rotates up/clockwise, negative rotates down/counterclockwise | `0.2`
+velocity | number | no | The rotation speed, in rotations per second. If not provided, XCTest's own default velocity is used | `1.0`
+
+### mobile: performHandGesture
+
+Performs a hand gesture on a watchOS Simulator. Only supported on watchOS. Wraps
+[`perform(handGesture:)`](https://developer.apple.com/documentation/xcuiautomation/xcuidevice/perform(handgesture:)).
+
+The following values are supported for `name`:
+
+* `doubleTap` (watchOS 10+)
+* `flick` (watchOS 26+)
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+name | string | yes | The name of the hand gesture to perform (case-insensitive). Must match one of the values listed above | `doubleTap`
+
 ### mobile: pushNotification
 
 Simulates push notification delivery to Simulator.

--- a/lib/commands/helpers/guards.ts
+++ b/lib/commands/helpers/guards.ts
@@ -2,7 +2,7 @@ import type {Simulator} from 'appium-ios-simulator';
 import {errors} from 'appium/driver.js';
 
 import type {RealDevice} from '../../device/real-device-management.js';
-import {upperFirst} from '../../utils/index.js';
+import {isWatchOs, upperFirst} from '../../utils/index.js';
 
 export interface DeviceGuardDriver {
   isSimulator(): boolean;
@@ -12,6 +12,10 @@ export interface DeviceGuardDriver {
 
 export interface WebContextGuardDriver {
   isWebContext(): boolean;
+}
+
+export interface PlatformGuardDriver {
+  readonly opts: {platformName?: string | null};
 }
 
 /**
@@ -42,5 +46,14 @@ export function requireRealDevice(driver: DeviceGuardDriver, action: string): Re
 export function requireWebContext(driver: WebContextGuardDriver, message?: string): void {
   if (!driver.isWebContext()) {
     throw new errors.NotImplementedError(message);
+  }
+}
+
+/**
+ * Requires that the given driver's session was started with `platformName: watchOS`.
+ */
+export function requireWatchOs(driver: PlatformGuardDriver, action: string): void {
+  if (!isWatchOs(driver.opts.platformName)) {
+    throw new errors.NotImplementedError(`${upperFirst(action)} can only be performed on watchOS`);
   }
 }

--- a/lib/commands/helpers/index.ts
+++ b/lib/commands/helpers/index.ts
@@ -11,8 +11,8 @@ export {
 
 export {TimeoutError, withTimeout} from './async.js';
 
-export {requireRealDevice, requireSimulator, requireWebContext} from './guards.js';
-export type {DeviceGuardDriver, WebContextGuardDriver} from './guards.js';
+export {requireRealDevice, requireSimulator, requireWatchOs, requireWebContext} from './guards.js';
+export type {DeviceGuardDriver, PlatformGuardDriver, WebContextGuardDriver} from './guards.js';
 
 export {encodeBase64OrUpload, getPIDsListeningOnPort, isLocalHost} from './network.js';
 export type {UploadOptions} from './network.js';

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -370,6 +370,11 @@ export type ButtonName = AnyCase<
 >;
 
 /**
+ * watchOS hand gesture names; used by the {@linkcode XCUITest.mobilePerformHandGesture mobile: performHandGesture} command.
+ */
+export type HandGestureName = AnyCase<'doubleTap' | 'flick'>;
+
+/**
  * Returned in the {@linkcode XCUITest.mobileGetAppearance mobile: getAppearance} command response.
  */
 export type Style = 'dark' | 'light' | 'unsupported' | 'unknown';

--- a/lib/commands/watch.ts
+++ b/lib/commands/watch.ts
@@ -13,11 +13,7 @@ import type {HandGestureName} from './types.js';
  * velocity is used.
  * @group watchOS Only
  */
-export async function mobileRotateDigitalCrown(
-  this: XCUITestDriver,
-  delta: number,
-  velocity?: number,
-): Promise<void> {
+export async function mobileRotateDigitalCrown(this: XCUITestDriver, delta: number, velocity?: number): Promise<void> {
   requireWatchOs(this, 'Digital Crown rotation');
   return await this.proxyCommand('/wda/rotateDigitalCrown', 'POST', {delta, velocity});
 }

--- a/lib/commands/watch.ts
+++ b/lib/commands/watch.ts
@@ -1,0 +1,37 @@
+import type {XCUITestDriver} from '../driver.js';
+import {requireWatchOs} from './helpers/index.js';
+import type {HandGestureName} from './types.js';
+
+/**
+ * Rotates the Digital Crown on a watchOS Simulator.
+ *
+ * Wraps [`rotateDigitalCrown(delta:velocity:)`](https://developer.apple.com/documentation/xcuiautomation/xcuidevice/rotatedigitalcrown(delta:velocity:)).
+ *
+ * @param delta - The number of full crown rotations, e.g. `1.0` is one complete turn. The sign
+ * gives the direction: positive rotates up/clockwise, negative rotates down/counterclockwise.
+ * @param velocity - The rotation speed, in rotations per second. If omitted, XCTest's own default
+ * velocity is used.
+ * @group watchOS Only
+ */
+export async function mobileRotateDigitalCrown(
+  this: XCUITestDriver,
+  delta: number,
+  velocity?: number,
+): Promise<void> {
+  requireWatchOs(this, 'Digital Crown rotation');
+  return await this.proxyCommand('/wda/rotateDigitalCrown', 'POST', {delta, velocity});
+}
+
+/**
+ * Performs a hand gesture on a watchOS Simulator.
+ *
+ * Wraps [`perform(handGesture:)`](https://developer.apple.com/documentation/xcuiautomation/xcuidevice/perform(handgesture:)).
+ *
+ * @param name - The name of the hand gesture to perform (case-insensitive). One of `doubleTap`
+ * (watchOS 10+) or `flick` (watchOS 26+).
+ * @group watchOS Only
+ */
+export async function mobilePerformHandGesture(this: XCUITestDriver, name: HandGestureName): Promise<void> {
+  requireWatchOs(this, 'Hand gesture automation');
+  return await this.proxyCommand('/wda/performHandGesture', 'POST', {name});
+}

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -88,6 +88,7 @@ import * as systemMonitorCommands from './commands/system-monitor.js';
 import * as timeoutCommands from './commands/timeouts.js';
 import type {WaitingAtoms, LogListener, FullContext} from './commands/types.js';
 import * as voiceOverCommands from './commands/voiceover.js';
+import * as watchCommands from './commands/watch.js';
 import {isXcodebuildNeeded as isWdaXcodebuildNeeded} from './commands/wda/constants.js';
 import {start} from './commands/wda/startup.js';
 import {stop} from './commands/wda/stop.js';
@@ -521,6 +522,12 @@ export class XCUITestDriver
   mobileIsVoiceOverEnabled = voiceOverCommands.mobileIsVoiceOverEnabled;
   mobileVoiceOverMove = voiceOverCommands.mobileVoiceOverMove;
   mobileVoiceOverCurrentSpeech = voiceOverCommands.mobileVoiceOverCurrentSpeech;
+
+  /*-------+
+   | WATCH |
+   +-------+*/
+  mobileRotateDigitalCrown = watchCommands.mobileRotateDigitalCrown;
+  mobilePerformHandGesture = watchCommands.mobilePerformHandGesture;
 
   /*---------+
    | GESTURE |

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -284,6 +284,19 @@ export const executeMethodMap = {
       optional: ['durationSeconds'],
     },
   },
+  'mobile: rotateDigitalCrown': {
+    command: 'mobileRotateDigitalCrown',
+    params: {
+      required: ['delta'],
+      optional: ['velocity'],
+    },
+  },
+  'mobile: performHandGesture': {
+    command: 'mobilePerformHandGesture',
+    params: {
+      required: ['name'],
+    },
+  },
   'mobile: enrollBiometric': {
     command: 'mobileEnrollBiometric',
     params: {

--- a/test/unit/commands/watch.spec.ts
+++ b/test/unit/commands/watch.spec.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import {describe, it, beforeEach, afterEach} from 'node:test';
+
+import sinon from 'sinon';
+
+import {XCUITestDriver} from '../../../lib/driver.js';
+
+describe('watch commands', function () {
+  const driver = new XCUITestDriver({} as any);
+
+  let mockDriver: sinon.SinonMock;
+
+  beforeEach(function () {
+    mockDriver = sinon.mock(driver);
+    driver.opts.platformName = 'watchOS';
+  });
+
+  afterEach(function () {
+    mockDriver.verify();
+  });
+
+  describe('mobileRotateDigitalCrown', function () {
+    it('should proxy delta and velocity to WDA', async function () {
+      mockDriver
+        .expects('proxyCommand')
+        .once()
+        .withExactArgs('/wda/rotateDigitalCrown', 'POST', {delta: 0.2, velocity: 1.0});
+      await driver.mobileRotateDigitalCrown(0.2, 1.0);
+    });
+
+    it('should proxy without velocity if it is not provided', async function () {
+      mockDriver
+        .expects('proxyCommand')
+        .once()
+        .withExactArgs('/wda/rotateDigitalCrown', 'POST', {delta: -0.5, velocity: undefined});
+      await driver.mobileRotateDigitalCrown(-0.5);
+    });
+
+    it('should throw if platform is not watchOS', async function () {
+      driver.opts.platformName = 'iOS';
+      await assert.rejects(driver.mobileRotateDigitalCrown(0.2));
+    });
+  });
+
+  describe('mobilePerformHandGesture', function () {
+    it('should proxy the gesture name to WDA', async function () {
+      mockDriver.expects('proxyCommand').once().withExactArgs('/wda/performHandGesture', 'POST', {name: 'doubleTap'});
+      await driver.mobilePerformHandGesture('doubleTap' as any);
+    });
+
+    it('should throw if platform is not watchOS', async function () {
+      driver.opts.platformName = 'iOS';
+      await assert.rejects(driver.mobilePerformHandGesture('doubleTap' as any));
+    });
+  });
+});


### PR DESCRIPTION
Exposes WDA's /wda/rotateDigitalCrown and /wda/performHandGesture routes, which were previously only reachable directly. Both are watchOS-only, enforced via a new requireWatchOs guard.