### PR TITLE
fix: route refresh/getUrl/title through waitForAtom for alert detection

### DIFF
--- a/lib/commands/web-native-bridge.ts
+++ b/lib/commands/web-native-bridge.ts
@@ -364,12 +364,14 @@ export async function translateWebCoords(this: XCUITestDriver, x: number, y: num
   const cmd =
     '(function () {return {innerWidth: window.innerWidth, innerHeight: window.innerHeight, ' +
     'outerWidth: window.outerWidth, outerHeight: window.outerHeight}; })()';
-  const wvDims = await this.remote.execute<{
-    innerWidth: number;
-    innerHeight: number;
-    outerWidth: number;
-    outerHeight: number;
-  }>(cmd);
+  const wvDims = await this.waitForAtom(
+    this.remote.execute<{
+      innerWidth: number;
+      innerHeight: number;
+      outerWidth: number;
+      outerHeight: number;
+    }>(cmd),
+  );
   // https://tripleodeon.com/2011/12/first-understand-your-screen/
   const shouldApplyPixelRatio = wvDims.innerWidth > wvDims.outerWidth || wvDims.innerHeight > wvDims.outerHeight;
   const newCoords = {
@@ -442,7 +444,9 @@ async function findWebviewRect(this: XCUITestDriver): Promise<Rect> {
  * top-level page's viewport, regardless of the current frame.
  */
 async function computeViewportSignature(this: XCUITestDriver): Promise<string> {
-  const state = await this.remote.execute<Omit<ViewportState, 'orientation'>>(READ_VIEWPORT_STATE_SCRIPT);
+  const state = await this.waitForAtom(
+    this.remote.execute<Omit<ViewportState, 'orientation'>>(READ_VIEWPORT_STATE_SCRIPT),
+  );
   const orientation: ViewportState['orientation'] = state.innerHeight >= state.innerWidth ? 'PORTRAIT' : 'LANDSCAPE';
   return `${this.curContext ?? ''}::${viewportSignature({...state, orientation})}`;
 }
@@ -466,7 +470,7 @@ async function performCalibration(this: XCUITestDriver): Promise<CalibrationCach
     const centerX = rect.x + rect.width / 2;
     const centerY = rect.y + rect.height / 2;
 
-    await this.remote.execute(INJECT_CALIBRATION_OVERLAY_SCRIPT);
+    await this.waitForAtom(this.remote.execute(INJECT_CALIBRATION_OVERLAY_SCRIPT));
     try {
       const samples: CalibrationSample[] = [];
       for (const [i, sign] of [-1, 1].entries()) {
@@ -481,7 +485,7 @@ async function performCalibration(this: XCUITestDriver): Promise<CalibrationCach
           CALIBRATION_TAP_READBACK_RETRIES,
           CALIBRATION_TAP_READBACK_INTERVAL_MS,
           async () => {
-            const result = await this.remote.execute<Position[]>(READ_CALIBRATION_TAPS_SCRIPT);
+            const result = await this.waitForAtom(this.remote.execute<Position[]>(READ_CALIBRATION_TAPS_SCRIPT));
             if (!Array.isArray(result) || result.length < expectedCount) {
               throw new Error('The calibration overlay has not observed this tap yet');
             }
@@ -499,7 +503,7 @@ async function performCalibration(this: XCUITestDriver): Promise<CalibrationCach
       entry = {signature, data};
     } finally {
       try {
-        await this.remote.execute(REMOVE_CALIBRATION_OVERLAY_SCRIPT);
+        await this.waitForAtom(this.remote.execute(REMOVE_CALIBRATION_OVERLAY_SCRIPT));
       } catch (err) {
         // Don't let a cleanup hiccup mask a real error from the try block
         // above, or abort the retry loop on its own; the overlay-inject

--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -122,7 +122,7 @@ export async function submit(this: XCUITestDriver, el: string | Element): Promis
 export async function refresh(this: XCUITestDriver): Promise<void> {
   requireWebContext(this);
 
-  await this.remote.execute('window.location.reload()');
+  await this.waitForAtom(this.remote.execute('window.location.reload()'));
 }
 
 /**
@@ -134,7 +134,7 @@ export async function refresh(this: XCUITestDriver): Promise<void> {
 export async function getUrl(this: XCUITestDriver): Promise<string> {
   requireWebContext(this);
 
-  return await this.remote.execute<string>('window.location.href');
+  return await this.waitForAtom(this.remote.execute<string>('window.location.href'));
 }
 
 /**
@@ -146,7 +146,7 @@ export async function getUrl(this: XCUITestDriver): Promise<string> {
 export async function title(this: XCUITestDriver): Promise<string> {
   requireWebContext(this);
 
-  return await this.remote.execute<string>('window.document.title');
+  return await this.waitForAtom(this.remote.execute<string>('window.document.title'));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Several webview JS-execution call sites use `this.remote.execute()` directly instead of going through `executeAtom`/`waitForAtom`, so they don't get the alert-monitoring wrapper other webview commands rely on.
- If a native alert (e.g. a JS `alert()`, or a native dialog like Safari's popup-blocker prompt) blocks the page's JS thread while one of these runs, the call just hangs - nothing is polling `checkForAlert()` - instead of failing fast with `UnexpectedAlertOpenError` like the atom-wrapped commands do.
- Wrapped each affected `this.remote.execute(...)` call in `this.waitForAtom(...)`, matching how every other JS-executing webview command already behaves. No change to the underlying JS or its semantics.

Affected call sites:
- `lib/commands/web.ts`: `refresh()`, `getUrl()`, `title()`
- `lib/commands/web-native-bridge.ts`: `translateWebCoords`'s viewport-dimension read, and `performCalibration`'s calibration-overlay inject/readback/remove calls (native-web-tap coordinate calibration)

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [ ] CI unit/e2e suite
