### PR TITLE
fix: do not zip the host temp dir when pulling a container root on real devices

### DIFF
--- a/lib/device/afc-client.ts
+++ b/lib/device/afc-client.ts
@@ -8,6 +8,7 @@ import {services} from 'appium-ios-device';
 /** @ts-expect-error no types */
 import type {AfcService as IOSDeviceAfcService} from 'appium-ios-device';
 import type {AfcService as RemoteXPCAfcService} from 'appium-ios-remotexpc';
+import {errors} from 'appium/driver.js';
 import {fs, util} from 'appium/support.js';
 
 import {withTimeout} from '../commands/helpers/index.js';
@@ -353,9 +354,8 @@ export class AfcClient {
     overwrite: boolean,
     onEntry?: AfcPullOptions['onEntry'],
   ): Promise<void> {
-    const localFilePath = (await this.isLocalDirectory(localPath))
-      ? path.join(localPath, path.posix.basename(remotePath))
-      : localPath;
+    const baseName = requireRemoteBaseName(remotePath);
+    const localFilePath = (await this.isLocalDirectory(localPath)) ? path.join(localPath, baseName) : localPath;
 
     await this.checkOverwrite(localFilePath, overwrite);
     await this.pullSingleFile(remotePath, localFilePath);
@@ -371,8 +371,9 @@ export class AfcClient {
     localPath: string,
     onEntry?: AfcPullOptions['onEntry'],
   ): Promise<string> {
+    const baseName = requireRemoteBaseName(remotePath);
     const localDstIsDirectory = await this.isLocalDirectory(localPath);
-    const localRootDir = localDstIsDirectory ? path.join(localPath, path.posix.basename(remotePath)) : localPath;
+    const localRootDir = localDstIsDirectory ? path.join(localPath, baseName) : localPath;
 
     await fs.mkdirp(localRootDir);
 
@@ -512,6 +513,15 @@ export class AfcClient {
       return false;
     }
   }
+}
+
+/** Returns the basename of a remote path, rejecting root-like paths that have none. */
+function requireRemoteBaseName(remotePath: string): string {
+  const baseName = path.posix.basename(remotePath);
+  if (!baseName) {
+    throw new errors.InvalidArgumentError(`Cannot pull the root path '${remotePath}'`);
+  }
+  return baseName;
 }
 
 /**

--- a/test/unit/real-device-management.spec.ts
+++ b/test/unit/real-device-management.spec.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
+import {Readable} from 'node:stream';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
+import {errors} from 'appium/driver.js';
 import {fs} from 'appium/support.js';
 import {createSandbox} from 'sinon';
 import type {SinonStub} from 'sinon';
 
 import {AfcClient} from '../../lib/device/afc-client.js';
-import {installToRealDevice, RealDevice} from '../../lib/device/real-device-management.js';
+import {installToRealDevice, pullFolder, RealDevice} from '../../lib/device/real-device-management.js';
 import type {RemoteXPCFacade} from '../../lib/device/remote-xpc/index.js';
 import {ZipConduitClient} from '../../lib/device/zip-conduit-client.js';
 import {XCUITestDriver} from '../../lib/driver.js';
@@ -280,5 +282,39 @@ describe('RealDevice host utility fallback policy', function () {
       assert.strictEqual(listAppsStub.notCalled, true);
       assert.strictEqual(fetchAppInfoStub.calledOnce, true);
     });
+  });
+});
+
+describe('pullFolder', function () {
+  /** Fake legacy (non-RemoteXPC) AFC service serving a fixed tree rooted at '/'. */
+  const createWalkDirService = (tree: Record<string, string[]>) => {
+    const walk = async (dir: string, onPath: (p: string, isDirectory: boolean) => unknown): Promise<void> => {
+      for (const entry of tree[dir] ?? []) {
+        const isDirectory = entry in tree;
+        await onPath(entry, isDirectory);
+        if (isDirectory) {
+          await walk(entry, onPath);
+        }
+      }
+    };
+    return {
+      getFileInfo: async (p: string) => ({isDirectory: () => p in tree}),
+      createReadStream: async (p: string) => Readable.from([`content of ${p}`]),
+      walkDir: async (dir: string, _recursive: boolean, onPath: (p: string, isDirectory: boolean) => unknown) =>
+        await walk(dir, onPath),
+    };
+  };
+
+  it('rejects pulling the container root instead of zipping the temp folder parent', async function () {
+    const service = createWalkDirService({'/': ['/a.txt', '/sub'], '/sub': ['/sub/b.txt']});
+    const client: AfcClient = Reflect.construct(AfcClient, [service, false]);
+
+    await assert.rejects(pullFolder(client, '/'), errors.InvalidArgumentError);
+  });
+
+  it('rejects a single-file pull of a remote path without a basename', async function () {
+    const client: AfcClient = Reflect.construct(AfcClient, [createWalkDirService({}), false]);
+
+    await assert.rejects(client.pull('/', '/nonexistent/local'), errors.InvalidArgumentError);
   });
 });


### PR DESCRIPTION
`mobile: pullFolder` with a `remotePath` of `/` or `@bundle.id/` on the legacy AFC path computes an empty basename for the local root folder, so pulled files land directly in the per-call temp folder and the zip step archives its parent, the OS temp directory. Reject such paths with an invalid argument error instead.

Adds unit tests asserting that folder and single-file pulls of a path without a basename
are rejected.
