### PR TITLE
feat: bump appium-webdriveragent to 16.8.0 and document accessibilityDeadline

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -18,6 +18,24 @@ expression, where the search root is the alert element itself, for example, ```*
 If the provided selector is wrong or does not match any element, the default button location
 algorithm is used.
 
+## accessibilityDeadline
+
+| Type | Default |
+| -- | -- |
+| `float` | `0` |
+
+The maximum time in seconds to wait for the frontmost application to confirm its main run loop is
+responsive before an accessibility snapshot request (element attribute lookups, active app
+detection, etc). XCTest has no bounded timeout of its own for this, so an application whose main
+thread stops responding (e.g. it deadlocks, or is kept constantly busy by video/animation
+playback) could otherwise block WebDriverAgent forever.
+
+Setting this value to `0` (the default) or a negative number disables the check, restoring the
+unbounded behavior. Once the deadline is exceeded, the pending request is aborted with an error
+instead of hanging indefinitely. See the
+[WebDriverAgent Slowness](../troubleshooting/wda-slowness.md#unresponsive-application) guide for
+more details.
+
 ## activeAppDetectionPoint
 
 | Type | Default |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -32,7 +32,13 @@ playback) could otherwise block WebDriverAgent forever.
 
 Setting this value to `0` (the default) or a negative number disables the check, restoring the
 unbounded behavior. Once the deadline is exceeded, the pending request is aborted with an error
-instead of hanging indefinitely. See the
+instead of hanging indefinitely.
+
+This is not a silver bullet: if the application under test genuinely has long-running animations
+or transitions, a low deadline would make requests fail (or retry, and thus become much slower)
+rather than simply waiting them out. Since this is a per-session setting, it is best applied
+surgically, e.g. only around the specific steps of your test where an unresponsive app is a real
+risk, rather than left enabled for the whole session. See the
 [WebDriverAgent Slowness](../troubleshooting/wda-slowness.md#unresponsive-application) guide for
 more details.
 

--- a/docs/troubleshooting/wda-slowness.md
+++ b/docs/troubleshooting/wda-slowness.md
@@ -186,6 +186,27 @@ All suggestions mentioned for the [Slow Element Search Using XPath pattern](#sol
 here.
 
 
+## Unresponsive Application
+
+You observe WebDriverAgent hanging indefinitely (e.g. on element lookups or active app detection)
+when the application under test stops responding, instead of failing with a timeout error.
+
+### Causes
+
+Most element/attribute lookups rely on an underlying accessibility snapshot request, for which
+XCTest provides no bounded timeout. If the application's main run loop stops responding, this
+request can block WDA forever. This can happen if the app deadlocks, but also if it simply keeps
+the main thread constantly busy (e.g. playing video/animations without yielding), which prevents
+it from acknowledging the accessibility request in time.
+
+### Solutions
+
+Set the [`accessibilityDeadline`](../reference/settings.md#accessibilitydeadline) setting to a
+positive value (in seconds). Once enabled, WDA first confirms the application is responsive before
+proceeding with the snapshot request, and aborts with an error if it does not respond within the
+deadline, instead of hanging indefinitely. This setting is disabled by default.
+
+
 ## Slow Element Interactions
 
 You observe timeouts or unusual slowness while clicking elements or performing other

--- a/docs/troubleshooting/wda-slowness.md
+++ b/docs/troubleshooting/wda-slowness.md
@@ -206,6 +206,14 @@ positive value (in seconds). Once enabled, WDA first confirms the application is
 proceeding with the snapshot request, and aborts with an error if it does not respond within the
 deadline, instead of hanging indefinitely. This setting is disabled by default.
 
+This setting is not a silver bullet: it only helps avoid situations where the driver/WDA response
+is blocked for too long, and does not speed up or fix genuinely slow interactions. If the
+application under test has legitimately long animations or transitions, enabling this setting for
+the whole session may make unrelated requests fail or retry, and thus become (much) slower.
+Because it is a per-session setting, it is best applied surgically, i.e. toggled on only around the
+critical steps of your test where an unresponsive app is an actual risk, and toggled back off
+afterwards.
+
 
 ## Slow Element Interactions
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "appium-ios-device": "^3.1.12",
     "appium-ios-simulator": "^9.0.0",
     "appium-remote-debugger": "^17.1.0",
-    "appium-webdriveragent": "^16.5.0",
+    "appium-webdriveragent": "^16.8.0",
     "appium-xcode": "^7.0.0",
     "async-lock": "^1.4.0",
     "asyncbox": "^6.3.0",


### PR DESCRIPTION
Documents the new setting from appium/WebDriverAgent#1214, which bounds accessibility snapshot requests so an unresponsive app no longer blocks WDA indefinitely.