### PR TITLE
fix: log the real error when session creation fails

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -890,7 +890,7 @@ export class XCUITestDriver
 
       return [sessionId, caps];
     } catch (e) {
-      this.log.error(JSON.stringify(e));
+      this.log.error((e as Error).stack ?? String(e));
       await this.deleteSession();
       throw e;
     }

--- a/test/unit/driver.spec.ts
+++ b/test/unit/driver.spec.ts
@@ -299,6 +299,27 @@ describe('XCUITestDriver', function () {
         assert.strictEqual((resCaps[1] as any).javascriptEnabled, true);
       });
 
+      it('logs the real error when session startup fails', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
+        const bootError = new Error('WDA failed to start on port 8100');
+        sandbox.stub(driver, 'start').rejects(bootError);
+        sandbox.stub(driver, 'deleteSession').resolves();
+        const errorSpy = sandbox.spy(driver.log, 'error');
+
+        await assert.rejects(
+          driver.createSession(null as any, null as any, structuredClone(caps) as any),
+          /WDA failed to start on port 8100/,
+        );
+
+        const logged = errorSpy
+          .getCalls()
+          .map((c: any) => String(c.args[0]))
+          .join('\n');
+        assert.ok(
+          logged.includes('WDA failed to start on port 8100'),
+          `Expected the startup failure to be logged, got: ${JSON.stringify(logged)}`,
+        );
+      });
+
       it('should call startLogCapture', {timeout: UNIT_LONG_TIMEOUT_MS}, async function () {
         const resCaps = await driver.createSession(
           null as any,


### PR DESCRIPTION
## Issue
When session creation fails, the catch block logged the error with `JSON.stringify(e)`. For an `Error` object this prints `{}` because `message` and `stack` are non enumerable, so the real cause was missing from the server logs.

## Fix
Log the error stack instead, so the actual message and trace show up in the logs.

Added a test to verify this.