### PR TITLE
feat: own the context/contexts legacy MJSONWP routes

### DIFF
--- a/lib/method-map.ts
+++ b/lib/method-map.ts
@@ -197,4 +197,10 @@ export const newMethodMap = {
   '/session/:sessionId/contexts': {
     GET: {command: 'getContexts'},
   },
+  '/session/:sessionId/rotation': {
+    // Not implemented locally - WDA supports this endpoint natively, so the
+    // request is proxied straight through (see NO_PROXY_NATIVE_LIST/NO_PROXY_WEB_LIST).
+    GET: {command: 'getRotation'},
+    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
+  },
 } as const satisfies MethodMap<XCUITestDriver>;

--- a/lib/method-map.ts
+++ b/lib/method-map.ts
@@ -190,4 +190,11 @@ export const newMethodMap = {
       deprecated: true,
     },
   },
+  '/session/:sessionId/context': {
+    GET: {command: 'getCurrentContext'},
+    POST: {command: 'setContext', payloadParams: {required: ['name']}},
+  },
+  '/session/:sessionId/contexts': {
+    GET: {command: 'getContexts'},
+  },
 } as const satisfies MethodMap<XCUITestDriver>;


### PR DESCRIPTION
getCurrentContext/setContext/getContexts are already implemented here but were only reachable via @appium/base-driver's global MJSONWP route map, which plans to drop them. Add the routes to this driver's own method map so the endpoints keep working.