### PR TITLE
feat: resolve web element origins to native coordinates in W3C actions

### DIFF
--- a/lib/commands/gesture.ts
+++ b/lib/commands/gesture.ts
@@ -3,7 +3,7 @@ import {errors} from 'appium/driver.js';
 import {util} from 'appium/support.js';
 
 import type {XCUITestDriver} from '../driver.js';
-import {hasElementId, isPlainObject} from '../utils/index.js';
+import {hasWebElementId, isPlainObject} from '../utils/index.js';
 import {requireSimulator} from './helpers/index.js';
 import type {Direction} from './types.js';
 
@@ -598,10 +598,9 @@ export async function mobileRotateElement(
  * Asserts that the action sequence does not contain web elements.
  *
  * A native-context action legitimately can reference a native element as its origin (WDA
- * understands those just fine) - it is wrapped exactly the same way a web element is
- * ({@linkcode hasElementId} can't tell the two apart by shape alone), so this also checks
- * `webElementsCache` (populated only by the atoms/web-execution machinery) to confirm an
- * element-shaped origin is actually a *web* element before rejecting it.
+ * understands those just fine) - it is wrapped exactly the same way a web element is, so
+ * {@linkcode hasWebElementId} is used to confirm an element-shaped origin is actually a *web*
+ * element (tracked in `webElementsCache`) before rejecting it.
  *
  * @param driver - The driver instance, used to distinguish web elements from native ones
  * @param actionSeq - Action sequence to check
@@ -609,9 +608,7 @@ export async function mobileRotateElement(
  */
 function assertNoWebElements(driver: XCUITestDriver, actionSeq: ActionSequence[]): void {
   const isOriginWebElement = (gesture: any) =>
-    isPlainObject(gesture) &&
-    hasElementId(gesture.origin) &&
-    driver.webElementsCache.has(util.unwrapElement(gesture.origin));
+    isPlainObject(gesture) && hasWebElementId(driver.webElementsCache, gesture.origin);
   const hasWebElements = actionSeq.some((action) => (action?.actions || []).some(isOriginWebElement));
   if (hasWebElements) {
     throw new errors.InvalidArgumentError(

--- a/lib/commands/gesture.ts
+++ b/lib/commands/gesture.ts
@@ -3,7 +3,7 @@ import {errors} from 'appium/driver.js';
 import {util} from 'appium/support.js';
 
 import type {XCUITestDriver} from '../driver.js';
-import {isPlainObject} from '../utils/index.js';
+import {hasElementId, isPlainObject} from '../utils/index.js';
 import {requireSimulator} from './helpers/index.js';
 import type {Direction} from './types.js';
 
@@ -82,12 +82,13 @@ export async function performActions(this: XCUITestDriver, actions: ActionSequen
  *
  * Shared by the native-context path above and {@linkcode AtomsBackend}'s `performActions` -
  * atoms have no actions implementation of their own, but WDA can still drive on-screen web
- * content this way.
+ * content this way. `AtomsBackend` resolves web element origins into native coordinates before
+ * calling this, so by the time actions reach here from that path they are already element-free.
  *
- * @throws {errors.InvalidArgumentError} If actions contain web elements
+ * @throws {errors.InvalidArgumentError} If actions still contain web elements
  */
 export async function performActionsViaWDA(driver: XCUITestDriver, actions: ActionSequence[]): Promise<void> {
-  assertNoWebElements(actions);
+  assertNoWebElements(driver, actions);
   // This is mandatory, since WDA only supports TOUCH pointer type
   // and Selenium API uses MOUSE as the default one
   const preprocessedActions = actions
@@ -596,20 +597,29 @@ export async function mobileRotateElement(
 /**
  * Asserts that the action sequence does not contain web elements.
  *
+ * A native-context action legitimately can reference a native element as its origin (WDA
+ * understands those just fine) - it is wrapped exactly the same way a web element is
+ * ({@linkcode hasElementId} can't tell the two apart by shape alone), so this also checks
+ * `webElementsCache` (populated only by the atoms/web-execution machinery) to confirm an
+ * element-shaped origin is actually a *web* element before rejecting it.
+ *
+ * @param driver - The driver instance, used to distinguish web elements from native ones
  * @param actionSeq - Action sequence to check
  * @throws {errors.InvalidArgumentError} If web elements are found in the action sequence
  */
-function assertNoWebElements(actionSeq: ActionSequence[]): void {
+function assertNoWebElements(driver: XCUITestDriver, actionSeq: ActionSequence[]): void {
   const isOriginWebElement = (gesture: any) =>
-    isPlainObject(gesture) && 'origin' in gesture && JSON.stringify(gesture.origin).includes(':wdc:');
+    isPlainObject(gesture) &&
+    hasElementId(gesture.origin) &&
+    driver.webElementsCache.has(util.unwrapElement(gesture.origin));
   const hasWebElements = actionSeq.some((action) => (action?.actions || []).some(isOriginWebElement));
   if (hasWebElements) {
     throw new errors.InvalidArgumentError(
-      `The XCUITest driver only supports W3C actions execution in the native context. ` +
-        `Although, your W3C action contains one or more web elements, ` +
-        `which cannot be automatically mapped to the native context. ` +
-        `Consider mapping their absolute web coordinates to native context coordinates ` +
-        `and passing them to your gesture instead.`,
+      `Your W3C action contains one or more web elements, which cannot be automatically mapped ` +
+        `to the current context. Web elements are only automatically resolved to native ` +
+        `coordinates when performActions is called from within the web view context they came ` +
+        `from. Switch back into that web view context before performing this action, or map ` +
+        `their absolute web coordinates to native context coordinates yourself and pass those instead.`,
     );
   }
 }

--- a/lib/commands/web.ts
+++ b/lib/commands/web.ts
@@ -6,7 +6,7 @@ import {errors, isErrorType} from 'appium/driver.js';
 import {timing, util} from 'appium/support.js';
 
 import type {XCUITestDriver} from '../driver.js';
-import {isEmpty, isPlainObject, toErrorMessage} from '../utils/index.js';
+import {hasElementId, isEmpty, isPlainObject, toErrorMessage} from '../utils/index.js';
 import {
   requireAutomationSessionActive,
   requireSimulator,
@@ -295,7 +295,7 @@ export function getAtomsElement<S extends string = string>(
  */
 export function convertElementsForAtoms(this: XCUITestDriver, args: readonly unknown[] = []): unknown[] {
   return args.map((arg) => {
-    if (isElementLike(arg)) {
+    if (hasElementId(arg)) {
       try {
         return this.getAtomsElement(arg);
       } catch (err) {
@@ -316,17 +316,7 @@ export function convertElementsForAtoms(this: XCUITestDriver, args: readonly unk
  * @returns Element ID if found, undefined otherwise
  */
 export function getElementId(element: unknown): string | undefined {
-  return isElementLike(element) ? util.unwrapElement(element) : undefined;
-}
-
-/**
- * Checks if an object has an element ID (type guard).
- *
- * @param element - Object to check
- * @returns True if the object has an element ID
- */
-export function hasElementId(element: unknown): element is Element {
-  return isElementLike(element);
+  return hasElementId(element) ? util.unwrapElement(element) : undefined;
 }
 
 /**
@@ -628,20 +618,6 @@ async function alertMonitorLoop(this: XCUITestDriver, abortController: AbortCont
       break;
     }
   }
-}
-
-/**
- * Checks whether a value looks like an atoms/W3C element wrapper.
- *
- * @param element - Value to check
- * @returns True if the value has an element ID
- */
-function isElementLike(element: unknown): element is Element {
-  if (!isPlainObject(element)) {
-    return false;
-  }
-  const unwrapped: unknown = util.unwrapElement(element as unknown as Element);
-  return unwrapped !== element;
 }
 
 /**

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -126,7 +126,14 @@ import {executeMethodMap} from './execute-method-map.js';
 import {newMethodMap} from './method-map.js';
 import {sessionClaimHandler} from './session-claim-handler.js';
 import type {CalibrationCacheEntry, IConditionInducer, LifecycleData} from './types.js';
-import {isEmpty, isPlainObject, isWatchOs, memoize, normalizePlatformVersion} from './utils/index.js';
+import {
+  hasElementId as hasElementIdUtil,
+  isEmpty,
+  isPlainObject,
+  isWatchOs,
+  memoize,
+  normalizePlatformVersion,
+} from './utils/index.js';
 import {AtomsBackend} from './web-execution/atoms-backend.js';
 import {AutomationSessionBackend} from './web-execution/automation-session-backend.js';
 import type {WebExecutionBackend} from './web-execution/types.js';
@@ -738,7 +745,7 @@ export class XCUITestDriver
   /** @deprecated */
   getElementId = webCommands.getElementId;
   /** @deprecated */
-  hasElementId = webCommands.hasElementId;
+  hasElementId = hasElementIdUtil;
   findWebElementOrElements = webCommands.findWebElementOrElements;
   /** @deprecated */
   checkForAlert = webCommands.checkForAlert;

--- a/lib/utils/element.ts
+++ b/lib/utils/element.ts
@@ -16,3 +16,18 @@ export function hasElementId(element: unknown): element is Element {
   const unwrapped: unknown = util.unwrapElement(element as unknown as Element);
   return unwrapped !== element;
 }
+
+/**
+ * Checks whether a value is a *web* element specifically, as opposed to a native one (type guard).
+ *
+ * A native element is wrapped exactly the same way a web element is - {@linkcode hasElementId}
+ * can't tell the two apart by shape alone - so this also confirms the id is tracked in
+ * `webElementsCache`, which is populated only by the atoms/web-execution machinery.
+ *
+ * @param webElementsCache - The driver's `webElementsCache`
+ * @param element - Value to check
+ * @returns True if the value is a web element tracked in `webElementsCache`
+ */
+export function hasWebElementId(webElementsCache: {has(key: string): boolean}, element: unknown): element is Element {
+  return hasElementId(element) && webElementsCache.has(util.unwrapElement(element));
+}

--- a/lib/utils/element.ts
+++ b/lib/utils/element.ts
@@ -1,0 +1,18 @@
+import type {Element} from '@appium/types';
+import {util} from 'appium/support.js';
+
+import {isPlainObject} from './lang.js';
+
+/**
+ * Checks whether a value looks like an atoms/W3C element wrapper (type guard).
+ *
+ * @param element - Value to check
+ * @returns True if the value has an element ID
+ */
+export function hasElementId(element: unknown): element is Element {
+  if (!isPlainObject(element)) {
+    return false;
+  }
+  const unwrapped: unknown = util.unwrapElement(element as unknown as Element);
+  return unwrapped !== element;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -9,7 +9,7 @@ export {
   truncateString,
   upperFirst,
 } from './lang.js';
-export {hasElementId} from './element.js';
+export {hasElementId, hasWebElementId} from './element.js';
 export {cropBase64Image, requireSharp} from './image.js';
 export {memoize} from './memoize.js';
 export {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -9,6 +9,7 @@ export {
   truncateString,
   upperFirst,
 } from './lang.js';
+export {hasElementId} from './element.js';
 export {cropBase64Image, requireSharp} from './image.js';
 export {memoize} from './memoize.js';
 export {

--- a/lib/web-execution/atoms-backend.ts
+++ b/lib/web-execution/atoms-backend.ts
@@ -6,9 +6,9 @@ import {waitForCondition} from 'asyncbox';
 import {NATIVE_WIN} from '../commands/constants.js';
 import {prepareInputValue} from '../commands/element.js';
 import {performActionsViaWDA} from '../commands/gesture.js';
-import {checkForAlert, createJSCookie, hasElementId} from '../commands/web.js';
+import {checkForAlert, createJSCookie} from '../commands/web.js';
 import type {XCUITestDriver} from '../driver.js';
-import {isEmpty, toErrorMessage} from '../utils/index.js';
+import {hasElementId, isEmpty, toErrorMessage} from '../utils/index.js';
 import type {WebExecutionBackend} from './types.js';
 
 const CLOSE_WINDOW_TIMEOUT_MS = 5000;
@@ -346,9 +346,10 @@ export class AtomsBackend implements WebExecutionBackend {
 
   async performActions(actions: ActionSequence[]): Promise<void> {
     // atoms have no actions implementation of their own, but WDA can still drive real touch
-    // input against on-screen web content - as long as no action originates from a web element,
-    // which requires an automation session (see 'mobile: startAutomationSession').
-    await performActionsViaWDA(this.driver, actions);
+    // input against on-screen web content. Web element origins are resolved to native
+    // coordinates first, the same way `nativeWebTap` does, since WDA has no notion of them.
+    const resolvedActions = await this.resolveWebElementActionOrigins(actions);
+    await performActionsViaWDA(this.driver, resolvedActions);
   }
 
   async releaseActions(): Promise<void> {
@@ -386,5 +387,54 @@ export class AtomsBackend implements WebExecutionBackend {
   private async removeCookie(cookie: Cookie): Promise<void> {
     const url = `http${cookie.secure ? 's' : ''}://${cookie.domain}${cookie.path}`;
     await this.driver.remote.deleteCookie(cookie.name, url);
+  }
+
+  /**
+   * Resolves every web element origin in a W3C action sequence (a `pointerMove` or `scroll`
+   * action whose `origin` is a web element, e.g. `driver.action('pointer').move({origin: el})`)
+   * into a `'viewport'`-relative native screen coordinate, so the result can be driven through
+   * WDA's `/actions` endpoint via {@linkcode performActionsViaWDA}.
+   *
+   * @param actions - Array of action sequences, potentially containing web element origins
+   * @returns A deep copy of `actions` with every web element origin replaced by native coordinates
+   */
+  private async resolveWebElementActionOrigins(actions: ActionSequence[]): Promise<ActionSequence[]> {
+    const resolvedActions = structuredClone(actions);
+    for (const sequence of resolvedActions) {
+      for (const action of ((sequence as any).actions ?? []) as any[]) {
+        if (!hasElementId(action?.origin)) {
+          continue;
+        }
+        const {x, y} = await this.resolveElementOriginToNativeCoords(action.origin, action.x, action.y);
+        action.origin = 'viewport';
+        action.x = x;
+        action.y = y;
+      }
+    }
+    return resolvedActions;
+  }
+
+  /**
+   * Converts a single web element origin (plus its action's own `x`/`y` offset from the element's
+   * center) into native screen coordinates, using the same web-to-native coordinate translation
+   * `nativeWebTap` falls back on. Unlike `nativeWebTap`, this never performs a tap itself - it
+   * only resolves a coordinate, since a `pointerMove` action doesn't imply one.
+   *
+   * @see {@linkcode resolveWebElementActionOrigins}
+   */
+  private async resolveElementOriginToNativeCoords(
+    origin: Element,
+    offsetX: number,
+    offsetY: number,
+  ): Promise<Position> {
+    const atomsElement = this.driver.getAtomsElement(origin);
+    const [size, coordinates] = (await Promise.all([
+      this.driver.executeAtom('get_size', [atomsElement]),
+      this.driver.executeAtom('get_top_left_coordinates', [atomsElement]),
+    ])) as [Size, Position];
+    return await this.driver.translateWebCoords(
+      coordinates.x + size.width / 2 + offsetX,
+      coordinates.y + size.height / 2 + offsetY,
+    );
   }
 }

--- a/lib/web-execution/atoms-backend.ts
+++ b/lib/web-execution/atoms-backend.ts
@@ -8,7 +8,7 @@ import {prepareInputValue} from '../commands/element.js';
 import {performActionsViaWDA} from '../commands/gesture.js';
 import {checkForAlert, createJSCookie} from '../commands/web.js';
 import type {XCUITestDriver} from '../driver.js';
-import {hasElementId, isEmpty, toErrorMessage} from '../utils/index.js';
+import {hasElementId, hasWebElementId, isEmpty, toErrorMessage} from '../utils/index.js';
 import type {WebExecutionBackend} from './types.js';
 
 const CLOSE_WINDOW_TIMEOUT_MS = 5000;
@@ -395,6 +395,10 @@ export class AtomsBackend implements WebExecutionBackend {
    * into a `'viewport'`-relative native screen coordinate, so the result can be driven through
    * WDA's `/actions` endpoint via {@linkcode performActionsViaWDA}.
    *
+   * An origin shaped like an element but not tracked in `webElementsCache` is a native element,
+   * not a web one - {@linkcode hasWebElementId} tells the two apart, since WDA understands native
+   * elements just fine, such an origin is left untouched for `performActionsViaWDA` to pass through.
+   *
    * @param actions - Array of action sequences, potentially containing web element origins
    * @returns A deep copy of `actions` with every web element origin replaced by native coordinates
    */
@@ -402,7 +406,7 @@ export class AtomsBackend implements WebExecutionBackend {
     const resolvedActions = structuredClone(actions);
     for (const sequence of resolvedActions) {
       for (const action of ((sequence as any).actions ?? []) as any[]) {
-        if (!hasElementId(action?.origin)) {
+        if (!hasWebElementId(this.driver.webElementsCache, action?.origin)) {
           continue;
         }
         const {x, y} = await this.resolveElementOriginToNativeCoords(action.origin, action.x, action.y);

--- a/lib/web-execution/atoms-backend.ts
+++ b/lib/web-execution/atoms-backend.ts
@@ -6,6 +6,7 @@ import {waitForCondition} from 'asyncbox';
 import {NATIVE_WIN} from '../commands/constants.js';
 import {prepareInputValue} from '../commands/element.js';
 import {performActionsViaWDA} from '../commands/gesture.js';
+import {translateWebCoords} from '../commands/web-native-bridge.js';
 import {checkForAlert, createJSCookie} from '../commands/web.js';
 import type {XCUITestDriver} from '../driver.js';
 import {hasElementId, hasWebElementId, isEmpty, toErrorMessage} from '../utils/index.js';
@@ -436,7 +437,8 @@ export class AtomsBackend implements WebExecutionBackend {
       this.driver.executeAtom('get_size', [atomsElement]),
       this.driver.executeAtom('get_top_left_coordinates', [atomsElement]),
     ])) as [Size, Position];
-    return await this.driver.translateWebCoords(
+    return await translateWebCoords.call(
+      this.driver,
       coordinates.x + size.width / 2 + offsetX,
       coordinates.y + size.height / 2 + offsetY,
     );

--- a/lib/web-execution/atoms-backend.ts
+++ b/lib/web-execution/atoms-backend.ts
@@ -18,6 +18,28 @@ const CLOSE_WINDOW_INTERVAL_MS = 100;
 // WebKit's wording for a cross-origin frame access failure.
 const CROSS_ORIGIN_FRAME_ERROR_PATTERN = /cross-origin frame|blocked a frame with origin/i;
 
+// Calculates the W3C "in-view center point" of arguments[0] - its getBoundingClientRect(),
+// clipped to the current viewport - returning null when the clipped rectangle is empty (the
+// element is entirely out of view). Deliberately reads via getBoundingClientRect() rather than
+// the get_top_left_coordinates/get_size atoms, which scroll the element into view as a side
+// effect: resolveWebElementActionOrigins resolves every origin in a sequence up front, before WDA
+// drives any input, so a lookup that scrolls could shift the page and invalidate coordinates
+// already resolved for an earlier origin in that same sequence.
+const IN_VIEW_CENTER_POINT_SCRIPT = `
+  var el = arguments[0];
+  var rect = el.getBoundingClientRect();
+  var clientWidth = document.documentElement.clientWidth;
+  var clientHeight = document.documentElement.clientHeight;
+  var x0 = Math.max(0, Math.min(rect.left, rect.left + rect.width));
+  var x1 = Math.min(clientWidth, Math.max(rect.left, rect.left + rect.width));
+  var y0 = Math.max(0, Math.min(rect.top, rect.top + rect.height));
+  var y1 = Math.min(clientHeight, Math.max(rect.top, rect.top + rect.height));
+  if (x0 >= x1 || y0 >= y1) {
+    return null;
+  }
+  return {x: (x0 + x1) / 2, y: (y0 + y1) / 2};
+`;
+
 /**
  * Routes web-execution commands through the driver's existing Selenium-atoms machinery
  * (`executeAtom`, `getAtomsElement`, `convertElementsForAtoms`, `cacheWebElements`, the remote
@@ -421,11 +443,11 @@ export class AtomsBackend implements WebExecutionBackend {
 
   /**
    * Converts a single web element origin (plus its action's own `x`/`y` offset from the element's
-   * center) into native screen coordinates, using the same web-to-native coordinate translation
-   * `nativeWebTap` falls back on. Unlike `nativeWebTap`, this never performs a tap itself - it
-   * only resolves a coordinate, since a `pointerMove` action doesn't imply one.
+   * W3C "in-view center point" - its bounding rectangle, clipped to the current viewport) into
+   * native screen coordinates via {@linkcode translateWebCoords}'s calibrated transform.
    *
    * @see {@linkcode resolveWebElementActionOrigins}
+   * @throws {errors.MoveTargetOutOfBoundsError} If the element is currently entirely out of view
    */
   private async resolveElementOriginToNativeCoords(
     origin: Element,
@@ -433,14 +455,15 @@ export class AtomsBackend implements WebExecutionBackend {
     offsetY: number,
   ): Promise<Position> {
     const atomsElement = this.driver.getAtomsElement(origin);
-    const [size, coordinates] = (await Promise.all([
-      this.driver.executeAtom('get_size', [atomsElement]),
-      this.driver.executeAtom('get_top_left_coordinates', [atomsElement]),
-    ])) as [Size, Position];
-    return await translateWebCoords.call(
-      this.driver,
-      coordinates.x + size.width / 2 + offsetX,
-      coordinates.y + size.height / 2 + offsetY,
-    );
+    const center = (await this.driver.executeAtom('execute_script', [
+      IN_VIEW_CENTER_POINT_SCRIPT,
+      [atomsElement],
+    ])) as Position | null;
+    if (!center) {
+      throw new errors.MoveTargetOutOfBoundsError(
+        'The element used as a W3C action origin is currently out of view, so its coordinates cannot be resolved',
+      );
+    }
+    return await translateWebCoords.call(this.driver, center.x + offsetX, center.y + offsetY);
   }
 }

--- a/test/fixtures/guinea-pig/test/guinea-pig-drag-and-drop.html
+++ b/test/fixtures/guinea-pig/test/guinea-pig-drag-and-drop.html
@@ -21,6 +21,13 @@
     .column.over { border: 4px dashed #333; }
     #column-a { background: red; }
     #column-b { background: blue; }
+    /* Far below the fold - out of view without scrolling the page down to it. */
+    #off-screen-column {
+      width: 100px;
+      height: 100px;
+      margin-top: 3000px;
+      background: green;
+    }
   </style>
 </head>
 <body>
@@ -28,6 +35,7 @@
     <div id="column-a" class="column">A</div>
     <div id="column-b" class="column">B</div>
   </div>
+  <div id="off-screen-column" class="column">C</div>
   <script>
     // Mirrors the-internet.herokuapp.com/drag_and_drop's dragstart/dragover/drop/dragend
     // behavior (swap the two columns' text, dim the dragged column, highlight the column

--- a/test/fixtures/guinea-pig/test/guinea-pig-drag-and-drop.html
+++ b/test/fixtures/guinea-pig/test/guinea-pig-drag-and-drop.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Drag and Drop</title>
+  <style>
+    html, body { margin: 0; padding: 0; }
+    #columns { width: 100%; }
+    .column {
+      width: 100px;
+      height: 100px;
+      padding: 10px;
+      float: left;
+      box-sizing: border-box;
+      text-align: center;
+      font: bold 40px sans-serif;
+      opacity: 1;
+      /* Prevents the browser's default touch gesture handling (scrolling, etc.) from
+         interfering with the synthetic touch input driving this page. */
+      touch-action: none;
+    }
+    .column.over { border: 4px dashed #333; }
+    #column-a { background: red; }
+    #column-b { background: blue; }
+  </style>
+</head>
+<body>
+  <div id="columns">
+    <div id="column-a" class="column">A</div>
+    <div id="column-b" class="column">B</div>
+  </div>
+  <script>
+    // Mirrors the-internet.herokuapp.com/drag_and_drop's dragstart/dragover/drop/dragend
+    // behavior (swap the two columns' text, dim the dragged column, highlight the column
+    // underneath it), but driven by Pointer Events instead of the native HTML5 Drag and Drop
+    // API: iOS WebKit does not dispatch dragstart/dragover/drop from touch input, only mouse.
+    var dragged = null;
+
+    function columnUnder(x, y) {
+      var hit = document.elementFromPoint(x, y);
+      return hit && hit.closest ? hit.closest('.column') : null;
+    }
+
+    document.addEventListener('pointerdown', function (e) {
+      var col = columnUnder(e.clientX, e.clientY);
+      if (!col) {
+        return;
+      }
+      dragged = col;
+      col.style.opacity = '0.5';
+    }, true);
+
+    document.addEventListener('pointermove', function (e) {
+      if (!dragged) {
+        return;
+      }
+      var col = columnUnder(e.clientX, e.clientY);
+      document.querySelectorAll('.column').forEach(function (c) {
+        c.classList.remove('over');
+      });
+      if (col && col !== dragged) {
+        col.classList.add('over');
+      }
+    }, true);
+
+    document.addEventListener('pointerup', function (e) {
+      if (!dragged) {
+        return;
+      }
+      var target = columnUnder(e.clientX, e.clientY);
+      if (target && target !== dragged) {
+        var draggedText = dragged.textContent;
+        dragged.textContent = target.textContent;
+        target.textContent = draggedText;
+      }
+      dragged.style.opacity = '1';
+      document.querySelectorAll('.column').forEach(function (c) {
+        c.classList.remove('over');
+      });
+      dragged = null;
+    }, true);
+  </script>
+</body>
+</html>

--- a/test/functional/helpers/guinea-pig/index.ts
+++ b/test/functional/helpers/guinea-pig/index.ts
@@ -21,6 +21,10 @@ export function guineaPigAppBannerPage(baseUrl: string): string {
   return buildGuineaPigUrl(baseUrl, '/test/guinea-pig-app-banner');
 }
 
+export function guineaPigDragAndDropPage(baseUrl: string): string {
+  return buildGuineaPigUrl(baseUrl, '/test/guinea-pig-drag-and-drop.html');
+}
+
 export function guineaPigFramePage(baseUrl: string): string {
   return buildGuineaPigUrl(baseUrl, '/test/frameset.html');
 }

--- a/test/functional/web/actions-e2e.spec.ts
+++ b/test/functional/web/actions-e2e.spec.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import {describe, it, before, after} from 'node:test';
+
+import type {Browser} from 'webdriverio';
+
+import {amendCapabilities, SAFARI_CAPS, DEVICE_NAME} from '../desired.js';
+import {initSession, deleteSession} from '../helpers/session.js';
+import {createGuineaPigServerSession, guineaPigDragAndDropPage, openPage} from './helpers/index.js';
+
+describe('w3c actions - webview -', function () {
+  let driver: Browser;
+  let baseUrl: string;
+  const guineaPigServer = createGuineaPigServerSession();
+
+  before(async function () {
+    baseUrl = (await guineaPigServer.setup()).baseUrl;
+    driver = await initSession(
+      amendCapabilities(SAFARI_CAPS, {
+        'appium:deviceName': DEVICE_NAME,
+        'appium:safariInitialUrl': guineaPigDragAndDropPage(baseUrl),
+      }),
+    );
+  });
+
+  after(async function () {
+    await deleteSession();
+    await guineaPigServer.teardown();
+  });
+
+  it('should perform a drag and drop via the W3C actions API while handled by native WDA', async function () {
+    await openPage(driver, guineaPigDragAndDropPage(baseUrl));
+
+    const columnA = await driver.$('#column-a');
+    const columnB = await driver.$('#column-b');
+    await columnA.waitForExist({timeout: 5000});
+    await columnB.waitForExist({timeout: 5000});
+
+    assert.strictEqual((await columnA.getText()).trim(), 'A');
+    assert.strictEqual((await columnB.getText()).trim(), 'B');
+
+    // in a plain webview (no automation session), performActions is handled by native WDA, which
+    // has no notion of web elements - column-a/column-b here must be resolved to native
+    // coordinates. Moving the pointer over the drop target repeatedly (not just teleporting
+    // there in one jump) mirrors how a real drag gesture is driven.
+    let action = driver
+      .action('pointer', {parameters: {pointerType: 'touch'}})
+      .move({duration: 0, origin: columnA})
+      .down({button: 0})
+      .pause(100);
+    for (let i = 0; i < 10; i++) {
+      action = action.move({duration: 60, origin: columnB}).pause(40);
+    }
+    await action.pause(300).up({button: 0}).perform();
+
+    await driver.waitUntil(async () => (await columnA.getText()).trim() === 'B', {
+      timeout: 5000,
+      timeoutMsg: 'columns did not swap content after performing the drag and drop actions',
+    });
+
+    // content swapped between the two columns
+    assert.strictEqual((await columnA.getText()).trim(), 'B');
+    assert.strictEqual((await columnB.getText()).trim(), 'A');
+
+    // further validation: the pointerup handler must have fired too, resetting the
+    // opacity/hover styling set on pointerdown/pointermove, proving the full drag
+    // lifecycle ran to completion
+    const aStyle = ((await columnA.getAttribute('style')) ?? '').replace(/\s/g, '');
+    assert.ok(aStyle.includes('opacity:1'), `Expected column-a opacity to be reset, got style="${aStyle}"`);
+
+    const aClass = (await columnA.getAttribute('class')) ?? '';
+    const bClass = (await columnB.getAttribute('class')) ?? '';
+    assert.ok(!aClass.includes('over'), `Expected column-a to not have the "over" class, got "${aClass}"`);
+    assert.ok(!bClass.includes('over'), `Expected column-b to not have the "over" class, got "${bClass}"`);
+  });
+});

--- a/test/functional/web/actions-e2e.spec.ts
+++ b/test/functional/web/actions-e2e.spec.ts
@@ -72,4 +72,27 @@ describe('w3c actions - webview -', function () {
     assert.ok(!aClass.includes('over'), `Expected column-a to not have the "over" class, got "${aClass}"`);
     assert.ok(!bClass.includes('over'), `Expected column-b to not have the "over" class, got "${bClass}"`);
   });
+
+  it('should reject a W3C action whose element origin is currently out of view', async function () {
+    await openPage(driver, guineaPigDragAndDropPage(baseUrl));
+
+    // never scrolled into view - a native-context action can't be driven against it, since WDA
+    // can only see whatever's actually on screen right now
+    const offScreenColumn = await driver.$('#off-screen-column');
+    await offScreenColumn.waitForExist({timeout: 5000});
+
+    let rejected = false;
+    try {
+      await driver
+        .action('pointer', {parameters: {pointerType: 'touch'}})
+        .move({duration: 0, origin: offScreenColumn})
+        .down({button: 0})
+        .up({button: 0})
+        .perform();
+    } catch (err) {
+      rejected = true;
+      assert.match((err as Error).message, /out of (view|bounds)/i);
+    }
+    assert.ok(rejected, 'Expected the action to be rejected for an out-of-view element origin');
+  });
 });

--- a/test/functional/web/helpers/index.ts
+++ b/test/functional/web/helpers/index.ts
@@ -4,6 +4,7 @@ export {
   guineaPigPage,
   guineaPigScrollablePage,
   guineaPigAppBannerPage,
+  guineaPigDragAndDropPage,
   guineaPigFramePage,
   guineaPigIframePage,
   guineaPigIframeWrapPage,

--- a/test/unit/commands/gesture.spec.ts
+++ b/test/unit/commands/gesture.spec.ts
@@ -442,10 +442,25 @@ describe('performActions', function () {
   it('rejects an action sequence that references a web element when proxying to WDA', async function () {
     sandbox.stub(driver, 'isWebContext').returns(false);
     sandbox.stub(driver, 'proxyCommand');
+    driver.webElementsCache.set(':wdc:123', ':wdc:123');
     const actions = [
       {type: 'pointer', id: 'finger1', actions: [{type: 'pointerMove', origin: {ELEMENT: ':wdc:123'}}]},
     ] as any;
 
     await assert.rejects(driver.performActions(actions), errors.InvalidArgumentError);
+  });
+
+  it('allows a native element origin through to WDA - it is shaped just like a web element, but is not one', async function () {
+    sandbox.stub(driver, 'isWebContext').returns(false);
+    const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
+    // never cached via the web-execution machinery, so this is a native element, not a web one
+    const actions = [
+      {type: 'pointer', id: 'finger1', actions: [{type: 'pointerMove', origin: {ELEMENT: 'native-element-id'}}]},
+    ] as any;
+
+    await driver.performActions(actions);
+
+    assert.strictEqual(proxyStub.calledOnce, true);
+    assert.strictEqual(proxyStub.firstCall.args[0], '/actions');
   });
 });

--- a/test/unit/web-execution/atoms-backend.spec.ts
+++ b/test/unit/web-execution/atoms-backend.spec.ts
@@ -5,6 +5,7 @@ import {errors} from 'appium/driver.js';
 import {createSandbox} from 'sinon';
 import type sinon from 'sinon';
 
+import {viewportSignature} from '../../../lib/commands/web-native-bridge.js';
 import {XCUITestDriver} from '../../../lib/driver.js';
 import {AtomsBackend} from '../../../lib/web-execution/atoms-backend.js';
 
@@ -435,8 +436,31 @@ describe('AtomsBackend', function () {
     const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
     executeAtomStub.withArgs('get_size').resolves({width: 40, height: 20});
     executeAtomStub.withArgs('get_top_left_coordinates').resolves({x: 100, y: 200});
-    const translateStub = sandbox.stub(driver, 'translateWebCoords').resolves({x: 321, y: 654});
     driver.webElementsCache.set(':wdc:123', ':wdc:123');
+
+    // translateWebCoords is no longer a stubbable driver method (it's imported directly from
+    // web-native-bridge.js), so drive its real calibration transform instead: an identity
+    // transform pre-seeded into the cache under the signature it will actually compute from the
+    // (stubbed) viewport state, so no real calibration tap sequence runs.
+    sandbox.stub(driver, 'waitForAtom').callsFake((p: any) => p);
+    const viewportState = {
+      innerWidth: 400,
+      innerHeight: 800,
+      outerWidth: 400,
+      outerHeight: 800,
+      isScrolledToTop: true,
+      visualViewportWidth: 400,
+      visualViewportHeight: 800,
+      visualViewportOffsetLeft: 0,
+      visualViewportOffsetTop: 0,
+      visualViewportScale: 1,
+    };
+    remoteStub.execute.returns(viewportState);
+    driver._webviewCalibrationCache = {
+      signature: `${driver.curContext}::${viewportSignature({...viewportState, orientation: 'PORTRAIT'})}`,
+      data: {offsetX: 0, offsetY: 0, pixelRatioX: 1, pixelRatioY: 1},
+    };
+
     const actions = [
       {
         type: 'pointer',
@@ -447,18 +471,17 @@ describe('AtomsBackend', function () {
 
     await backend.performActions(actions);
 
-    // center (100 + 20, 200 + 10) offset by the action's own (5, -5)
-    assert.strictEqual(translateStub.calledOnceWithExactly(125, 205), true);
     assert.strictEqual(proxyStub.calledOnce, true);
     const proxiedAction = (proxyStub.firstCall.args[2] as any).actions[0].actions[0];
     assert.strictEqual(proxiedAction.origin, 'viewport');
-    assert.strictEqual(proxiedAction.x, 321);
-    assert.strictEqual(proxiedAction.y, 654);
+    // identity transform, so native coords equal the web ones: center (100 + 20, 200 + 10)
+    // offset by the action's own (5, -5)
+    assert.strictEqual(proxiedAction.x, 125);
+    assert.strictEqual(proxiedAction.y, 205);
   });
 
   it('performActions leaves a native element origin untouched - it is shaped just like a web element, but is not one', async function () {
     const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
-    const translateStub = sandbox.stub(driver, 'translateWebCoords');
     // never cached via the web-execution machinery, so this is a native element, not a web one
     const actions = [
       {
@@ -470,7 +493,6 @@ describe('AtomsBackend', function () {
 
     await backend.performActions(actions);
 
-    assert.strictEqual(translateStub.called, false);
     assert.strictEqual(executeAtomStub.called, false);
     const proxiedAction = (proxyStub.firstCall.args[2] as any).actions[0].actions[0];
     assert.deepStrictEqual(proxiedAction.origin, {ELEMENT: 'native-element-id'});

--- a/test/unit/web-execution/atoms-backend.spec.ts
+++ b/test/unit/web-execution/atoms-backend.spec.ts
@@ -39,6 +39,32 @@ describe('AtomsBackend', function () {
     sandbox.restore();
   });
 
+  // translateWebCoords is no longer a stubbable driver method (it's imported directly from
+  // web-native-bridge.js), so tests that need it drive its real calibration transform instead:
+  // an identity transform pre-seeded into the cache under the signature it will actually compute
+  // from the (stubbed) viewport state, so no real calibration tap sequence runs, and native
+  // coordinates come out equal to the web ones passed in.
+  function seedIdentityCalibration(): void {
+    sandbox.stub(driver, 'waitForAtom').callsFake((p: any) => p);
+    const viewportState = {
+      innerWidth: 400,
+      innerHeight: 800,
+      outerWidth: 400,
+      outerHeight: 800,
+      isScrolledToTop: true,
+      visualViewportWidth: 400,
+      visualViewportHeight: 800,
+      visualViewportOffsetLeft: 0,
+      visualViewportOffsetTop: 0,
+      visualViewportScale: 1,
+    };
+    remoteStub.execute.returns(viewportState);
+    driver._webviewCalibrationCache = {
+      signature: `${driver.curContext}::${viewportSignature({...viewportState, orientation: 'PORTRAIT'})}`,
+      data: {offsetX: 0, offsetY: 0, pixelRatioX: 1, pixelRatioY: 1},
+    };
+  }
+
   describe('elements backed by a single atom call', function () {
     const cases: [string, string][] = [
       ['clear', 'clear'],
@@ -434,32 +460,10 @@ describe('AtomsBackend', function () {
 
   it('performActions resolves a web-element origin to native coordinates before proxying to WDA', async function () {
     const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
-    executeAtomStub.withArgs('get_size').resolves({width: 40, height: 20});
-    executeAtomStub.withArgs('get_top_left_coordinates').resolves({x: 100, y: 200});
+    // the element's in-view center point (already clipped to the viewport by the script)
+    executeAtomStub.withArgs('execute_script').resolves({x: 120, y: 210});
     driver.webElementsCache.set(':wdc:123', ':wdc:123');
-
-    // translateWebCoords is no longer a stubbable driver method (it's imported directly from
-    // web-native-bridge.js), so drive its real calibration transform instead: an identity
-    // transform pre-seeded into the cache under the signature it will actually compute from the
-    // (stubbed) viewport state, so no real calibration tap sequence runs.
-    sandbox.stub(driver, 'waitForAtom').callsFake((p: any) => p);
-    const viewportState = {
-      innerWidth: 400,
-      innerHeight: 800,
-      outerWidth: 400,
-      outerHeight: 800,
-      isScrolledToTop: true,
-      visualViewportWidth: 400,
-      visualViewportHeight: 800,
-      visualViewportOffsetLeft: 0,
-      visualViewportOffsetTop: 0,
-      visualViewportScale: 1,
-    };
-    remoteStub.execute.returns(viewportState);
-    driver._webviewCalibrationCache = {
-      signature: `${driver.curContext}::${viewportSignature({...viewportState, orientation: 'PORTRAIT'})}`,
-      data: {offsetX: 0, offsetY: 0, pixelRatioX: 1, pixelRatioY: 1},
-    };
+    seedIdentityCalibration();
 
     const actions = [
       {
@@ -474,10 +478,61 @@ describe('AtomsBackend', function () {
     assert.strictEqual(proxyStub.calledOnce, true);
     const proxiedAction = (proxyStub.firstCall.args[2] as any).actions[0].actions[0];
     assert.strictEqual(proxiedAction.origin, 'viewport');
-    // identity transform, so native coords equal the web ones: center (100 + 20, 200 + 10)
+    // identity transform, so native coords equal the web ones: in-view center (120, 210)
     // offset by the action's own (5, -5)
     assert.strictEqual(proxiedAction.x, 125);
     assert.strictEqual(proxiedAction.y, 205);
+  });
+
+  it('performActions throws MoveTargetOutOfBoundsError for a web-element origin currently out of view', async function () {
+    sandbox.stub(driver, 'proxyCommand').resolves();
+    // the in-view center point script returns null when the element's clipped rectangle is empty
+    executeAtomStub.withArgs('execute_script').resolves(null);
+    driver.webElementsCache.set(':wdc:123', ':wdc:123');
+    const actions = [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [{type: 'pointerMove', duration: 0, origin: {ELEMENT: ':wdc:123'}, x: 0, y: 0}],
+      },
+    ] as any;
+
+    await assert.rejects(backend.performActions(actions), errors.MoveTargetOutOfBoundsError);
+  });
+
+  it('performActions resolves each web-element origin independently - a lookup that scrolled could invalidate an earlier one', async function () {
+    const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
+    driver.webElementsCache.set(':wdc:source', ':wdc:source');
+    driver.webElementsCache.set(':wdc:target', ':wdc:target');
+    seedIdentityCalibration();
+    // distinct, already-in-view centers for each element - if resolving the second element's
+    // coordinates scrolled the page (as get_top_left_coordinates/get_size would), the first
+    // element's already-resolved coordinates would no longer point at it
+    executeAtomStub
+      .withArgs('execute_script')
+      .onFirstCall()
+      .resolves({x: 10, y: 10})
+      .onSecondCall()
+      .resolves({x: 300, y: 300});
+    const actions = [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [
+          {type: 'pointerMove', duration: 0, origin: {ELEMENT: ':wdc:source'}, x: 0, y: 0},
+          {type: 'pointerMove', duration: 60, origin: {ELEMENT: ':wdc:target'}, x: 0, y: 0},
+        ],
+      },
+    ] as any;
+
+    await backend.performActions(actions);
+
+    // executeAtom is stubbed for every call, so no scroll-triggering get_top_left_coordinates or
+    // get_size call is possible here in the first place - this asserts the two lookups instead
+    // resolve to the two distinct, independent coordinates set up above
+    const [moveToSource, moveToTarget] = (proxyStub.firstCall.args[2] as any).actions[0].actions;
+    assert.deepStrictEqual({x: moveToSource.x, y: moveToSource.y}, {x: 10, y: 10});
+    assert.deepStrictEqual({x: moveToTarget.x, y: moveToTarget.y}, {x: 300, y: 300});
   });
 
   it('performActions leaves a native element origin untouched - it is shaped just like a web element, but is not one', async function () {

--- a/test/unit/web-execution/atoms-backend.spec.ts
+++ b/test/unit/web-execution/atoms-backend.spec.ts
@@ -436,6 +436,7 @@ describe('AtomsBackend', function () {
     executeAtomStub.withArgs('get_size').resolves({width: 40, height: 20});
     executeAtomStub.withArgs('get_top_left_coordinates').resolves({x: 100, y: 200});
     const translateStub = sandbox.stub(driver, 'translateWebCoords').resolves({x: 321, y: 654});
+    driver.webElementsCache.set(':wdc:123', ':wdc:123');
     const actions = [
       {
         type: 'pointer',
@@ -453,6 +454,26 @@ describe('AtomsBackend', function () {
     assert.strictEqual(proxiedAction.origin, 'viewport');
     assert.strictEqual(proxiedAction.x, 321);
     assert.strictEqual(proxiedAction.y, 654);
+  });
+
+  it('performActions leaves a native element origin untouched - it is shaped just like a web element, but is not one', async function () {
+    const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
+    const translateStub = sandbox.stub(driver, 'translateWebCoords');
+    // never cached via the web-execution machinery, so this is a native element, not a web one
+    const actions = [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [{type: 'pointerMove', duration: 0, origin: {ELEMENT: 'native-element-id'}, x: 5, y: -5}],
+      },
+    ] as any;
+
+    await backend.performActions(actions);
+
+    assert.strictEqual(translateStub.called, false);
+    assert.strictEqual(executeAtomStub.called, false);
+    const proxiedAction = (proxyStub.firstCall.args[2] as any).actions[0].actions[0];
+    assert.deepStrictEqual(proxiedAction.origin, {ELEMENT: 'native-element-id'});
   });
 
   it('releaseActions is a harmless no-op', async function () {

--- a/test/unit/web-execution/atoms-backend.spec.ts
+++ b/test/unit/web-execution/atoms-backend.spec.ts
@@ -431,11 +431,28 @@ describe('AtomsBackend', function () {
     assert.strictEqual(proxyStub.firstCall.args[0], '/actions');
   });
 
-  it('performActions rejects a web-element-origin sequence - atoms/WDA cannot resolve those', async function () {
+  it('performActions resolves a web-element origin to native coordinates before proxying to WDA', async function () {
+    const proxyStub = sandbox.stub(driver, 'proxyCommand').resolves();
+    executeAtomStub.withArgs('get_size').resolves({width: 40, height: 20});
+    executeAtomStub.withArgs('get_top_left_coordinates').resolves({x: 100, y: 200});
+    const translateStub = sandbox.stub(driver, 'translateWebCoords').resolves({x: 321, y: 654});
     const actions = [
-      {type: 'pointer', id: 'finger1', actions: [{type: 'pointerMove', origin: {ELEMENT: ':wdc:123'}}]},
+      {
+        type: 'pointer',
+        id: 'finger1',
+        actions: [{type: 'pointerMove', duration: 0, origin: {ELEMENT: ':wdc:123'}, x: 5, y: -5}],
+      },
     ] as any;
-    await assert.rejects(backend.performActions(actions), errors.InvalidArgumentError);
+
+    await backend.performActions(actions);
+
+    // center (100 + 20, 200 + 10) offset by the action's own (5, -5)
+    assert.strictEqual(translateStub.calledOnceWithExactly(125, 205), true);
+    assert.strictEqual(proxyStub.calledOnce, true);
+    const proxiedAction = (proxyStub.firstCall.args[2] as any).actions[0].actions[0];
+    assert.strictEqual(proxiedAction.origin, 'viewport');
+    assert.strictEqual(proxiedAction.x, 321);
+    assert.strictEqual(proxiedAction.y, 654);
   });
 
   it('releaseActions is a harmless no-op', async function () {


### PR DESCRIPTION
In a plain webview (no automation session), performActions is handled by native WDA, which has no notion of web elements - an action whose origin is a web element used to be rejected outright. AtomsBackend now resolves such origins to native coordinates first, using the same web-to-native translation nativeWebTap falls back on, then drives the resolved action through WDA as before.