### PR TITLE
fix: resolve nested .ipa paths when downloading a remote .zip on real devices

### DIFF
--- a/lib/commands/helpers/app.ts
+++ b/lib/commands/helpers/app.ts
@@ -563,15 +563,16 @@ async function downloadIpa(driver: XCUITestDriver, stream: Readable, headers: HT
         );
       }
       for (const matchedPath of matchedPaths) {
+        const fullPath = path.join(rootDir, matchedPath);
         try {
-          await driver.appInfosCache.put(matchedPath);
+          await driver.appInfosCache.put(fullPath);
         } catch (e: any) {
           driver.log.info(e.message);
           continue;
         }
         driver.log.debug(`Selecting the application at '${matchedPath}'`);
-        const isolatedPath = path.join(await tempDir.openDir(), path.basename(matchedPath));
-        await fs.mv(matchedPath, isolatedPath);
+        const isolatedPath = path.join(await tempDir.openDir(), path.basename(fullPath));
+        await fs.mv(fullPath, isolatedPath);
         return isolatedPath;
       }
       throw new Error(`The remote archive does not contain any valid ${IPA_EXT} applications`);

--- a/test/unit/app-utils.spec.ts
+++ b/test/unit/app-utils.spec.ts
@@ -3,8 +3,10 @@ import path from 'node:path';
 import {describe, it, before} from 'node:test';
 
 import {fs, tempDir, zip} from 'appium/support.js';
+import {createSandbox} from 'sinon';
 
-import {unzipStream, unzipFile} from '../../lib/commands/helpers/app.js';
+import {onDownloadApp, unzipStream, unzipFile} from '../../lib/commands/helpers/app.js';
+import {XCUITestDriver} from '../../lib/driver.js';
 import {getUIKitCatalogPath} from '../setup.js';
 
 describe('app-utils', function () {
@@ -89,6 +91,46 @@ describe('app-utils', function () {
         await assert.rejects(unzipFile(tmpSrc));
       } finally {
         await fs.rimraf(tmpDir);
+      }
+    });
+  });
+
+  describe('onDownloadApp', function () {
+    it('should select an .ipa nested in a remote .zip on a real device', async function () {
+      try {
+        await fs.which('bsdtar');
+      } catch {
+        return;
+      }
+
+      const sandbox = createSandbox();
+      const tmpDir = await tempDir.openDir();
+      let resultPath: string | undefined;
+      try {
+        const payloadDir = path.join(tmpDir, 'stage', 'Payload', 'UIKitCatalog.app');
+        await fs.mkdirp(payloadDir);
+        await fs.copyFile(path.join(uiCatalogAppPath, 'Info.plist'), path.join(payloadDir, 'Info.plist'));
+        const archiveRoot = path.join(tmpDir, 'archive', 'sub');
+        await fs.mkdirp(archiveRoot);
+        await zip.toArchive(path.join(archiveRoot, 'Foo.ipa'), {cwd: path.join(tmpDir, 'stage')});
+        const zipPath = path.join(tmpDir, 'build.zip');
+        await zip.toArchive(zipPath, {cwd: path.join(tmpDir, 'archive')});
+
+        const driver = new XCUITestDriver({} as any);
+        sandbox.stub(driver, 'isRealDevice').returns(true);
+        resultPath = await onDownloadApp.call(driver, {
+          url: 'http://example.com/build.zip',
+          headers: {'content-disposition': 'attachment; filename="build.zip"'},
+          stream: fs.createReadStream(zipPath),
+        });
+        assert.strictEqual(path.basename(resultPath), 'Foo.ipa');
+        assert.strictEqual(await fs.exists(resultPath), true);
+      } finally {
+        sandbox.restore();
+        await fs.rimraf(tmpDir);
+        if (resultPath) {
+          await fs.rimraf(path.dirname(resultPath));
+        }
       }
     });
   });


### PR DESCRIPTION
## Problem

`downloadIpa` uses paths from `findApps` as-is. They are relative to the extracted archive root, so `appInfosCache.put` and `fs.mv` stat them against server cwd, hit ENOENT, and every candidate is skipped. Any remote `.zip` served with `Content-Disposition: attachment; filename="*.zip"` fails on real devices with `The remote archive does not contain any valid .ipa applications`.

## Fix

Join `rootDir` with matched path before `put`, `basename` and `mv`. Same as `unzipApp` already does.
