### PR TITLE
fix: stop using deprecated appium/support imageUtil, rely on local sharp

### DIFF
--- a/lib/commands/helpers/mjpeg.ts
+++ b/lib/commands/helpers/mjpeg.ts
@@ -2,9 +2,9 @@ import {Transform, Writable, type Readable, type TransformCallback, type Writabl
 
 import {logger} from 'appium/support.js';
 import axios from 'axios';
-import type sharp from 'sharp';
 
 import type {XCUITestDriver} from '../../driver.js';
+import {requireSharp} from '../../utils/index.js';
 
 const log = logger.getLogger('MJPEG');
 
@@ -97,26 +97,6 @@ export class MjpegFrameParser extends Transform {
     this.buffer = null;
     this.expectedLength = 0;
     this.bytesWritten = 0;
-  }
-}
-
-let sharpModule: typeof sharp | null = null;
-
-async function requireSharp(): Promise<typeof sharp> {
-  if (sharpModule) {
-    return sharpModule;
-  }
-  try {
-    sharpModule = (await import('sharp')).default;
-    return sharpModule;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `Cannot load the 'sharp' module needed for MJPEG frame processing. ` +
-        `Consider visiting https://sharp.pixelplumbing.com/install for troubleshooting. ` +
-        `Original error: ${message}`,
-      {cause: err},
-    );
   }
 }
 

--- a/lib/commands/screenshots.ts
+++ b/lib/commands/screenshots.ts
@@ -1,11 +1,11 @@
 import type {Element} from '@appium/types';
 import type {Simulator} from 'appium-ios-simulator';
 import {errors} from 'appium/driver.js';
-import {util, imageUtil} from 'appium/support.js';
+import {util} from 'appium/support.js';
 import {retryInterval} from 'asyncbox';
 
 import type {XCUITestDriver} from '../driver.js';
-import {capitalize} from '../utils/index.js';
+import {capitalize, cropBase64Image, requireSharp} from '../utils/index.js';
 
 /**
  * Takes a screenshot of the current screen.
@@ -120,7 +120,7 @@ export async function getViewportScreenshot(this: XCUITestDriver): Promise<strin
     return screenshot;
   }
 
-  const sharp = imageUtil.requireSharp();
+  const sharp = await requireSharp();
   const {width, height} = await sharp(Buffer.from(screenshot, 'base64')).metadata();
   if (!width || !height) {
     throw new errors.UnableToCaptureScreen('The device screenshot is empty');
@@ -136,5 +136,5 @@ export async function getViewportScreenshot(this: XCUITestDriver): Promise<strin
     region.height = height - region.top;
   }
   this.log.debug(`Calculated viewport rect: ${JSON.stringify(region)}`);
-  return await imageUtil.cropBase64Image(screenshot, region);
+  return await cropBase64Image(screenshot, region);
 }

--- a/lib/utils/image.ts
+++ b/lib/utils/image.ts
@@ -1,0 +1,41 @@
+import type sharp from 'sharp';
+import type {Region} from 'sharp';
+
+let sharpModule: typeof sharp | null = null;
+
+/**
+ * Lazily imports the optional `sharp` dependency.
+ *
+ * @returns The sharp module for image processing
+ */
+export async function requireSharp(): Promise<typeof sharp> {
+  if (sharpModule) {
+    return sharpModule;
+  }
+  try {
+    sharpModule = (await import('sharp')).default;
+    return sharpModule;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Cannot load the 'sharp' module needed for image processing. ` +
+        `Consider visiting https://sharp.pixelplumbing.com/install for troubleshooting. ` +
+        `Original error: ${message}`,
+      {cause: err},
+    );
+  }
+}
+
+/**
+ * Crops the image by the given rectangle (base64 string in, base64 string out).
+ *
+ * @param base64Image The string with base64 encoded image.
+ * Supports all image formats natively supported by Sharp library.
+ * @param region The selected region of the image
+ * @returns base64 encoded string of the cropped image
+ */
+export async function cropBase64Image(base64Image: string, region: Region): Promise<string> {
+  const sharpInstance = await requireSharp();
+  const buf = await sharpInstance(Buffer.from(base64Image, 'base64')).extract(region).toBuffer();
+  return buf.toString('base64');
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -9,6 +9,7 @@ export {
   truncateString,
   upperFirst,
 } from './lang.js';
+export {cropBase64Image, requireSharp} from './image.js';
 export {memoize} from './memoize.js';
 export {
   toApiLevelRequirementText,


### PR DESCRIPTION
Replaces imageUtil.requireSharp()/cropBase64Image() in screenshots.ts with local implementations in lib/utils/image.ts, and dedupes mjpeg.ts's own inline requireSharp() to use the same shared helper.